### PR TITLE
Add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,22 @@
+linters:
+  enable:
+  - asciicheck
+  - errcheck
+  - errorlint
+  - gofmt
+  - goimports
+  - gosec
+  - gocritic
+  - importas
+  - prealloc
+  - revive
+  - misspell
+  - stylecheck
+  - tparallel
+  - unconvert
+  - unparam
+  - unused
+  - whitespace
 output:
   uniq-by-line: false
 run:

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -29,7 +29,8 @@ func ReadKeyBytes(key string) ([]byte, error) {
 		err error
 	)
 
-	if strings.HasPrefix(key, GPGKeyPrefix) {
+	switch {
+	case strings.HasPrefix(key, GPGKeyPrefix):
 		fingerprint := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(key, GPGKeyPrefix)))
 
 		command := exec.Command("gpg", "--export", "--armor", fingerprint)
@@ -47,7 +48,7 @@ func ReadKeyBytes(key string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else if strings.HasPrefix(key, FulcioPrefix) {
+	case strings.HasPrefix(key, FulcioPrefix):
 		keyID := strings.TrimPrefix(key, FulcioPrefix)
 		ks := strings.Split(keyID, "::")
 		if len(ks) != 2 {
@@ -68,7 +69,7 @@ func ReadKeyBytes(key string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	default:
 		kb, err = os.ReadFile(key)
 		if err != nil {
 			return nil, err

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -35,7 +35,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("authorize-key") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -53,7 +53,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("rule-pattern") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -25,7 +25,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	)
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -34,7 +34,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("rule-name") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -31,7 +31,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("message") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(_ *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -24,7 +24,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	)
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(_ *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -26,7 +26,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("policy-key") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -14,12 +14,9 @@ type options struct {
 	p *persistent.Options
 }
 
-func (o *options) AddFlags(cmd *cobra.Command) {
-	// This method currently does nothing but maintaining an empty body for
-	// consistency.
-}
+func (o *options) AddFlags(_ *cobra.Command) {}
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -26,7 +26,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagRequired("policy-key-ID") //nolint:errcheck
 }
 
-func (o *options) Run(cmd *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err

--- a/internal/cmd/verifycommit/verifycommit.go
+++ b/internal/cmd/verifycommit/verifycommit.go
@@ -11,7 +11,7 @@ import (
 
 type options struct{}
 
-func (o *options) AddFlags(cmd *cobra.Command) {}
+func (o *options) AddFlags(_ *cobra.Command) {}
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()

--- a/internal/cmd/verifytag/verifytag.go
+++ b/internal/cmd/verifytag/verifytag.go
@@ -11,7 +11,7 @@ import (
 
 type options struct{}
 
-func (o *options) AddFlags(cmd *cobra.Command) {}
+func (o *options) AddFlags(_ *cobra.Command) {}
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()

--- a/internal/gitinterface/blob_test.go
+++ b/internal/gitinterface/blob_test.go
@@ -86,7 +86,7 @@ func TestWriteBlob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	blobID, err := WriteBlob(repo, []byte(writeContents))
+	blobID, err := WriteBlob(repo, writeContents)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/gitinterface/changes.go
+++ b/internal/gitinterface/changes.go
@@ -13,7 +13,7 @@ import (
 // GetCommitFilePaths returns all the file paths of the provided commit object.
 // This strictly enumerates all the files recursively in the commit object's
 // tree.
-func GetCommitFilePaths(repo *git.Repository, commit *object.Commit) ([]string, error) {
+func GetCommitFilePaths(commit *object.Commit) ([]string, error) {
 	filesIter, err := commit.Files()
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func GetFilePathsChangedByCommit(repo *git.Repository, commit *object.Commit) ([
 
 	if len(commit.ParentHashes) == 0 {
 		// No parent, return all file paths for commit
-		return GetCommitFilePaths(repo, commit)
+		return GetCommitFilePaths(commit)
 	}
 
 	parentCommit, err := repo.CommitObject(commit.ParentHashes[0])
@@ -59,21 +59,21 @@ func GetFilePathsChangedByCommit(repo *git.Repository, commit *object.Commit) ([
 		return nil, err
 	}
 
-	return GetDiffFilePaths(repo, commit, parentCommit)
+	return GetDiffFilePaths(commit, parentCommit)
 }
 
 // GetDiffFilePaths enumerates all the changed file paths between the two
 // commits. If one of the commits is nil, the other commit's tree is enumerated.
-func GetDiffFilePaths(repo *git.Repository, commitA, commitB *object.Commit) ([]string, error) {
+func GetDiffFilePaths(commitA, commitB *object.Commit) ([]string, error) {
 	if commitA == nil && commitB == nil {
 		return nil, fmt.Errorf("both commits cannot be empty")
 	}
 
 	if commitA == nil {
-		return GetCommitFilePaths(repo, commitB)
+		return GetCommitFilePaths(commitB)
 	}
 	if commitB == nil {
-		return GetCommitFilePaths(repo, commitA)
+		return GetCommitFilePaths(commitA)
 	}
 
 	treeA, err := commitA.Tree()

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -75,7 +75,7 @@ func TestGetCommitFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		paths, err := GetCommitFilePaths(repo, commit)
+		paths, err := GetCommitFilePaths(commit)
 		assert.Nil(t, err, fmt.Sprintf("unexpected error in test %s", name))
 		assert.Equal(t, test.expectedPaths, paths, fmt.Sprintf("unexpected list of files received: expected %v, got %v in test %s", test.expectedPaths, paths, name))
 	}
@@ -128,7 +128,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a"}, diffs)
 	})
@@ -165,7 +165,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a", "b"}, diffs)
 	})
@@ -208,7 +208,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a", "b"}, diffs)
 	})
@@ -250,7 +250,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"b"}, diffs)
 	})
@@ -292,7 +292,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"b"}, diffs)
 	})
@@ -334,7 +334,7 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		diffs, err := GetDiffFilePaths(repo, commitA, commitB)
+		diffs, err := GetDiffFilePaths(commitA, commitB)
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a", "b"}, diffs)
 	})

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -159,14 +159,15 @@ func RefSpec(repo *git.Repository, refName, remoteName string, fastForwardOnly b
 
 func RemoteRef(refName, remoteName string) string {
 	var remotePath string
-	if strings.HasPrefix(refName, BranchRefPrefix) {
+	switch {
+	case strings.HasPrefix(refName, BranchRefPrefix):
 		// refs/heads/<path> -> refs/remotes/<remote>/<path>
 		rest := strings.TrimPrefix(refName, BranchRefPrefix)
 		remotePath = path.Join(RemoteRefPrefix, remoteName, rest)
-	} else if strings.HasPrefix(refName, TagRefPrefix) {
+	case strings.HasPrefix(refName, TagRefPrefix):
 		// refs/tags/<path> -> refs/tags/<path>
 		remotePath = refName
-	} else {
+	default:
 		// refs/<path> -> refs/remotes/<remote>/<path>
 		rest := strings.TrimPrefix(refName, RefPrefix)
 		remotePath = path.Join(RemoteRefPrefix, remoteName, rest)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -137,11 +137,12 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.Entry) (
 	)
 
 	for _, e := range policyRootTree.Entries {
-		if e.Name == metadataTreeEntryName {
+		switch e.Name {
+		case metadataTreeEntryName:
 			metadataTreeID = e.Hash
-		} else if e.Name == rootPublicKeysTreeEntryName {
+		case rootPublicKeysTreeEntryName:
 			keysTreeID = e.Hash
-		} else {
+		default:
 			return nil, ErrInvalidPolicyTree
 		}
 	}
@@ -169,11 +170,12 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.Entry) (
 			return nil, err
 		}
 
-		if entry.Name == fmt.Sprintf("%s.json", RootRoleName) {
+		switch entry.Name {
+		case fmt.Sprintf("%s.json", RootRoleName):
 			state.RootEnvelope = env
-		} else if entry.Name == fmt.Sprintf("%s.json", TargetsRoleName) {
+		case fmt.Sprintf("%s.json", TargetsRoleName):
 			state.TargetsEnvelope = env
-		} else {
+		default:
 			if state.DelegationEnvelopes == nil {
 				state.DelegationEnvelopes = map[string]*sslibdsse.Envelope{}
 			}
@@ -471,16 +473,16 @@ func (s *State) Verify(ctx context.Context) error {
 		}
 
 		delegationMetadata := &tuf.TargetsMetadata{}
-		if delegationContents, err := delegationEnvelope.DecodeB64Payload(); err != nil {
+		delegationContents, err := delegationEnvelope.DecodeB64Payload()
+		if err != nil {
 			return err
-		} else {
-			if err := json.Unmarshal(delegationContents, delegationMetadata); err != nil {
-				return err
-			}
+		}
+		if err := json.Unmarshal(delegationContents, delegationMetadata); err != nil {
+			return err
+		}
 
-			if err := delegationMetadata.Validate(); err != nil {
-				return err
-			}
+		if err := delegationMetadata.Validate(); err != nil {
+			return err
 		}
 
 		if delegationMetadata.Delegations == nil {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -217,7 +217,6 @@ func TestStateFindPublicKeysForPath(t *testing.T) {
 		assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
 		assert.Equal(t, test.keys, keys, fmt.Sprintf("policy keys for path '%s' don't match expected keys in test '%s'", test.path, name))
 	}
-
 }
 
 func TestGetStateForCommit(t *testing.T) {

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -346,8 +346,8 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 	var (
 		trustedKeys           []*tuf.Key
 		err                   error
-		gitNamespaceVerified  bool = false
-		pathNamespaceVerified bool = true // Assume paths are verified until we find out otherwise
+		gitNamespaceVerified  = false
+		pathNamespaceVerified = true // Assume paths are verified until we find out otherwise
 	)
 
 	// 1. Find authorized public keys for entry's ref
@@ -624,7 +624,7 @@ func getChangedPaths(repo *git.Repository, entry *rsl.ReferenceEntry) ([]string,
 	}
 
 	if firstEntry {
-		return gitinterface.GetCommitFilePaths(repo, currentCommit)
+		return gitinterface.GetCommitFilePaths(currentCommit)
 	}
 
 	priorCommit, err := repo.CommitObject(priorRefEntry.TargetID)
@@ -632,5 +632,5 @@ func getChangedPaths(repo *git.Repository, entry *rsl.ReferenceEntry) ([]string,
 		return nil, err
 	}
 
-	return gitinterface.GetDiffFilePaths(repo, currentCommit, priorCommit)
+	return gitinterface.GetDiffFilePaths(currentCommit, priorCommit)
 }

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -32,10 +32,8 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Reposito
 	_, err := os.Stat(dir)
 	if err == nil {
 		return nil, errors.Join(ErrCloningRepository, ErrDirExists)
-	} else {
-		if !os.IsNotExist(err) {
-			return nil, errors.Join(ErrCloningRepository, err)
-		}
+	} else if !os.IsNotExist(err) {
+		return nil, errors.Join(ErrCloningRepository, err)
 	}
 
 	if err := os.Mkdir(dir, 0755); err != nil {

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -404,7 +404,6 @@ func GetLatestReferenceEntryForRefBefore(repo *git.Repository, refName string, a
 		if err != nil {
 			return nil, nil, err
 		}
-
 	}
 
 	annotations := filterAnnotationsForRelevantAnnotations(allAnnotations, targetEntry.ID)

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -1252,10 +1252,8 @@ func TestParseRSLEntryText(t *testing.T) {
 			entry, err := parseRSLEntryText(plumbing.ZeroHash, test.message)
 			if err != nil {
 				assert.ErrorIs(t, err, test.expectedError)
-			} else {
-				if !assert.Equal(t, test.expectedEntry, entry) {
-					t.Errorf("expected\n%+v\n\ngot\n%+v", test.expectedEntry, entry)
-				}
+			} else if !assert.Equal(t, test.expectedEntry, entry) {
+				t.Errorf("expected\n%+v\n\ngot\n%+v", test.expectedEntry, entry)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ func main() {
 
 	rootCmd := root.New()
 	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
+		// We can ignore the linter here (deferred functions are not executed
+		// when os.Exit is invoked) because if we do have an error, we don't
+		// have a panic, which is what the deferred function is looking for.
+		os.Exit(1) //nolint:gocritic
 	}
 }


### PR DESCRIPTION
Blocked by #137.

In #137, we broke out golangci-lint's config into a separate file. This PR adds more checks to this config and submits fixes flagged by the new checks. This can only be reviewed after #137 (and a rebase) to get the actual diff.