### PR TITLE
implement gittuf add-hooks to configure pre-push hook

### DIFF
--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package addhooks
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	force bool
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVarP(
+		&o.force,
+		"force",
+		"f",
+		false,
+		"Overwrite hooks, if they already exist",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	err = repo.UpdateHook(repository.HookPrePush, prePushScript, o.force)
+	var hookErr *repository.ErrHookExists
+	if errors.As(err, &hookErr) {
+		fmt.Fprintf(
+			cmd.ErrOrStderr(),
+			"'%s' already exists. Use --force flag or merge existing hook and the following script manually:\n\n%s\n",
+			string(hookErr.HookType),
+			prePushScript,
+		)
+	}
+	return err
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "add-hooks",
+		Short: "Add git hooks that automatically create and sync RSL.",
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -20,7 +20,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"force",
 		"f",
 		false,
-		"Overwrite hooks, if they already exist",
+		"overwrite hooks, if they already exist",
 	)
 }
 

--- a/internal/cmd/addhooks/prepush.go
+++ b/internal/cmd/addhooks/prepush.go
@@ -1,0 +1,22 @@
+package addhooks
+
+var prePushScript = []byte(`#!/bin/sh
+set -e
+
+remote="$1"
+url="$2"
+
+if ! command -v gittuf > /dev/null
+then
+    echo "gittuf could not be found"
+    echo "Download from: https://github.com/gittuf/gittuf/releases/latest"
+    exit 1
+fi
+
+echo "Pulling RSL from ${remote}."
+gittuf rsl remote pull ${remote}
+echo "Creating new RSL record for HEAD."
+gittuf rsl record HEAD
+echo "Pushing RSL to ${remote}."
+gittuf rsl remote push ${remote}
+`)

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -17,7 +17,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"branch",
 		"b",
 		"",
-		"Specify branch to check out",
+		"specify branch to check out",
 	)
 }
 

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/gittuf/gittuf/internal/cmd/addhooks"
 	"github.com/gittuf/gittuf/internal/cmd/clone"
 	"github.com/gittuf/gittuf/internal/cmd/policy"
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
@@ -44,6 +45,7 @@ func New() *cobra.Command {
 
 	o.AddFlags(cmd)
 
+	cmd.AddCommand(addhooks.New())
 	cmd.AddCommand(clone.New())
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())

--- a/internal/repository/hook.go
+++ b/internal/repository/hook.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+)
+
+type ErrHookExists struct {
+	HookType HookType
+}
+
+func (e *ErrHookExists) Error() string {
+	return fmt.Sprintf("hook '%s' already exists", e.HookType)
+}
+
+type HookType string
+
+var HookPrePush = HookType("pre-push")
+
+// UpdateHook updates a git hook in the repositorie's .git/hooks folder.
+// Existing hook files are not overwritten, unless force flag is set.
+func (r *Repository) UpdateHook(hookType HookType, content []byte, force bool) error {
+	// TODO: rely on go-git to find .git folder, once
+	// https://github.com/go-git/go-git/issues/977 is available.
+	// Note, until then gittuf does not support separate git dir.
+	tree, err := r.r.Worktree()
+	if err != nil {
+		return fmt.Errorf("reading worktree: %w", err)
+	}
+	if tree == nil {
+		return fmt.Errorf("worktree is nil, can't update hooks")
+	}
+	repoRoot := tree.Filesystem.Root()
+	hookFolder := path.Join(repoRoot, ".git", "hooks")
+	if err := os.MkdirAll(hookFolder, 0o750); err != nil {
+		return fmt.Errorf("making sure folder exist: %w", err)
+	}
+
+	hookFile := path.Join(hookFolder, string(hookType))
+	hookExists, err := doesFileExist(hookFile)
+	if err != nil {
+		return fmt.Errorf("checking if hookFile '%s' exists: %w", hookFile, err)
+	}
+
+	if hookExists && !force {
+		return &ErrHookExists{
+			HookType: hookType,
+		}
+	}
+
+	if err := os.WriteFile(hookFile, content, 0o700); err != nil { // nolint:gosec
+		return fmt.Errorf("writing %s hook: %w", hookType, err)
+	}
+	return nil
+}
+
+func doesFileExist(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}

--- a/internal/repository/hook_test.go
+++ b/internal/repository/hook_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package repository
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdatePrePushHook(t *testing.T) {
+	t.Run("write hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		repo, err := git.PlainInit(tmpDir, false)
+		require.NoError(t, err)
+		r := &Repository{r: repo}
+
+		err = r.UpdateHook(HookPrePush, []byte("some content"), false)
+		require.NoError(t, err)
+
+		hookFile := path.Join(tmpDir, ".git", "hooks", "pre-push")
+		prepushScript, err := os.ReadFile(hookFile)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("some content"), prepushScript)
+	})
+
+	t.Run("hook exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		repo, err := git.PlainInit(tmpDir, false)
+		require.NoError(t, err)
+		r := &Repository{r: repo}
+
+		hookDir := path.Join(tmpDir, ".git", "hooks")
+		hookFile := path.Join(hookDir, "pre-push")
+		err = os.Mkdir(hookDir, 0o750)
+		require.NoError(t, err)
+		err = os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec
+		require.NoError(t, err)
+
+		err = r.UpdateHook(HookPrePush, []byte("new hook script"), false)
+		var hookErr *ErrHookExists
+		if assert.ErrorAs(t, err, &hookErr) {
+			assert.Equal(t, HookPrePush, hookErr.HookType)
+		}
+	})
+
+	t.Run("force overwrite hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		repo, err := git.PlainInit(tmpDir, false)
+		require.NoError(t, err)
+		r := &Repository{r: repo}
+
+		hookDir := path.Join(tmpDir, ".git", "hooks")
+		hookFile := path.Join(hookDir, "pre-push")
+		err = os.Mkdir(hookDir, 0o750)
+		require.NoError(t, err)
+		err = os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec
+		require.NoError(t, err)
+
+		err = r.UpdateHook(HookPrePush, []byte("new hook script"), true)
+		assert.NoError(t, err)
+
+		content, err := os.ReadFile(hookFile)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("new hook script"), content)
+	})
+}


### PR DESCRIPTION
Manage hooks as described in: #158 

Added `UpdateHook` functionality. There doesn't seem to be support for managing hooks in go-git (https://github.com/src-d/go-git/issues?q=is%3Aissue+is%3Aopen+hook) 

~~Unit test currently breaks as the `conf.Core.Worktree` value is not populated when creating a repo with `PlainInit`. Any input appreciated.~~ done

Add following tests / features before merging: 
* make sure hook is executable
* do not overwrite hook script unless force

Further considerations:
* `gittuf rsl record HEAD` should not add a record when executed multiple times. We need a new issue for this.