### PR TITLE
Added functionality for key revocation in rules, without having to remove the whole rule

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -18,7 +18,7 @@ Tools to manage gittuf policies
 ### SEE ALSO
 
 * [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
-* [gittuf policy add-key](gittuf_policy_add-key.md)	 - Add a trusted key to a policy file
+* [gittuf policy add-key](gittuf_policy_add-key.md)	 - Add trusted keys to a policy file
 * [gittuf policy add-rule](gittuf_policy_add-rule.md)	 - Add a new rule to a policy file
 * [gittuf policy init](gittuf_policy_init.md)	 - Initialize policy file
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state

--- a/docs/cli/gittuf_policy_add-key.md
+++ b/docs/cli/gittuf_policy_add-key.md
@@ -1,10 +1,10 @@
 ## gittuf policy add-key
 
-Add a trusted key to a policy file
+Add trusted keys to a policy file
 
 ### Synopsis
 
-This command allows users to add a trusted key to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+This command allows users to add trusted keys to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
 
 ```
 gittuf policy add-key [flags]

--- a/internal/cmd/policy/removekey/removekey.go
+++ b/internal/cmd/policy/removekey/removekey.go
@@ -25,14 +25,14 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.policyName,
 		"policy-name",
 		policy.TargetsRoleName,
-		"policy file to add rule to",
+		"policy file to remove key from",
 	)
 
 	cmd.Flags().StringArrayVar(
 		&o.authorizedKeys,
 		"authorize-key",
 		[]string{},
-		"authorized public key for rule",
+		"authorized public keys to remove from rule",
 	)
 	cmd.MarkFlagRequired("authorize-key") //nolint:errcheck
 }

--- a/internal/cmd/policy/removekey/removekey.go
+++ b/internal/cmd/policy/removekey/removekey.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-package addkey
+package removekey
 
 import (
 	"os"
@@ -9,7 +9,6 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/repository"
-	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
 
@@ -46,30 +45,26 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	signer, err := common.LoadSigner(keyBytes)
-	if err != nil {
-		return err
-	}
 
-	authorizedKeys := []*tuf.Key{}
+	authorizedKeysBytes := [][]byte{}
 	for _, key := range o.authorizedKeys {
-		key, err := common.LoadPublicKey(key)
+		kb, err := common.ReadKeyBytes(key) //nolint:staticcheck
 		if err != nil {
 			return err
 		}
 
-		authorizedKeys = append(authorizedKeys, key)
+		authorizedKeysBytes = append(authorizedKeysBytes, kb)
 	}
 
-	return repo.AddKeyToTargets(cmd.Context(), signer, o.policyName, authorizedKeys, true)
+	return repo.RemoveKeyFromTargets(cmd.Context(), keyBytes, o.policyName, authorizedKeysBytes, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "add-key",
-		Short:             "Add trusted keys to a policy file",
-		Long:              `This command allows users to add trusted keys to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Use:               "remove-key",
+		Short:             "remove trusted keys to a policy file",
+		Long:              `This command allows users to remove trusted keys from the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
 		PreRunE:           common.CheckIfSigningViable,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -530,3 +530,31 @@ func TestStateHasFileRule(t *testing.T) {
 		assert.False(t, hasFileRule)
 	})
 }
+
+func TestStateCountofKeyUse(t *testing.T) {
+	t.Run("with file rules", func(t *testing.T) {
+		gpgkey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		state := createTestStateWithPolicy(t)
+
+		count, err := state.CountofKeyUse(gpgkey)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("with no file rules", func(t *testing.T) {
+		gpgkey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		state := createTestStateWithOnlyRoot(t)
+
+		count, err := state.CountofKeyUse(gpgkey)
+		assert.Nil(t, err)
+		assert.Equal(t, 0, count)
+	})
+}

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -101,6 +101,16 @@ func AddKeyToTargets(targetsMetadata *tuf.TargetsMetadata, authorizedKeys []*tuf
 	return targetsMetadata, nil
 }
 
+func RemoveKeysFromTargets(targetsMetadata *tuf.TargetsMetadata, authorizedKeys []*tuf.Key) (*tuf.TargetsMetadata, error) {
+	for _, key := range authorizedKeys {
+		if err := targetsMetadata.Delegations.RemoveKey(key.KeyID); err != nil {
+			return nil, err
+		}
+	}
+
+	return targetsMetadata, nil
+}
+
 // AllowRule returns the default, last rule for all policy files.
 func AllowRule() tuf.Delegation {
 	return tuf.Delegation{

--- a/internal/policy/targets_test.go
+++ b/internal/policy/targets_test.go
@@ -125,6 +125,9 @@ func TestRemoveKeyFromTargets(t *testing.T) {
 
 	t.Run("remove single key", func(t *testing.T) {
 		signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		targetsMetadata := InitializeTargetsMetadata()
 		targetsEnv, err := dsse.CreateEnvelope(targetsMetadata)
@@ -152,7 +155,9 @@ func TestRemoveKeyFromTargets(t *testing.T) {
 
 	t.Run("add multiple keys and remove multiple keys", func(t *testing.T) {
 		signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
-
+		if err != nil {
+			t.Fatal(err)
+		}
 		targetsMetadata := InitializeTargetsMetadata()
 		targetsEnv, err := dsse.CreateEnvelope(targetsMetadata)
 		if err != nil {

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -280,7 +280,7 @@ func (r *Repository) RemoveKeyFromTargets(ctx context.Context, signer sslibdsse.
 		return err
 	}
 
-	targetsMetadata, err = policy.RemoveKeysFromTargets(targetsMetadata, authorizedKeys)
+	targetsMetadata, err = policy.RemoveKeysFromTargets(state, targetsMetadata, authorizedKeys)
 	if err != nil {
 		return err
 	}

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"path"
 
 	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
@@ -183,14 +182,10 @@ func (d *Delegations) AddKey(key *Key) {
 	d.Keys[key.KeyID] = key
 }
 
-func (d *Delegations) RemoveKey(keyID string) error {
-	if _, ok := d.Keys[keyID]; !ok {
-		return fmt.Errorf("key %s, is not in this rule", keyID)
+func (d *Delegations) RemoveKey(keyID string) {
+	if _, ok := d.Keys[keyID]; ok {
+		delete(d.Keys, keyID)
 	}
-
-	delete(d.Keys, keyID)
-
-	return nil
 }
 
 // AddDelegation adds a new delegation.

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"path"
 
 	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
@@ -19,9 +20,7 @@ import (
 
 const specVersion = "1.0"
 
-var (
-	ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
-)
+var ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
 
 // Key defines the structure for how public keys are stored in TUF metadata.
 type Key = signerverifier.SSLibKey
@@ -182,6 +181,16 @@ func (d *Delegations) AddKey(key *Key) {
 	}
 
 	d.Keys[key.KeyID] = key
+}
+
+func (d *Delegations) RemoveKey(keyID string) error {
+	if _, ok := d.Keys[keyID]; !ok {
+		return fmt.Errorf("key %s, is not in this rule", keyID)
+	}
+
+	delete(d.Keys, keyID)
+
+	return nil
 }
 
 // AddDelegation adds a new delegation.

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -183,9 +183,7 @@ func (d *Delegations) AddKey(key *Key) {
 }
 
 func (d *Delegations) RemoveKey(keyID string) {
-	if _, ok := d.Keys[keyID]; ok {
-		delete(d.Keys, keyID)
-	}
+	delete(d.Keys, keyID)
 }
 
 // AddDelegation adds a new delegation.

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -126,12 +126,13 @@ func TestTargetsMetadataAndDelegations(t *testing.T) {
 
 	delegations := &Delegations{}
 
-	t.Run("test AddKey", func(t *testing.T) {
+	t.Run("test AddKey and RemoveKey", func(t *testing.T) {
 		assert.Nil(t, delegations.Keys)
 		delegations.AddKey(key)
 		assert.Equal(t, key, delegations.Keys[key.KeyID])
+		err := delegations.RemoveKey(key.KeyID)
+		assert.ErrorIs(t, err, nil)
 	})
-
 	t.Run("test AddDelegation", func(t *testing.T) {
 		assert.Nil(t, delegations.Roles)
 		d := Delegation{

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -130,8 +131,8 @@ func TestTargetsMetadataAndDelegations(t *testing.T) {
 		assert.Nil(t, delegations.Keys)
 		delegations.AddKey(key)
 		assert.Equal(t, key, delegations.Keys[key.KeyID])
-		err := delegations.RemoveKey(key.KeyID)
-		assert.ErrorIs(t, err, nil)
+		delegations.RemoveKey(key.KeyID)
+		assert.Equal(t, map[string]*signerverifier.SSLibKey{}, delegations.Keys)
 	})
 	t.Run("test AddDelegation", func(t *testing.T) {
 		assert.Nil(t, delegations.Roles)


### PR DESCRIPTION
- Currently to remove a key from a rule, the whole rule will have to be removed, and then recreated without that key
- The `addkey` command docs have been changed, since multiple rules can be added at once, which was not reflected in the docs