### PR TITLE
Refactor state.Verify() to avoid promiscuous delegations

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -413,6 +413,11 @@ func (s *State) FindVerifiersForPath(ctx context.Context, path string) ([]*Verif
 				verifiers = append(verifiers, verifier)
 
 				if s.HasTargetsRole(delegation.Name) {
+					env := s.DelegationEnvelopes[delegation.Name]
+					if err := verifier.Verify(ctx, nil, env); err != nil {
+						return nil, err
+					}
+
 					delegatedMetadata, err := s.GetTargetsMetadata(delegation.Name)
 					if err != nil {
 						return nil, err

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -314,6 +314,8 @@ func (s *State) FindAuthorizedSigningKeyIDs(ctx context.Context, roleName string
 
 // FindPublicKeysForPath identifies the trusted keys for the path. If the path
 // protected in gittuf policy, the trusted keys are returned.
+//
+// Deprecated: use FindVerifiersForPath.
 func (s *State) FindPublicKeysForPath(ctx context.Context, path string) ([]*tuf.Key, error) {
 	if err := s.Verify(ctx); err != nil {
 		return nil, err
@@ -365,11 +367,15 @@ func (s *State) FindPublicKeysForPath(ctx context.Context, path string) ([]*tuf.
 	}
 }
 
+// FindVerifiersForPath identifies the trusted set of verifiers for the
+// specified path. While walking the delegation graph for the path, signatures
+// for delegated metadata files are verified using the verifier context.
 func (s *State) FindVerifiersForPath(ctx context.Context, path string) ([]*Verifier, error) {
 	if err := s.Verify(ctx); err != nil {
 		return nil, err
 	}
 
+	// TODO: verify root from original state
 	rootVerifier := s.getRootVerifier()
 	if err := rootVerifier.Verify(ctx, nil, s.RootEnvelope); err != nil {
 		return nil, err

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -145,23 +145,33 @@ func TestStateKeys(t *testing.T) {
 }
 
 func TestStateVerify(t *testing.T) {
-	state := createTestStateWithOnlyRoot(t)
+	t.Run("only root", func(t *testing.T) {
+		state := createTestStateWithOnlyRoot(t)
 
-	if err := state.Verify(context.Background()); err != nil {
-		t.Error(err)
-	}
+		if err := state.Verify(testCtx); err != nil {
+			t.Error(err)
+		}
 
-	rootKeys := []*tuf.Key{}
-	copy(rootKeys, state.RootPublicKeys)
-	state.RootPublicKeys = []*tuf.Key{}
+		rootKeys := []*tuf.Key{}
+		copy(rootKeys, state.RootPublicKeys)
+		state.RootPublicKeys = []*tuf.Key{}
 
-	err := state.Verify(context.Background())
-	assert.NotNil(t, err)
+		err := state.Verify(context.Background())
+		assert.NotNil(t, err)
 
-	state.RootPublicKeys = rootKeys
-	state.RootEnvelope.Signatures = []sslibdsse.Signature{}
-	err = state.Verify(context.Background())
-	assert.NotNil(t, err)
+		state.RootPublicKeys = rootKeys
+		state.RootEnvelope.Signatures = []sslibdsse.Signature{}
+		err = state.Verify(context.Background())
+		assert.NotNil(t, err)
+	})
+
+	t.Run("with policy", func(t *testing.T) {
+		state := createTestStateWithPolicy(t)
+
+		if err := state.Verify(testCtx); err != nil {
+			t.Error(err)
+		}
+	})
 }
 
 func TestStateCommit(t *testing.T) {

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -770,9 +770,9 @@ func (v *Verifier) Verify(ctx context.Context, gitObject object.Object, attestat
 	}
 
 	if attestation != nil {
-		// combining the attestation and the git object we still do not have
-		// sufficient signatures
 		if (1 + len(attestation.Signatures)) < v.threshold {
+			// Combining the attestation and the git object we still do not have
+			// sufficient signatures
 			return ErrVerifierConditionsUnmet
 		}
 	}
@@ -832,6 +832,8 @@ func (v *Verifier) Verify(ctx context.Context, gitObject object.Object, attestat
 	verifiers := make([]sslibdsse.Verifier, 0, len(v.keys)-1)
 	for _, key := range v.keys {
 		if key.KeyID == keyIDUsed {
+			// Do not create a DSSE verifier for the key used to verify the Git
+			// signature
 			continue
 		}
 

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -20,10 +20,6 @@ func (r *Repository) InitializeTargets(ctx context.Context, targetsKeyBytes []by
 	if err != nil {
 		return err
 	}
-	keyID, err := sv.KeyID()
-	if err != nil {
-		return err
-	}
 
 	state, err := policy.LoadCurrentState(ctx, r.r)
 	if err != nil {
@@ -33,15 +29,12 @@ func (r *Repository) InitializeTargets(ctx context.Context, targetsKeyBytes []by
 		return ErrCannotReinitialize
 	}
 
-	// Verify if targetsKeyBytes is authorized to sign for the role
-	authorizedKeyIDs, err := state.FindAuthorizedSigningKeyIDs(ctx, targetsRoleName)
-	if err != nil {
-		return err
-	}
-
-	if !isKeyAuthorized(authorizedKeyIDs, keyID) {
-		return ErrUnauthorizedKey
-	}
+	// TODO: verify is role can be signed using the presented key. This requires
+	// the user to pass in the delegating role as well as we do not want to
+	// assume which role is the delegating role (diamond delegations are legal).
+	// See: https://github.com/theupdateframework/specification/issues/19,
+	// https://github.com/theupdateframework/specification/issues/214, and
+	// https://github.com/theupdateframework/python-tuf/issues/660.
 
 	targetsMetadata := policy.InitializeTargetsMetadata()
 
@@ -76,10 +69,6 @@ func (r *Repository) AddDelegation(ctx context.Context, signingKeyBytes []byte, 
 	if err != nil {
 		return err
 	}
-	keyID, err := sv.KeyID()
-	if err != nil {
-		return err
-	}
 
 	state, err := policy.LoadCurrentState(ctx, r.r)
 	if err != nil {
@@ -89,13 +78,12 @@ func (r *Repository) AddDelegation(ctx context.Context, signingKeyBytes []byte, 
 		return policy.ErrMetadataNotFound
 	}
 
-	authorizedKeyIDsForRole, err := state.FindAuthorizedSigningKeyIDs(ctx, targetsRoleName)
-	if err != nil {
-		return err
-	}
-	if !isKeyAuthorized(authorizedKeyIDsForRole, keyID) {
-		return ErrUnauthorizedKey
-	}
+	// TODO: verify is role can be signed using the presented key. This requires
+	// the user to pass in the delegating role as well as we do not want to
+	// assume which role is the delegating role (diamond delegations are legal).
+	// See: https://github.com/theupdateframework/specification/issues/19,
+	// https://github.com/theupdateframework/specification/issues/214, and
+	// https://github.com/theupdateframework/python-tuf/issues/660.
 
 	authorizedKeys := []*tuf.Key{}
 	for _, kb := range authorizedKeysBytes {
@@ -147,10 +135,6 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signingKeyBytes []byt
 	if err != nil {
 		return err
 	}
-	keyID, err := sv.KeyID()
-	if err != nil {
-		return err
-	}
 
 	state, err := policy.LoadCurrentState(ctx, r.r)
 	if err != nil {
@@ -160,13 +144,12 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signingKeyBytes []byt
 		return policy.ErrMetadataNotFound
 	}
 
-	authorizedKeyIDsForRole, err := state.FindAuthorizedSigningKeyIDs(ctx, targetsRoleName)
-	if err != nil {
-		return err
-	}
-	if !isKeyAuthorized(authorizedKeyIDsForRole, keyID) {
-		return ErrUnauthorizedKey
-	}
+	// TODO: verify is role can be signed using the presented key. This requires
+	// the user to pass in the delegating role as well as we do not want to
+	// assume which role is the delegating role (diamond delegations are legal).
+	// See: https://github.com/theupdateframework/specification/issues/19,
+	// https://github.com/theupdateframework/specification/issues/214, and
+	// https://github.com/theupdateframework/python-tuf/issues/660.
 
 	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
 	if err != nil {
@@ -208,10 +191,6 @@ func (r *Repository) AddKeyToTargets(ctx context.Context, signingKeyBytes []byte
 	if err != nil {
 		return err
 	}
-	keyID, err := sv.KeyID()
-	if err != nil {
-		return err
-	}
 
 	state, err := policy.LoadCurrentState(ctx, r.r)
 	if err != nil {
@@ -221,13 +200,12 @@ func (r *Repository) AddKeyToTargets(ctx context.Context, signingKeyBytes []byte
 		return policy.ErrMetadataNotFound
 	}
 
-	authorizedKeyIDsForRole, err := state.FindAuthorizedSigningKeyIDs(ctx, targetsRoleName)
-	if err != nil {
-		return err
-	}
-	if !isKeyAuthorized(authorizedKeyIDsForRole, keyID) {
-		return ErrUnauthorizedKey
-	}
+	// TODO: verify is role can be signed using the presented key. This requires
+	// the user to pass in the delegating role as well as we do not want to
+	// assume which role is the delegating role (diamond delegations are legal).
+	// See: https://github.com/theupdateframework/specification/issues/19,
+	// https://github.com/theupdateframework/specification/issues/214, and
+	// https://github.com/theupdateframework/python-tuf/issues/660.
 
 	authorizedKeys := []*tuf.Key{}
 	keyIDs := ""

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -32,9 +32,7 @@ func (r *Repository) InitializeTargets(ctx context.Context, targetsKeyBytes []by
 	// TODO: verify is role can be signed using the presented key. This requires
 	// the user to pass in the delegating role as well as we do not want to
 	// assume which role is the delegating role (diamond delegations are legal).
-	// See: https://github.com/theupdateframework/specification/issues/19,
-	// https://github.com/theupdateframework/specification/issues/214, and
-	// https://github.com/theupdateframework/python-tuf/issues/660.
+	// See: https://github.com/gittuf/gittuf/issues/246.
 
 	targetsMetadata := policy.InitializeTargetsMetadata()
 
@@ -81,9 +79,7 @@ func (r *Repository) AddDelegation(ctx context.Context, signingKeyBytes []byte, 
 	// TODO: verify is role can be signed using the presented key. This requires
 	// the user to pass in the delegating role as well as we do not want to
 	// assume which role is the delegating role (diamond delegations are legal).
-	// See: https://github.com/theupdateframework/specification/issues/19,
-	// https://github.com/theupdateframework/specification/issues/214, and
-	// https://github.com/theupdateframework/python-tuf/issues/660.
+	// See: https://github.com/gittuf/gittuf/issues/246.
 
 	authorizedKeys := []*tuf.Key{}
 	for _, kb := range authorizedKeysBytes {
@@ -147,9 +143,7 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signingKeyBytes []byt
 	// TODO: verify is role can be signed using the presented key. This requires
 	// the user to pass in the delegating role as well as we do not want to
 	// assume which role is the delegating role (diamond delegations are legal).
-	// See: https://github.com/theupdateframework/specification/issues/19,
-	// https://github.com/theupdateframework/specification/issues/214, and
-	// https://github.com/theupdateframework/python-tuf/issues/660.
+	// See: https://github.com/gittuf/gittuf/issues/246.
 
 	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
 	if err != nil {
@@ -203,9 +197,7 @@ func (r *Repository) AddKeyToTargets(ctx context.Context, signingKeyBytes []byte
 	// TODO: verify is role can be signed using the presented key. This requires
 	// the user to pass in the delegating role as well as we do not want to
 	// assume which role is the delegating role (diamond delegations are legal).
-	// See: https://github.com/theupdateframework/specification/issues/19,
-	// https://github.com/theupdateframework/specification/issues/214, and
-	// https://github.com/theupdateframework/python-tuf/issues/660.
+	// See: https://github.com/gittuf/gittuf/issues/246.
 
 	authorizedKeys := []*tuf.Key{}
 	keyIDs := ""


### PR DESCRIPTION
Prior to this PR, gittuf performed self-contained verification for each policy state. The idea was to validate all metadata in the policy state was signed by the right keys etc. Unfortunately, this doesn't work well because the exact delegating role to use is unclear as multiple roles can delegate to the same role with different keys + threshold requirements. This can only be reconciled when verifying for a specific path / namespace, which the self contained verification does not have. This has been previously encountered in TUF (https://github.com/theupdateframework/specification/issues/19, https://github.com/theupdateframework/specification/issues/214, https://github.com/theupdateframework/python-tuf/issues/660) and this PR modifies `state.Verify` in gittuf to avoid the issue.