### PR TITLE
*: Make full verification default in verify-ref

### DIFF
--- a/internal/cmd/verifyref/verifyref.go
+++ b/internal/cmd/verifyref/verifyref.go
@@ -8,16 +8,15 @@ import (
 )
 
 type options struct {
-	full bool
+	latestOnly bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVarP(
-		&o.full,
-		"full",
-		"f",
+	cmd.Flags().BoolVar(
+		&o.latestOnly,
+		"latest-only",
 		false,
-		"perform verification from the start of the RSL",
+		"perform verification against latest entry in the RSL",
 	)
 }
 
@@ -26,7 +25,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return repo.VerifyRef(cmd.Context(), args[0], o.full)
+	return repo.VerifyRef(cmd.Context(), args[0], o.latestOnly)
 }
 
 func New() *cobra.Command {

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -20,7 +20,7 @@ import (
 // another is to create a new RSL entry for the current state.
 var ErrRefStateDoesNotMatchRSL = errors.New("Git reference's current state does not match latest RSL entry") //nolint:stylecheck
 
-func (r *Repository) VerifyRef(ctx context.Context, target string, full bool) error {
+func (r *Repository) VerifyRef(ctx context.Context, target string, latestOnly bool) error {
 	var (
 		expectedTip plumbing.Hash
 		err         error
@@ -31,10 +31,10 @@ func (r *Repository) VerifyRef(ctx context.Context, target string, full bool) er
 		return err
 	}
 
-	if full {
-		expectedTip, err = policy.VerifyRefFull(ctx, r.r, target)
-	} else {
+	if latestOnly {
 		expectedTip, err = policy.VerifyRef(ctx, r.r, target)
+	} else {
+		expectedTip, err = policy.VerifyRefFull(ctx, r.r, target)
 	}
 	if err != nil {
 		return err

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -29,35 +29,35 @@ func TestVerifyRef(t *testing.T) {
 	entry.ID = entryID
 
 	tests := map[string]struct {
-		target string
-		full   bool
-		err    error
+		target     string
+		latestOnly bool
+		err        error
 	}{
 		"absolute ref, not full": {
-			target: "refs/heads/main",
-			full:   false,
+			target:     "refs/heads/main",
+			latestOnly: true,
 		},
 		"absolute ref, full": {
-			target: "refs/heads/main",
-			full:   true,
+			target:     "refs/heads/main",
+			latestOnly: false,
 		},
 		"relative ref, not full": {
-			target: "main",
-			full:   false,
+			target:     "main",
+			latestOnly: true,
 		},
 		"relative ref, full": {
-			target: "main",
-			full:   true,
+			target:     "main",
+			latestOnly: false,
 		},
 		"unknown ref, full": {
-			target: "refs/heads/unknown",
-			full:   true,
-			err:    rsl.ErrRSLEntryNotFound,
+			target:     "refs/heads/unknown",
+			latestOnly: false,
+			err:        rsl.ErrRSLEntryNotFound,
 		},
 	}
 
 	for name, test := range tests {
-		err := repo.VerifyRef(context.Background(), test.target, test.full)
+		err := repo.VerifyRef(context.Background(), test.target, test.latestOnly)
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {


### PR DESCRIPTION
Flips cmd flags for `gittuf verify-ref` to perform full verification by default. Until we implement #245, this is a safer default.