### PR TITLE
Added flag to VerifyCommit for extra verification

### DIFF
--- a/docs/cli/gittuf_verify-commit.md
+++ b/docs/cli/gittuf_verify-commit.md
@@ -9,7 +9,8 @@ gittuf verify-commit [flags]
 ### Options
 
 ```
-  -h, --help   help for verify-commit
+  -a, --apply-file-policies   check if the file paths modified by the commit are allowed by the policy
+  -h, --help                  help for verify-commit
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/verifycommit/verifycommit.go
+++ b/internal/cmd/verifycommit/verifycommit.go
@@ -9,9 +9,19 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	applyFilePolicies bool
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(
+		&o.applyFilePolicies,
+		"apply-file-policies",
+		"a",
+		false,
+		"check if the file paths modified by the commit are allowed by the policy",
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()
@@ -19,7 +29,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	status := repo.VerifyCommit(cmd.Context(), args...)
+	status := repo.VerifyCommit(cmd.Context(), o.applyFilePolicies, args...)
 
 	for _, id := range args {
 		fmt.Printf("%s: %s\n", id, status[id])

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -1025,14 +1025,14 @@ func checkCommitAgainstModifiedPaths(ctx context.Context, repo *git.Repository, 
 
 		for _, verifier := range verifiers {
 			err := verifier.Verify(ctx, commit, referenceAttesation)
-			if err == nil {
+			switch {
+			case err == nil:
 				goodKey = true
-				break
-			} else if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+			case errors.Is(err, gitinterface.ErrUnknownSigningMethod):
 				// We encounter this for key types that can be used for gittuf
 				// policy metadata but not Git objects
 				continue
-			} else if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
+			case !errors.Is(err, gitinterface.ErrIncorrectVerificationKey):
 				// Unexpected error
 				break
 			}

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -73,9 +73,9 @@ func (r *Repository) VerifyRefFromEntry(ctx context.Context, target, entryID str
 	return r.verifyRefTip(target, expectedTip)
 }
 
-func (r *Repository) VerifyCommit(ctx context.Context, ids ...string) map[string]string {
+func (r *Repository) VerifyCommit(ctx context.Context, applyFilePolicies bool, ids ...string) map[string]string {
 	slog.Debug("Verifying commit signature...")
-	return policy.VerifyCommit(ctx, r.r, ids...)
+	return policy.VerifyCommit(ctx, r.r, applyFilePolicies, ids...)
 }
 
 func (r *Repository) VerifyTag(ctx context.Context, ids []string) map[string]string {


### PR DESCRIPTION
- Added flag to VerifyCommit so that it can check if a given commit is allowed to modify the files it is modifying.
- Solves issue #121 

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>