### PR TITLE
rsl: Add functions to find unskipped entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## Next
+
+* Add support to RSL to find unskipped entries
+
 ## v0.1.0
 
 * Implemented reference state log (RSL)


### PR DESCRIPTION
Part of #138

This PR adds functions to find the latest unskipped RSL reference entry for the specified ref.