### PR TITLE
Added add and remove root keys to cmd

### DIFF
--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package addrootkey
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p          *persistent.Options
+	newRootKey string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.newRootKey,
+		"root-key",
+		"",
+		"root key to add to root of trust",
+	)
+	cmd.MarkFlagRequired("root-key") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	rootKeyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	newRootKeyBytes, err := common.ReadKeyBytes(o.newRootKey)
+	if err != nil {
+		return err
+	}
+
+	return repo.AddRootKey(cmd.Context(), rootKeyBytes, newRootKeyBytes, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:     "add-root-key",
+		Short:   "Add Root key to gittuf root of trust",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/removerootkey/removerootkey.go
+++ b/internal/cmd/trust/removerootkey/removerootkey.go
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package removerootkey
+
+import (
+	"os"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p         *persistent.Options
+	rootKeyID string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.rootKeyID,
+		"root-key-ID",
+		"",
+		"ID of Root key to be removed from root of trust",
+	)
+	cmd.MarkFlagRequired("root-key-ID") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	rootKeyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	return repo.RemoveRootKey(cmd.Context(), rootKeyBytes, strings.ToLower(o.rootKeyID), true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:     "remove-root-key",
+		Short:   "Remove Root key from gittuf root of trust",
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -4,9 +4,11 @@ package trust
 
 import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpolicykey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/addrootkey"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removepolicykey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/removerootkey"
 	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +23,9 @@ func New() *cobra.Command {
 
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(addpolicykey.New(o))
+	cmd.AddCommand(addrootkey.New(o))
 	cmd.AddCommand(removepolicykey.New(o))
+	cmd.AddCommand(removerootkey.New(o))
 
 	remoteCmd := remote.New()
 	cmd.AddCommand(remoteCmd)

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
+	"github.com/go-git/go-billy/v5/memfs"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/memory"
+)
+
+//go:embed test-data/gpg-pubkey.asc
+var gpgPubKeyBytes []byte
+
+//go:embed test-data/gpg-privkey.asc
+var gpgKeyBytes []byte
+
+//go:embed test-data/root
+var rootKeyBytes []byte
+
+//go:embed test-data/targets
+var targetsKeyBytes []byte
+
+//go:embed test-data/targets.pub
+var targetsPubKeyBytes []byte
+
+var testCtx = context.Background()
+
+func createTestRepositoryWithRoot(t *testing.T, location string) (*Repository, []byte) {
+	t.Helper()
+
+	var (
+		repo *git.Repository
+		err  error
+	)
+	if location == "" {
+		repo, err = git.Init(memory.NewStorage(), memfs.New())
+	} else {
+		repo, err = git.PlainInit(location, true)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := &Repository{r: repo}
+
+	if err := r.InitializeRoot(testCtx, rootKeyBytes, false); err != nil {
+		t.Fatal(err)
+	}
+
+	return r, rootKeyBytes
+}
+
+func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
+	t.Helper()
+
+	r, keyBytes := createTestRepositoryWithRoot(t, location)
+
+	if err := r.AddTopLevelTargetsKey(testCtx, keyBytes, targetsPubKeyBytes, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.InitializeTargets(testCtx, targetsKeyBytes, policy.TargetsRoleName, false); err != nil {
+		t.Fatal(err)
+	}
+
+	gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kb, err := json.Marshal(gpgKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorizedKeys := [][]byte{kb}
+
+	if err := r.AddDelegation(testCtx, targetsKeyBytes, policy.TargetsRoleName, "protect-main", authorizedKeys, []string{"git:refs/heads/main"}, false); err != nil {
+		t.Fatal(err)
+	}
+
+	return r
+}
+
+func createTestRepositoryWithTargets(t *testing.T) (*Repository, []byte) {
+	t.Helper()
+
+	r, rootKeyBytes := createTestRepositoryWithRoot(t, "")
+
+	if err := r.AddTopLevelTargetsKey(testCtx, rootKeyBytes, targetsKeyBytes, false); err != nil {
+		t.Fatal(err)
+	}
+
+	err := r.InitializeTargets(testCtx, targetsKeyBytes, policy.TargetsRoleName, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return r, targetsKeyBytes
+}

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -4,8 +4,6 @@ package repository
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/policy"
@@ -13,6 +11,7 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	sslibsignerverifier "github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,6 +38,105 @@ func TestInitializeRoot(t *testing.T) {
 	assert.Equal(t, key.KeyID, rootMetadata.Roles[policy.RootRoleName].KeyIDs[0])
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
 
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
+	assert.Nil(t, err)
+}
+
+func TestAddRootKey(t *testing.T) {
+	r, keyBytes := createTestRepositoryWithRoot(t, "")
+
+	key, err := tuf.LoadKeyFromBytes(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var newRootKey *sslibsignerverifier.SSLibKey
+
+	newRootKey, err = tuf.LoadKeyFromBytes(targetsKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r.AddRootKey(context.Background(), keyBytes, targetsKeyBytes, false)
+	assert.Nil(t, err)
+
+	state, err := policy.LoadCurrentState(context.Background(), r.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata, err := state.GetRootMetadata()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, rootMetadata.Version)
+	assert.Equal(t, []string{key.KeyID, newRootKey.KeyID}, rootMetadata.Roles[policy.RootRoleName].KeyIDs)
+	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
+
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
+	assert.Nil(t, err)
+}
+
+func TestRemoveRootKey(t *testing.T) {
+	r, keyBytes := createTestRepositoryWithRoot(t, "")
+
+	rootKey, err := tuf.LoadKeyFromBytes(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sv, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(keyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r.AddRootKey(context.Background(), keyBytes, keyBytes, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newRootKey, err := tuf.LoadKeyFromBytes(targetsKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = r.AddRootKey(context.Background(), keyBytes, targetsKeyBytes, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := policy.LoadCurrentState(context.Background(), r.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata, err := state.GetRootMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 3, rootMetadata.Version)
+	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, rootKey.KeyID)
+	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, newRootKey.KeyID)
+	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
+	assert.Nil(t, err)
+
+	err = r.RemoveRootKey(context.Background(), keyBytes, rootKey.KeyID, false)
+	assert.Nil(t, err)
+
+	state, err = policy.LoadCurrentState(context.Background(), r.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata, err = state.GetRootMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 4, rootMetadata.Version)
+	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, newRootKey.KeyID)
 	err = dsse.VerifyEnvelope(context.Background(), state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 }
@@ -87,11 +185,6 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 	}
 
 	err = r.AddTopLevelTargetsKey(context.Background(), keyBytes, keyBytes, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	targetsKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets.pub"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repository/sync_test.go
+++ b/internal/repository/sync_test.go
@@ -5,7 +5,6 @@ package repository
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/gitinterface"
@@ -24,18 +23,6 @@ func TestClone(t *testing.T) {
 		t.Fatal(err)
 	}
 	remoteRepo := &Repository{r: remoteR}
-	rootKeyBytes, err := os.ReadFile(filepath.Join("test-data", "root"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	targetsPubKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets.pub"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	targetsKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets"))
-	if err != nil {
-		t.Fatal(err)
-	}
 	if err := remoteRepo.InitializeRoot(context.Background(), rootKeyBytes, false); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/policy"
@@ -15,9 +13,6 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/stretchr/testify/assert"
 )
-
-//go:embed test-data/gpg-pubkey.asc
-var gpgPubKeyBytes []byte
 
 func TestInitializeTargets(t *testing.T) {
 	// The helper also runs InitializeTargets for this test
@@ -160,26 +155,4 @@ func TestAddKeyToTargets(t *testing.T) {
 	targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(targetsMetadata.Delegations.Keys))
-}
-
-func createTestRepositoryWithTargets(t *testing.T) (*Repository, []byte) {
-	t.Helper()
-
-	r, rootKeyBytes := createTestRepositoryWithRoot(t, "")
-
-	targetsKeyBytes, err := os.ReadFile(filepath.Join("test-data", "targets"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := r.AddTopLevelTargetsKey(context.Background(), rootKeyBytes, targetsKeyBytes, false); err != nil {
-		t.Fatal(err)
-	}
-
-	err = r.InitializeTargets(context.Background(), targetsKeyBytes, policy.TargetsRoleName, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return r, targetsKeyBytes
 }


### PR DESCRIPTION
- Added functionality to cmd to add and remove root keys from, which needs a key already in the root to allow adding or removing keys from the root.
- Partially fixes issue https://github.com/gittuf/gittuf/issues/117