### PR TITLE
lint: Use latest version by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
         with:
-          version: v1.54.2
+          version: latest


### PR DESCRIPTION
This saves us the trouble of manually updating golangci-lint's version.