### PR TITLE
Restrict push workflows to main to prevent double running CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: test
 on:
   push:
+    branches: ['main']
     paths-ignore:
       - "docs/*"
   pull_request:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
 name: golangci-lint
 on:
   push:
+    branches: ['main']
     paths-ignore:
       - "docs/*"
   pull_request:


### PR DESCRIPTION
This can happen commonly for dependabot and other PRs that are opened from inside the same repo.