### PR TITLE
gitinterface: Add TreeBuilder

### DIFF
--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -3,13 +3,19 @@
 package gitinterface
 
 import (
+	"errors"
+	"path"
 	"sort"
+	"strings"
 
 	"github.com/gittuf/gittuf/internal/third_party/go-git"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/filemode"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/object"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/storage/memory"
 )
+
+var ErrNoEntries = errors.New("no entries specified to write tree")
 
 // WriteTree creates a Git tree with the specified entries. It sorts the entries
 // prior to creating the tree.
@@ -36,4 +42,95 @@ func EmptyTree() plumbing.Hash {
 	tree.Encode(obj) //nolint:errcheck
 
 	return obj.Hash()
+}
+
+// TreeBuilder is used to create multi-level trees in a repository.
+// Based on `buildTreeHelper` in go-git.
+type TreeBuilder struct {
+	r       *git.Repository
+	trees   map[string]*object.Tree
+	entries map[string]*object.TreeEntry
+}
+
+// NewTreeBuilder returns a TreeBuilder instance for the repository.
+func NewTreeBuilder(repo *git.Repository) *TreeBuilder {
+	return &TreeBuilder{r: repo}
+}
+
+// WriteRootTreeFromBlobIDs accepts a map of paths to their blob IDs and returns
+// the root tree ID that contains these files.
+func (t *TreeBuilder) WriteRootTreeFromBlobIDs(files map[string]plumbing.Hash) (plumbing.Hash, error) {
+	if len(files) == 0 {
+		return plumbing.ZeroHash, ErrNoEntries
+	}
+
+	rootNodeKey := ""
+	t.trees = map[string]*object.Tree{rootNodeKey: {}}
+	t.entries = map[string]*object.TreeEntry{}
+
+	for path, blobID := range files {
+		t.buildIntermediates(path, blobID)
+	}
+
+	return t.writeTrees(rootNodeKey, t.trees[rootNodeKey])
+}
+
+// buildIntermediates identifies the intermediate trees that must be constructed
+// for the specified path.
+func (t *TreeBuilder) buildIntermediates(name string, blobID plumbing.Hash) {
+	parts := strings.Split(name, "/")
+
+	var fullPath string
+	for _, part := range parts {
+		parent := fullPath
+		fullPath = path.Join(fullPath, part)
+
+		t.buildTree(name, parent, fullPath, blobID)
+	}
+}
+
+// buildTree populates tree and entry information for each tree that must be
+// created.
+func (t *TreeBuilder) buildTree(name, parent, fullPath string, blobID plumbing.Hash) {
+	if _, ok := t.trees[fullPath]; ok {
+		return
+	}
+
+	if _, ok := t.entries[fullPath]; ok {
+		return
+	}
+
+	entry := object.TreeEntry{Name: path.Base(fullPath)}
+
+	if fullPath == name {
+		entry.Mode = filemode.Regular
+		entry.Hash = blobID
+	} else {
+		entry.Mode = filemode.Dir
+		t.trees[fullPath] = &object.Tree{}
+	}
+
+	t.trees[parent].Entries = append(t.trees[parent].Entries, entry)
+}
+
+// writeTrees recursively stores each tree that must be created in the
+// repository's object store. It returns the ID of the tree created at each
+// invocation.
+func (t *TreeBuilder) writeTrees(parent string, tree *object.Tree) (plumbing.Hash, error) {
+	for i, e := range tree.Entries {
+		if e.Mode != filemode.Dir && !e.Hash.IsZero() {
+			continue
+		}
+
+		p := path.Join(parent, e.Name)
+		entryID, err := t.writeTrees(p, t.trees[p])
+		if err != nil {
+			return plumbing.ZeroHash, err
+		}
+		e.Hash = entryID
+
+		tree.Entries[i] = e
+	}
+
+	return WriteTree(t.r, tree.Entries)
 }

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/third_party/go-git"
+	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/filemode"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/plumbing/object"
 	"github.com/gittuf/gittuf/internal/third_party/go-git/storage/memory"
@@ -64,4 +65,170 @@ func TestEmptyTree(t *testing.T) {
 	// SHA-1 ID used by Git to denote an empty tree
 	// $ git hash-object -t tree --stdin < /dev/null
 	assert.Equal(t, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", hash.String())
+}
+
+func TestTreeBuilder(t *testing.T) {
+	repo, err := git.Init(memory.NewStorage(), memfs.New())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobA, err := WriteBlob(repo, []byte("a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	blobB, err := WriteBlob(repo, []byte("b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("no blobs", func(t *testing.T) {
+		treeBuilder := NewTreeBuilder(repo)
+		_, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+		assert.ErrorIs(t, err, ErrNoEntries)
+
+		_, err = treeBuilder.WriteRootTreeFromBlobIDs(map[string]plumbing.Hash{})
+		assert.ErrorIs(t, err, ErrNoEntries)
+	})
+
+	t.Run("both blobs in the root directory", func(t *testing.T) {
+		treeBuilder := NewTreeBuilder(repo)
+
+		input := map[string]plumbing.Hash{
+			"a": blobA,
+			"b": blobB,
+		}
+
+		rootTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(input)
+		assert.Nil(t, err)
+
+		tree, err := repo.TreeObject(rootTreeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Assert number of entries
+		assert.Equal(t, 2, len(tree.Entries))
+
+		// Find entry "a"
+		entryA, err := tree.FindEntry("a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobA, entryA.Hash)
+
+		// Find entry "b"
+		entryB, err := tree.FindEntry("b")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobB, entryB.Hash)
+	})
+
+	t.Run("both blobs in same subdirectory", func(t *testing.T) {
+		treeBuilder := NewTreeBuilder(repo)
+
+		input := map[string]plumbing.Hash{
+			"dir/a": blobA,
+			"dir/b": blobB,
+		}
+
+		rootTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(input)
+		assert.Nil(t, err)
+
+		tree, err := repo.TreeObject(rootTreeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Assert number of entries, and that it's the subdirectory
+		assert.Equal(t, 1, len(tree.Entries))
+		assert.Equal(t, filemode.Dir, tree.Entries[0].Mode)
+
+		// Find entry "a"
+		entryA, err := tree.FindEntry("dir/a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobA, entryA.Hash)
+
+		// Find entry "b"
+		entryB, err := tree.FindEntry("dir/b")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobB, entryB.Hash)
+	})
+
+	t.Run("both blobs in different subdirectories", func(t *testing.T) {
+		treeBuilder := NewTreeBuilder(repo)
+
+		input := map[string]plumbing.Hash{
+			"foo/a": blobA,
+			"bar/b": blobB,
+		}
+
+		rootTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(input)
+		assert.Nil(t, err)
+
+		tree, err := repo.TreeObject(rootTreeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Assert number of entries, and that it's the two subdirectories
+		assert.Equal(t, 2, len(tree.Entries))
+		assert.Equal(t, filemode.Dir, tree.Entries[0].Mode)
+		assert.Equal(t, filemode.Dir, tree.Entries[1].Mode)
+
+		// Find entry "a"
+		entryA, err := tree.FindEntry("foo/a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobA, entryA.Hash)
+
+		// Find entry "b"
+		entryB, err := tree.FindEntry("bar/b")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobB, entryB.Hash)
+	})
+
+	t.Run("blobs in mix of root directory and subdirectories", func(t *testing.T) {
+		treeBuilder := NewTreeBuilder(repo)
+
+		input := map[string]plumbing.Hash{
+			"a":                blobA,
+			"foo/bar/foobar/b": blobB,
+		}
+
+		rootTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(input)
+		assert.Nil(t, err)
+
+		tree, err := repo.TreeObject(rootTreeID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Assert number of entries, and that it's one file and one directory
+		assert.Equal(t, 2, len(tree.Entries))
+		assert.Equal(t, filemode.Regular, tree.Entries[0].Mode)
+		assert.Equal(t, filemode.Dir, tree.Entries[1].Mode)
+
+		// Find entry "a"
+		entryA, err := tree.FindEntry("a")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobA, entryA.Hash)
+
+		// Find entry "b"
+		entryB, err := tree.FindEntry("foo/bar/foobar/b")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, blobB, entryB.Hash)
+	})
 }


### PR DESCRIPTION
TreeBuilder allows for adding multiple files (with their blob IDs) to a tree, creating intermediate trees on the fly based on the files' paths.

This is based significantly off "buildTreeHelper" in go-git. It's possible this will eventually be upstreamed to go-git in plumbing and used in "buildTreeHelper".

cc @pjbgf