### PR TITLE
Fix nil delegations

### DIFF
--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/storage/memory"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State) (*git.Repository, *State) {
@@ -74,9 +73,8 @@ func createTestStateWithOnlyRoot(t *testing.T) *State {
 	}
 
 	return &State{
-		RootPublicKeys:      []*tuf.Key{key},
-		RootEnvelope:        rootEnv,
-		DelegationEnvelopes: map[string]*sslibdsse.Envelope{},
+		RootPublicKeys: []*tuf.Key{key},
+		RootEnvelope:   rootEnv,
 	}
 }
 
@@ -144,9 +142,8 @@ func createTestStateWithPolicy(t *testing.T) *State {
 	}
 
 	return &State{
-		RootEnvelope:        rootEnv,
-		TargetsEnvelope:     targetsEnv,
-		DelegationEnvelopes: map[string]*sslibdsse.Envelope{}, // FIXME: this isn't the best fix. Instead, LoadState* methods should set this to nil when no delegated roles exist.
-		RootPublicKeys:      []*tuf.Key{key},
+		RootEnvelope:    rootEnv,
+		TargetsEnvelope: targetsEnv,
+		RootPublicKeys:  []*tuf.Key{key},
 	}
 }

--- a/internal/repository/root.go
+++ b/internal/repository/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	d "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 // InitializeRoot is the interface for the user to create the repository's root
@@ -91,7 +91,7 @@ func (r *Repository) AddTopLevelTargetsKey(ctx context.Context, rootKeyBytes, ta
 	}
 
 	env := state.RootEnvelope
-	env.Signatures = []d.Signature{}
+	env.Signatures = []sslibdsse.Signature{}
 	env.Payload = base64.StdEncoding.EncodeToString(rootMetadataBytes)
 
 	env, err = dsse.SignEnvelope(ctx, env, sv)
@@ -144,7 +144,7 @@ func (r *Repository) RemoveTopLevelTargetsKey(ctx context.Context, rootKeyBytes 
 	}
 
 	env := state.RootEnvelope
-	env.Signatures = []d.Signature{}
+	env.Signatures = []sslibdsse.Signature{}
 	env.Payload = base64.StdEncoding.EncodeToString(rootMetadataBytes)
 
 	env, err = dsse.SignEnvelope(ctx, env, sv)

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	d "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,7 +37,7 @@ func TestInitializeRoot(t *testing.T) {
 	assert.Equal(t, key.KeyID, rootMetadata.Roles[policy.RootRoleName].KeyIDs[0])
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
 
-	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []d.Verifier{sv}, 1)
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 }
 
@@ -68,7 +68,7 @@ func TestAddTopLevelTargetsKey(t *testing.T) {
 	assert.Equal(t, key.KeyID, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs[0])
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
 
-	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []d.Verifier{sv}, 1)
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 }
 
@@ -118,7 +118,7 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 	assert.Equal(t, rootKey.KeyID, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs[0])
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, rootKey.KeyID)
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, targetsKey.KeyID)
-	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []d.Verifier{sv}, 1)
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 
 	err = r.RemoveTopLevelTargetsKey(context.Background(), keyBytes, rootKey.KeyID, false)
@@ -136,6 +136,6 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 
 	assert.Equal(t, 4, rootMetadata.Version)
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, targetsKey.KeyID)
-	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []d.Verifier{sv}, 1)
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 }

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
-	d "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,10 +52,10 @@ func TestVerifyEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Nil(t, VerifyEnvelope(context.Background(), env, []d.Verifier{verifier}, 1))
+	assert.Nil(t, VerifyEnvelope(context.Background(), env, []sslibdsse.Verifier{verifier}, 1))
 }
 
-func createSignedEnvelope() (*d.Envelope, error) {
+func createSignedEnvelope() (*sslibdsse.Envelope, error) {
 	privateKeyPath := filepath.Join("test-data", "test-key")
 	privateKeyBytes, err := os.ReadFile(privateKeyPath)
 	if err != nil {
@@ -70,10 +70,10 @@ func createSignedEnvelope() (*d.Envelope, error) {
 	message := []byte("test payload")
 	payload := base64.StdEncoding.EncodeToString(message)
 
-	env := &d.Envelope{
+	env := &sslibdsse.Envelope{
 		PayloadType: "application/vnd.gittuf+text",
 		Payload:     payload,
-		Signatures:  []d.Signature{},
+		Signatures:  []sslibdsse.Signature{},
 	}
 
 	env, err = SignEnvelope(context.Background(), env, signer)


### PR DESCRIPTION
Also updates import alias from "d" to "sslibdsse" for the upstream DSSE library. "d" was a mistake in retrospect.

Fixes: https://github.com/gittuf/gittuf/pull/114#discussion_r1327651423