### PR TITLE
Check that the tip of a ref matches latest corresponding RSL entry

### DIFF
--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -43,44 +43,46 @@ var (
 )
 
 // VerifyRef verifies the signature on the latest RSL entry for the target ref
-// using the latest policy.
-func VerifyRef(ctx context.Context, repo *git.Repository, target string) error {
+// using the latest policy. The expected Git ID for the ref in the latest RSL
+// entry is returned if the policy verification is successful.
+func VerifyRef(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
 	// 1. Get latest policy entry
 	policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
 	if err != nil {
-		return err
+		return plumbing.ZeroHash, err
 	}
 	policyState, err := LoadStateForEntry(ctx, repo, policyEntry)
 	if err != nil {
-		return err
+		return plumbing.ZeroHash, err
 	}
 
 	// 2. Find latest entry for target
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
 	if err != nil {
-		return err
+		return plumbing.ZeroHash, err
 	}
 
-	return verifyEntry(ctx, repo, policyState, latestEntry)
+	return latestEntry.TargetID, verifyEntry(ctx, repo, policyState, latestEntry)
 }
 
 // VerifyRefFull verifies the entire RSL for the target ref from the first
-// entry.
-func VerifyRefFull(ctx context.Context, repo *git.Repository, target string) error {
+// entry. The expected Git ID for the ref in the latest RSL entry is returned if
+// the policy verification is successful.
+func VerifyRefFull(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
 	// 1. Trace RSL back to the start
 	firstEntry, _, err := rsl.GetFirstEntry(repo)
 	if err != nil {
-		return err
+		return plumbing.ZeroHash, err
 	}
 
 	// 2. Find latest entry for target
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
 	if err != nil {
-		return err
+		return plumbing.ZeroHash, err
 	}
 
 	// 3. Do a relative verify from start entry to the latest entry (firstEntry here == policyEntry)
-	return VerifyRelativeForRef(ctx, repo, firstEntry, firstEntry, latestEntry, target)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, firstEntry, latestEntry, target)
 }
 
 // VerifyRelativeForRef verifies the RSL between specified start and end entries

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -63,8 +63,9 @@ func TestVerifyRef(t *testing.T) {
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyName)
 
-	err := VerifyRef(context.Background(), repo, refName)
+	currentTip, err := VerifyRef(context.Background(), repo, refName)
 	assert.Nil(t, err)
+	assert.Equal(t, commitIDs[0], currentTip)
 }
 
 func TestVerifyRefFull(t *testing.T) {
@@ -83,8 +84,9 @@ func TestVerifyRefFull(t *testing.T) {
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyName)
 
-	err := VerifyRefFull(context.Background(), repo, refName)
+	currentTip, err := VerifyRefFull(context.Background(), repo, refName)
 	assert.Nil(t, err)
+	assert.Equal(t, commitIDs[0], currentTip)
 }
 
 func TestVerifyRelativeForRef(t *testing.T) {

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -4,22 +4,43 @@ package repository
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
+// ErrRefStateDoesNotMatchRSL is returned when a Git reference being verified
+// does not have the same tip as identified in the latest RSL entry for the
+// reference. This can happen for a number of reasons such as incorrectly
+// modifying reference state away from what's recorded in the RSL to not
+// creating an RSL entry for some new changes. Depending on the context, one
+// resolution is to update the reference state to match the RSL entry, while
+// another is to create a new RSL entry for the current state.
+var ErrRefStateDoesNotMatchRSL = errors.New("Git reference's current state does not match latest RSL entry") //nolint:stylecheck
+
 func (r *Repository) VerifyRef(ctx context.Context, target string, full bool) error {
-	target, err := gitinterface.AbsoluteReference(r.r, target)
+	var (
+		expectedTip plumbing.Hash
+		err         error
+	)
+
+	target, err = gitinterface.AbsoluteReference(r.r, target)
 	if err != nil {
 		return err
 	}
 
 	if full {
-		return policy.VerifyRefFull(ctx, r.r, target)
+		expectedTip, err = policy.VerifyRefFull(ctx, r.r, target)
+	} else {
+		expectedTip, err = policy.VerifyRef(ctx, r.r, target)
+	}
+	if err != nil {
+		return err
 	}
 
-	return policy.VerifyRef(ctx, r.r, target)
+	return r.verifyRefTip(target, expectedTip)
 }
 
 func (r *Repository) VerifyCommit(ctx context.Context, ids ...string) map[string]string {
@@ -28,4 +49,17 @@ func (r *Repository) VerifyCommit(ctx context.Context, ids ...string) map[string
 
 func (r *Repository) VerifyTag(ctx context.Context, ids []string) map[string]string {
 	return policy.VerifyTag(ctx, r.r, ids)
+}
+
+func (r *Repository) verifyRefTip(target string, expectedTip plumbing.Hash) error {
+	ref, err := r.r.Reference(plumbing.ReferenceName(target), true)
+	if err != nil {
+		return err
+	}
+
+	if ref.Hash() != expectedTip {
+		return ErrRefStateDoesNotMatchRSL
+	}
+
+	return nil
 }

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -64,4 +64,11 @@ func TestVerifyRef(t *testing.T) {
 			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
 		}
 	}
+
+	// Add another commit
+	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyName)
+	err := repo.VerifyRef(context.Background(), refName, true)
+	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
+	err = repo.VerifyRef(context.Background(), refName, false)
+	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
 }


### PR DESCRIPTION
This updates the repository package to check that the current state of the tested ref matches the latest RSL entry.