### PR TITLE
Various fixes to gitinterface

### DIFF
--- a/internal/gitinterface/sync.go
+++ b/internal/gitinterface/sync.go
@@ -84,21 +84,21 @@ func FetchRefSpec(ctx context.Context, repo *git.Repository, remoteName string, 
 // specified remote. For more information on the Git refspec, please consult:
 // https://git-scm.com/book/en/v2/Git-Internals-The-Refspec.
 //
-// The refspecs are constructed to allow non-fast-forward fetches. This function
-// constructs a refspec such that the target is the same as the requested ref.
-// Also, the remote tracker for the ref is also always updated.
-func Fetch(ctx context.Context, repo *git.Repository, remoteName string, refs []string) error {
+// The fastForwardOnly flag controls if the constructed refspec allows
+// non-fast-forward fetches. The target of the refspec is the same as the
+// requested ref. Also, the remote tracker for the ref is also always updated.
+func Fetch(ctx context.Context, repo *git.Repository, remoteName string, refs []string, fastForwardOnly bool) error {
 	refSpecs := make([]config.RefSpec, 0, len(refs))
 	for _, r := range refs {
 		// Add the remote tracker destination
-		refSpec, err := RefSpec(repo, r, remoteName, false)
+		refSpec, err := RefSpec(repo, r, remoteName, fastForwardOnly)
 		if err != nil {
 			return err
 		}
 		refSpecs = append(refSpecs, refSpec)
 
 		// Add the regular destination
-		refSpec, err = RefSpec(repo, r, "", false)
+		refSpec, err = RefSpec(repo, r, "", fastForwardOnly)
 		if err != nil {
 			return err
 		}
@@ -116,7 +116,7 @@ func CloneAndFetch(ctx context.Context, remoteURL, dir, initialBranch string, re
 		return nil, err
 	}
 
-	return fetchRefs(ctx, repo, refs)
+	return fetchRefs(ctx, repo, refs, true)
 }
 
 // CloneAndFetchToMemory clones an in-memory repository using the specified URL
@@ -127,7 +127,7 @@ func CloneAndFetchToMemory(ctx context.Context, remoteURL, initialBranch string,
 		return nil, err
 	}
 
-	return fetchRefs(ctx, repo, refs)
+	return fetchRefs(ctx, repo, refs, true)
 }
 
 func createCloneOptions(remoteURL, initialBranch string) *git.CloneOptions {
@@ -139,9 +139,9 @@ func createCloneOptions(remoteURL, initialBranch string) *git.CloneOptions {
 	return cloneOptions
 }
 
-func fetchRefs(ctx context.Context, repo *git.Repository, refs []string) (*git.Repository, error) {
+func fetchRefs(ctx context.Context, repo *git.Repository, refs []string, fastForwardOnly bool) (*git.Repository, error) {
 	if len(refs) > 0 {
-		err := Fetch(ctx, repo, DefaultRemoteName, refs)
+		err := Fetch(ctx, repo, DefaultRemoteName, refs, fastForwardOnly)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gitinterface/sync.go
+++ b/internal/gitinterface/sync.go
@@ -84,25 +84,23 @@ func FetchRefSpec(ctx context.Context, repo *git.Repository, remoteName string, 
 // specified remote. For more information on the Git refspec, please consult:
 // https://git-scm.com/book/en/v2/Git-Internals-The-Refspec.
 //
-// The refspecs are constructed to allow non-fast-forward fetches. Additionally,
-// trackRemote controls if the change is fetched to a local remote tracker.
-func Fetch(ctx context.Context, repo *git.Repository, remoteName string, refs []string, trackRemote bool) error {
+// The refspecs are constructed to allow non-fast-forward fetches. This function
+// constructs a refspec such that the target is the same as the requested ref.
+// Also, the remote tracker for the ref is also always updated.
+func Fetch(ctx context.Context, repo *git.Repository, remoteName string, refs []string) error {
 	refSpecs := make([]config.RefSpec, 0, len(refs))
 	for _, r := range refs {
-		var (
-			refSpec config.RefSpec
-			err     error
-		)
-		if trackRemote {
-			refSpec, err = RefSpec(repo, r, remoteName, false)
-			if err != nil {
-				return err
-			}
-		} else {
-			refSpec, err = RefSpec(repo, r, "", false)
-			if err != nil {
-				return err
-			}
+		// Add the remote tracker destination
+		refSpec, err := RefSpec(repo, r, remoteName, false)
+		if err != nil {
+			return err
+		}
+		refSpecs = append(refSpecs, refSpec)
+
+		// Add the regular destination
+		refSpec, err = RefSpec(repo, r, "", false)
+		if err != nil {
+			return err
 		}
 		refSpecs = append(refSpecs, refSpec)
 	}
@@ -111,27 +109,25 @@ func Fetch(ctx context.Context, repo *git.Repository, remoteName string, refs []
 }
 
 // CloneAndFetch clones a repository using the specified URL and additionally
-// fetches the specified refs. If trackRemote is set, the refs are fetched to a
-// local remote tracker.
-func CloneAndFetch(ctx context.Context, remoteURL, dir, initialBranch string, refs []string, trackRemote bool) (*git.Repository, error) {
+// fetches the specified refs.
+func CloneAndFetch(ctx context.Context, remoteURL, dir, initialBranch string, refs []string) (*git.Repository, error) {
 	repo, err := git.PlainCloneContext(ctx, dir, false, createCloneOptions(remoteURL, initialBranch))
 	if err != nil {
 		return nil, err
 	}
 
-	return fetchRefs(ctx, repo, refs, trackRemote)
+	return fetchRefs(ctx, repo, refs)
 }
 
 // CloneAndFetchToMemory clones an in-memory repository using the specified URL
-// and additionally fetches the specified refs. If trackRemote is set, the refs
-// are fetched to a local remote tracker.
-func CloneAndFetchToMemory(ctx context.Context, remoteURL, initialBranch string, refs []string, trackRemote bool) (*git.Repository, error) {
+// and additionally fetches the specified refs.
+func CloneAndFetchToMemory(ctx context.Context, remoteURL, initialBranch string, refs []string) (*git.Repository, error) {
 	repo, err := git.CloneContext(ctx, memory.NewStorage(), memfs.New(), createCloneOptions(remoteURL, initialBranch))
 	if err != nil {
 		return nil, err
 	}
 
-	return fetchRefs(ctx, repo, refs, trackRemote)
+	return fetchRefs(ctx, repo, refs)
 }
 
 func createCloneOptions(remoteURL, initialBranch string) *git.CloneOptions {
@@ -143,9 +139,9 @@ func createCloneOptions(remoteURL, initialBranch string) *git.CloneOptions {
 	return cloneOptions
 }
 
-func fetchRefs(ctx context.Context, repo *git.Repository, refs []string, trackRemote bool) (*git.Repository, error) {
+func fetchRefs(ctx context.Context, repo *git.Repository, refs []string) (*git.Repository, error) {
 	if len(refs) > 0 {
-		err := Fetch(ctx, repo, DefaultRemoteName, refs, trackRemote)
+		err := Fetch(ctx, repo, DefaultRemoteName, refs)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/gitinterface/sync_test.go
+++ b/internal/gitinterface/sync_test.go
@@ -442,7 +442,7 @@ func TestFetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName})
+		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName}, true)
 		assert.Nil(t, err)
 
 		// This time, the empty tree object must also be in the local repo
@@ -488,7 +488,7 @@ func TestFetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName})
+		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName}, true)
 		assert.Nil(t, err)
 
 		assertLocalRefAndRemoteTrackerRef(t, repoLocal, refName, remoteName, remoteCommitID)
@@ -521,7 +521,7 @@ func TestFetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName})
+		err = Fetch(context.Background(), repoLocal, remoteName, []string{refName}, true)
 		assert.Nil(t, err)
 	})
 }

--- a/internal/gitinterface/sync_test.go
+++ b/internal/gitinterface/sync_test.go
@@ -299,6 +299,10 @@ func TestFetchRefSpec(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
+			t.Fatal(err)
+		}
+
 		// Create tmp dir for remote repo so we have a URL for it
 		tmpDir, err := os.MkdirTemp("", "gittuf")
 		if err != nil {
@@ -344,6 +348,10 @@ func TestFetchRefSpec(t *testing.T) {
 		// The local repo can be in-memory
 		repoLocal, err := git.Init(memory.NewStorage(), memfs.New())
 		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -396,6 +404,10 @@ func TestFetchRefSpec(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
+			t.Fatal(err)
+		}
+
 		// Create tmp dir for remote repo so we have a URL for it
 		tmpDir, err := os.MkdirTemp("", "gittuf")
 		if err != nil {
@@ -430,6 +442,10 @@ func TestFetch(t *testing.T) {
 		// The local repo can be in-memory
 		repoLocal, err := git.Init(memory.NewStorage(), memfs.New())
 		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -484,6 +500,10 @@ func TestFetch(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
+			t.Fatal(err)
+		}
+
 		// Create tmp dir for remote repo so we have a URL for it
 		tmpDir, err := os.MkdirTemp("", "gittuf")
 		if err != nil {
@@ -523,6 +543,10 @@ func TestFetch(t *testing.T) {
 		// The local repo can be in-memory
 		repoLocal, err := git.Init(memory.NewStorage(), memfs.New())
 		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repoLocal.Storer.SetReference(plumbing.NewSymbolicReference(plumbing.HEAD, refNameTyped)); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/gitinterface/sync_test.go
+++ b/internal/gitinterface/sync_test.go
@@ -5,7 +5,6 @@ package gitinterface
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/go-git/go-billy/v5/memfs"
@@ -31,11 +30,7 @@ func TestPushRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -79,11 +74,7 @@ func TestPushRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -128,11 +119,7 @@ func TestPushRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		_, err = git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -165,11 +152,7 @@ func TestPush(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -213,11 +196,7 @@ func TestPush(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -262,11 +241,7 @@ func TestPush(t *testing.T) {
 		}
 
 		// Create tmp dir for remote so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		_, err = git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -304,11 +279,7 @@ func TestFetchRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -356,11 +327,7 @@ func TestFetchRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -409,11 +376,7 @@ func TestFetchRefSpec(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		_, err = git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -450,11 +413,7 @@ func TestFetch(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -505,11 +464,7 @@ func TestFetch(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		repoRemote, err := git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -551,11 +506,7 @@ func TestFetch(t *testing.T) {
 		}
 
 		// Create tmp dir for remote repo so we have a URL for it
-		tmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(tmpDir) //nolint:errcheck
+		tmpDir := t.TempDir()
 
 		_, err = git.PlainInit(tmpDir, true)
 		if err != nil {
@@ -580,17 +531,8 @@ func TestCloneAndFetch(t *testing.T) {
 	anotherRefName := "refs/heads/feature"
 
 	t.Run("clone and fetch remote repository, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
-
-		localTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
+		localTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
@@ -632,17 +574,8 @@ func TestCloneAndFetch(t *testing.T) {
 	})
 
 	t.Run("clone and fetch remote repository without specifying initial branch, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
-
-		localTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
+		localTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
@@ -684,17 +617,8 @@ func TestCloneAndFetch(t *testing.T) {
 	})
 
 	t.Run("clone and fetch remote repository with only one ref, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
-
-		localTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
+		localTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
@@ -734,11 +658,7 @@ func TestCloneAndFetchToMemory(t *testing.T) {
 	// refs := []config.RefSpec{config.RefSpec(fmt.Sprintf("%s:%s", anotherRefName, anotherRefName))}
 
 	t.Run("clone and fetch remote repository, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
@@ -780,17 +700,7 @@ func TestCloneAndFetchToMemory(t *testing.T) {
 	})
 
 	t.Run("clone and fetch remote repository without specifying initial branch, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
-
-		localTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)
@@ -832,11 +742,7 @@ func TestCloneAndFetchToMemory(t *testing.T) {
 	})
 
 	t.Run("clone and fetch remote repository with only one ref, verify refs match", func(t *testing.T) {
-		remoteTmpDir, err := os.MkdirTemp("", "gittuf")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(remoteTmpDir) //nolint:errcheck
+		remoteTmpDir := t.TempDir()
 
 		// Create remote repo on disk so we can use its URL
 		remoteRepo, err := git.PlainInit(remoteTmpDir, true)

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -85,6 +85,15 @@ func AbsoluteReference(repo *git.Repository, target string) (string, error) {
 		return target, nil
 	}
 
+	if target == plumbing.HEAD.String() {
+		ref, err := repo.Reference(plumbing.HEAD, false)
+		if err != nil {
+			return "", err
+		}
+
+		return ref.Target().String(), nil
+	}
+
 	// Check if branch
 	refName := plumbing.NewBranchReferenceName(target)
 	_, err := repo.Reference(refName, false)

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -144,18 +144,7 @@ func RefSpec(repo *git.Repository, refName, remoteName string, fastForwardOnly b
 	localPath := refPath
 	var remotePath string
 	if len(remoteName) > 0 {
-		if strings.HasPrefix(refPath, BranchRefPrefix) {
-			// refs/heads/<path> -> refs/remotes/<remote>/<path>
-			rest := strings.TrimPrefix(refPath, BranchRefPrefix)
-			remotePath = path.Join(RemoteRefPrefix, remoteName, rest)
-		} else if strings.HasPrefix(refPath, TagRefPrefix) {
-			// refs/tags/<path> -> refs/tags/<path>
-			remotePath = refPath
-		} else {
-			// refs/<path> -> refs/remotes/<remote>/<path>
-			rest := strings.TrimPrefix(refPath, RefPrefix)
-			remotePath = path.Join(RemoteRefPrefix, remoteName, rest)
-		}
+		remotePath = RemoteRef(refPath, remoteName)
 	} else {
 		remotePath = refPath
 	}
@@ -166,4 +155,22 @@ func RefSpec(repo *git.Repository, refName, remoteName string, fastForwardOnly b
 	}
 
 	return config.RefSpec(refSpecString), nil
+}
+
+func RemoteRef(refName, remoteName string) string {
+	var remotePath string
+	if strings.HasPrefix(refName, BranchRefPrefix) {
+		// refs/heads/<path> -> refs/remotes/<remote>/<path>
+		rest := strings.TrimPrefix(refName, BranchRefPrefix)
+		remotePath = path.Join(RemoteRefPrefix, remoteName, rest)
+	} else if strings.HasPrefix(refName, TagRefPrefix) {
+		// refs/tags/<path> -> refs/tags/<path>
+		remotePath = refName
+	} else {
+		// refs/<path> -> refs/remotes/<remote>/<path>
+		rest := strings.TrimPrefix(refName, RefPrefix)
+		remotePath = path.Join(RemoteRefPrefix, remoteName, rest)
+	}
+
+	return remotePath
 }

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -140,7 +140,7 @@ func RefSpec(repo *git.Repository, refName, remoteName string, fastForwardOnly b
 		fastForwardOnly = true
 	}
 
-	// local is always refPath, destination depends on trackRemote
+	// local is always refPath, destination depends on remoteName
 	localPath := refPath
 	var remotePath string
 	if len(remoteName) > 0 {

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -242,7 +242,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -292,7 +292,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -334,7 +334,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -384,7 +384,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 
 		// Clone remote repository
 		// TODO: this should be handled by the Repository package
-		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref}, false)
+		localR, err := gitinterface.CloneAndFetchToMemory(context.Background(), tmpDir, refName, []string{rsl.Ref})
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This PR introduces various fixes to gitinterface, some of which were previously seen in #115.

1. AbsoluteReference can now handle HEAD by resolving it to the target and returning that absolute path
2. Previously, there was some code to create the remote tracking ref for some ref, this has been broken out into a reusable component
3. Fetch had a trackRemote option to choose whether the fetch was for the remote tracker or not, this behavior has been updated to always fetch to the specified target ref (so `refs/heads/main:refs/heads/main`) _and_ the corresponding remote tracker
4. Some Fetch* tests missed a symbolic reference for HEAD, this is going to become an issue as we implement other sync interfaces alongside #134 
5. Some tests were using manual tmp dir handling, this has been updated to use `t.TempDir()` based on a prior review