### PR TITLE
*: Route GetObject requests through gitinterface

### DIFF
--- a/internal/gitinterface/blob.go
+++ b/internal/gitinterface/blob.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/third_party/go-git"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/object"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/storage/memory"
 )
 
@@ -15,7 +16,7 @@ var ErrWrittenBlobLengthMismatch = errors.New("length of blob written does not m
 
 // ReadBlob returns the contents of a the blob referenced by blobID.
 func ReadBlob(repo *git.Repository, blobID plumbing.Hash) ([]byte, error) {
-	blob, err := repo.BlobObject(blobID)
+	blob, err := GetBlob(repo, blobID)
 	if err != nil {
 		return nil, err
 	}
@@ -49,6 +50,11 @@ func WriteBlob(repo *git.Repository, contents []byte) (plumbing.Hash, error) {
 	}
 
 	return repo.Storer.SetEncodedObject(obj)
+}
+
+// GetBlob returns the requested blob object.
+func GetBlob(repo *git.Repository, commitID plumbing.Hash) (*object.Blob, error) {
+	return repo.BlobObject(commitID)
 }
 
 // EmptyBlob returns the hash of an empty blob in a Git repository.

--- a/internal/gitinterface/blob_test.go
+++ b/internal/gitinterface/blob_test.go
@@ -94,7 +94,7 @@ func TestWriteBlob(t *testing.T) {
 	expectedHash := plumbing.NewHash("999c05e9578e5d244920306842f516789a2498f7")
 	assert.Equal(t, expectedHash, blobID)
 
-	obj, err := repo.BlobObject(blobID)
+	obj, err := GetBlob(repo, blobID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitinterface/changes.go
+++ b/internal/gitinterface/changes.go
@@ -54,7 +54,7 @@ func GetFilePathsChangedByCommit(repo *git.Repository, commit *object.Commit) ([
 		return GetCommitFilePaths(commit)
 	}
 
-	parentCommit, err := repo.CommitObject(commit.ParentHashes[0])
+	parentCommit, err := GetCommit(repo, commit.ParentHashes[0])
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -70,7 +70,7 @@ func TestGetCommitFilePaths(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		commit, err := repo.CommitObject(commitID)
+		commit, err := GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,11 +119,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,11 +156,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -199,11 +199,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -241,11 +241,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -283,11 +283,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -325,11 +325,11 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commitA, err := repo.CommitObject(cAID)
+		commitA, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		commitB, err := repo.CommitObject(cBID)
+		commitB, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -378,7 +378,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -411,7 +411,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -450,7 +450,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -488,7 +488,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -526,7 +526,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -564,7 +564,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cBID)
+		commit, err := GetCommit(repo, cBID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -588,7 +588,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		commit, err := repo.CommitObject(cAID)
+		commit, err := GetCommit(repo, cAID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/commit.go
+++ b/internal/gitinterface/commit.go
@@ -131,12 +131,17 @@ func KnowsCommit(repo *git.Repository, commitID plumbing.Hash, commit *object.Co
 		return true, nil
 	}
 
-	commitUnderTest, err := repo.CommitObject(commitID)
+	commitUnderTest, err := GetCommit(repo, commitID)
 	if err != nil {
 		return false, err
 	}
 
 	return commit.IsAncestor(commitUnderTest)
+}
+
+// GetCommit returns the requested commit object.
+func GetCommit(repo *git.Repository, commitID plumbing.Hash) (*object.Commit, error) {
+	return repo.CommitObject(commitID)
 }
 
 func signCommit(commit *object.Commit) (string, error) {

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -145,7 +145,7 @@ func TestKnowsCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	firstCommitID := ref.Hash()
-	firstCommit, err := repo.CommitObject(firstCommitID)
+	firstCommit, err := GetCommit(repo, firstCommitID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestKnowsCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	secondCommitID := ref.Hash()
-	secondCommit, err := repo.CommitObject(secondCommitID)
+	secondCommit, err := GetCommit(repo, secondCommitID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitinterface/log.go
+++ b/internal/gitinterface/log.go
@@ -62,7 +62,7 @@ func GetCommitsBetweenRange(repo *git.Repository, commitNewID, commitOldID plumb
 
 	commits := make([]*object.Commit, 0, len(commitRange))
 	for _, commitID := range commitRange {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := GetCommit(repo, commitID)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				// Returned for non-commit objects

--- a/internal/gitinterface/log_test.go
+++ b/internal/gitinterface/log_test.go
@@ -68,7 +68,7 @@ func TestGetCommitsBetweenRange(t *testing.T) {
 
 	allCommits := make([]*object.Commit, 0, len(commitIDs))
 	for _, commitID := range commitIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/tag.go
+++ b/internal/gitinterface/tag.go
@@ -31,7 +31,7 @@ func IsTag(repo *git.Repository, target string) bool {
 		}
 	}
 
-	_, err = repo.TagObject(plumbing.NewHash(target))
+	_, err = GetTag(repo, plumbing.NewHash(target))
 	return err == nil
 }
 
@@ -124,6 +124,11 @@ func VerifyTagSignature(ctx context.Context, tag *object.Tag, key *tuf.Key) erro
 	}
 
 	return ErrUnknownSigningMethod
+}
+
+// GetTag returns the requested tag object.
+func GetTag(repo *git.Repository, commitID plumbing.Hash) (*object.Tag, error) {
+	return repo.TagObject(commitID)
 }
 
 func signTag(tag *object.Tag) (string, error) {

--- a/internal/gitinterface/tag_test.go
+++ b/internal/gitinterface/tag_test.go
@@ -54,7 +54,7 @@ func TestTag(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "8b195348588d8a48060ec8d5436459b825a1b352", tagHash.String())
 
-	tag, err := repo.TagObject(tagHash)
+	tag, err := GetTag(repo, tagHash)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -27,6 +27,11 @@ func WriteTree(repo *git.Repository, entries []object.TreeEntry) (plumbing.Hash,
 	return repo.Storer.SetEncodedObject(obj)
 }
 
+// GetTree returns the requested tree object.
+func GetTree(repo *git.Repository, commitID plumbing.Hash) (*object.Tree, error) {
+	return repo.TreeObject(commitID)
+}
+
 // EmptyTree returns the hash of an empty tree in a Git repository.
 // Note: it is generated on the fly rather than stored as a constant to support
 // SHA-256 repositories in future.

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -49,7 +49,7 @@ func TestWriteTree(t *testing.T) {
 		t.Error(err)
 	}
 
-	tree, err := repo.TreeObject(treeHash)
+	tree, err := GetTree(repo, treeHash)
 	if err != nil {
 		t.Error(err)
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -117,12 +117,12 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.Entry) (
 		return nil, rsl.ErrRSLEntryDoesNotMatchRef
 	}
 
-	policyCommit, err := repo.CommitObject(entry.TargetID)
+	policyCommit, err := gitinterface.GetCommit(repo, entry.TargetID)
 	if err != nil {
 		return nil, err
 	}
 
-	policyRootTree, err := repo.TreeObject(policyCommit.TreeHash)
+	policyRootTree, err := gitinterface.GetTree(repo, policyCommit.TreeHash)
 	if err != nil {
 		return nil, err
 	}
@@ -149,12 +149,12 @@ func LoadStateForEntry(ctx context.Context, repo *git.Repository, e rsl.Entry) (
 
 	state := &State{}
 
-	metadataTree, err := repo.TreeObject(metadataTreeID)
+	metadataTree, err := gitinterface.GetTree(repo, metadataTreeID)
 	if err != nil {
 		return nil, err
 	}
 
-	keysTree, err := repo.TreeObject(keysTreeID)
+	keysTree, err := gitinterface.GetTree(repo, keysTreeID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -243,7 +243,7 @@ func TestGetStateForCommit(t *testing.T) {
 	}
 
 	// No RSL entry for commit => no state yet
-	commit, err := repo.CommitObject(commitID)
+	commit, err := gitinterface.GetCommit(repo, commitID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,7 +274,7 @@ func TestGetStateForCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newCommit, err := repo.CommitObject(newCommitID)
+	newCommit, err := gitinterface.GetCommit(repo, newCommitID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -166,7 +166,7 @@ func VerifyCommit(ctx context.Context, repo *git.Repository, ids ...string) map[
 			status[id] = unableToResolveRevisionMessage
 			continue
 		}
-		commit, err := repo.CommitObject(*rev)
+		commit, err := gitinterface.GetCommit(repo, *rev)
 		if err != nil {
 			if errors.Is(err, plumbing.ErrObjectNotFound) {
 				status[id] = nonCommitMessage
@@ -254,7 +254,7 @@ func VerifyTag(ctx context.Context, repo *git.Repository, ids []string) map[stri
 
 			// Must be a hash
 			// verifyTagEntry also finds the tag object, wasteful?
-			tagObj, err := repo.TagObject(plumbing.NewHash(id))
+			tagObj, err := gitinterface.GetTag(repo, plumbing.NewHash(id))
 			if err != nil {
 				status[id] = nonTagMessage
 				continue
@@ -362,7 +362,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 	}
 
 	// 2. Find commit object for the RSL entry
-	commitObj, err := repo.CommitObject(entry.ID)
+	commitObj, err := gitinterface.GetCommit(repo, entry.ID)
 	if err != nil {
 		return err
 	}
@@ -512,7 +512,7 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 	}
 
 	// 2. Find commit object for the RSL entry
-	commitObj, err := repo.CommitObject(entry.ID)
+	commitObj, err := gitinterface.GetCommit(repo, entry.ID)
 	if err != nil {
 		return err
 	}
@@ -542,7 +542,7 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 
 	// 4. Verify tag object
 	tagObjVerified := false
-	tagObj, err := repo.TagObject(entry.TargetID)
+	tagObj, err := gitinterface.GetTag(repo, entry.TargetID)
 	if err != nil {
 		// Likely indicates the ref is not pointing to a tag object
 		// What about lightweight tags?
@@ -609,7 +609,7 @@ func getCommits(repo *git.Repository, entry *rsl.ReferenceEntry) ([]*object.Comm
 func getChangedPaths(repo *git.Repository, entry *rsl.ReferenceEntry) ([]string, error) {
 	firstEntry := false
 
-	currentCommit, err := repo.CommitObject(entry.TargetID)
+	currentCommit, err := gitinterface.GetCommit(repo, entry.TargetID)
 	if err != nil {
 		return nil, err
 	}
@@ -627,7 +627,7 @@ func getChangedPaths(repo *git.Repository, entry *rsl.ReferenceEntry) ([]string,
 		return gitinterface.GetCommitFilePaths(currentCommit)
 	}
 
-	priorCommit, err := repo.CommitObject(priorRefEntry.TargetID)
+	priorCommit, err := gitinterface.GetCommit(repo, priorRefEntry.TargetID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -298,7 +298,7 @@ func TestGetCommits(t *testing.T) {
 	expectedCommitIDs := []plumbing.Hash{commitIDs[1], commitIDs[2], commitIDs[3], commitIDs[4]}
 	expectedCommits := make([]*object.Commit, 0, len(expectedCommitIDs))
 	for _, commitID := range expectedCommitIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -55,7 +55,7 @@ func (r *Repository) RecordRSLEntryForReferenceAtCommit(refName string, commitID
 		return err
 	}
 
-	commit, err := r.r.CommitObject(plumbing.NewHash(commitID))
+	commit, err := gitinterface.GetCommit(r.r, plumbing.NewHash(commitID))
 	if err != nil {
 		return err
 	}
@@ -129,11 +129,11 @@ func (r *Repository) CheckRemoteRSLForUpdates(ctx context.Context, remoteName st
 	}
 
 	// Next, check if remote is ahead of local
-	remoteCommit, err := r.r.CommitObject(remoteRefState.Hash())
+	remoteCommit, err := gitinterface.GetCommit(r.r, remoteRefState.Hash())
 	if err != nil {
 		return false, false, err
 	}
-	localCommit, err := r.r.CommitObject(localRefState.Hash())
+	localCommit, err := gitinterface.GetCommit(r.r, localRefState.Hash())
 	if err != nil {
 		return false, false, err
 	}

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -204,7 +204,7 @@ func (a *AnnotationEntry) createCommitMessage() (string, error) {
 
 // GetEntry returns the entry corresponding to entryID.
 func GetEntry(repo *git.Repository, entryID plumbing.Hash) (Entry, error) {
-	commitObj, err := repo.CommitObject(entryID)
+	commitObj, err := gitinterface.GetCommit(repo, entryID)
 	if err != nil {
 		return nil, ErrRSLEntryNotFound
 	}
@@ -214,7 +214,7 @@ func GetEntry(repo *git.Repository, entryID plumbing.Hash) (Entry, error) {
 
 // GetParentForEntry returns the entry's parent RSL entry.
 func GetParentForEntry(repo *git.Repository, entry Entry) (Entry, error) {
-	commitObj, err := repo.CommitObject(entry.GetID())
+	commitObj, err := gitinterface.GetCommit(repo, entry.GetID())
 	if err != nil {
 		return nil, err
 	}
@@ -295,7 +295,7 @@ func GetLatestEntry(repo *git.Repository) (Entry, error) {
 		return nil, err
 	}
 
-	commitObj, err := repo.CommitObject(ref.Hash())
+	commitObj, err := gitinterface.GetCommit(repo, ref.Hash())
 	if err != nil {
 		return nil, ErrRSLEntryNotFound
 	}

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -75,7 +75,7 @@ func TestNewReferenceEntry(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEqual(t, plumbing.ZeroHash, ref.Hash())
 
-	commitObj, err := repo.CommitObject(ref.Hash())
+	commitObj, err := gitinterface.GetCommit(repo, ref.Hash())
 	if err != nil {
 		t.Error(err)
 	}
@@ -94,7 +94,7 @@ func TestNewReferenceEntry(t *testing.T) {
 		t.Error(err)
 	}
 
-	commitObj, err = repo.CommitObject(ref.Hash())
+	commitObj, err = gitinterface.GetCommit(repo, ref.Hash())
 	if err != nil {
 		t.Error(err)
 	}
@@ -697,7 +697,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 
 	// Right now, the RSL has no entries.
 	for _, commitID := range initialTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -716,7 +716,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, commitID := range initialTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -745,7 +745,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 
 	// The RSL hasn't seen these new commits, however.
 	for _, commitID := range featureTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -760,7 +760,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 	// At this point, searching for any of the original commits' entry should
 	// return the first RSL entry.
 	for _, commitID := range initialTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -775,7 +775,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, commitID := range featureTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -802,7 +802,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 	// Testing for any of the feature commits should return the feature branch
 	// entry, not the main branch entry.
 	for _, commitID := range featureTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -819,7 +819,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 
 	latestEntry := latestEntryT.(*ReferenceEntry)
 	for _, commitID := range featureTargetIDs {
-		commit, err := repo.CommitObject(commitID)
+		commit, err := gitinterface.GetCommit(repo, commitID)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This allows us to perform additional checks in future such as whether an object is replaced by a replace ref. It also makes it easier to switch between go-git and another mechanism to invoke Git, such as directly using the binary.

See: #133 
Related: #2 