### PR TITLE
policy: Verify new policy against previous policy

### DIFF
--- a/internal/policy/test-data/targets-1
+++ b/internal/policy/test-data/targets-1
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "fab3bbe2c6be62bd1f678449f7ca365096e22735860a267689f658942274901b", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "7680a7152b651ff8baa702e61ce85096fa1a20fdf9e1c086d9c67296fec60357", "private": "102339f4e3df6904ee07be7dc52c0e9facb15b7bb7e9d909bb2ee30354d107f3"}}

--- a/internal/policy/test-data/targets-2
+++ b/internal/policy/test-data/targets-2
@@ -1,0 +1,1 @@
+{"keytype": "ed25519", "scheme": "ed25519", "keyid": "437cdafde81f715cf81e75920d7d4a9ce4cab83aac5a8a5984c3902da6bf2ab7", "keyid_hash_algorithms": ["sha256", "sha512"], "keyval": {"public": "df7d2d271e57638550d0bf61a6a023003400ca129821abd86325ba37b94cc77d", "private": "0668261747386e653fceadb87b6bf6befeb63b24c91ff67a4f04966ba888e904"}}


### PR DESCRIPTION
So far, we were verifying each policy state internally. We weren't verifying that a new policy's root role is signed by keys trusted in the previous policy's root. This adds that check, and in the process, I think we solve the issue of not verifying RSL entry signatures for policy changes.