### PR TITLE
policy: Apply file rules only if they exist

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -510,3 +510,21 @@ func TestListRules(t *testing.T) {
 		assert.Equal(t, expectedRules, rules)
 	})
 }
+
+func TestStateHasFileRule(t *testing.T) {
+	t.Run("with file rules", func(t *testing.T) {
+		state := createTestStateWithPolicy(t)
+
+		hasFileRule, err := state.hasFileRule()
+		assert.Nil(t, err)
+		assert.True(t, hasFileRule)
+	})
+
+	t.Run("with no file rules", func(t *testing.T) {
+		state := createTestStateWithOnlyRoot(t)
+
+		hasFileRule, err := state.hasFileRule()
+		assert.Nil(t, err)
+		assert.False(t, hasFileRule)
+	})
+}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -453,7 +453,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 	)
 
 	// 1. Find authorized verifiers for entry's ref
-	verifiers, err := policy.FindVerifiersForPath(ctx, fmt.Sprintf("git:%s", entry.RefName)) // FIXME: "git:" shouldn't be here
+	verifiers, err := policy.FindVerifiersForPath(ctx, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName))
 	if err != nil {
 		return err
 	}
@@ -485,6 +485,15 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 
 	if !gitNamespaceVerified {
 		return fmt.Errorf("verifying Git namespace policies failed, %w", ErrUnauthorizedSignature)
+	}
+
+	hasFileRule, err := policy.hasFileRule()
+	if err != nil {
+		return err
+	}
+
+	if !hasFileRule {
+		return nil
 	}
 
 	// 4. Verify modified files
@@ -520,7 +529,7 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 		pathsVerified := make([]bool, len(paths))
 		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
 		for j, path := range paths {
-			verifiers, err := commitPolicy.FindVerifiersForPath(ctx, fmt.Sprintf("file:%s", path)) // FIXME: "file:" shouldn't be here
+			verifiers, err := commitPolicy.FindVerifiersForPath(ctx, fmt.Sprintf("%s:%s", fileRuleScheme, path))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This is a first step at making verifyEntry more efficient. We now only check for file protection rules if the policy state has at least one in any targets role.

Also, this commit sets constants for the Git reference and file rule schemes.