### PR TITLE
Clone repository with gittuf namespaces and push RSL and policy namespaces to remote

### DIFF
--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package clone
+
+import (
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	branch string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o.branch,
+		"branch",
+		"b",
+		"",
+		"Specify branch to check out",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	var dir string
+	if len(args) > 1 {
+		dir = args[1]
+	}
+	_, err := repository.Clone(cmd.Context(), args[0], dir, o.branch)
+	return err
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "clone",
+		Short: "Clone repository and its gittuf references",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -8,6 +8,7 @@ import (
 	i "github.com/gittuf/gittuf/internal/cmd/policy/init"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/policy/removerule"
+	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(addkey.New(o))
 	cmd.AddCommand(addrule.New(o))
+	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removerule.New(o))
 
 	return cmd

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -3,6 +3,7 @@
 package root
 
 import (
+	"github.com/gittuf/gittuf/internal/cmd/clone"
 	"github.com/gittuf/gittuf/internal/cmd/policy"
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
 	"github.com/gittuf/gittuf/internal/cmd/trust"
@@ -18,6 +19,7 @@ func New() *cobra.Command {
 		Short: "A security layer for Git repositories, powered by TUF",
 	}
 
+	cmd.AddCommand(clone.New())
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())
 	cmd.AddCommand(rsl.New())

--- a/internal/cmd/rsl/remote/push/push.go
+++ b/internal/cmd/rsl/remote/push/push.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package push
+
+import (
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.PushRSL(cmd.Context(), args[0])
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "push <remote>",
+		Short: "Push RSL to the specified remote",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.Run,
+	}
+
+	return cmd
+}

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -4,6 +4,7 @@ package remote
 
 import (
 	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/check"
+	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/push"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,7 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddCommand(check.New())
+	cmd.AddCommand(push.New())
 
 	return cmd
 }

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -7,6 +7,7 @@ import (
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removepolicykey"
+	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -20,6 +21,7 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(addpolicykey.New(o))
+	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removepolicykey.New(o))
 
 	return cmd

--- a/internal/cmd/trustpolicy/remote/push/push.go
+++ b/internal/cmd/trustpolicy/remote/push/push.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package push
+
+import (
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.PushPolicy(cmd.Context(), args[0])
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "push <remote>",
+		Short: "Push policy to the specified remote",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.Run,
+	}
+
+	return cmd
+}

--- a/internal/cmd/trustpolicy/remote/remote.go
+++ b/internal/cmd/trustpolicy/remote/remote.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package remote
+
+import (
+	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote/push"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remote",
+		Short: "Tools for managing remote policies",
+	}
+
+	cmd.AddCommand(push.New())
+
+	return cmd
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -75,7 +75,7 @@ func CreateTestRSLEntryCommit(t *testing.T, repo *git.Repository, entry *rsl.Ent
 			When:  testClock.Now(),
 		},
 		Message:      commitMessage,
-		TreeHash:     plumbing.ZeroHash,
+		TreeHash:     gitinterface.EmptyTree(),
 		ParentHashes: []plumbing.Hash{ref.Hash()},
 	}
 

--- a/internal/repository/common_test.go
+++ b/internal/repository/common_test.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+)
+
+func assertLocalAndRemoteRefsMatch(t *testing.T, localRepo, remoteRepo *git.Repository, refName string) {
+	t.Helper()
+
+	refNameT := plumbing.ReferenceName(refName)
+
+	localRef, err := localRepo.Reference(refNameT, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remoteRef, err := remoteRepo.Reference(refNameT, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, localRef.Hash(), remoteRef.Hash())
+}

--- a/internal/repository/policy.go
+++ b/internal/repository/policy.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/rsl"
+)
+
+var ErrPushingPolicy = errors.New("unable to push policy")
+
+// PushPolicy pushes the local gittuf policy to the specified remote. As this
+// push defaults to fast-forward only, divergent policy states are detected.
+// Note that this also pushes the RSL as the policy cannot change without an
+// update to the RSL.
+func (r *Repository) PushPolicy(ctx context.Context, remoteName string) error {
+	if err := gitinterface.Push(ctx, r.r, remoteName, []string{policy.PolicyRef, rsl.Ref}); err != nil {
+		return errors.Join(ErrPushingPolicy, err)
+	}
+
+	return nil
+}

--- a/internal/repository/policy_test.go
+++ b/internal/repository/policy_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPushPolicy(t *testing.T) {
+	remoteName := "origin"
+
+	t.Run("successful push", func(t *testing.T) {
+		remoteTmpDir := t.TempDir()
+
+		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		localRepo := createTestRepositoryWithPolicy(t)
+		if _, err := localRepo.r.CreateRemote(&config.RemoteConfig{
+			Name: remoteName,
+			URLs: []string{remoteTmpDir},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.PushPolicy(context.Background(), remoteName)
+		assert.Nil(t, err)
+
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, policy.PolicyRef)
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, rsl.Ref)
+
+		// No updates, successful push
+		err = localRepo.PushPolicy(context.Background(), remoteName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("divergent policies, unsuccessful push", func(t *testing.T) {
+		remoteTmpDir := t.TempDir()
+
+		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(remoteRepo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.NewEntry(policy.PolicyRef, plumbing.ZeroHash).Commit(remoteRepo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		localRepo := createTestRepositoryWithPolicy(t)
+		if _, err := localRepo.r.CreateRemote(&config.RemoteConfig{
+			Name: remoteName,
+			URLs: []string{remoteTmpDir},
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.PushPolicy(context.Background(), remoteName)
+		assert.ErrorIs(t, err, ErrPushingPolicy)
+	})
+}

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -14,7 +14,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport"
 )
 
-var ErrCommitNotInRef = errors.New("specified commit is not in ref")
+var (
+	ErrCommitNotInRef = errors.New("specified commit is not in ref")
+	ErrPushingRSL     = errors.New("unable to push RSL")
+)
 
 // RecordRSLEntryForReference is the interface for the user to add an RSL entry
 // for the specified Git reference.
@@ -153,4 +156,14 @@ func (r *Repository) CheckRemoteRSLForUpdates(ctx context.Context, remoteName st
 		return false, false, nil
 	}
 	return true, true, nil
+}
+
+// PushRSL pushes the local RSL to the specified remote. As this push defaults
+// to fast-forward only, divergent RSL states are detected.
+func (r *Repository) PushRSL(ctx context.Context, remoteName string) error {
+	if err := gitinterface.Push(ctx, r.r, remoteName, []string{rsl.Ref}); err != nil {
+		return errors.Join(ErrPushingRSL, err)
+	}
+
+	return nil
 }

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -439,17 +439,7 @@ func TestPushRSL(t *testing.T) {
 		err = localRepo.PushRSL(context.Background(), remoteName)
 		assert.Nil(t, err)
 
-		remoteLatestEntry, err := rsl.GetLatestEntry(remoteRepo)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		localLatestEntry, err := rsl.GetLatestEntry(localRepo.r)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assert.Equal(t, localLatestEntry, remoteLatestEntry)
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, rsl.Ref)
 
 		// No updates, successful push
 		err = localRepo.PushRSL(context.Background(), remoteName)

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+var (
+	ErrCloningRepository = errors.New("unable to clone repository")
+	ErrDirExists         = errors.New("directory exists")
+)
+
+// Clone wraps a typical git clone invocation, fetching gittuf refs in addition
+// to the standard refs. It performs a verification of the RSL against the
+// specified HEAD after cloning the repository.
+// TODO: resolve how root keys are trusted / bootstrapped.
+func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Repository, error) {
+	if dir == "" {
+		// FIXME: my understanding is backslashes are not used in URLs but I haven't dived into the RFCs to check yet
+		split := strings.Split(strings.TrimSpace(strings.ReplaceAll(remoteURL, "\\", "/")), "/")
+		dir = strings.TrimSuffix(split[len(split)-1], ".git")
+	}
+	_, err := os.Stat(dir)
+	if err == nil {
+		return nil, errors.Join(ErrCloningRepository, ErrDirExists)
+	} else {
+		if !os.IsNotExist(err) {
+			return nil, errors.Join(ErrCloningRepository, err)
+		}
+	}
+
+	if err := os.Mkdir(dir, 0755); err != nil {
+		return nil, errors.Join(ErrCloningRepository, err)
+	}
+
+	refs := []string{rsl.Ref, policy.PolicyRef}
+
+	r, err := gitinterface.CloneAndFetch(ctx, remoteURL, dir, initialBranch, refs)
+	if err != nil {
+		if e := os.RemoveAll(dir); e != nil {
+			return nil, errors.Join(ErrCloningRepository, err, e)
+		}
+		return nil, errors.Join(ErrCloningRepository, err)
+	}
+	head, err := r.Reference(plumbing.HEAD, false)
+	if err != nil {
+		return nil, errors.Join(ErrCloningRepository, err)
+	}
+
+	repository := &Repository{r: r}
+	return repository, repository.VerifyRef(ctx, head.Target().String(), true)
+}

--- a/internal/repository/sync_test.go
+++ b/internal/repository/sync_test.go
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClone(t *testing.T) {
+	remoteTmpDir := t.TempDir()
+
+	remoteR, err := git.PlainInit(remoteTmpDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteRepo := &Repository{r: remoteR}
+	rootKeyBytes, err := os.ReadFile(filepath.Join("test-data", "root"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetsPubKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets.pub"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetsKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.InitializeRoot(context.Background(), rootKeyBytes, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.AddTopLevelTargetsKey(context.Background(), rootKeyBytes, targetsPubKeyBytes, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.InitializeTargets(context.Background(), targetsKeyBytes, policy.TargetsRoleName, false); err != nil {
+		t.Fatal(err)
+	}
+	emptyTreeHash, err := gitinterface.WriteTree(remoteRepo.r, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refName := "refs/heads/main"
+	anotherRefName := "refs/heads/feature"
+	commitID, err := gitinterface.Commit(remoteRepo.r, emptyTreeHash, refName, "Initial commit", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.RecordRSLEntryForReference(refName, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.r.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, plumbing.ReferenceName(refName))); err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(anotherRefName), commitID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := remoteRepo.RecordRSLEntryForReference(anotherRefName, false); err != nil {
+		t.Fatal(err)
+	}
+
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	remoteRSLRef, err := remoteRepo.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	remotePolicyRef, err := remoteRepo.r.Reference(plumbing.ReferenceName(policy.PolicyRef), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("successful clone without specifying dir", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(context.Background(), remoteTmpDir, "", "")
+		assert.Nil(t, err)
+		head, err := repo.r.Head()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, head.Hash())
+
+		localRSLRef, err := repo.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remoteRSLRef.Hash(), localRSLRef.Hash())
+		localPolicyRef, err := repo.r.Reference(plumbing.ReferenceName(policy.PolicyRef), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remotePolicyRef.Hash(), localPolicyRef.Hash())
+	})
+
+	t.Run("successful clone with dir", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		dirName := "myRepo"
+		repo, err := Clone(context.Background(), remoteTmpDir, dirName, "")
+		assert.Nil(t, err)
+		head, err := repo.r.Head()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, head.Hash())
+
+		dirInfo, err := os.Stat(dirName)
+		assert.Nil(t, err)
+		assert.True(t, dirInfo.IsDir())
+
+		localRSLRef, err := repo.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remoteRSLRef.Hash(), localRSLRef.Hash())
+		localPolicyRef, err := repo.r.Reference(plumbing.ReferenceName(policy.PolicyRef), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remotePolicyRef.Hash(), localPolicyRef.Hash())
+	})
+
+	t.Run("successful clone without specifying dir, with non-HEAD initial branch", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(context.Background(), remoteTmpDir, "", anotherRefName)
+		assert.Nil(t, err)
+		head, err := repo.r.Head()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, head.Hash())
+		assert.Equal(t, plumbing.ReferenceName(anotherRefName), head.Name())
+
+		localRSLRef, err := repo.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remoteRSLRef.Hash(), localRSLRef.Hash())
+		localPolicyRef, err := repo.r.Reference(plumbing.ReferenceName(policy.PolicyRef), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remotePolicyRef.Hash(), localPolicyRef.Hash())
+	})
+
+	t.Run("unsuccessful clone when unspecified dir already exists", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		_, err = Clone(context.Background(), remoteTmpDir, "", "")
+		assert.Nil(t, err)
+
+		_, err = Clone(context.Background(), remoteTmpDir, "", "")
+		assert.ErrorIs(t, err, ErrDirExists)
+	})
+
+	t.Run("unsuccessful clone when specified dir already exists", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		dirName := "myRepo"
+		if err := os.Mkdir(dirName, 0755); err != nil {
+			t.Fatal(err)
+		}
+		_, err = Clone(context.Background(), remoteTmpDir, dirName, "")
+		assert.ErrorIs(t, err, ErrDirExists)
+	})
+}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -50,6 +50,12 @@ func InitializeNamespace(repo *git.Repository) error {
 		return ErrRSLExists
 	}
 
+	// Write empty tree into the object store as all RSL commits use that for
+	// the tree hash. If the tree isn't in the object store, syncs will fail.
+	if _, err := gitinterface.WriteTree(repo, nil); err != nil {
+		return err
+	}
+
 	return repo.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(Ref), plumbing.ZeroHash))
 }
 


### PR DESCRIPTION
Based on https://github.com/gittuf/gittuf/pull/115#issuecomment-1756038262.

This PR adds a clone command that clones a repository from the specified remote location with its gittuf namespaces. Additionally, it implements a push command for the policy and RSL namespaces. The remote subcommand for `gittuf policy` and `gittuf trust` are shared in a new package.