### PR TITLE
(WIP) Add early support for attestations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
+	github.com/in-toto/attestation v0.1.1-0.20231030161412-99d851228fe2
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/kevinburke/ssh_config v1.2.0
@@ -26,6 +27,7 @@ require (
 	golang.org/x/crypto v0.14.0
 	golang.org/x/net v0.17.0
 	golang.org/x/sys v0.13.0
+	google.golang.org/protobuf v1.31.0
 )
 
 require (
@@ -123,7 +125,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20230803162519-f966b187b2e5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230807174057-1744710a1577 // indirect
 	google.golang.org/grpc v1.57.1 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,8 @@ github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/in-toto/attestation v0.1.1-0.20231030161412-99d851228fe2 h1:Iri/sa93bC+HMN5PaHfNC+j27fSZMj/yQ2ZJwyKETN4=
+github.com/in-toto/attestation v0.1.1-0.20231030161412-99d851228fe2/go.mod h1:hCR5COCuENh5+VfojEkJnt7caOymbEgvyZdKifD6pOw=
 github.com/in-toto/in-toto-golang v0.9.0 h1:tHny7ac4KgtsfrG6ybU8gVOZux2H8jN05AXJ9EBM1XU=
 github.com/in-toto/in-toto-golang v0.9.0/go.mod h1:xsBVrVsHNsB61++S6Dy2vWosKhuA3lUTQd+eF9HdeMo=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=

--- a/internal/attestations/attestations.go
+++ b/internal/attestations/attestations.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"errors"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/internal/third_party/go-git"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/filemode"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/object"
+)
+
+const (
+	Ref                         = "refs/gittuf/attestations"
+	authorizationsTreeEntryName = "authorizations"
+	initialCommitMessage        = "Initial commit"
+	defaultCommitMessage        = "Update attestations"
+)
+
+var ErrAttestationsExist = errors.New("cannot initialize attestations namespace as it exists already")
+
+func InitializeNamespace(repo *git.Repository) error {
+	if ref, err := repo.Reference(plumbing.ReferenceName(Ref), true); err != nil {
+		if !errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return err
+		}
+	} else if !ref.Hash().IsZero() {
+		return ErrAttestationsExist
+	}
+
+	treeHash, err := gitinterface.WriteTree(repo, nil)
+	if err != nil {
+		return err
+	}
+
+	_, err = gitinterface.Commit(repo, treeHash, Ref, initialCommitMessage, false)
+	return err
+}
+
+type Attestations struct {
+	authorizations map[string]plumbing.Hash // refPath/from-to -> blob ID
+}
+
+func LoadCurrentAttestations(repo *git.Repository) (*Attestations, error) {
+	entry, _, err := rsl.GetLatestReferenceEntryForRef(repo, Ref)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return nil, err
+		}
+
+		return &Attestations{}, nil
+	}
+
+	return LoadAttestationsForEntry(repo, entry)
+}
+
+func LoadAttestationsForEntry(repo *git.Repository, entry *rsl.ReferenceEntry) (*Attestations, error) {
+	if entry.RefName != Ref {
+		return nil, rsl.ErrRSLEntryDoesNotMatchRef
+	}
+
+	attestationsCommit, err := gitinterface.GetCommit(repo, entry.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	attestationsRootTree, err := gitinterface.GetTree(repo, attestationsCommit.TreeHash)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(attestationsRootTree.Entries) == 0 {
+		// this happens in the initial commit for the attestations namespace,
+		// with no entries in the tree at all
+		return &Attestations{}, nil
+	}
+
+	var authorizationsTreeID plumbing.Hash
+	for _, e := range attestationsRootTree.Entries {
+		if e.Name == authorizationsTreeEntryName {
+			authorizationsTreeID = e.Hash
+		}
+	}
+
+	authorizationsTree, err := gitinterface.GetTree(repo, authorizationsTreeID)
+	if err != nil {
+		return nil, err
+	}
+
+	attestations := &Attestations{authorizations: map[string]plumbing.Hash{}}
+
+	filesIter := authorizationsTree.Files()
+	if err := filesIter.ForEach(func(f *object.File) error {
+		attestations.authorizations[f.Name] = f.Blob.Hash
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return attestations, nil
+}
+
+func (a *Attestations) Commit(repo *git.Repository, commitMessage string, signCommit bool) error {
+	if len(commitMessage) == 0 {
+		commitMessage = defaultCommitMessage
+	}
+
+	attestationsTreeEntries := []object.TreeEntry{}
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+
+	// Add authorizations tree
+	authorizationsTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(a.authorizations)
+	if err != nil {
+		return err
+	}
+	attestationsTreeEntries = append(attestationsTreeEntries, object.TreeEntry{
+		Name: authorizationsTreeEntryName,
+		Mode: filemode.Dir,
+		Hash: authorizationsTreeID,
+	})
+
+	attestationsTreeID, err := gitinterface.WriteTree(repo, attestationsTreeEntries)
+	if err != nil {
+		return err
+	}
+
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+	if err != nil {
+		return err
+	}
+	priorCommitID := ref.Hash()
+
+	commitID, err := gitinterface.Commit(repo, attestationsTreeID, Ref, commitMessage, signCommit)
+	if err != nil {
+		return err
+	}
+
+	// We must reset to original attestation commit if err != nil from here onwards.
+
+	if err := rsl.NewReferenceEntry(Ref, commitID).Commit(repo, signCommit); err != nil {
+		return gitinterface.ResetDueToError(err, repo, Ref, priorCommitID)
+	}
+
+	return nil
+}

--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/third_party/go-git"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/storage/memory"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeNamespace(t *testing.T) {
+	t.Run("clean repository", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Error(err)
+		}
+
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		initialCommit, err := gitinterface.GetCommit(repo, ref.Hash())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, initialCommitMessage, initialCommit.Message)
+		assert.Equal(t, gitinterface.EmptyTree(), initialCommit.TreeHash)
+	})
+
+	t.Run("existing attestations namespace", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		err = InitializeNamespace(repo)
+		assert.ErrorIs(t, err, ErrAttestationsExist)
+	})
+}
+
+func TestLoadCurrentAttestations(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := plumbing.ZeroHash.String()
+	testAttestation, err := NewAuthorizationAttestation(testRef, testID, testID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnv, err := dsse.CreateEnvelope(testAttestation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnvBytes, err := json.Marshal(testEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("no RSL entry", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		attestations, err := LoadCurrentAttestations(repo)
+		assert.Nil(t, err)
+		assert.Empty(t, attestations.authorizations)
+	})
+
+	t.Run("with RSL entry but empty", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.NewReferenceEntry(Ref, ref.Hash()).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		attestations, err := LoadCurrentAttestations(repo)
+		assert.Nil(t, err)
+		assert.Empty(t, attestations.authorizations)
+	})
+
+	t.Run("with RSL entry and with an attestation", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		blobID, err := gitinterface.WriteBlob(repo, testEnvBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorizations := map[string]plumbing.Hash{authorizationPath(testRef, testID, testID): blobID}
+
+		attestations := &Attestations{authorizations: authorizations}
+		if err := attestations.Commit(repo, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.NewReferenceEntry(Ref, ref.Hash()).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		attestations, err = LoadCurrentAttestations(repo)
+		assert.Nil(t, err)
+		assert.Equal(t, authorizations, attestations.authorizations)
+	})
+}
+
+func TestLoadAttestationsForEntry(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := plumbing.ZeroHash.String()
+	testAttestation, err := NewAuthorizationAttestation(testRef, testID, testID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnv, err := dsse.CreateEnvelope(testAttestation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnvBytes, err := json.Marshal(testEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("with RSL entry but empty", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.NewReferenceEntry(Ref, ref.Hash()).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		attestations, err := LoadAttestationsForEntry(repo, entry.(*rsl.ReferenceEntry))
+		assert.Nil(t, err)
+		assert.Empty(t, attestations.authorizations)
+	})
+
+	t.Run("with RSL entry and with an attestation", func(t *testing.T) {
+		repo, err := git.Init(memory.NewStorage(), memfs.New())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := InitializeNamespace(repo); err != nil {
+			t.Fatal(err)
+		}
+
+		blobID, err := gitinterface.WriteBlob(repo, testEnvBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorizations := map[string]plumbing.Hash{authorizationPath(testRef, testID, testID): blobID}
+
+		attestations := &Attestations{authorizations: authorizations}
+		if err := attestations.Commit(repo, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+
+		ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := rsl.NewReferenceEntry(Ref, ref.Hash()).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		attestations, err = LoadAttestationsForEntry(repo, entry.(*rsl.ReferenceEntry))
+		assert.Nil(t, err)
+		assert.Equal(t, authorizations, attestations.authorizations)
+	})
+}
+
+func TestAttestationsCommit(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := plumbing.ZeroHash.String()
+	testAttestation, err := NewAuthorizationAttestation(testRef, testID, testID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnv, err := dsse.CreateEnvelope(testAttestation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEnvBytes, err := json.Marshal(testEnv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobID, err := gitinterface.WriteBlob(repo, testEnvBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := InitializeNamespace(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	ref, err := repo.Reference(plumbing.ReferenceName(Ref), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit, err := gitinterface.GetCommit(repo, ref.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, gitinterface.EmptyTree(), commit.TreeHash)
+
+	authorizations := map[string]plumbing.Hash{authorizationPath(testRef, testID, testID): blobID}
+	attestations := &Attestations{authorizations: authorizations}
+
+	if err := attestations.Commit(repo, "Test commit", false); err != nil {
+		t.Error(err)
+	}
+
+	ref, err = repo.Reference(plumbing.ReferenceName(Ref), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit, err = gitinterface.GetCommit(repo, ref.Hash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.NotEqual(t, gitinterface.EmptyTree(), commit.TreeHash)
+
+	rootTree, err := gitinterface.GetTree(repo, commit.TreeHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 1, len(rootTree.Entries))
+	assert.Equal(t, authorizationsTreeEntryName, rootTree.Entries[0].Name)
+
+	// We don't need to check every level of the tree because we do it in the
+	// tree builder API
+	attestations, err = LoadCurrentAttestations(repo)
+	assert.Nil(t, err)
+	assert.Equal(t, attestations.authorizations, authorizations)
+}

--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/third_party/go-git"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	ita "github.com/in-toto/attestation/go/v1"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	AuthorizationPredicateType = "https://gittuf.dev/authorization/v0.1"
+	digestGitCommitKey         = "gitCommit"
+)
+
+var (
+	ErrInvalidAuthorization  = errors.New("authorization attestation does not match expected details")
+	ErrAuthorizationNotFound = errors.New("requested authorization not found")
+)
+
+type Authorization struct {
+	TargetRef    string `json:"targetRef"`
+	FromTargetID string `json:"fromTargetID"`
+	ToTargetID   string `json:"toTargetID"`
+}
+
+func NewAuthorizationAttestation(targetRef, fromTargetID, toTargetID string) (*ita.Statement, error) {
+	predicate := &Authorization{
+		TargetRef:    targetRef,
+		FromTargetID: fromTargetID,
+		ToTargetID:   toTargetID,
+	}
+
+	predicateBytes, err := json.Marshal(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	predicateInterface := &map[string]any{}
+	if err := json.Unmarshal(predicateBytes, predicateInterface); err != nil {
+		return nil, err
+	}
+
+	predicateStruct, err := structpb.NewStruct(*predicateInterface)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitCommitKey: toTargetID},
+			},
+		},
+		PredicateType: AuthorizationPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+func (a *Attestations) AddAuthorizationAttestation(repo *git.Repository, env *sslibdsse.Envelope, refName, fromID, toID string) error {
+	if err := validateAuthorization(env, refName, fromID, toID); err != nil {
+		return err
+	}
+
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := gitinterface.WriteBlob(repo, envBytes)
+	if err != nil {
+		return err
+	}
+
+	if a.authorizations == nil {
+		a.authorizations = map[string]plumbing.Hash{}
+	}
+
+	a.authorizations[authorizationPath(refName, fromID, toID)] = blobID
+	return nil
+}
+
+func (a *Attestations) RemoveAuthorization(repo *git.Repository, refName, fromID, toID, keyID string) error {
+	env, err := a.GetAuthorizationAttestationFor(repo, refName, fromID, toID)
+	if err != nil {
+		return err
+	}
+
+	if err := validateAuthorization(env, refName, fromID, toID); err != nil {
+		return err
+	}
+
+	signatures := []sslibdsse.Signature{}
+	for _, sig := range env.Signatures {
+		if sig.KeyID != keyID {
+			signatures = append(signatures, sig)
+		}
+	}
+
+	if len(signatures) == len(env.Signatures) {
+		// can't revoke a signature that doesn't exist
+		return ErrAuthorizationNotFound
+	}
+
+	if len(signatures) == 0 {
+		delete(a.authorizations, authorizationPath(refName, fromID, toID))
+		return nil
+	}
+
+	// Write new env with reduced number of signatures
+	env.Signatures = signatures
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := gitinterface.WriteBlob(repo, envBytes)
+	if err != nil {
+		return err
+	}
+
+	a.authorizations[authorizationPath(refName, fromID, toID)] = blobID
+	return nil
+}
+
+func (a *Attestations) GetAuthorizationAttestationFor(repo *git.Repository, refName, fromID, toID string) (*sslibdsse.Envelope, error) {
+	blobID, has := a.authorizations[authorizationPath(refName, fromID, toID)]
+	if !has {
+		return nil, ErrAuthorizationNotFound
+	}
+
+	envBytes, err := gitinterface.ReadBlob(repo, blobID)
+	if err != nil {
+		return nil, err
+	}
+
+	env := &sslibdsse.Envelope{}
+	if err := json.Unmarshal(envBytes, env); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+func validateAuthorization(env *sslibdsse.Envelope, refName, fromID, toID string) error {
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	attestation := &ita.Statement{}
+	if err := json.Unmarshal(payload, attestation); err != nil {
+		return err
+	}
+
+	if attestation.Subject[0].Digest["gitCommit"] != toID {
+		return ErrInvalidAuthorization
+	}
+
+	predicate := attestation.Predicate.AsMap()
+
+	if predicate["toTargetID"] != toID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate["fromTargetID"] != fromID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate["targetRef"] != refName {
+		return ErrInvalidAuthorization
+	}
+
+	return nil
+}
+
+func authorizationPath(refName, fromID, toID string) string {
+	return path.Join(refName, fmt.Sprintf("%s-%s", fromID, toID))
+}

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/third_party/go-git"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/storage/memory"
+	"github.com/go-git/go-billy/v5/memfs"
+	ita "github.com/in-toto/attestation/go/v1"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAuthorizationAttestation(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := plumbing.ZeroHash.String()
+
+	authorization, err := NewAuthorizationAttestation(testRef, testID, testID)
+	assert.Nil(t, err)
+
+	// Check value of statement type
+	assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+
+	// Check subject contents
+	assert.Equal(t, 1, len(authorization.Subject))
+	assert.Contains(t, authorization.Subject[0].Digest, digestGitCommitKey)
+	assert.Equal(t, authorization.Subject[0].Digest[digestGitCommitKey], testID)
+
+	// Check predicate type
+	assert.Equal(t, AuthorizationPredicateType, authorization.PredicateType)
+
+	// Check predicate
+	predicate := authorization.Predicate.AsMap()
+	assert.Equal(t, predicate["targetRef"], testRef)
+	assert.Equal(t, predicate["toTargetID"], testID)
+	assert.Equal(t, predicate["fromTargetID"], testID)
+}
+
+func TestAddAuthorizationAttestation(t *testing.T) {
+	testRef := "refs/heads/main"
+	testAnotherRef := "refs/heads/feature"
+	testID := plumbing.ZeroHash.String()
+	mainZeroZero := createUnsignedAuthorizationAttestationEnvelopes(t, testRef, testID, testID)
+	featureZeroZero := createUnsignedAuthorizationAttestationEnvelopes(t, testAnotherRef, testID, testID)
+
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attestations := &Attestations{}
+
+	err = attestations.AddAuthorizationAttestation(repo, mainZeroZero, testRef, testID, testID)
+	assert.Nil(t, err)
+	assert.Contains(t, attestations.authorizations, authorizationPath(testRef, testID, testID))
+	assert.NotContains(t, attestations.authorizations, authorizationPath(testAnotherRef, testID, testID))
+
+	err = attestations.AddAuthorizationAttestation(repo, featureZeroZero, testAnotherRef, testID, testID)
+	assert.Nil(t, err)
+	assert.Contains(t, attestations.authorizations, authorizationPath(testRef, testID, testID))
+	assert.Contains(t, attestations.authorizations, authorizationPath(testAnotherRef, testID, testID))
+}
+
+func createUnsignedAuthorizationAttestationEnvelopes(t *testing.T, refName, fromID, toID string) *sslibdsse.Envelope {
+	t.Helper()
+
+	authorization, err := NewAuthorizationAttestation(refName, fromID, toID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}

--- a/internal/cmd/authorize/add/add.go
+++ b/internal/cmd/authorize/add/add.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package add
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/authorize/persistent"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p           *persistent.Options
+	fromRefName string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o.fromRefName,
+		"from",
+		"f",
+		"",
+		"Specify source ref for authorization",
+	)
+	cmd.MarkFlagRequired("from") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	return repo.AddAuthorization(cmd.Context(), args[0], o.fromRefName, keyBytes, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:   "add <refName>",
+		Short: "Add authorization for updating the state of a ref",
+		Args:  cobra.ExactArgs(1),
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/authorize/authorize.go
+++ b/internal/cmd/authorize/authorize.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package authorize
+
+import (
+	"github.com/gittuf/gittuf/internal/cmd/authorize/add"
+	"github.com/gittuf/gittuf/internal/cmd/authorize/persistent"
+	"github.com/gittuf/gittuf/internal/cmd/authorize/revoke"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	o := &persistent.Options{}
+	cmd := &cobra.Command{
+		Use:   "authorize",
+		Short: "Add or revoke a detached authorization",
+	}
+	o.AddPersistentFlags(cmd)
+
+	cmd.AddCommand(add.New(o))
+	cmd.AddCommand(revoke.New(o))
+
+	return cmd
+}

--- a/internal/cmd/authorize/persistent/persistent.go
+++ b/internal/cmd/authorize/persistent/persistent.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package persistent
+
+import "github.com/spf13/cobra"
+
+type Options struct {
+	SigningKey string
+}
+
+func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(
+		&o.SigningKey,
+		"signing-key",
+		"k",
+		"",
+		"signing key to use to sign authorization",
+	)
+	cmd.MarkPersistentFlagRequired("signing-key") //nolint:errcheck
+}

--- a/internal/cmd/authorize/revoke/revoke.go
+++ b/internal/cmd/authorize/revoke/revoke.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package revoke
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/authorize/persistent"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p       *persistent.Options
+	refName string
+	fromID  string
+	toID    string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o.refName,
+		"ref",
+		"r",
+		"",
+		"Specify ref for which the authorization is to be removed",
+	)
+	cmd.MarkFlagRequired("ref") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.fromID,
+		"from-ID",
+		"",
+		"Specify the from ID for which the authorization is to be removed",
+	)
+	cmd.MarkFlagRequired("from-ID") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.toID,
+		"to-ID",
+		"",
+		"Specify the to ID for which the authorization is to be removed",
+	)
+	cmd.MarkFlagRequired("to-ID") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	return repo.RemoveAuthorization(cmd.Context(), o.refName, o.fromID, o.toID, keyBytes, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:   "revoke",
+		Short: "Revoke authorization granted for updating the state of a ref",
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -3,6 +3,7 @@
 package root
 
 import (
+	"github.com/gittuf/gittuf/internal/cmd/authorize"
 	"github.com/gittuf/gittuf/internal/cmd/clone"
 	"github.com/gittuf/gittuf/internal/cmd/policy"
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
@@ -20,6 +21,7 @@ func New() *cobra.Command {
 		Short: "A security layer for Git repositories, powered by TUF",
 	}
 
+	cmd.AddCommand(authorize.New())
 	cmd.AddCommand(clone.New())
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())

--- a/internal/repository/attestations.go
+++ b/internal/repository/attestations.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/attestations"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/internal/signerverifier"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+)
+
+func (r *Repository) AddAuthorization(ctx context.Context, targetRefName, sourceRefName string, signingKeyBytes []byte, signCommit bool) error {
+	sv, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(signingKeyBytes)
+	if err != nil {
+		return err
+	}
+
+	keyID, err := sv.KeyID()
+	if err != nil {
+		return err
+	}
+
+	absTargetRefName, err := gitinterface.AbsoluteReference(r.r, targetRefName)
+	if err != nil {
+		return err
+	}
+	absSourceRefName, err := gitinterface.AbsoluteReference(r.r, sourceRefName)
+	if err != nil {
+		return err
+	}
+
+	// TODO: get unskipped entry?
+	fromEntry, _, err := rsl.GetLatestReferenceEntryForRef(r.r, absTargetRefName)
+	if err != nil {
+		return err
+	}
+	// TODO: get unskipped entry?
+	toEntry, _, err := rsl.GetLatestReferenceEntryForRef(r.r, absSourceRefName)
+	if err != nil {
+		return err
+	}
+
+	// The current accepted state of the target ref is the from ID.
+	// The source ref is a feature branch or other ref that contains the change
+	// that must be applied to the target ref.
+	// TODO: support merge commits
+	fromID := fromEntry.TargetID.String()
+	toID := toEntry.TargetID.String()
+
+	currentAttestations, err := attestations.LoadCurrentAttestations(r.r)
+	if err != nil {
+		return err
+	}
+
+	env, err := currentAttestations.GetAuthorizationAttestationFor(r.r, absTargetRefName, fromID, toID)
+	if err != nil && !errors.Is(err, attestations.ErrAuthorizationNotFound) {
+		return err
+	}
+
+	if env == nil {
+		authorization, err := attestations.NewAuthorizationAttestation(absTargetRefName, fromID, toID)
+		if err != nil {
+			return err
+		}
+
+		env, err = dsse.CreateEnvelope(authorization)
+		if err != nil {
+			return err
+		}
+	}
+
+	env, err = dsse.SignEnvelope(ctx, env, sv)
+	if err != nil {
+		return err
+	}
+
+	if err := currentAttestations.AddAuthorizationAttestation(r.r, env, absTargetRefName, fromID, toID); err != nil {
+		return err
+	}
+
+	commitMessage := fmt.Sprintf("Add authorization of %s to move %s from %s to %s", keyID, absTargetRefName, fromID, toID)
+	return currentAttestations.Commit(r.r, commitMessage, signCommit)
+}
+
+func (r *Repository) RemoveAuthorization(ctx context.Context, refName, fromID, toID string, keyBytes []byte, signCommit bool) error {
+	// We pass in the signing key because we want to be able to gate revocation
+	// to the authorizing identity We need to think about this in the policy
+	// context as well though
+	sv, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	// TODO: sslib should have a "CanSign" method for us to check if we actually
+	// have a signer
+	if _, err := sv.Sign(ctx, []byte{}); err != nil {
+		return err
+	}
+
+	keyID, err := sv.KeyID()
+	if err != nil {
+		return err
+	}
+
+	absRefName, err := gitinterface.AbsoluteReference(r.r, refName)
+	if err != nil {
+		return err
+	}
+
+	currentAttestations, err := attestations.LoadCurrentAttestations(r.r)
+	if err != nil {
+		return err
+	}
+
+	if err := currentAttestations.RemoveAuthorization(r.r, absRefName, fromID, toID, keyID); err != nil {
+		if errors.Is(err, attestations.ErrAuthorizationNotFound) {
+			return nil
+		}
+
+		return err
+	}
+
+	commitMessage := fmt.Sprintf("Revoke %s's authorization to move %s from %s to %s", keyID, absRefName, fromID, toID)
+	return currentAttestations.Commit(r.r, commitMessage, signCommit)
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"errors"
 
+	"github.com/gittuf/gittuf/internal/attestations"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/third_party/go-git"
@@ -32,6 +33,10 @@ func LoadRepository() (*Repository, error) {
 
 func (r *Repository) InitializeNamespaces() error {
 	if err := rsl.InitializeNamespace(r.r); err != nil {
+		return err
+	}
+
+	if err := attestations.InitializeNamespace(r.r); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is a prototype of adding support for attestations. It starts with a very simple authorization attestation meant to accompany an RSL reference entry.