### PR TITLE
common: Updates to test helpers

### DIFF
--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const gpgKeyName = "gpg-privkey.asc"
+
 func TestVerifyRef(t *testing.T) {
 	repo := createTestRepositoryWithPolicy(t)
 
@@ -21,9 +23,9 @@ func TestVerifyRef(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1)
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyName)
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry)
+	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyName)
 	entry.ID = entryID
 
 	tests := map[string]struct {


### PR DESCRIPTION
The `common` package has some helpers to create signed commits for use in tests. They used to default to the standard GPG key but some upcoming changes (#138) will use different keys to test for failure cases. This puts the invokers in control of the signing key to use.

The second change in this PR adds the ability to create test annotation entries, much like the existing standard entry creation function.