### PR TITLE
Fix RSL terminology

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -40,17 +40,17 @@ var (
 	testClock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
 )
 
-// CreateTestRSLEntryCommit is a test helper used to create a **signed** RSL
-// entry using the GPG key stored in the repository. It is used to substitute
-// for the default RSL entry creation and signing mechanism which relies on the
-// user's Git config.
-func CreateTestRSLEntryCommit(t *testing.T, repo *git.Repository, entry *rsl.Entry) plumbing.Hash {
+// CreateTestRSLReferenceEntryCommit is a test helper used to create a
+// **signed** reference entry using the GPG key stored in the repository. It is
+// used to substitute for the default RSL entry creation and signing mechanism
+// which relies on the user's Git config.
+func CreateTestRSLReferenceEntryCommit(t *testing.T, repo *git.Repository, entry *rsl.ReferenceEntry) plumbing.Hash {
 	t.Helper()
 
 	// We do this manually because rsl.Commit() will not sign using our test key
 
 	lines := []string{
-		rsl.EntryHeader,
+		rsl.ReferenceEntryHeader,
 		"",
 		fmt.Sprintf("%s: %s", rsl.RefKey, entry.RefName),
 		fmt.Sprintf("%s: %s", rsl.TargetIDKey, entry.TargetID.String()),

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -97,7 +97,7 @@ func LoadState(ctx context.Context, repo *git.Repository, rslEntryID plumbing.Ha
 // LoadCurrentState returns the State corresponding to the repository's current
 // active policy.
 func LoadCurrentState(ctx context.Context, repo *git.Repository) (*State, error) {
-	e, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	e, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
 	if err != nil {
 		return nil, err
 	}
@@ -107,8 +107,8 @@ func LoadCurrentState(ctx context.Context, repo *git.Repository) (*State, error)
 
 // LoadStateForEntry returns the State for a specified RSL entry for the policy
 // namespace.
-func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.EntryType) (*State, error) {
-	entry, ok := e.(*rsl.Entry)
+func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.Entry) (*State, error) {
+	entry, ok := e.(*rsl.ReferenceEntry)
 	if !ok {
 		return nil, ErrNotRSLEntry
 	}
@@ -214,7 +214,7 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.EntryTyp
 // error is returned. Identifying the policy in this case is left to the calling
 // workflow.
 func GetStateForCommit(ctx context.Context, repo *git.Repository, commit *object.Commit) (*State, error) {
-	firstSeenEntry, _, err := rsl.GetFirstEntryForCommit(repo, commit)
+	firstSeenEntry, _, err := rsl.GetFirstReferenceEntryForCommit(repo, commit)
 	if err != nil {
 		if errors.Is(err, rsl.ErrNoRecordOfCommit) {
 			return nil, nil
@@ -222,7 +222,7 @@ func GetStateForCommit(ctx context.Context, repo *git.Repository, commit *object
 		return nil, err
 	}
 
-	commitPolicyEntry, _, err := rsl.GetLatestEntryForRefBefore(repo, PolicyRef, firstSeenEntry.ID)
+	commitPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, firstSeenEntry.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func (s *State) Commit(ctx context.Context, repo *git.Repository, commitMessage 
 
 	// We must reset to original policy commit if err != nil from here onwards.
 
-	if err := rsl.NewEntry(PolicyRef, commitID).Commit(repo, signCommit); err != nil {
+	if err := rsl.NewReferenceEntry(PolicyRef, commitID).Commit(repo, signCommit); err != nil {
 		return gitinterface.ResetDueToError(err, repo, PolicyRef, originalCommitID)
 	}
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -92,7 +92,7 @@ func TestLoadCurrentState(t *testing.T) {
 func TestLoadStateForEntry(t *testing.T) {
 	repo, state := createTestRepository(t, createTestStateWithOnlyRoot)
 
-	entry, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	entry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +173,7 @@ func TestStateCommit(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	entry := tmpEntry.(*rsl.Entry)
+	entry := tmpEntry.(*rsl.ReferenceEntry)
 	assert.Equal(t, entry.TargetID, policyRef.Hash())
 }
 
@@ -244,7 +244,7 @@ func TestGetStateForCommit(t *testing.T) {
 	assert.Nil(t, state)
 
 	// Record RSL entry for commit
-	if err := rsl.NewEntry(refName, commitID).Commit(repo, false); err != nil {
+	if err := rsl.NewReferenceEntry(refName, commitID).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -262,7 +262,7 @@ func TestGetStateForCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := rsl.NewEntry(anotherRefName, newCommitID).Commit(repo, false); err != nil {
+	if err := rsl.NewReferenceEntry(anotherRefName, newCommitID).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -319,7 +319,7 @@ func TestGetStateForCommit(t *testing.T) {
 	}
 
 	// Record in RSL
-	if err := rsl.NewEntry(refName, newCommitID).Commit(repo, false); err != nil {
+	if err := rsl.NewReferenceEntry(refName, newCommitID).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -36,8 +36,8 @@ func TestVerifyRef(t *testing.T) {
 	}
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1)
-	entry := rsl.NewEntry(refName, commitIDs[0])
-	common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 
 	err := VerifyRef(context.Background(), repo, refName)
 	assert.Nil(t, err)
@@ -56,8 +56,8 @@ func TestVerifyRefFull(t *testing.T) {
 	}
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1)
-	entry := rsl.NewEntry(refName, commitIDs[0])
-	common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 
 	err := VerifyRefFull(context.Background(), repo, refName)
 	assert.Nil(t, err)
@@ -75,14 +75,14 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	policyEntry, _, err := rsl.GetLatestEntryForRef(repo, PolicyRef)
+	policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1)
-	entry := rsl.NewEntry(refName, commitIDs[0])
-	entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 	entry.ID = entryID
 
 	err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
@@ -105,8 +105,8 @@ func TestVerifyCommit(t *testing.T) {
 	}
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3)
-	entry := rsl.NewEntry(refName, commitIDs[len(commitIDs)-1])
-	entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 	entry.ID = entryID
 
 	expectedStatus := make(map[string]string, len(commitIDs))
@@ -155,8 +155,8 @@ func TestVerifyTag(t *testing.T) {
 	refName := "refs/heads/main"
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3)
-	entry := rsl.NewEntry(refName, commitIDs[len(commitIDs)-1])
-	entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 	entry.ID = entryID
 
 	tagName := "v1"
@@ -166,8 +166,8 @@ func TestVerifyTag(t *testing.T) {
 	status := VerifyTag(context.Background(), repo, []string{tagID.String()})
 	assert.Equal(t, expectedStatus, status)
 
-	entry = rsl.NewEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
-	entryID = common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry = rsl.NewReferenceEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
+	entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 	entry.ID = entryID
 
 	// Use tag ID
@@ -195,8 +195,8 @@ func TestVerifyEntry(t *testing.T) {
 	refName := "refs/heads/main"
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1)
-	entry := rsl.NewEntry(refName, commitIDs[0])
-	entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 	entry.ID = entryID
 
 	err := verifyEntry(context.Background(), repo, state, entry)
@@ -216,15 +216,15 @@ func TestVerifyTagEntry(t *testing.T) {
 		refName := "refs/heads/main"
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3)
-		entry := rsl.NewEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		tagName := "v1"
 		tagID := common.CreateTestSignedTag(t, repo, tagName, commitIDs[len(commitIDs)-1])
 
-		entry = rsl.NewEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
-		entryID = common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry = rsl.NewReferenceEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		err := verifyTagEntry(context.Background(), repo, policy, entry)
@@ -236,15 +236,15 @@ func TestVerifyTagEntry(t *testing.T) {
 		refName := "refs/heads/main"
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3)
-		entry := rsl.NewEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		tagName := "v1"
 		tagID := common.CreateTestSignedTag(t, repo, tagName, commitIDs[len(commitIDs)-1])
 
-		entry = rsl.NewEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
-		entryID = common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry = rsl.NewReferenceEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		err := verifyTagEntry(context.Background(), repo, policy, entry)
@@ -256,15 +256,15 @@ func TestVerifyTagEntry(t *testing.T) {
 		refName := "refs/heads/main"
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3)
-		entry := rsl.NewEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		tagName := "v1"
 		tagID := common.CreateTestSignedTag(t, repo, tagName, commitIDs[len(commitIDs)-1])
 
-		entry = rsl.NewEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
-		entryID = common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry = rsl.NewReferenceEntry(string(plumbing.NewTagReferenceName(tagName)), tagID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		err := verifyTagEntry(context.Background(), repo, policy, entry)
@@ -285,12 +285,12 @@ func TestGetCommits(t *testing.T) {
 	// helper like createTestStateWithPolicy. The RSL could then also
 	// incorporate policy changes and so on.
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5)
-	firstEntry := rsl.NewEntry(refName, commitIDs[0])
-	firstEntryID := common.CreateTestRSLEntryCommit(t, repo, firstEntry)
+	firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry)
 	firstEntry.ID = firstEntryID
 
-	secondEntry := rsl.NewEntry(refName, commitIDs[4])
-	secondEntryID := common.CreateTestRSLEntryCommit(t, repo, secondEntry)
+	secondEntry := rsl.NewReferenceEntry(refName, commitIDs[4])
+	secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry)
 	secondEntry.ID = secondEntryID
 
 	expectedCommitIDs := []plumbing.Hash{commitIDs[1], commitIDs[2], commitIDs[3], commitIDs[4]}
@@ -326,10 +326,10 @@ func TestGetChangedPaths(t *testing.T) {
 	// helper like createTestStateWithPolicy. The RSL could then also
 	// incorporate policy changes and so on.
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 2)
-	entries := []*rsl.Entry{}
+	entries := []*rsl.ReferenceEntry{}
 	for _, commitID := range commitIDs {
-		entry := rsl.NewEntry(refName, commitID)
-		entryID := common.CreateTestRSLEntryCommit(t, repo, entry)
+		entry := rsl.NewReferenceEntry(refName, commitID)
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry)
 		entry.ID = entryID
 
 		entries = append(entries, entry)

--- a/internal/repository/policy_test.go
+++ b/internal/repository/policy_test.go
@@ -56,7 +56,7 @@ func TestPushPolicy(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := rsl.NewEntry(policy.PolicyRef, plumbing.ZeroHash).Commit(remoteRepo, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, plumbing.ZeroHash).Commit(remoteRepo, false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -35,7 +35,7 @@ func (r *Repository) RecordRSLEntryForReference(refName string, signCommit bool)
 	// TODO: once policy verification is in place, the signing key used by
 	// signCommit must be verified for the refName in the delegation tree.
 
-	return rsl.NewEntry(absRefName, ref.Hash()).Commit(r.r, signCommit)
+	return rsl.NewReferenceEntry(absRefName, ref.Hash()).Commit(r.r, signCommit)
 }
 
 // RecordRSLEntryForReferenceAtCommit is a special version of
@@ -70,7 +70,7 @@ func (r *Repository) RecordRSLEntryForReferenceAtCommit(refName string, commitID
 	// TODO: once policy verification is in place, the signing key used by
 	// signCommit must be verified for the refName in the delegation tree.
 
-	return rsl.NewEntry(absRefName, plumbing.NewHash(commitID)).Commit(r.r, signCommit)
+	return rsl.NewReferenceEntry(absRefName, plumbing.NewHash(commitID)).Commit(r.r, signCommit)
 }
 
 // RecordRSLAnnotation is the interface for the user to add an RSL annotation
@@ -84,7 +84,7 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 	// TODO: once policy verification is in place, the signing key used by
 	// signCommit must be verified for the refNames of the rslEntryIDs.
 
-	return rsl.NewAnnotation(rslEntryHashes, skip, message).Commit(r.r, signCommit)
+	return rsl.NewAnnotationEntry(rslEntryHashes, skip, message).Commit(r.r, signCommit)
 }
 
 // CheckRemoteRSLForUpdates checks if the RSL at the specified remote remote

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -51,7 +51,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entry, ok := entryType.(*rsl.Entry)
+	entry, ok := entryType.(*rsl.ReferenceEntry)
 	if !ok {
 		t.Fatal(fmt.Errorf("invalid entry type"))
 	}
@@ -79,7 +79,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	entry, ok = entryType.(*rsl.Entry)
+	entry, ok = entryType.(*rsl.ReferenceEntry)
 	if !ok {
 		t.Fatal(fmt.Errorf("invalid entry type"))
 	}
@@ -117,8 +117,8 @@ func TestRecordRSLEntryForReferenceAtCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, refName, latestEntry.(*rsl.Entry).RefName)
-	assert.Equal(t, commitID, latestEntry.(*rsl.Entry).TargetID)
+	assert.Equal(t, refName, latestEntry.(*rsl.ReferenceEntry).RefName)
+	assert.Equal(t, commitID, latestEntry.(*rsl.ReferenceEntry).TargetID)
 
 	// Now checkout another branch, add another commit
 	if err := repo.r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(anotherRefName), commitID)); err != nil {
@@ -188,9 +188,9 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.IsType(t, &rsl.Annotation{}, latestEntry)
+	assert.IsType(t, &rsl.AnnotationEntry{}, latestEntry)
 
-	annotation := latestEntry.(*rsl.Annotation)
+	annotation := latestEntry.(*rsl.AnnotationEntry)
 	assert.Equal(t, "test annotation", annotation.Message)
 	assert.Equal(t, []plumbing.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.False(t, annotation.Skip)
@@ -202,9 +202,9 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.IsType(t, &rsl.Annotation{}, latestEntry)
+	assert.IsType(t, &rsl.AnnotationEntry{}, latestEntry)
 
-	annotation = latestEntry.(*rsl.Annotation)
+	annotation = latestEntry.(*rsl.AnnotationEntry)
 	assert.Equal(t, "skip annotation", annotation.Message)
 	assert.Equal(t, []plumbing.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.True(t, annotation.Skip)
@@ -458,7 +458,7 @@ func TestPushRSL(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := rsl.NewEntry(policy.PolicyRef, plumbing.ZeroHash).Commit(remoteRepo, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, plumbing.ZeroHash).Commit(remoteRepo, false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -22,8 +22,8 @@ func TestVerifyRef(t *testing.T) {
 	}
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1)
-	entry := rsl.NewEntry(refName, commitIDs[0])
-	entryID := common.CreateTestRSLEntryCommit(t, repo.r, entry)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry)
 	entry.ID = entryID
 
 	tests := map[string]struct {


### PR DESCRIPTION
Closes #130

Renames:
Entry -> ~StandardEntry~ ReferenceEntry
Annotation -> AnnotationEntry
EntryType -> Entry

Some APIs like GetEntry... have been renamed depending on whether they return a standard entry or a generic entry.