### PR TITLE
Evaluation mode

### DIFF
--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -14,7 +14,10 @@ import (
 const (
 	GPGKeyPrefix = "gpg:"
 	FulcioPrefix = "fulcio:"
+	EvalModeKey  = "GITTUF_EVAL"
 )
+
+var ErrNotInEvalMode = fmt.Errorf("this feature is only available with eval mode, and can UNDERMINE repository security; override by setting %s=1", EvalModeKey)
 
 // ReadKeyBytes returns public key bytes using the custom securesystemslib
 // format. It uses the underlying gpg binary to import a PGP key.
@@ -76,4 +79,8 @@ func ReadKeyBytes(key string) ([]byte, error) {
 	}
 
 	return kb, nil
+}
+
+func EvalMode() bool {
+	return os.Getenv(EvalModeKey) == "1"
 }

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -1,16 +1,39 @@
 package record
 
 import (
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	commitID string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o.commitID,
+		"commit",
+		"c",
+		"",
+		fmt.Sprintf("commit ID (eval mode only, set %s=1)", common.EvalModeKey),
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err
+	}
+
+	if len(o.commitID) > 0 {
+		if !common.EvalMode() {
+			return common.ErrNotInEvalMode
+		}
+
+		return repo.RecordRSLEntryForReferenceAtCommit(args[0], o.commitID, true)
 	}
 
 	return repo.RecordRSLEntryForReference(args[0], true)
@@ -24,6 +47,7 @@ func New() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE:  o.Run,
 	}
+	o.AddFlags(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
This adds an evaluation mode to gittuf and the first eval-only function, the ability to record RSL entries for non-latest commits. This is required to evaluate gittuf on existing repositories to simulate its behaviour over time.