### PR TITLE
Add support for setting and verifying threshold for rules / delegations

### DIFF
--- a/docs/cli/gittuf_policy_add-rule.md
+++ b/docs/cli/gittuf_policy_add-rule.md
@@ -18,6 +18,7 @@ gittuf policy add-rule [flags]
       --policy-name string          name of policy file to add rule to (default "targets")
       --rule-name string            name of rule
       --rule-pattern stringArray    patterns used to identify namespaces rule applies to
+      --threshold int               threshold of required valid signatures (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_policy_update-rule.md
+++ b/docs/cli/gittuf_policy_update-rule.md
@@ -18,6 +18,7 @@ gittuf policy update-rule [flags]
       --policy-name string          name of policy file to add rule to (default "targets")
       --rule-name string            name of rule
       --rule-pattern stringArray    patterns used to identify namespaces rule applies to
+      --threshold int               threshold of required valid signatures (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -27,4 +27,5 @@ Tools for gittuf's root of trust
 * [gittuf trust remote](gittuf_trust_remote.md)	 - Tools for managing remote policies
 * [gittuf trust remove-policy-key](gittuf_trust_remove-policy-key.md)	 - Remove Policy key from gittuf root of trust
 * [gittuf trust remove-root-key](gittuf_trust_remove-root-key.md)	 - Remove Root key from gittuf root of trust
+* [gittuf trust update-policy-threshold](gittuf_trust_update-policy-threshold.md)	 - Update Policy threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
 

--- a/docs/cli/gittuf_trust_update-policy-threshold.md
+++ b/docs/cli/gittuf_trust_update-policy-threshold.md
@@ -1,0 +1,36 @@
+## gittuf trust update-policy-threshold
+
+Update Policy threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+
+### Synopsis
+
+This command allows users to update the threshold of valid signatures required for the policy.
+
+DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
+Until then, this command is available in developer mode only, set GITTUF_DEV=1 to use.
+
+```
+gittuf trust update-policy-threshold [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for update-policy-threshold
+      --threshold int   threshold of valid signatures required for main policy (default -1)
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -19,6 +19,7 @@ type options struct {
 	ruleName       string
 	authorizedKeys []string
 	rulePatterns   []string
+	threshold      int
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -52,6 +53,13 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"patterns used to identify namespaces rule applies to",
 	)
 	cmd.MarkFlagRequired("rule-pattern") //nolint:errcheck
+
+	cmd.Flags().IntVar(
+		&o.threshold,
+		"threshold",
+		1,
+		"threshold of required valid signatures",
+	)
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
@@ -79,7 +87,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		authorizedKeys = append(authorizedKeys, key)
 	}
 
-	return repo.AddDelegation(cmd.Context(), signer, o.policyName, o.ruleName, authorizedKeys, o.rulePatterns, true)
+	return repo.AddDelegation(cmd.Context(), signer, o.policyName, o.ruleName, authorizedKeys, o.rulePatterns, o.threshold, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -19,6 +19,7 @@ type options struct {
 	ruleName       string
 	authorizedKeys []string
 	rulePatterns   []string
+	threshold      int
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -52,6 +53,13 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"patterns used to identify namespaces rule applies to",
 	)
 	cmd.MarkFlagRequired("rule-pattern") //nolint:errcheck
+
+	cmd.Flags().IntVar(
+		&o.threshold,
+		"threshold",
+		1,
+		"threshold of required valid signatures",
+	)
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
@@ -79,7 +87,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		authorizedKeys = append(authorizedKeys, key)
 	}
 
-	return repo.UpdateDelegation(cmd.Context(), signer, o.policyName, o.ruleName, authorizedKeys, o.rulePatterns, true)
+	return repo.UpdateDelegation(cmd.Context(), signer, o.policyName, o.ruleName, authorizedKeys, o.rulePatterns, o.threshold, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removepolicykey"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removerootkey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/updatepolicythreshold"
 	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addrootkey.New(o))
 	cmd.AddCommand(removepolicykey.New(o))
 	cmd.AddCommand(removerootkey.New(o))
+	cmd.AddCommand(updatepolicythreshold.New(o))
 
 	remoteCmd := remote.New()
 	cmd.AddCommand(remoteCmd)

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package updatepolicythreshold
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/dev"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p         *persistent.Options
+	threshold int
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().IntVar(
+		&o.threshold,
+		"threshold",
+		-1,
+		"threshold of valid signatures required for main policy",
+	)
+	cmd.MarkFlagRequired("threshold") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	if !dev.InDevMode() {
+		return dev.ErrNotInDevMode
+	}
+
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	rootKeyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	signer, err := common.LoadSigner(rootKeyBytes)
+	if err != nil {
+		return err
+	}
+
+	return repo.UpdateTopLevelTargetsThreshold(cmd.Context(), signer, o.threshold, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:   "update-policy-threshold",
+		Short: fmt.Sprintf("Update Policy threshold in the gittuf root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Long: fmt.Sprintf(`This command allows users to update the threshold of valid signatures required for the policy.
+
+DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
+Until then, this command is available in developer mode only, set %s=1 to use.`, dev.DevModeKey),
+		PreRunE: common.CheckIfSigningViable,
+		RunE:    o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gittuf/gittuf/internal/attestations"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
@@ -45,6 +46,9 @@ func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State) (*
 		t.Fatal(err)
 	}
 	if err := rsl.InitializeNamespace(repo); err != nil {
+		t.Fatal(err)
+	}
+	if err := attestations.InitializeNamespace(repo); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -120,12 +120,12 @@ func createTestStateWithPolicy(t *testing.T) *State {
 	}
 
 	targetsMetadata := InitializeTargetsMetadata()
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Add a file protection rule. When used with common.AddNTestCommitsToSpecifiedRef, we have files with names 1, 2, 3,...n.
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []string{"file:1", "file:2"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []string{"file:1", "file:2"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,12 +189,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	// Create the root targets metadata
 	targetsMetadata := InitializeTargetsMetadata()
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "1", []*tuf.Key{key}, []string{"file:1/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "1", []*tuf.Key{key}, []string{"file:1/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "2", []*tuf.Key{key}, []string{"file:2/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "2", []*tuf.Key{key}, []string{"file:2/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,12 +211,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 
 	// Create the second level of delegations
 	delegation1Metadata := InitializeTargetsMetadata()
-	delegation1Metadata, err = AddDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []string{"file:1/subpath1/*"})
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []string{"file:1/subpath1/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	delegation1Metadata, err = AddDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []string{"file:1/subpath2/*"})
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []string{"file:1/subpath2/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,6 +257,48 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	return curState
 }
 
+func createTestStateWithThresholdPolicy(t *testing.T) *State {
+	t.Helper()
+
+	state := createTestStateWithPolicy(t)
+
+	gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	approverKey, err := tuf.LoadKeyFromBytes(targets1PubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set threshold = 2 for existing rule with the added key
+	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []string{"git:refs/heads/main"}, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targetsEnv, err := dsse.CreateEnvelope(targetsMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetsEnv, err = dsse.SignEnvelope(context.Background(), targetsEnv, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.TargetsEnvelope = targetsEnv
+
+	return state
+}
+
 func createTestStateWithTagPolicy(t *testing.T) *State {
 	t.Helper()
 
@@ -270,7 +312,7 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []string{"git:refs/tags/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []string{"git:refs/tags/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +350,7 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []string{"git:refs/tags/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []string{"git:refs/tags/*"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -281,7 +281,7 @@ func createTestStateWithThresholdPolicy(t *testing.T) *State {
 	}
 
 	// Set threshold = 2 for existing rule with the added key
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []string{"git:refs/heads/main"}, 2)
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []string{"git:refs/heads/main"}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -342,7 +342,11 @@ func TestGetStateForCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{}, []string{"*"}) // just a dummy rule
+	key, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{key}, []string{"*"}, 1) // just a dummy rule
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/targets_test.go
+++ b/internal/policy/targets_test.go
@@ -31,7 +31,7 @@ func TestAddDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Keys[key1.KeyID])
@@ -58,7 +58,7 @@ func TestUpdateDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1}, []string{"test/"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1}, []string{"test/"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestUpdateDelegation(t *testing.T) {
 		Role:        tuf.Role{KeyIDs: []string{key1.KeyID}, Threshold: 1},
 	}, targetsMetadata.Delegations.Roles[0])
 
-	targetsMetadata, err = UpdateDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"})
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Keys[key1.KeyID])
@@ -95,7 +95,7 @@ func TestRemoveDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key}, []string{"test/"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key}, []string{"test/"}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/attestations"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier"
@@ -51,52 +52,60 @@ var (
 // using the latest policy. The expected Git ID for the ref in the latest RSL
 // entry is returned if the policy verification is successful.
 func VerifyRef(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
-	// 1. Get latest policy entry
+	// Get latest policy entry
 	slog.Debug("Loading policy...")
 	policyState, err := LoadCurrentState(ctx, repo)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	// 2. Find latest entry for target
+	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
+	// Find latest set of attestations
+	slog.Debug("Loading current set of attestations...")
+	attestationsState, err := attestations.LoadCurrentAttestations(repo)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
 	slog.Debug("Verifying entry...")
-	return latestEntry.TargetID, verifyEntry(ctx, repo, policyState, latestEntry)
+	return latestEntry.TargetID, verifyEntry(ctx, repo, policyState, attestationsState, latestEntry)
 }
 
 // VerifyRefFull verifies the entire RSL for the target ref from the first
 // entry. The expected Git ID for the ref in the latest RSL entry is returned if
 // the policy verification is successful.
 func VerifyRefFull(ctx context.Context, repo *git.Repository, target string) (plumbing.Hash, error) {
-	// 1. Trace RSL back to the start
+	// Trace RSL back to the start
 	slog.Debug("Identifying first RSL entry...")
 	firstEntry, _, err := rsl.GetFirstEntry(repo)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	// 2. Find latest entry for target
+	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	// 3. Do a relative verify from start entry to the latest entry (firstEntry here == policyEntry)
+	// Do a relative verify from start entry to the latest entry (firstEntry here == policyEntry)
+	// Also, attestations is initially nil because we haven't seen any yet
 	slog.Debug("Verifying all entries...")
-	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, firstEntry, latestEntry, target)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, nil, firstEntry, latestEntry, target)
 }
 
 // VerifyRefFromEntry performs verification for the reference from a specific
 // RSL entry. The expected Git ID for the ref in the latest RSL entry is
 // returned if the policy verification is successful.
 func VerifyRefFromEntry(ctx context.Context, repo *git.Repository, target string, entryID plumbing.Hash) (plumbing.Hash, error) {
-	// 1. Load starting point entry
+	// Load starting point entry
 	slog.Debug("Identifying starting RSL entry...")
 	fromEntryT, err := rsl.GetEntry(repo, entryID)
 	if err != nil {
@@ -110,33 +119,45 @@ func VerifyRefFromEntry(ctx context.Context, repo *git.Repository, target string
 		return plumbing.ZeroHash, err
 	}
 
-	// 2. Find latest entry for target
+	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	// 3. Find policy entry before the starting point entry
+	// Find policy entry before the starting point entry
 	slog.Debug("Identifying applicable policy entry...")
 	policyEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, fromEntry.GetID())
 	if err != nil {
 		return plumbing.ZeroHash, err
 	}
 
-	// 4. Do a relative verify from start entry to the latest entry
+	slog.Debug("Identifying applicable attestations entry...")
+	var attestationsEntry *rsl.ReferenceEntry
+	attestationsEntry, _, err = rsl.GetLatestReferenceEntryForRefBefore(repo, attestations.Ref, fromEntry.GetID())
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return plumbing.ZeroHash, err
+		}
+	}
+
+	// Do a relative verify from start entry to the latest entry
 	slog.Debug("Verifying all entries...")
-	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, policyEntry, fromEntry, latestEntry, target)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, policyEntry, attestationsEntry, fromEntry, latestEntry, target)
 }
 
 // VerifyRelativeForRef verifies the RSL between specified start and end entries
 // using the provided policy entry for the first entry.
 //
 // TODO: should the policy entry be inferred from the specified first entry?
-func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPolicyEntry, firstEntry, lastEntry *rsl.ReferenceEntry, target string) error {
-	var currentPolicy *State
+func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPolicyEntry, initialAttestationsEntry, firstEntry, lastEntry *rsl.ReferenceEntry, target string) error {
+	var (
+		currentPolicy       *State
+		currentAttestations *attestations.Attestations
+	)
 
-	// 1. Load policy applicable at firstEntry
+	// Load policy applicable at firstEntry
 	slog.Debug("Loading initial policy...")
 	state, err := LoadState(ctx, repo, initialPolicyEntry)
 	if err != nil {
@@ -144,14 +165,23 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 	}
 	currentPolicy = state
 
-	// 2. Enumerate RSL entries between firstEntry and lastEntry, ignoring irrelevant ones
+	if initialAttestationsEntry != nil {
+		slog.Debug("Loading attestations...")
+		attestationsState, err := attestations.LoadAttestationsForEntry(repo, initialAttestationsEntry)
+		if err != nil {
+			return err
+		}
+		currentAttestations = attestationsState
+	}
+
+	// Enumerate RSL entries between firstEntry and lastEntry, ignoring irrelevant ones
 	slog.Debug("Identifying all entries in range...")
 	entries, annotations, err := rsl.GetReferenceEntriesInRangeForRef(repo, firstEntry.ID, lastEntry.ID, target)
 	if err != nil {
 		return err
 	}
 
-	// 3. Verify each entry, looking for a fix when an invalid entry is encountered
+	// Verify each entry, looking for a fix when an invalid entry is encountered
 	var invalidEntry *rsl.ReferenceEntry
 	var verificationErr error
 	for len(entries) != 0 {
@@ -180,8 +210,19 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 				continue
 			}
 
+			slog.Debug("Checking if entry is for attestations reference...")
+			if entry.RefName == attestations.Ref {
+				newAttestationsState, err := attestations.LoadAttestationsForEntry(repo, entry)
+				if err != nil {
+					return err
+				}
+
+				currentAttestations = newAttestationsState
+				continue
+			}
+
 			slog.Debug("Verifying changes...")
-			if err := verifyEntry(ctx, repo, currentPolicy, entry); err != nil {
+			if err := verifyEntry(ctx, repo, currentPolicy, currentAttestations, entry); err != nil {
 				slog.Debug("Violation found, checking if entry has been revoked...")
 				// If the invalid entry is never marked as skipped, we return err
 				if !entry.SkippedBy(annotations[entry.ID]) {
@@ -476,9 +517,8 @@ func (s *State) VerifyNewState(ctx context.Context, newPolicy *State) error {
 // via the RSL across all refs. Then, it uses the policy applicable at the
 // commit's first entry into the repository. If the commit is brand new to the
 // repository, the specified policy is used.
-func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry *rsl.ReferenceEntry) error {
-	// TODO: discuss how / if we want to verify RSL entry signatures for the policy namespace
-	if entry.RefName == PolicyRef {
+func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) error {
+	if entry.RefName == PolicyRef || entry.RefName == attestations.Ref {
 		return nil
 	}
 
@@ -491,7 +531,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 		pathNamespaceVerified = true // Assume paths are verified until we find out otherwise
 	)
 
-	// 1. Find authorized verifiers for entry's ref
+	// Find authorized verifiers for entry's ref
 	verifiers, err := policy.FindVerifiersForPath(fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName))
 	if err != nil {
 		return err
@@ -502,15 +542,23 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 		gitNamespaceVerified = true
 	}
 
-	// 2. Find commit object for the RSL entry
+	// Find commit object for the RSL entry
 	commitObj, err := gitinterface.GetCommit(repo, entry.ID)
 	if err != nil {
 		return err
 	}
 
-	// 3. Use each verifier to verify signature
+	var authorizationAttestation *sslibdsse.Envelope
+	if attestationsState != nil {
+		authorizationAttestation, err = getAuthorizationAttestation(repo, attestationsState, entry)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Use each verifier to verify signature
 	for _, verifier := range verifiers {
-		err := verifier.Verify(ctx, commitObj, nil)
+		err := verifier.Verify(ctx, commitObj, authorizationAttestation)
 		if err == nil {
 			// Signature verification succeeded
 			gitNamespaceVerified = true
@@ -535,7 +583,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 		return nil
 	}
 
-	// 4. Verify modified files
+	// Verify modified files
 
 	// First, get all commits between the current and last entry for the ref.
 	commits, err := getCommits(repo, entry) // note: this is ordered by commit ID
@@ -590,7 +638,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 			}
 
 			for _, verifier := range verifiers {
-				err := verifier.Verify(ctx, commit, nil)
+				err := verifier.Verify(ctx, commit, authorizationAttestation)
 				if err == nil {
 					// Signature verification succeeded
 					pathsVerified[j] = true
@@ -716,6 +764,35 @@ func verifyTagEntry(ctx context.Context, repo *git.Repository, policy *State, en
 	}
 
 	return nil
+}
+
+func getAuthorizationAttestation(repo *git.Repository, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) (*sslibdsse.Envelope, error) {
+	firstEntry := false
+
+	priorRefEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, entry.RefName, entry.ID)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return nil, err
+		}
+
+		firstEntry = true
+	}
+
+	fromID := plumbing.ZeroHash
+	if !firstEntry {
+		fromID = priorRefEntry.TargetID
+	}
+
+	attestation, err := attestationsState.GetReferenceAuthorizationFor(repo, entry.RefName, fromID.String(), entry.TargetID.String())
+	if err != nil {
+		if errors.Is(err, attestations.ErrAuthorizationNotFound) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return attestation, nil
 }
 
 // getCommits identifies the commits introduced to the entry's ref since the

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -780,20 +780,22 @@ func TestVerifyTag(t *testing.T) {
 }
 
 func TestVerifyEntry(t *testing.T) {
-	// FIXME: currently this test is nearly identical to the one for VerifyRef.
-	// This is because it's not trivial to create a bunch of test policy / RSL
-	// states cleanly. We need something that is easy to maintain and add cases
-	// to.
-	repo, state := createTestRepository(t, createTestStateWithPolicy)
-	refName := "refs/heads/main"
+	t.Run("successful verification", func(t *testing.T) {
+		repo, state := createTestRepository(t, createTestStateWithPolicy)
+		refName := "refs/heads/main"
 
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-	entry.ID = entryID
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
 
-	err := verifyEntry(context.Background(), repo, state, entry)
-	assert.Nil(t, err)
+		err := verifyEntry(context.Background(), repo, state, entry)
+		assert.Nil(t, err)
+	})
+
+	t.Run("successful verification with higher threshold", func(t *testing.T) {
+		createTestRepository(t, createTestStateWithThresholdPolicy)
+	})
 
 	// FIXME: test for file policy passing for situations where a commit is seen
 	// by the RSL before its signing key is rotated out. This commit should be

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gittuf/gittuf/internal/attestations"
 	"github.com/gittuf/gittuf/internal/common"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
@@ -135,10 +136,10 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, entry, policyEntry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, entry, policyEntry, refName)
 		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 	})
 
@@ -160,7 +161,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -170,7 +171,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -187,7 +188,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -209,7 +210,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -219,7 +220,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -236,7 +237,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -258,7 +259,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -268,7 +269,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -297,7 +298,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -319,7 +320,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -329,7 +330,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -358,7 +359,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -380,7 +381,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -390,7 +391,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs := []plumbing.Hash{entryID}
@@ -401,7 +402,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's still in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs = append(invalidEntryIDs, entryID)
@@ -420,7 +421,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -442,7 +443,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -452,7 +453,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs := []plumbing.Hash{entryID}
@@ -463,7 +464,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's still in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -480,7 +481,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// An invalid entry is not marked as skipped
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrInvalidEntryNotSkipped)
 	})
 
@@ -502,7 +503,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -512,7 +513,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -529,7 +530,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		// Send it into invalid state again
@@ -539,7 +540,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -556,7 +557,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -579,7 +580,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		invalidLastGoodCommitID := commitIDs[len(commitIDs)-1]
@@ -590,7 +591,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3, gpgUnauthorizedKeyBytes)
@@ -599,7 +600,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the invalid last good commit
@@ -616,7 +617,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 
@@ -638,7 +639,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
@@ -648,7 +649,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -677,14 +678,14 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.Nil(t, err)
 
 		// Skip the recovery entry as well
 		annotation = rsl.NewAnnotationEntry([]plumbing.Hash{entryID}, true, "invalid entry")
 		annotationID = common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
 		annotation.ID = annotationID
-		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(context.Background(), repo, policyEntry, nil, policyEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 }
@@ -780,21 +781,70 @@ func TestVerifyTag(t *testing.T) {
 }
 
 func TestVerifyEntry(t *testing.T) {
+	refName := "refs/heads/main"
+
 	t.Run("successful verification", func(t *testing.T) {
 		repo, state := createTestRepository(t, createTestStateWithPolicy)
-		refName := "refs/heads/main"
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
 		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyEntry(context.Background(), repo, state, entry)
+		err := verifyEntry(context.Background(), repo, state, nil, entry)
 		assert.Nil(t, err)
 	})
 
 	t.Run("successful verification with higher threshold", func(t *testing.T) {
-		createTestRepository(t, createTestStateWithThresholdPolicy)
+		repo, state := createTestRepository(t, createTestStateWithThresholdPolicy)
+
+		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+
+		// Create authorization for this change
+		// TODO: determine authorization format, this requires the target commit
+		// ID instead of something that could be determined ahead of time like
+		// the tree ID
+		authorization, err := attestations.NewReferenceAuthorization(refName, plumbing.ZeroHash.String(), commitIDs[0].String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targets1KeyBytes) //nolint:staticcheck
+		if err != nil {
+			t.Fatal(err)
+		}
+		env, err := dsse.CreateEnvelope(authorization)
+		if err != nil {
+			t.Fatal(err)
+		}
+		env, err = dsse.SignEnvelope(testCtx, env, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, plumbing.ZeroHash.String(), commitIDs[0].String()); err != nil {
+			t.Fatal(err)
+		}
+		if err := currentAttestations.Commit(repo, "Add authorization", false); err != nil {
+			t.Fatal(err)
+		}
+
+		currentAttestations, err = attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+		assert.Nil(t, err)
 	})
 
 	// FIXME: test for file policy passing for situations where a commit is seen

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -94,7 +94,7 @@ func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
 		t.Fatal(err)
 	}
 
-	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"}, false); err != nil {
+	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"}, 1, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -73,7 +73,7 @@ func (r *Repository) InitializeTargets(ctx context.Context, signer sslibdsse.Sig
 
 // AddDelegation is the interface for the user to add a new rule to gittuf
 // policy.
-func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, signCommit bool) error {
+func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int, signCommit bool) error {
 	if ruleName == policy.RootRoleName {
 		return ErrInvalidPolicyName
 	}
@@ -110,7 +110,7 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 	}
 
 	slog.Debug("Adding rule to rule file...")
-	targetsMetadata, err = policy.AddDelegation(targetsMetadata, ruleName, authorizedKeys, rulePatterns)
+	targetsMetadata, err = policy.AddDelegation(targetsMetadata, ruleName, authorizedKeys, rulePatterns, threshold)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -142,7 +142,7 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 
 // UpdateDelegation is the interface for the user to update a rule to gittuf
 // policy.
-func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, signCommit bool) error {
+func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int, signCommit bool) error {
 	if ruleName == policy.RootRoleName {
 		return ErrInvalidPolicyName
 	}
@@ -174,7 +174,7 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 	}
 
 	slog.Debug("Updating rule in rule file...")
-	targetsMetadata, err = policy.UpdateDelegation(targetsMetadata, ruleName, authorizedKeys, rulePatterns)
+	targetsMetadata, err = policy.UpdateDelegation(targetsMetadata, ruleName, authorizedKeys, rulePatterns, threshold)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -148,7 +148,7 @@ func TestUpdateDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = r.UpdateDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey, targetsKey}, []string{"git:refs/heads/main"}, false)
+	err = r.UpdateDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey, targetsKey}, []string{"git:refs/heads/main"}, 1, false)
 	assert.Nil(t, err)
 
 	state, err := policy.LoadCurrentState(context.Background(), r.r)

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -100,7 +100,7 @@ func TestAddDelegation(t *testing.T) {
 		assert.Equal(t, 2, len(targetsMetadata.Delegations.Roles))
 		assert.Contains(t, targetsMetadata.Delegations.Roles, policy.AllowRule())
 
-		err = r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, false)
+		err = r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, 1, false)
 		assert.Nil(t, err)
 
 		state, err = policy.LoadCurrentState(context.Background(), r.r)
@@ -126,7 +126,7 @@ func TestAddDelegation(t *testing.T) {
 	t.Run("invalid rule name", func(t *testing.T) {
 		r := createTestRepositoryWithPolicy(t, "")
 
-		err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, policy.RootRoleName, nil, nil, false)
+		err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, policy.RootRoleName, nil, nil, 1, false)
 		assert.ErrorIs(t, err, ErrInvalidPolicyName)
 	})
 }
@@ -187,7 +187,7 @@ func TestRemoveDelegation(t *testing.T) {
 	authorizedKeyBytes := []*tuf.Key{targetsPubKey}
 	rulePatterns := []string{"git:branch=main"}
 
-	err = r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, false)
+	err = r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, 1, false)
 	assert.Nil(t, err)
 
 	state, err := policy.LoadCurrentState(context.Background(), r.r)


### PR DESCRIPTION
This PR adds support for specifying thresholds in gittuf rules. For full threshold support, we need #260 / #45 merged / resolved, so that the top level targets role can meet the threshold in the refs/gittuf/policy.

As a start, though, this can be used to specify thresholds in rules that are expected to be met using RSL entry signatures / commit signatures / attestations (#254).