### PR TITLE
Check that git signing is viable

### DIFF
--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -9,8 +9,10 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	sslibsv "github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -77,6 +79,12 @@ func ReadKeyBytes(key string) ([]byte, error) {
 	}
 
 	return kb, nil
+}
+
+func CheckIfSigningViable(_ *cobra.Command, _ []string) error {
+	_, _, err := gitinterface.GetSigningCommand()
+
+	return err
 }
 
 func EvalMode() bool {

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -62,10 +62,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "add-key",
-		Short: "Add a trusted key to a policy file",
-		Long:  `This command allows users to add a trusted key to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		RunE:  o.Run,
+		Use:     "add-key",
+		Short:   "Add a trusted key to a policy file",
+		Long:    `This command allows users to add a trusted key to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -80,10 +80,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "add-rule",
-		Short: "Add a new rule to a policy file",
-		Long:  `This command allows users to add a new rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		RunE:  o.Run,
+		Use:     "add-rule",
+		Short:   "Add a new rule to a policy file",
+		Long:    `This command allows users to add a new rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -5,6 +5,7 @@ package init
 import (
 	"os"
 
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/repository"
@@ -42,9 +43,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize policy file",
-		RunE:  o.Run,
+		Use:     "init",
+		Short:   "Initialize policy file",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -5,6 +5,7 @@ package removerule
 import (
 	"os"
 
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/repository"
@@ -51,9 +52,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "remove-rule",
-		Short: "Remove rule from a policy file",
-		RunE:  o.Run,
+		Use:     "remove-rule",
+		Short:   "Remove rule from a policy file",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -3,6 +3,7 @@
 package annotate
 
 import (
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
 )
@@ -43,10 +44,11 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:   "annotate",
-		Short: "Annotate prior RSL entries",
-		Args:  cobra.MinimumNArgs(1),
-		RunE:  o.Run,
+		Use:     "annotate",
+		Short:   "Annotate prior RSL entries",
+		Args:    cobra.MinimumNArgs(1),
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -44,10 +44,11 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:   "record",
-		Short: "Record latest state of a Git reference in the RSL",
-		Args:  cobra.ExactArgs(1),
-		RunE:  o.Run,
+		Use:     "record",
+		Short:   "Record latest state of a Git reference in the RSL",
+		Args:    cobra.ExactArgs(1),
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -48,10 +48,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "add-policy-key",
-		Short: "Add Policy key to gittuf root of trust",
-		Long:  `This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		RunE:  o.Run,
+		Use:     "add-policy-key",
+		Short:   "Add Policy key to gittuf root of trust",
+		Long:    `This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk using the custom securesystemslib format, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -5,6 +5,7 @@ package init
 import (
 	"os"
 
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
@@ -33,9 +34,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize gittuf root of trust for repository",
-		RunE:  o.Run,
+		Use:     "init",
+		Short:   "Initialize gittuf root of trust for repository",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
@@ -43,9 +44,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "remove-policy-key",
-		Short: "Remove Policy key from gittuf root of trust",
-		RunE:  o.Run,
+		Use:     "remove-policy-key",
+		Short:   "Remove Policy key from gittuf root of trust",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)
 


### PR DESCRIPTION
This PR addresses #147 where we'd like to ensure that we can sign git commits before we touch anything in the repository. 

With this change, invoking `gittuf rsl record` will cause gittuf to check that a signing key is specified and usable before continuing. For now, only `record.go` is modified - we can move this up to `rsl.go` if we want all rsl commands to inherit this check, as well as add this check to other commands if need be.