### PR TITLE
Removed createTestRepositoryWithTargets in favor of createTestRepositoryWithPolicy

### DIFF
--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -86,20 +86,3 @@ func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
 
 	return r
 }
-
-func createTestRepositoryWithTargets(t *testing.T) (*Repository, []byte) {
-	t.Helper()
-
-	r, rootKeyBytes := createTestRepositoryWithRoot(t, "")
-
-	if err := r.AddTopLevelTargetsKey(testCtx, rootKeyBytes, targetsKeyBytes, false); err != nil {
-		t.Fatal(err)
-	}
-
-	err := r.InitializeTargets(testCtx, targetsKeyBytes, policy.TargetsRoleName, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return r, targetsKeyBytes
-}

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -64,6 +64,7 @@ func TestAddDelegation(t *testing.T) {
 	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(targetsMetadata.Delegations.Keys))
+	assert.Equal(t, 2, len(targetsMetadata.Delegations.Roles))
 	assert.Contains(t, targetsMetadata.Delegations.Roles, policy.AllowRule())
 
 	err = r.AddDelegation(context.Background(), targetsKeyBytes, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, false)


### PR DESCRIPTION
- Removed createTestRepositoryWithTargets in favor of createTestRepositoryWithPolicy, since both have similar functions.
- With the embeded key bytes in helpers_test, we do not need the return value of createTestRepositoryWithTargets
- Addresses https://github.com/gittuf/gittuf/pull/225#discussion_r1437251654