### PR TITLE
Add from flag to verify-ref

### DIFF
--- a/docs/cli/gittuf_verify-ref.md
+++ b/docs/cli/gittuf_verify-ref.md
@@ -9,6 +9,7 @@ gittuf verify-ref [flags]
 ### Options
 
 ```
+      --from string   start point for verification
   -h, --help          help for verify-ref
       --latest-only   perform verification against latest entry in the RSL
 ```

--- a/docs/cli/gittuf_verify-ref.md
+++ b/docs/cli/gittuf_verify-ref.md
@@ -9,9 +9,9 @@ gittuf verify-ref [flags]
 ### Options
 
 ```
-      --from string   start point for verification
-  -h, --help          help for verify-ref
-      --latest-only   perform verification against latest entry in the RSL
+      --from-entry string   perform verification from specified RSL entry (developer mode only, set GITTUF_DEV=1)
+  -h, --help                help for verify-ref
+      --latest-only         perform verification against latest entry in the RSL
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/verifyref/verifyref.go
+++ b/internal/cmd/verifyref/verifyref.go
@@ -9,6 +9,7 @@ import (
 
 type options struct {
 	latestOnly bool
+	from       string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -18,6 +19,15 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		false,
 		"perform verification against latest entry in the RSL",
 	)
+
+	cmd.Flags().StringVar(
+		&o.from,
+		"from",
+		"",
+		"start point for verification",
+	)
+
+	cmd.MarkFlagsMutuallyExclusive("latest-only", "from")
 }
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
@@ -25,7 +35,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return repo.VerifyRef(cmd.Context(), args[0], o.latestOnly)
+	return repo.VerifyRef(cmd.Context(), args[0], o.latestOnly, o.from)
 }
 
 func New() *cobra.Command {

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -89,6 +89,25 @@ func VerifyRefFull(ctx context.Context, repo *git.Repository, target string) (pl
 	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, firstEntry, latestEntry, target)
 }
 
+// VerifyFromRef bootstraps the information needed in order to call VerifyRelativeForRef,
+// used when performing verification starting from a certain RSL entry.
+func VerifyFromRef(ctx context.Context, repo *git.Repository, target string, from string) (plumbing.Hash, error) {
+	// 1. Trace RSL back to the entry for the from ref
+	fromEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, from)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	// 2. Find latest entry for target
+	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	// 3. Do a relative verify from start entry to the latest entry (firstEntry here == policyEntry)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, fromEntry, fromEntry, latestEntry, target)
+}
+
 // VerifyRelativeForRef verifies the RSL between specified start and end entries
 // using the provided policy entry for the first entry.
 //

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -17,14 +17,15 @@ import (
 )
 
 var (
-	gpgKeyBytes        = artifacts.GPGKey1Private
-	gpgPubKeyBytes     = artifacts.GPGKey1Public
-	rootKeyBytes       = artifacts.SSLibKey1Private
-	rootPubKeyBytes    = artifacts.SSLibKey1Public
-	targetsKeyBytes    = artifacts.SSLibKey2Private
-	targetsPubKeyBytes = artifacts.SSLibKey2Public
-	rsaKeyBytes        = artifacts.SSHRSAPrivate
-	ecdsaKeyBytes      = artifacts.SSHECDSAPrivate
+	gpgKeyBytes             = artifacts.GPGKey1Private
+	gpgPubKeyBytes          = artifacts.GPGKey1Public
+	gpgUnauthorizedKeyBytes = artifacts.GPGKey2Private
+	rootKeyBytes            = artifacts.SSLibKey1Private
+	rootPubKeyBytes         = artifacts.SSLibKey1Public
+	targetsKeyBytes         = artifacts.SSLibKey2Private
+	targetsPubKeyBytes      = artifacts.SSLibKey2Public
+	rsaKeyBytes             = artifacts.SSHRSAPrivate
+	ecdsaKeyBytes           = artifacts.SSHECDSAPrivate
 
 	testCtx = context.Background()
 )

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -58,5 +58,5 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Reposito
 	}
 
 	repository := &Repository{r: r}
-	return repository, repository.VerifyRef(ctx, head.Target().String(), true, "")
+	return repository, repository.VerifyRef(ctx, head.Target().String(), true)
 }

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -58,5 +58,5 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Reposito
 	}
 
 	repository := &Repository{r: r}
-	return repository, repository.VerifyRef(ctx, head.Target().String(), true)
+	return repository, repository.VerifyRef(ctx, head.Target().String(), true, "")
 }

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -20,7 +20,7 @@ import (
 // another is to create a new RSL entry for the current state.
 var ErrRefStateDoesNotMatchRSL = errors.New("Git reference's current state does not match latest RSL entry") //nolint:stylecheck
 
-func (r *Repository) VerifyRef(ctx context.Context, target string, latestOnly bool) error {
+func (r *Repository) VerifyRef(ctx context.Context, target string, latestOnly bool, from string) error {
 	var (
 		expectedTip plumbing.Hash
 		err         error
@@ -31,11 +31,15 @@ func (r *Repository) VerifyRef(ctx context.Context, target string, latestOnly bo
 		return err
 	}
 
-	if latestOnly {
+	switch {
+	case from != "":
+		expectedTip, err = policy.VerifyFromRef(ctx, r.r, target, from)
+	case latestOnly:
 		expectedTip, err = policy.VerifyRef(ctx, r.r, target)
-	} else {
+	default:
 		expectedTip, err = policy.VerifyRefFull(ctx, r.r, target)
 	}
+
 	if err != nil {
 		return err
 	}

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -55,7 +55,7 @@ func TestVerifyRef(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		err := repo.VerifyRef(context.Background(), test.target, test.latestOnly)
+		err := repo.VerifyRef(context.Background(), test.target, test.latestOnly, "")
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {
@@ -65,8 +65,8 @@ func TestVerifyRef(t *testing.T) {
 
 	// Add another commit
 	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
-	err := repo.VerifyRef(context.Background(), refName, true)
+	err := repo.VerifyRef(context.Background(), refName, true, "")
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
-	err = repo.VerifyRef(context.Background(), refName, false)
+	err = repo.VerifyRef(context.Background(), refName, false, "")
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
 }

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/common"
+	"github.com/gittuf/gittuf/internal/dev"
+	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/stretchr/testify/assert"
@@ -55,7 +57,7 @@ func TestVerifyRef(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		err := repo.VerifyRef(context.Background(), test.target, test.latestOnly, "")
+		err := repo.VerifyRef(context.Background(), test.target, test.latestOnly)
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {
@@ -65,8 +67,83 @@ func TestVerifyRef(t *testing.T) {
 
 	// Add another commit
 	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
-	err := repo.VerifyRef(context.Background(), refName, true, "")
+	err := repo.VerifyRef(context.Background(), refName, true)
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
-	err = repo.VerifyRef(context.Background(), refName, false, "")
+	err = repo.VerifyRef(context.Background(), refName, false)
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
+}
+
+func TestVerifyRefFromEntry(t *testing.T) {
+	t.Setenv(dev.DevModeKey, "1")
+
+	repo := createTestRepositoryWithPolicy(t, "")
+
+	refName := "refs/heads/main"
+	if err := repo.r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(refName), plumbing.ZeroHash)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Policy violation
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgUnauthorizedKeyBytes)
+	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+	violatingEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgUnauthorizedKeyBytes)
+
+	// No policy violation
+	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
+	goodEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
+
+	// No policy violation (latest)
+	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
+
+	tests := map[string]struct {
+		target      string
+		fromEntryID plumbing.Hash
+		err         error
+	}{
+		"absolute ref, from non-violating": {
+			target:      "refs/heads/main",
+			fromEntryID: goodEntryID,
+		},
+		"absolute ref, from violating": {
+			target:      "refs/heads/main",
+			fromEntryID: violatingEntryID,
+			err:         policy.ErrUnauthorizedSignature,
+		},
+		"relative ref, from non-violating": {
+			target:      "main",
+			fromEntryID: goodEntryID,
+		},
+		"relative ref, from violating": {
+			target:      "main",
+			fromEntryID: violatingEntryID,
+			err:         policy.ErrUnauthorizedSignature,
+		},
+		"unknown ref": {
+			target: "refs/heads/unknown",
+			err:    rsl.ErrRSLEntryNotFound,
+		},
+	}
+
+	for name, test := range tests {
+		err := repo.VerifyRefFromEntry(testCtx, test.target, test.fromEntryID.String())
+		if test.err != nil {
+			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
+		} else {
+			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
+		}
+	}
+
+	// Add another commit
+	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+
+	// Verifying from only good entry tells us ref does not match RSL
+	err := repo.VerifyRefFromEntry(testCtx, refName, goodEntryID.String())
+	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
+
+	// Verifying from violating entry tells us unauthorized signature
+	err = repo.VerifyRefFromEntry(testCtx, refName, violatingEntryID.String())
+	assert.ErrorIs(t, err, policy.ErrUnauthorizedSignature)
 }


### PR DESCRIPTION
This PR adds a `--from-entry` flag to verify a ref from a certain RSL entry onwards.