### PR TITLE
github: Minor issue template nits

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,5 @@
 name: Bug Report
 description: File a bug report
-title: "[Bug]: "
 labels: ["bug"]
 assignees:
   - adityasaky

--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -1,8 +1,6 @@
-name: Issue
+name: Discussion / Feature Request
 description: Open a discussion for gittuf workflows or a feature request
 labels: ["discussion"]
-assignees:
-  - adityasaky
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
In the default issue type, we currently have "Issue: Issue" because of the template's name. This one also skips auto-assigning me to the issue, which we want in bug reports for immediate triage.