### PR TITLE
Update license header

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2022 New York University
+Copyright 2023 gittuf a Series of LF Projects, LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Per #128, this PR updates the license file's header. The same header is used in the gittuf GitHub Action (https://github.com/gittuf/gittuf-installer/blob/main/LICENSE).