### PR TITLE
rsl: Support annotations in RSL APIs

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -95,7 +95,7 @@ func LoadState(ctx context.Context, repo *git.Repository, rslEntryID plumbing.Ha
 // LoadCurrentState returns the State corresponding to the repository's current
 // active policy.
 func LoadCurrentState(ctx context.Context, repo *git.Repository) (*State, error) {
-	e, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	e, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.EntryTyp
 // error is returned. Identifying the policy in this case is left to the calling
 // workflow.
 func GetStateForCommit(ctx context.Context, repo *git.Repository, commit *object.Commit) (*State, error) {
-	firstSeenEntry, err := rsl.GetFirstEntryForCommit(repo, commit)
+	firstSeenEntry, _, err := rsl.GetFirstEntryForCommit(repo, commit)
 	if err != nil {
 		if errors.Is(err, rsl.ErrNoRecordOfCommit) {
 			return nil, nil
@@ -215,7 +215,7 @@ func GetStateForCommit(ctx context.Context, repo *git.Repository, commit *object
 		return nil, err
 	}
 
-	commitPolicyEntry, err := rsl.GetLatestEntryForRefBefore(repo, PolicyRef, firstSeenEntry.ID)
+	commitPolicyEntry, _, err := rsl.GetLatestEntryForRefBefore(repo, PolicyRef, firstSeenEntry.ID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -90,7 +90,7 @@ func TestLoadCurrentState(t *testing.T) {
 func TestLoadStateForEntry(t *testing.T) {
 	repo, state := createTestRepository(t, createTestStateWithOnlyRoot)
 
-	entry, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	entry, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -43,7 +43,7 @@ var (
 // using the latest policy.
 func VerifyRef(ctx context.Context, repo *git.Repository, target string) error {
 	// 1. Get latest policy entry
-	policyEntry, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	policyEntry, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func VerifyRef(ctx context.Context, repo *git.Repository, target string) error {
 	}
 
 	// 2. Find latest entry for target
-	latestEntry, err := rsl.GetLatestEntryForRef(repo, target)
+	latestEntry, _, err := rsl.GetLatestEntryForRef(repo, target)
 	if err != nil {
 		return err
 	}
@@ -65,13 +65,13 @@ func VerifyRef(ctx context.Context, repo *git.Repository, target string) error {
 // entry.
 func VerifyRefFull(ctx context.Context, repo *git.Repository, target string) error {
 	// 1. Trace RSL back to the start
-	firstEntry, err := rsl.GetFirstEntry(repo)
+	firstEntry, _, err := rsl.GetFirstEntry(repo)
 	if err != nil {
 		return err
 	}
 
 	// 2. Find latest entry for target
-	latestEntry, err := rsl.GetLatestEntryForRef(repo, target)
+	latestEntry, _, err := rsl.GetLatestEntryForRef(repo, target)
 	if err != nil {
 		return err
 	}
@@ -284,18 +284,18 @@ func VerifyTag(ctx context.Context, repo *git.Repository, ids []string) map[stri
 			absPath = string(plumbing.NewTagReferenceName(tagObj.Name))
 		}
 
-		entry, err := rsl.GetLatestEntryForRef(repo, absPath)
+		entry, _, err := rsl.GetLatestEntryForRef(repo, absPath)
 		if err != nil {
 			status[id] = unableToFindRSLEntryMessage
 			continue
 		}
 
-		if _, err := rsl.GetLatestEntryForRefBefore(repo, absPath, entry.GetID()); err == nil {
+		if _, _, err := rsl.GetLatestEntryForRefBefore(repo, absPath, entry.GetID()); err == nil {
 			status[id] = multipleTagRSLEntriesFoundMessage
 			continue
 		}
 
-		policyEntry, err := rsl.GetLatestEntryForRefBefore(repo, PolicyRef, entry.ID)
+		policyEntry, _, err := rsl.GetLatestEntryForRefBefore(repo, PolicyRef, entry.ID)
 		if err != nil {
 			status[id] = fmt.Sprintf(unableToLoadPolicyMessageFmt, err.Error())
 			continue
@@ -605,7 +605,7 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 func getCommits(repo *git.Repository, entry *rsl.Entry) ([]*object.Commit, error) {
 	firstEntry := false
 
-	priorRefEntry, err := rsl.GetLatestEntryForRefBefore(repo, entry.RefName, entry.ID)
+	priorRefEntry, _, err := rsl.GetLatestEntryForRefBefore(repo, entry.RefName, entry.ID)
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return nil, err
@@ -636,7 +636,7 @@ func getChangedPaths(repo *git.Repository, entry *rsl.Entry) ([]string, error) {
 		return nil, err
 	}
 
-	priorRefEntry, err := rsl.GetLatestEntryForRefBefore(repo, entry.RefName, entry.ID)
+	priorRefEntry, _, err := rsl.GetLatestEntryForRefBefore(repo, entry.RefName, entry.ID)
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return nil, err

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -73,7 +73,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	policyEntry, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	policyEntry, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -176,7 +176,6 @@ func (a Annotation) createCommitMessage() (string, error) {
 }
 
 // GetEntry returns the entry corresponding to entryID.
-// TODO: There is no information yet about the signature for the entry.
 func GetEntry(repo *git.Repository, entryID plumbing.Hash) (EntryType, error) {
 	commitObj, err := repo.CommitObject(entryID)
 	if err != nil {
@@ -187,7 +186,6 @@ func GetEntry(repo *git.Repository, entryID plumbing.Hash) (EntryType, error) {
 }
 
 // GetParentForEntry returns the entry's parent RSL entry.
-// TODO: There is no information yet about the signature for the parent entry.
 func GetParentForEntry(repo *git.Repository, entry EntryType) (EntryType, error) {
 	commitObj, err := repo.CommitObject(entry.GetID())
 	if err != nil {
@@ -207,7 +205,6 @@ func GetParentForEntry(repo *git.Repository, entry EntryType) (EntryType, error)
 
 // GetNonGittufParentForEntry returns the first RSL entry starting from the
 // specified entry's parent that is not for the gittuf namespace.
-// TODO: There is no information yet about the signature for the entry.
 func GetNonGittufParentForEntry(repo *git.Repository, entry EntryType) (*Entry, error) {
 	it, err := GetParentForEntry(repo, entry)
 	if err != nil {
@@ -229,7 +226,6 @@ func GetNonGittufParentForEntry(repo *git.Repository, entry EntryType) (*Entry, 
 }
 
 // GetLatestEntry returns the latest entry available locally in the RSL.
-// TODO: There is no information yet about the signature for the entry.
 func GetLatestEntry(repo *git.Repository) (EntryType, error) {
 	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
 	if err != nil {
@@ -246,7 +242,6 @@ func GetLatestEntry(repo *git.Repository) (EntryType, error) {
 
 // GetLatestNonGittufEntry returns the first RSL entry that is not for the
 // gittuf namespace.
-// TODO: There is no information yet about the signature for the entry.
 func GetLatestNonGittufEntry(repo *git.Repository) (*Entry, error) {
 	it, err := GetLatestEntry(repo)
 	if err != nil {
@@ -269,14 +264,12 @@ func GetLatestNonGittufEntry(repo *git.Repository) (*Entry, error) {
 
 // GetLatestEntryForRef returns the latest entry available locally in the RSL
 // for the specified refName.
-// TODO: There is no information yet about the signature for the entry.
 func GetLatestEntryForRef(repo *git.Repository, refName string) (*Entry, error) {
 	return GetLatestEntryForRefBefore(repo, refName, plumbing.ZeroHash)
 }
 
 // GetLatestEntryForRefBefore returns the latest entry available locally in the
 // RSL for the specified refName before the specified anchor.
-// TODO: There is no information yet about the signature for the entry.
 func GetLatestEntryForRefBefore(repo *git.Repository, refName string, anchor plumbing.Hash) (*Entry, error) {
 	var (
 		iteratorT EntryType
@@ -325,7 +318,6 @@ func GetLatestEntryForRefBefore(repo *git.Repository, refName string, anchor plu
 
 // GetFirstEntry returns the very first entry in the RSL. It is expected to be
 // *Entry as the first entry in the RSL cannot be an annotation.
-// TODO: There is no information yet about the signature for the entry.
 func GetFirstEntry(repo *git.Repository) (*Entry, error) {
 	iteratorT, err := GetLatestEntry(repo)
 	if err != nil {
@@ -353,9 +345,6 @@ func GetFirstEntry(repo *git.Repository) (*Entry, error) {
 // time a commit was seen in the repository, irrespective of the ref it was
 // associated with, and we can infer things like the active developers who could
 // have signed the commit.
-// TODO: There is no information yet about the signature for the entry.
-// TODO: What if the first seen RSL entry is invalid? Should it be verified
-// against policy here? Probably not as this is strictly the RSL library.
 func GetFirstEntryForCommit(repo *git.Repository, commit *object.Commit) (*Entry, error) {
 	// We check entries in pairs. In the initial case, we have the latest entry
 	// and its parent. At all times, the parent in the pair is being tested.

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -80,19 +80,19 @@ func NewEntry(refName string, targetID plumbing.Hash) *Entry {
 	return &Entry{RefName: refName, TargetID: targetID}
 }
 
-func (e Entry) GetID() plumbing.Hash {
+func (e *Entry) GetID() plumbing.Hash {
 	return e.ID
 }
 
 // Commit creates a commit object in the RSL for the Entry.
-func (e Entry) Commit(repo *git.Repository, sign bool) error {
+func (e *Entry) Commit(repo *git.Repository, sign bool) error {
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
 	_, err := gitinterface.Commit(repo, gitinterface.EmptyTree(), Ref, message, sign)
 	return err
 }
 
-func (e Entry) createCommitMessage() (string, error) {
+func (e *Entry) createCommitMessage() (string, error) {
 	lines := []string{
 		EntryHeader,
 		"",
@@ -122,12 +122,12 @@ func NewAnnotation(rslEntryIDs []plumbing.Hash, skip bool, message string) *Anno
 	return &Annotation{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message}
 }
 
-func (a Annotation) GetID() plumbing.Hash {
+func (a *Annotation) GetID() plumbing.Hash {
 	return a.ID
 }
 
 // Commit creates a commit object in the RSL for the Annotation.
-func (a Annotation) Commit(repo *git.Repository, sign bool) error {
+func (a *Annotation) Commit(repo *git.Repository, sign bool) error {
 	// Check if referred entries exist in the RSL namespace.
 	for _, id := range a.RSLEntryIDs {
 		if _, err := GetEntry(repo, id); err != nil {
@@ -144,7 +144,7 @@ func (a Annotation) Commit(repo *git.Repository, sign bool) error {
 	return err
 }
 
-func (a Annotation) createCommitMessage() (string, error) {
+func (a *Annotation) createCommitMessage() (string, error) {
 	lines := []string{
 		AnnotationHeader,
 		"",

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -170,7 +170,7 @@ func TestGetLatestNonGittufEntry(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		latestEntry, err := GetLatestNonGittufEntry(repo)
+		latestEntry, _, err := GetLatestNonGittufEntry(repo)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedLatestEntry, latestEntry)
 
@@ -180,7 +180,7 @@ func TestGetLatestNonGittufEntry(t *testing.T) {
 		}
 
 		// At this point, the expected entry is the same as before
-		latestEntry, err = GetLatestNonGittufEntry(repo)
+		latestEntry, _, err = GetLatestNonGittufEntry(repo)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedLatestEntry, latestEntry)
 	})
@@ -200,7 +200,7 @@ func TestGetLatestNonGittufEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = GetLatestNonGittufEntry(repo)
+		_, _, err = GetLatestNonGittufEntry(repo)
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 
 		// Add another gittuf entry
@@ -208,7 +208,7 @@ func TestGetLatestNonGittufEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = GetLatestNonGittufEntry(repo)
+		_, _, err = GetLatestNonGittufEntry(repo)
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 	})
 }
@@ -232,7 +232,7 @@ func TestGetLatestEntryForRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if entry, err := GetLatestEntryForRef(repo, "main"); err != nil {
+	if entry, _, err := GetLatestEntryForRef(repo, "main"); err != nil {
 		t.Error(err)
 	} else {
 		assert.Equal(t, rslRef.Hash(), entry.ID)
@@ -242,7 +242,7 @@ func TestGetLatestEntryForRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if entry, err := GetLatestEntryForRef(repo, "main"); err != nil {
+	if entry, _, err := GetLatestEntryForRef(repo, "main"); err != nil {
 		t.Error(err)
 	} else {
 		assert.Equal(t, rslRef.Hash(), entry.ID)
@@ -274,23 +274,23 @@ func TestGetLatestEntryForRefBefore(t *testing.T) {
 			entryIDs = append(entryIDs, latest.GetID())
 		}
 
-		entry, err := GetLatestEntryForRefBefore(repo, "main", entryIDs[4])
+		entry, _, err := GetLatestEntryForRefBefore(repo, "main", entryIDs[4])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[2], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "main", entryIDs[3])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "main", entryIDs[3])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[2], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[4])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[4])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[3], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[3])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[3])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[1], entry.ID)
 
-		_, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[1])
+		_, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[1])
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 	})
 
@@ -327,23 +327,23 @@ func TestGetLatestEntryForRefBefore(t *testing.T) {
 			entryIDs = append(entryIDs, latest.GetID())
 		}
 
-		entry, err := GetLatestEntryForRefBefore(repo, "main", entryIDs[4])
+		entry, _, err := GetLatestEntryForRefBefore(repo, "main", entryIDs[4])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[0], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "main", entryIDs[3])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "main", entryIDs[3])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[0], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[6])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[6])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[2], entry.ID)
 
-		entry, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[7])
+		entry, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[7])
 		assert.Nil(t, err)
 		assert.Equal(t, entryIDs[6], entry.ID)
 
-		_, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[1])
+		_, _, err = GetLatestEntryForRefBefore(repo, "feature", entryIDs[1])
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 	})
 }
@@ -492,7 +492,7 @@ func TestGetNonGittufParentForEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		parentEntry, err := GetNonGittufParentForEntry(repo, latestEntry)
+		parentEntry, _, err := GetNonGittufParentForEntry(repo, latestEntry)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedEntry, parentEntry)
 
@@ -512,7 +512,7 @@ func TestGetNonGittufParentForEntry(t *testing.T) {
 		}
 
 		// The expected entry should be from before this latest gittuf addition
-		parentEntry, err = GetNonGittufParentForEntry(repo, latestEntry)
+		parentEntry, _, err = GetNonGittufParentForEntry(repo, latestEntry)
 		assert.Nil(t, err)
 		assert.Equal(t, expectedEntry, parentEntry)
 	})
@@ -536,7 +536,7 @@ func TestGetNonGittufParentForEntry(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = GetNonGittufParentForEntry(repo, latestEntry)
+		_, _, err = GetNonGittufParentForEntry(repo, latestEntry)
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 
 		// Add another gittuf entry
@@ -549,7 +549,7 @@ func TestGetNonGittufParentForEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = GetNonGittufParentForEntry(repo, latestEntry)
+		_, _, err = GetNonGittufParentForEntry(repo, latestEntry)
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 	})
 }
@@ -580,7 +580,7 @@ func TestGetFirstEntry(t *testing.T) {
 		}
 	}
 
-	testEntry, err := GetFirstEntry(repo)
+	testEntry, _, err := GetFirstEntry(repo)
 	assert.Nil(t, err)
 	assert.Equal(t, firstEntry, testEntry)
 
@@ -590,7 +590,7 @@ func TestGetFirstEntry(t *testing.T) {
 		}
 	}
 
-	testEntry, err = GetFirstEntry(repo)
+	testEntry, _, err = GetFirstEntry(repo)
 	assert.Nil(t, err)
 	assert.Equal(t, firstEntry, testEntry)
 }
@@ -631,7 +631,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = GetFirstEntryForCommit(repo, commit)
+		_, _, err = GetFirstEntryForCommit(repo, commit)
 		assert.ErrorIs(t, err, ErrNoRecordOfCommit)
 	}
 
@@ -650,7 +650,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		entry, err := GetFirstEntryForCommit(repo, commit)
+		entry, _, err := GetFirstEntryForCommit(repo, commit)
 		assert.Nil(t, err)
 		assert.Equal(t, latestEntryT, entry)
 	}
@@ -678,7 +678,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = GetFirstEntryForCommit(repo, commit)
+		_, _, err = GetFirstEntryForCommit(repo, commit)
 		assert.ErrorIs(t, err, ErrNoRecordOfCommit)
 	}
 
@@ -693,7 +693,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		entry, err := GetFirstEntryForCommit(repo, commit)
+		entry, _, err := GetFirstEntryForCommit(repo, commit)
 		assert.Nil(t, err)
 		assert.Equal(t, latestEntryT, entry)
 	}
@@ -707,7 +707,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		entry, err := GetFirstEntryForCommit(repo, commit)
+		entry, _, err := GetFirstEntryForCommit(repo, commit)
 		assert.Nil(t, err)
 		assert.Equal(t, latestEntryT, entry)
 	}
@@ -733,7 +733,7 @@ func TestGetFirstEntryForCommit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		entry, err := GetFirstEntryForCommit(repo, commit)
+		entry, _, err := GetFirstEntryForCommit(repo, commit)
 		assert.Nil(t, err)
 		assert.Equal(t, latestEntryT, entry)
 	}


### PR DESCRIPTION
See: #102

This PR also includes two trivial commits. The first removes earlier TODO statements regarding RSL entry signatures. This is now expected to be handled in the policy package (in fact the verification workflows are already in place for this, but annotations are not yet handled). The second updates the Entry and Annotation methods to use pointer receivers. I'm not sure why it wasn't already doing so.