### PR TITLE
Update go-git dependencies and imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/*
+/gittuf

--- a/internal/third_party/go-git/plumbing/format/packfile/fsobject.go
+++ b/internal/third_party/go-git/plumbing/format/packfile/fsobject.go
@@ -7,7 +7,7 @@ import (
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/cache"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/format/idxfile"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/utils/ioutil"
-	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5"
 )
 
 // FSObject is an object from the packfile on the filesystem.

--- a/internal/third_party/go-git/plumbing/format/packfile/packfile.go
+++ b/internal/third_party/go-git/plumbing/format/packfile/packfile.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/storer"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/utils/ioutil"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/utils/sync"
-	billy "github.com/go-git/go-billy/v5"
+	"github.com/go-git/go-billy/v5"
 )
 
 var (

--- a/internal/third_party/go-git/repository.go
+++ b/internal/third_party/go-git/repository.go
@@ -3,7 +3,6 @@ package git
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -23,7 +22,6 @@ import (
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/cache"
 	formatcfg "github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/format/config"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/format/packfile"
-	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/hash"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/object"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/storer"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/storage"
@@ -266,7 +264,7 @@ func PlainInitWithOptions(path string, opts *PlainInitOptions) (*Repository, err
 	}
 
 	if opts != nil {
-		if opts.ObjectFormat == formatcfg.SHA256 && hash.CryptoType != crypto.SHA256 {
+		if opts.ObjectFormat == formatcfg.SHA256 {
 			return nil, ErrSHA256NotSupported
 		}
 

--- a/internal/third_party/go-git/storage/memory/storage.go
+++ b/internal/third_party/go-git/storage/memory/storage.go
@@ -302,8 +302,8 @@ func (s *ShallowStorage) SetShallow(commits []plumbing.Hash) error {
 	return nil
 }
 
-func (s ShallowStorage) Shallow() ([]plumbing.Hash, error) {
-	return s, nil
+func (s *ShallowStorage) Shallow() ([]plumbing.Hash, error) {
+	return *s, nil
 }
 
 type ModuleStorage map[string]*Storage

--- a/internal/third_party/go-git/utils/merkletrie/change.go
+++ b/internal/third_party/go-git/utils/merkletrie/change.go
@@ -42,7 +42,7 @@ type Change struct {
 }
 
 // Action is convenience method that returns what Action c represents.
-func (c *Change) Action() (Action, error) {
+func (c Change) Action() (Action, error) {
 	if c.From == nil && c.To == nil {
 		return Action(0), fmt.Errorf("malformed change: nil from and to")
 	}


### PR DESCRIPTION
- Changed receiver when both were mixed https://go.dev/doc/faq#methods_on_values_or_pointers
- Removed import alias which was the same.
- Removed  hash.CryptoType != crypto.SHA256 which will never be true.
- Remove `crypto` and `hash` imports in `repository.go`