### PR TITLE
Add verify-commit

### DIFF
--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy"
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
 	"github.com/gittuf/gittuf/internal/cmd/trust"
+	"github.com/gittuf/gittuf/internal/cmd/verifycommit"
 	"github.com/gittuf/gittuf/internal/cmd/verifyref"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())
 	cmd.AddCommand(rsl.New())
+	cmd.AddCommand(verifycommit.New())
 	cmd.AddCommand(verifyref.New())
 
 	return cmd

--- a/internal/cmd/verifycommit/verifycommit.go
+++ b/internal/cmd/verifycommit/verifycommit.go
@@ -1,0 +1,40 @@
+package verifycommit
+
+import (
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) AddFlags(cmd *cobra.Command) {}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	status := repo.VerifyCommit(cmd.Context(), args...)
+
+	for _, id := range args {
+		fmt.Printf("%s: %s\n", id, status[id])
+	}
+
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "verify-commit",
+		Short: "Verify commit signatures using gittuf metadata",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/gitinterface/tag.go
+++ b/internal/gitinterface/tag.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
@@ -18,6 +19,19 @@ import (
 var (
 	ErrTagAlreadyExists = errors.New("tag already exists")
 )
+
+// IsTag returns true if the specified target is a tag in the repository.
+func IsTag(repo *git.Repository, target string) bool {
+	absPath, err := AbsoluteReference(repo, target)
+	if err == nil {
+		if strings.HasPrefix(absPath, TagRefPrefix) {
+			return true
+		}
+	}
+
+	_, err = repo.TagObject(plumbing.NewHash(target))
+	return err == nil
+}
 
 // Tag creates a new tag in the repository pointing to the specified target.
 func Tag(repo *git.Repository, target plumbing.Hash, name, message string, sign bool) (plumbing.Hash, error) {

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -17,6 +17,8 @@ import (
 	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
+var testCtx = context.Background()
+
 func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State) (*git.Repository, *State) {
 	t.Helper()
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -103,6 +103,35 @@ func TestLoadStateForEntry(t *testing.T) {
 	assert.Equal(t, state, loadedState)
 }
 
+func TestStateKeys(t *testing.T) {
+	state := createTestStateWithPolicy(t)
+
+	expectedKeys := map[string]*tuf.Key{}
+	rootKeyBytes, err := os.ReadFile(filepath.Join("test-data", "root.pub"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootKey, err := tuf.LoadKeyFromBytes(rootKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedKeys[rootKey.KeyID] = rootKey
+
+	gpgKeyBytes, err := os.ReadFile(filepath.Join("test-data", "gpg-pubkey.asc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedKeys[gpgKey.KeyID] = gpgKey
+
+	keys, err := state.PublicKeys()
+	assert.Nil(t, err, keys)
+	assert.Equal(t, expectedKeys, keys)
+}
+
 func TestStateVerify(t *testing.T) {
 	state := createTestStateWithOnlyRoot(t)
 

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -19,3 +19,7 @@ func (r *Repository) VerifyRef(ctx context.Context, target string, full bool) er
 
 	return policy.VerifyRef(ctx, r.r, target)
 }
+
+func (r *Repository) VerifyCommit(ctx context.Context, ids ...string) map[string]string {
+	return policy.VerifyCommit(ctx, r.r, ids...)
+}


### PR DESCRIPTION
Repurposing this PR to introduce verify-commit functionality. I have some draft code for verify-tag but it's a little more nuanced because a tag is both an object and a ref (so has RSL implications). For now, I think verify-commit is a go?

---

Original message:

WIP, needs more tests and clones some code also introduced in #82 and #100. Must only be merged after those.

TODO:
1. should we have a `gittuf policy add-key` or so that only adds a key somewhere without defining more granular policies? That'll allow for using gittuf only for simple signature checks.
2. should there be an optional --branch parameter for verify-commit so that it uses a specific policy state instead of all of them? Right now we have to use keys from all states, including revoked keys as we don't know when a commit was introduced wrt the RSL.
3. I think we may have a more broad `verify-merge` use case, on that note, for a commit <-> branch. In that case, we'd look ahead, find the RSL entry that introduced the commit to the branch, and verify that entry specifically.

Fixes #15 