### PR TITLE
Make CreateCommitObject Support Merge Commits

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -276,7 +276,7 @@ func AddNTestCommitsToSpecifiedRef(t *testing.T, repo *git.Repository, refName s
 
 	commitIDs := []plumbing.Hash{}
 	for i := 0; i < n; i++ {
-		commit := gitinterface.CreateCommitObject(testGitConfig, treeHashes[i], ref.Hash(), "Test commit", testClock)
+		commit := gitinterface.CreateCommitObject(testGitConfig, treeHashes[i], []plumbing.Hash{ref.Hash()}, "Test commit", testClock)
 		commit = SignTestCommit(t, repo, commit, keyName)
 		if _, err := gitinterface.ApplyCommit(repo, commit, ref); err != nil {
 			t.Fatal(err)

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -65,7 +65,7 @@ func TestGetCommitFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		c := CreateCommitObject(testGitConfig, treeHash, plumbing.ZeroHash, "Test commit", testClock)
+		c := CreateCommitObject(testGitConfig, treeHash, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		commitID, err := WriteCommit(repo, c)
 		if err != nil {
 			t.Fatal(err)
@@ -107,13 +107,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -144,13 +144,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -187,13 +187,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -229,13 +229,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -271,13 +271,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -313,13 +313,13 @@ func TestGetDiffFilePaths(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, plumbing.ZeroHash, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -366,13 +366,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -399,13 +399,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -438,13 +438,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -476,13 +476,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -514,13 +514,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -552,13 +552,13 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		cB := CreateCommitObject(testGitConfig, treeB, cAID, "Test commit", testClock)
+		cB := CreateCommitObject(testGitConfig, treeB, []plumbing.Hash{cAID}, "Test commit", testClock)
 		cBID, err := WriteCommit(repo, cB)
 		if err != nil {
 			t.Fatal(err)
@@ -582,7 +582,7 @@ func TestGetFilePathsChangedByCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cA := CreateCommitObject(testGitConfig, treeA, plumbing.ZeroHash, "Test commit", testClock)
+		cA := CreateCommitObject(testGitConfig, treeA, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 		cAID, err := WriteCommit(repo, cA)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -24,14 +24,45 @@ import (
 )
 
 func TestCreateCommitObject(t *testing.T) {
-	commit := CreateCommitObject(testGitConfig, plumbing.ZeroHash, plumbing.ZeroHash, "Test commit", testClock)
+	t.Run("zero commit and zero parent", func(t *testing.T) {
+		commit := CreateCommitObject(testGitConfig, plumbing.ZeroHash, []plumbing.Hash{plumbing.ZeroHash}, "Test commit", testClock)
 
-	enc := memory.NewStorage().NewEncodedObject()
-	if err := commit.Encode(enc); err != nil {
-		t.Error(err)
-	}
+		enc := memory.NewStorage().NewEncodedObject()
+		if err := commit.Encode(enc); err != nil {
+			t.Error(err)
+		}
 
-	assert.Equal(t, "22ddfd55fb5fba7b37b50b068d1527a1b0f9f561", enc.Hash().String())
+		assert.Equal(t, "22ddfd55fb5fba7b37b50b068d1527a1b0f9f561", enc.Hash().String())
+	})
+
+	t.Run("zero commit and single non-zero parent", func(t *testing.T) {
+		pHashes := []plumbing.Hash{EmptyTree()}
+		commit := CreateCommitObject(testGitConfig, plumbing.ZeroHash, pHashes, "Test commit", testClock)
+
+		enc := memory.NewStorage().NewEncodedObject()
+		if err := commit.Encode(enc); err != nil {
+			t.Error(err)
+		}
+
+		for parentHashInd := range commit.ParentHashes {
+			assert.Equal(t, pHashes[parentHashInd], commit.ParentHashes[parentHashInd])
+		}
+	})
+
+	t.Run("zero commit and multiple parents", func(t *testing.T) {
+		pHashes := []plumbing.Hash{EmptyTree(), EmptyTree()}
+
+		commit := CreateCommitObject(testGitConfig, plumbing.ZeroHash, pHashes, "Test commit", testClock)
+
+		enc := memory.NewStorage().NewEncodedObject()
+		if err := commit.Encode(enc); err != nil {
+			t.Error(err)
+		}
+
+		for parentHashInd := range commit.ParentHashes {
+			assert.Equal(t, pHashes[parentHashInd], commit.ParentHashes[parentHashInd])
+		}
+	})
 }
 
 func TestVerifyCommitSignature(t *testing.T) {

--- a/internal/gitinterface/log_test.go
+++ b/internal/gitinterface/log_test.go
@@ -53,7 +53,7 @@ func TestGetCommitsBetweenRange(t *testing.T) {
 
 	commitIDs := []plumbing.Hash{}
 	for i := 0; i < 5; i++ {
-		commit := CreateCommitObject(testGitConfig, treeHashes[i], ref.Hash(), "Test commit", testClock)
+		commit := CreateCommitObject(testGitConfig, treeHashes[i], []plumbing.Hash{ref.Hash()}, "Test commit", testClock)
 		if _, err := ApplyCommit(repo, commit, ref); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
- Make CreateCommitObject support merge commits, with multiple parent hashes
- Changed other files to use an array of parent hashes instead of a single hash