### PR TITLE
ci: Bump Go and linter versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.20.x, 1.21.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: '1.20'
+          go-version: '1.21.x'
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v1.51.0
+          version: v1.54.2
           args: --timeout=5m


### PR DESCRIPTION
This PR adds Go 1.21.x to the CI workflows. It also bumps up the version of golangci-lint used, which isn't auto updated by dependabot.