### PR TITLE
Add `gittuf policy add-key`

### DIFF
--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -1,0 +1,71 @@
+package addkey
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p              *persistent.Options
+	policyName     string
+	authorizedKeys []string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		policy.TargetsRoleName,
+		"policy file to add rule to",
+	)
+
+	cmd.Flags().StringArrayVar(
+		&o.authorizedKeys,
+		"authorize-key",
+		[]string{},
+		"authorized public key for rule",
+	)
+	cmd.MarkFlagRequired("authorize-key") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	authorizedKeysBytes := [][]byte{}
+	for _, key := range o.authorizedKeys {
+		kb, err := common.ReadKeyBytes(key)
+		if err != nil {
+			return err
+		}
+
+		authorizedKeysBytes = append(authorizedKeysBytes, kb)
+	}
+
+	return repo.AddKeyToTargets(cmd.Context(), keyBytes, o.policyName, authorizedKeysBytes, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:   "add-key",
+		Short: "Add a trusted key to a policy file",
+		Long:  `This command allows users to add a trusted key to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"github.com/gittuf/gittuf/internal/cmd/policy/addkey"
 	"github.com/gittuf/gittuf/internal/cmd/policy/addrule"
 	i "github.com/gittuf/gittuf/internal/cmd/policy/init"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
@@ -17,6 +18,7 @@ func New() *cobra.Command {
 	o.AddPersistentFlags(cmd)
 
 	cmd.AddCommand(i.New(o))
+	cmd.AddCommand(addkey.New(o))
 	cmd.AddCommand(addrule.New(o))
 	cmd.AddCommand(removerule.New(o))
 

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -90,6 +90,15 @@ func RemoveDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string) (*t
 	return targetsMetadata, nil
 }
 
+// AddKeyToTargets adds public keys to the specified targets metadata.
+func AddKeyToTargets(targetsMetadata *tuf.TargetsMetadata, authorizedKeys []*tuf.Key) (*tuf.TargetsMetadata, error) {
+	for _, key := range authorizedKeys {
+		targetsMetadata.Delegations.AddKey(key)
+	}
+
+	return targetsMetadata, nil
+}
+
 // AllowRule returns the default, last rule for all policy files.
 func AllowRule() tuf.Delegation {
 	return tuf.Delegation{


### PR DESCRIPTION
This allows users to simply add a public key to the specified policy file without using it in a delegation. This supports signature verification only scenarios.

Along with #101 and #122, this should resolve #15.