### PR TITLE
policy: Account for non Git signing keys in verify

### DIFF
--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -213,8 +213,8 @@ func VerifyCommit(ctx context.Context, repo *git.Repository, ids ...string) map[
 			}
 
 			if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
-				// We encounter this for key types that can be used for metadata
-				// but not Git objects
+				// We encounter this for key types that can be used for gittuf
+				// policy metadata but not Git objects
 				continue
 			}
 
@@ -375,6 +375,11 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 			gitNamespaceVerified = true
 			break
 		}
+		if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+			// We encounter this for key types that can be used for gittuf
+			// policy metadata but not Git objects
+			continue
+		}
 		if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
 			// Unexpected error
 			return err
@@ -458,6 +463,11 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 					verifiedKeyID = key.KeyID
 					break
 				}
+				if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+					// We encounter this for key types that can be used for
+					// gittuf policy metadata but not Git objects
+					continue
+				}
 				if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
 					// Unexpected error
 					return err
@@ -527,6 +537,8 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 			break
 		}
 		if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+			// We encounter this for key types that can be used for gittuf
+			// policy metadata but not Git objects
 			continue
 		}
 		if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
@@ -561,6 +573,8 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 			break
 		}
 		if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+			// We encounter this for key types that can be used for gittuf
+			// policy metadata but not Git objects
 			continue
 		}
 		if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {


### PR DESCRIPTION
This PR adds a check for cases where a key is technically trusted to sign for some namespace but it can only be used with gittuf policies, not Git objects. We have this check elsewhere.

Long term, this check can be pulled out because the signing method aligns with SSH keys. So I suggest we add this check in now and strip them out when we have support for Git <-> SSH keys.