### PR TITLE
Check remote RSL for updates

### DIFF
--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -1,7 +1,6 @@
 package addrule
 
 import (
-	"context"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/cmd/common"
@@ -73,7 +72,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		authorizedKeysBytes = append(authorizedKeysBytes, kb)
 	}
 
-	return repo.AddDelegation(context.Background(), keyBytes, o.policyName, o.ruleName, authorizedKeysBytes, o.rulePatterns, true)
+	return repo.AddDelegation(cmd.Context(), keyBytes, o.policyName, o.ruleName, authorizedKeysBytes, o.rulePatterns, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"context"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
@@ -35,7 +34,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.InitializeTargets(context.Background(), keyBytes, o.policyName, true)
+	return repo.InitializeTargets(cmd.Context(), keyBytes, o.policyName, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -1,7 +1,6 @@
 package removerule
 
 import (
-	"context"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
@@ -44,7 +43,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RemoveDelegation(context.Background(), keyBytes, o.policyName, o.ruleName, true)
+	return repo.RemoveDelegation(cmd.Context(), keyBytes, o.policyName, o.ruleName, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/rsl/remote/check/check.go
+++ b/internal/cmd/rsl/remote/check/check.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/gittuf/gittuf/internal/repository"
@@ -17,7 +16,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	hasUpdates, hasDiverged, err := repo.CheckRemoteRSLForUpdates(context.Background(), args[0])
+	hasUpdates, hasDiverged, err := repo.CheckRemoteRSLForUpdates(cmd.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/rsl/remote/check/check.go
+++ b/internal/cmd/rsl/remote/check/check.go
@@ -1,0 +1,49 @@
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	hasUpdates, hasDiverged, err := repo.CheckRemoteRSLForUpdates(context.Background(), args[0])
+	if err != nil {
+		return err
+	}
+
+	if hasUpdates {
+		fmt.Printf("RSL at remote %s has updates", args[0])
+		if hasDiverged {
+			fmt.Printf(" and has diverged from local RSL")
+		}
+	} else {
+		fmt.Printf("RSL at remote %s has no updates", args[0])
+	}
+
+	fmt.Println() // Trailing newline
+
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "check <remote>",
+		Short: "Check remote RSL for updates, for development use only",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.Run,
+	}
+
+	return cmd
+}

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -1,0 +1,17 @@
+package remote
+
+import (
+	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/check"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remote",
+		Short: "Tools for managing remote RSLs",
+	}
+
+	cmd.AddCommand(check.New())
+
+	return cmd
+}

--- a/internal/cmd/rsl/rsl.go
+++ b/internal/cmd/rsl/rsl.go
@@ -3,6 +3,7 @@ package rsl
 import (
 	"github.com/gittuf/gittuf/internal/cmd/rsl/annotate"
 	"github.com/gittuf/gittuf/internal/cmd/rsl/record"
+	"github.com/gittuf/gittuf/internal/cmd/rsl/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -12,8 +13,9 @@ func New() *cobra.Command {
 		Short: "Tools to manage the repository's reference state log",
 	}
 
-	cmd.AddCommand(record.New())
 	cmd.AddCommand(annotate.New())
+	cmd.AddCommand(record.New())
+	cmd.AddCommand(remote.New())
 
 	return cmd
 }

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -1,7 +1,6 @@
 package addpolicykey
 
 import (
-	"context"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/cmd/common"
@@ -41,7 +40,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.AddTopLevelTargetsKey(context.Background(), rootKeyBytes, targetsKeyBytes, true)
+	return repo.AddTopLevelTargetsKey(cmd.Context(), rootKeyBytes, targetsKeyBytes, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -1,7 +1,6 @@
 package init
 
 import (
-	"context"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
@@ -29,7 +28,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.InitializeRoot(context.Background(), keyBytes, true)
+	return repo.InitializeRoot(cmd.Context(), keyBytes, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -1,7 +1,6 @@
 package removepolicykey
 
 import (
-	"context"
 	"os"
 	"strings"
 
@@ -36,7 +35,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RemoveTopLevelTargetsKey(context.Background(), rootKeyBytes, strings.ToLower(o.targetsKeyID), true)
+	return repo.RemoveTopLevelTargetsKey(cmd.Context(), rootKeyBytes, strings.ToLower(o.targetsKeyID), true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/verifyref/verifyref.go
+++ b/internal/cmd/verifyref/verifyref.go
@@ -1,8 +1,6 @@
 package verifyref
 
 import (
-	"context"
-
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +24,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return repo.VerifyRef(context.Background(), args[0], o.full)
+	return repo.VerifyRef(cmd.Context(), args[0], o.full)
 }
 
 func New() *cobra.Command {

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -67,7 +67,7 @@ func CreateTestRSLEntryCommit(t *testing.T, repo *git.Repository, entry *rsl.Ent
 
 	commitMessage := strings.Join(lines, "\n")
 
-	ref, err := repo.Reference(plumbing.ReferenceName(rsl.RSLRef), true)
+	ref, err := repo.Reference(plumbing.ReferenceName(rsl.Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -53,7 +53,7 @@ var ErrPolicyExists = errors.New("cannot initialize Policy namespace as it exist
 // InitializeNamespace creates a git ref for the policy. Initially, the entry
 // has a zero hash.
 func InitializeNamespace(repo *git.Repository) error {
-	for _, name := range []string{PolicyRef, PolicyStagingRef} {
+	for _, name := range []string{PolicyRef /*, PolicyStagingRef*/} {
 		if _, err := repo.Reference(plumbing.ReferenceName(name), true); err != nil {
 			if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 				return err
@@ -63,11 +63,13 @@ func InitializeNamespace(repo *git.Repository) error {
 		}
 	}
 
-	if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyRef), plumbing.ZeroHash)); err != nil {
-		return err
-	}
+	// Disable PolicyStagingRef until it is actually used
+	// https://github.com/gittuf/gittuf/issues/45
+	// if err := repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyStagingRef), plumbing.ZeroHash)); err != nil {
+	// 	return err
+	// }
 
-	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyStagingRef), plumbing.ZeroHash))
+	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(PolicyRef), plumbing.ZeroHash))
 }
 
 // State contains the full set of metadata and root keys present in a policy

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -36,9 +36,11 @@ func TestInitializeNamespace(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, plumbing.ZeroHash, ref.Hash())
 
-		ref, err = repo.Reference(plumbing.ReferenceName(PolicyStagingRef), true)
-		assert.Nil(t, err)
-		assert.Equal(t, plumbing.ZeroHash, ref.Hash())
+		// Disable PolicyStagingRef until it is actually used
+		// https://github.com/gittuf/gittuf/issues/45
+		// ref, err = repo.Reference(plumbing.ReferenceName(PolicyStagingRef), true)
+		// assert.Nil(t, err)
+		// assert.Equal(t, plumbing.ZeroHash, ref.Hash())
 	})
 
 	t.Run("existing Policy namespace", func(t *testing.T) {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -61,7 +61,7 @@ func TestInitializeNamespace(t *testing.T) {
 func TestLoadState(t *testing.T) {
 	repo, state := createTestRepository(t, createTestStateWithOnlyRoot)
 
-	rslRef, err := repo.Reference(plumbing.ReferenceName(rsl.RSLRef), true)
+	rslRef, err := repo.Reference(plumbing.ReferenceName(rsl.Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestStateCommit(t *testing.T) {
 	}
 	assert.NotEqual(t, plumbing.ZeroHash, policyRef.Hash())
 
-	rslRef, err := repo.Reference(plumbing.ReferenceName(rsl.RSLRef), true)
+	rslRef, err := repo.Reference(plumbing.ReferenceName(rsl.Ref), true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -53,8 +53,8 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 // there is an update and the second return value indicates if the two RSLs have
 // diverged and need to be reconciled.
 func (r *Repository) CheckRemoteRSLForUpdates(ctx context.Context, remoteName string) (bool, bool, error) {
-	trackerRef := fmt.Sprintf(rsl.RSLRemoteTrackerRef, remoteName)
-	rslRemoteRefSpec := []config.RefSpec{config.RefSpec(fmt.Sprintf("%s:%s", rsl.RSLRef, trackerRef))}
+	trackerRef := rsl.RemoteTrackerRef(remoteName)
+	rslRemoteRefSpec := []config.RefSpec{config.RefSpec(fmt.Sprintf("%s:%s", rsl.Ref, trackerRef))}
 	if err := gitinterface.FetchRefSpec(ctx, r.r, remoteName, rslRemoteRefSpec); err != nil {
 		if errors.Is(err, transport.ErrEmptyRemoteRepository) {
 			// Check if remote is empty and exit appropriately
@@ -68,7 +68,7 @@ func (r *Repository) CheckRemoteRSLForUpdates(ctx context.Context, remoteName st
 		return false, false, err
 	}
 
-	localRefState, err := r.r.Reference(plumbing.ReferenceName(rsl.RSLRef), true)
+	localRefState, err := r.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
 	if err != nil {
 		return false, false, err
 	}

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -1,9 +1,15 @@
 package repository
 
 import (
+	"context"
+	"errors"
+	"fmt"
+
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
 // RecordRSLEntryForReference is the interface for the user to add an RSL entry
@@ -37,4 +43,75 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 	// signCommit must be verified for the refNames of the rslEntryIDs.
 
 	return rsl.NewAnnotation(rslEntryHashes, skip, message).Commit(r.r, signCommit)
+}
+
+// CheckRemoteRSLForUpdates checks if the RSL at the specified remote remote
+// repository has updated in comparison with the local repository's RSL. This is
+// done by fetching the remote RSL to the local repository's remote RSL tracker.
+// If the remote RSL has been updated, this method also checks if the local and
+// remote RSLs have diverged. In summary, the first return value indicates if
+// there is an update and the second return value indicates if the two RSLs have
+// diverged and need to be reconciled.
+func (r *Repository) CheckRemoteRSLForUpdates(ctx context.Context, remoteName string) (bool, bool, error) {
+	trackerRef := fmt.Sprintf(rsl.RSLRemoteTrackerRef, remoteName)
+	rslRemoteRefSpec := []config.RefSpec{config.RefSpec(fmt.Sprintf("%s:%s", rsl.RSLRef, trackerRef))}
+	if err := gitinterface.FetchRefSpec(ctx, r.r, remoteName, rslRemoteRefSpec); err != nil {
+		if errors.Is(err, transport.ErrEmptyRemoteRepository) {
+			// Check if remote is empty and exit appropriately
+			return false, false, nil
+		}
+		return false, false, err
+	}
+
+	remoteRefState, err := r.r.Reference(plumbing.ReferenceName(trackerRef), true)
+	if err != nil {
+		return false, false, err
+	}
+
+	localRefState, err := r.r.Reference(plumbing.ReferenceName(rsl.RSLRef), true)
+	if err != nil {
+		return false, false, err
+	}
+
+	// Check if local is nil and exit appropriately
+	if localRefState.Hash().IsZero() {
+		// Local RSL has not been populated but remote is not zero
+		// So there are updates the local can pull
+		return true, false, nil
+	}
+
+	// Check if equal and exit early if true
+	if remoteRefState.Hash() == localRefState.Hash() {
+		return false, false, nil
+	}
+
+	// Next, check if remote is ahead of local
+	remoteCommit, err := r.r.CommitObject(remoteRefState.Hash())
+	if err != nil {
+		return false, false, err
+	}
+	localCommit, err := r.r.CommitObject(localRefState.Hash())
+	if err != nil {
+		return false, false, err
+	}
+
+	knows, err := gitinterface.KnowsCommit(r.r, remoteCommit.Hash, localCommit)
+	if err != nil {
+		return false, false, err
+	}
+	if knows {
+		return true, false, nil
+	}
+
+	// If not ancestor, local may be ahead or they may have diverged
+	// If remote is ancestor, only local is ahead, no updates
+	// If remote is not ancestor, the two have diverged, local needs to pull updates
+	knows, err = gitinterface.KnowsCommit(r.r, localCommit.Hash, remoteCommit)
+	if err != nil {
+		return false, false, err
+	}
+	if knows {
+		return false, false, nil
+	}
+	return true, true, nil
 }

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -1,9 +1,12 @@
 package repository
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -138,4 +141,211 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	assert.Equal(t, "skip annotation", annotation.Message)
 	assert.Equal(t, []plumbing.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.True(t, annotation.Skip)
+}
+
+func TestCheckRemoteRSLForUpdates(t *testing.T) {
+	remoteName := "origin"
+	refName := "refs/heads/main"
+	anotherRefName := "refs/heads/feature"
+
+	t.Run("remote has updates for local", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gittuf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+		// Simulate remote actions
+		remoteR, err := git.PlainInit(tmpDir, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remoteRepo := &Repository{r: remoteR}
+
+		// We can't use remoteRepo.InitializeNamespaces() as it'll create zero
+		// namespace for policy, an issue when syncing.
+		if err := rsl.InitializeNamespace(remoteRepo.r); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		// TODO: this should be handled by the Repository package
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		// Simulate more remote actions
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Local should be notified that remote has updates
+		hasUpdates, hasDiverged, err := localRepo.CheckRemoteRSLForUpdates(context.Background(), remoteName)
+		assert.Nil(t, err)
+		assert.True(t, hasUpdates)
+		assert.False(t, hasDiverged)
+	})
+
+	t.Run("remote has no updates for local", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gittuf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+		// Simulate remote actions
+		remoteR, err := git.PlainInit(tmpDir, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remoteRepo := &Repository{r: remoteR}
+
+		// We can't use remoteRepo.InitializeNamespaces() as it'll create zero
+		// namespace for policy, an issue when syncing.
+		if err := rsl.InitializeNamespace(remoteRepo.r); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		// TODO: this should be handled by the Repository package
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		// Local should be notified that remote has no updates
+		hasUpdates, hasDiverged, err := localRepo.CheckRemoteRSLForUpdates(context.Background(), remoteName)
+		assert.Nil(t, err)
+		assert.False(t, hasUpdates)
+		assert.False(t, hasDiverged)
+	})
+
+	t.Run("local is ahead of remote", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gittuf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+		// Simulate remote actions
+		remoteR, err := git.PlainInit(tmpDir, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remoteRepo := &Repository{r: remoteR}
+
+		// We can't use remoteRepo.InitializeNamespaces() as it'll create zero
+		// namespace for policy, an issue when syncing.
+		if err := rsl.InitializeNamespace(remoteRepo.r); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		// TODO: this should be handled by the Repository package
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		// Simulate local actions
+		if _, err := gitinterface.Commit(localRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := localRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Local should be notified that remote has no updates
+		hasUpdates, hasDiverged, err := localRepo.CheckRemoteRSLForUpdates(context.Background(), remoteName)
+		assert.Nil(t, err)
+		assert.False(t, hasUpdates)
+		assert.False(t, hasDiverged)
+	})
+
+	t.Run("remote and local have diverged", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "gittuf")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+		// Simulate remote actions
+		remoteR, err := git.PlainInit(tmpDir, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		remoteRepo := &Repository{r: remoteR}
+
+		// We can't use remoteRepo.InitializeNamespaces() as it'll create zero
+		// namespace for policy, an issue when syncing.
+		if err := rsl.InitializeNamespace(remoteRepo.r); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		// TODO: this should be handled by the Repository package
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		// Simulate remote actions
+		if _, err := gitinterface.Commit(remoteRepo.r, gitinterface.EmptyTree(), refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate local actions
+		if _, err := gitinterface.Commit(localRepo.r, gitinterface.EmptyTree(), anotherRefName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := localRepo.RecordRSLEntryForReference(anotherRefName, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Local should be notified that remote has updates that needs to be
+		// reconciled
+		hasUpdates, hasDiverged, err := localRepo.CheckRemoteRSLForUpdates(context.Background(), remoteName)
+		assert.Nil(t, err)
+		assert.True(t, hasUpdates)
+		assert.True(t, hasDiverged)
+	})
 }

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -37,7 +37,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rslRef, err := repo.r.Reference(rsl.RSLRef, true)
+	rslRef, err := repo.r.Reference(rsl.Ref, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -65,7 +65,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rslRef, err = repo.r.Reference(rsl.RSLRef, true)
+	rslRef, err = repo.r.Reference(rsl.Ref, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -227,7 +227,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -269,7 +269,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -319,7 +319,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.RSLRef}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -14,8 +14,7 @@ import (
 
 const (
 	GittufNamespacePrefix      = "refs/gittuf/"
-	RSLRef                     = "refs/gittuf/reference-state-log"
-	RSLRemoteTrackerRef        = "refs/remotes/%s/gittuf/reference-state-log"
+	Ref                        = "refs/gittuf/reference-state-log"
 	EntryHeader                = "RSL Entry"
 	RefKey                     = "ref"
 	CommitIDKey                = "commitID"
@@ -25,6 +24,8 @@ const (
 	EndMessage                 = "-----END MESSAGE-----"
 	EntryIDKey                 = "entryID"
 	SkipKey                    = "skip"
+
+	remoteTrackerRef = "refs/remotes/%s/gittuf/reference-state-log"
 )
 
 var (
@@ -39,7 +40,7 @@ var (
 // InitializeNamespace creates a git ref for the reference state log. Initially,
 // the entry has a zero hash.
 func InitializeNamespace(repo *git.Repository) error {
-	if _, err := repo.Reference(plumbing.ReferenceName(RSLRef), true); err != nil {
+	if _, err := repo.Reference(plumbing.ReferenceName(Ref), true); err != nil {
 		if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return err
 		}
@@ -47,7 +48,14 @@ func InitializeNamespace(repo *git.Repository) error {
 		return ErrRSLExists
 	}
 
-	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(RSLRef), plumbing.ZeroHash))
+	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(Ref), plumbing.ZeroHash))
+}
+
+// RemoteTrackerRef returns the remote tracking ref for the specified remote
+// name. For example, for 'origin', the remote tracker ref is
+// 'refs/remotes/origin/gittuf/reference-state-log'.
+func RemoteTrackerRef(remote string) string {
+	return fmt.Sprintf(remoteTrackerRef, remote)
 }
 
 type EntryType interface {
@@ -80,7 +88,7 @@ func (e Entry) GetID() plumbing.Hash {
 func (e Entry) Commit(repo *git.Repository, sign bool) error {
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
-	_, err := gitinterface.Commit(repo, gitinterface.EmptyTree(), RSLRef, message, sign)
+	_, err := gitinterface.Commit(repo, gitinterface.EmptyTree(), Ref, message, sign)
 	return err
 }
 
@@ -132,7 +140,7 @@ func (a Annotation) Commit(repo *git.Repository, sign bool) error {
 		return err
 	}
 
-	_, err = gitinterface.Commit(repo, gitinterface.EmptyTree(), RSLRef, message, sign)
+	_, err = gitinterface.Commit(repo, gitinterface.EmptyTree(), Ref, message, sign)
 	return err
 }
 
@@ -223,7 +231,7 @@ func GetNonGittufParentForEntry(repo *git.Repository, entry EntryType) (*Entry, 
 // GetLatestEntry returns the latest entry available locally in the RSL.
 // TODO: There is no information yet about the signature for the entry.
 func GetLatestEntry(repo *git.Repository) (EntryType, error) {
-	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -15,6 +15,7 @@ import (
 const (
 	GittufNamespacePrefix      = "refs/gittuf/"
 	RSLRef                     = "refs/gittuf/reference-state-log"
+	RSLRemoteTrackerRef        = "refs/remotes/%s/gittuf/reference-state-log"
 	EntryHeader                = "RSL Entry"
 	RefKey                     = "ref"
 	CommitIDKey                = "commitID"

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -24,7 +24,7 @@ func TestInitializeNamespace(t *testing.T) {
 			t.Error(err)
 		}
 
-		ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 		assert.Nil(t, err)
 		assert.Equal(t, plumbing.ZeroHash, ref.Hash())
 	})
@@ -58,7 +58,7 @@ func TestNewEntry(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	assert.Nil(t, err)
 	assert.NotEqual(t, plumbing.ZeroHash, ref.Hash())
 
@@ -76,7 +76,7 @@ func TestNewEntry(t *testing.T) {
 
 	originalRefHash := ref.Hash()
 
-	ref, err = repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err = repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -124,7 +124,7 @@ func TestGetLatestEntry(t *testing.T) {
 		assert.NotEqual(t, plumbing.ZeroHash, e.CommitID)
 	}
 
-	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,7 +227,7 @@ func TestGetLatestEntryForRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rslRef, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	rslRef, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,7 +361,7 @@ func TestGetEntry(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err := repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +372,7 @@ func TestGetEntry(t *testing.T) {
 		t.Error(err)
 	}
 
-	ref, err = repo.Reference(plumbing.ReferenceName(RSLRef), true)
+	ref, err = repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR uses some of the semantics from #100 to check the remote RSL for updates. While the CLI command introduced here will be removed at a later date, the RSL update mechanism itself is plumbing for other sync workflows.

Part of #99.