### PR TITLE
Fix trust command issue with signing key not specified

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -56,11 +56,11 @@ var ErrPolicyExists = errors.New("cannot initialize Policy namespace as it exist
 // has a zero hash.
 func InitializeNamespace(repo *git.Repository) error {
 	for _, name := range []string{PolicyRef /*, PolicyStagingRef*/} {
-		if _, err := repo.Reference(plumbing.ReferenceName(name), true); err != nil {
+		if ref, err := repo.Reference(plumbing.ReferenceName(name), true); err != nil {
 			if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 				return err
 			}
-		} else {
+		} else if !ref.Hash().IsZero() {
 			return ErrPolicyExists
 		}
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -57,6 +57,15 @@ func TestInitializeNamespace(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Check if policy with zero hash is treated as uninitialized
+		err = InitializeNamespace(repo)
+		assert.Nil(t, err)
+
+		if err := repo.Storer.SetReference(plumbing.NewHashReference(PolicyRef, gitinterface.EmptyBlob())); err != nil {
+			t.Fatal(err)
+		}
+
+		// Now with something added, validate that we cannot initialize the policy again
 		err = InitializeNamespace(repo)
 		assert.ErrorIs(t, err, ErrPolicyExists)
 	})

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -42,11 +42,11 @@ var (
 // InitializeNamespace creates a git ref for the reference state log. Initially,
 // the entry has a zero hash.
 func InitializeNamespace(repo *git.Repository) error {
-	if _, err := repo.Reference(plumbing.ReferenceName(Ref), true); err != nil {
+	if ref, err := repo.Reference(plumbing.ReferenceName(Ref), true); err != nil {
 		if !errors.Is(err, plumbing.ErrReferenceNotFound) {
 			return err
 		}
-	} else {
+	} else if !ref.Hash().IsZero() {
 		return ErrRSLExists
 	}
 

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -43,6 +43,15 @@ func TestInitializeNamespace(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Check if RSL with zero hash is treated as uninitialized
+		err = InitializeNamespace(repo)
+		assert.Nil(t, err)
+
+		if err := NewReferenceEntry("refs/heads/main", plumbing.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Now with something added, validate that we cannot initialize the RSL again
 		err = InitializeNamespace(repo)
 		assert.ErrorIs(t, err, ErrRSLExists)
 	})


### PR DESCRIPTION
This PR has gittuf treat the RSL and policy with zero hashes as uninitialized. This fixes the issue where `gittuf trust init` is unable to proceed again after being invoked without a signing key specified in the user's git configuration.

Also see #147 