### PR TITLE
Fix bugs in root public key tracking

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -24,4 +24,5 @@ Tools to manage gittuf policies
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state
 * [gittuf policy remote](gittuf_policy_remote.md)	 - Tools for managing remote policies
 * [gittuf policy remove-rule](gittuf_policy_remove-rule.md)	 - Remove rule from a policy file
+* [gittuf policy sign](gittuf_policy_sign.md)	 - Sign policy file
 

--- a/docs/cli/gittuf_policy_sign.md
+++ b/docs/cli/gittuf_policy_sign.md
@@ -1,0 +1,30 @@
+## gittuf policy sign
+
+Sign policy file
+
+### Synopsis
+
+This command allows users to add their signature to the specified policy file.
+
+```
+gittuf policy sign [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for sign
+      --policy-name string   policy file to sign (default "targets")
+```
+
+### Options inherited from parent commands
+
+```
+  -k, --signing-key string   signing key to use to sign policy file
+      --verbose              enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/listrules"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/policy/removerule"
+	"github.com/gittuf/gittuf/internal/cmd/policy/sign"
 	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addrule.New(o))
 	cmd.AddCommand(listrules.New())
 	cmd.AddCommand(removerule.New(o))
+	cmd.AddCommand(sign.New(o))
 
 	remoteCmd := remote.New()
 	cmd.AddCommand(remoteCmd)

--- a/internal/cmd/policy/sign/sign.go
+++ b/internal/cmd/policy/sign/sign.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package sign
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p          *persistent.Options
+	policyName string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		policy.TargetsRoleName,
+		"policy file to sign",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	signer, err := common.LoadSigner(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	return repo.SignTargets(cmd.Context(), signer, o.policyName, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "sign",
+		Short:             "Sign policy file",
+		Long:              "This command allows users to add their signature to the specified policy file.",
+		PreRunE:           common.CheckIfSigningViable,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -136,29 +136,31 @@ func TestStateVerify(t *testing.T) {
 	t.Run("only root", func(t *testing.T) {
 		state := createTestStateWithOnlyRoot(t)
 
-		if err := state.Verify(testCtx); err != nil {
-			t.Error(err)
-		}
+		err := state.Verify(testCtx)
+		assert.Nil(t, err)
+	})
 
-		rootKeys := []*tuf.Key{}
-		copy(rootKeys, state.RootPublicKeys)
-		state.RootPublicKeys = []*tuf.Key{}
+	t.Run("only root, remove root keys", func(t *testing.T) {
+		state := createTestStateWithOnlyRoot(t)
 
-		err := state.Verify(context.Background())
-		assert.NotNil(t, err)
+		state.RootPublicKeys = nil
+		err := state.Verify(testCtx)
+		assert.ErrorIs(t, err, ErrInvalidVerifier)
+	})
 
-		state.RootPublicKeys = rootKeys
+	t.Run("only root, remove signatures", func(t *testing.T) {
+		state := createTestStateWithOnlyRoot(t)
+
 		state.RootEnvelope.Signatures = []sslibdsse.Signature{}
-		err = state.Verify(context.Background())
-		assert.NotNil(t, err)
+		err := state.Verify(testCtx)
+		assert.ErrorIs(t, err, ErrVerifierConditionsUnmet)
 	})
 
 	t.Run("with policy", func(t *testing.T) {
 		state := createTestStateWithPolicy(t)
 
-		if err := state.Verify(testCtx); err != nil {
-			t.Error(err)
-		}
+		err := state.Verify(testCtx)
+		assert.Nil(t, err)
 	})
 }
 

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -20,6 +20,7 @@ var (
 	gpgKeyBytes        = artifacts.GPGKey1Private
 	gpgPubKeyBytes     = artifacts.GPGKey1Public
 	rootKeyBytes       = artifacts.SSLibKey1Private
+	rootPubKeyBytes    = artifacts.SSLibKey1Public
 	targetsKeyBytes    = artifacts.SSLibKey2Private
 	targetsPubKeyBytes = artifacts.SSLibKey2Public
 	rsaKeyBytes        = artifacts.SSHRSAPrivate

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -225,3 +225,31 @@ func TestAddKeyToTargets(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(targetsMetadata.Delegations.Keys))
 }
+
+func TestSignTargets(t *testing.T) {
+	r := createTestRepositoryWithPolicy(t, "")
+
+	// Add root key as a targets key
+	rootSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootPubKey, err := tuf.LoadKeyFromBytes(rootPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.AddTopLevelTargetsKey(testCtx, rootSigner, rootPubKey, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add signature to targets
+	err = r.SignTargets(testCtx, rootSigner, policy.TargetsRoleName, false)
+	assert.Nil(t, err)
+
+	state, err := policy.LoadCurrentState(testCtx, r.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 2, len(state.TargetsEnvelope.Signatures))
+}


### PR DESCRIPTION
Fixes minor bugs in root key management subcommands. Also adds gittuf policy sign to add a signature to existing policy file.

Blocked by #264, #268, and #269.