### PR TITLE
repository: Fix clone not handling trailing slashes in repository path.

### DIFF
--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -26,7 +26,10 @@ var (
 func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Repository, error) {
 	if dir == "" {
 		// FIXME: my understanding is backslashes are not used in URLs but I haven't dived into the RFCs to check yet
-		split := strings.Split(strings.TrimSpace(strings.ReplaceAll(remoteURL, "\\", "/")), "/")
+		modifiedURL := strings.ReplaceAll(remoteURL, "\\", "/")
+		modifiedURL = strings.TrimRight(strings.TrimSpace(modifiedURL), "/") // Trim spaces and trailing slashes if any
+
+		split := strings.Split(modifiedURL, "/")
 		dir = strings.TrimSuffix(split[len(split)-1], ".git")
 	}
 	_, err := os.Stat(dir)

--- a/internal/repository/sync_test.go
+++ b/internal/repository/sync_test.go
@@ -202,4 +202,32 @@ func TestClone(t *testing.T) {
 		_, err = Clone(context.Background(), remoteTmpDir, dirName, "")
 		assert.ErrorIs(t, err, ErrDirExists)
 	})
+
+	t.Run("successful clone without specifying dir, with trailing slashes in repository path", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(context.Background(), remoteTmpDir+"//", "", "")
+		assert.Nil(t, err)
+		head, err := repo.r.Head()
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, head.Hash())
+
+		localRSLRef, err := repo.r.Reference(plumbing.ReferenceName(rsl.Ref), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remoteRSLRef.Hash(), localRSLRef.Hash())
+		localPolicyRef, err := repo.r.Reference(plumbing.ReferenceName(policy.PolicyRef), true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, remotePolicyRef.Hash(), localPolicyRef.Hash())
+	})
 }


### PR DESCRIPTION
Addresses #202 