### PR TITLE
policy: Apply latest policy for file changes

### DIFF
--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -515,21 +515,10 @@ func verifyEntry(ctx context.Context, repo *git.Repository, policy *State, entry
 			return err
 		}
 
-		var commitPolicy *State
-		commitPolicy, err = GetStateForCommit(ctx, repo, commit)
-		if err != nil {
-			return err
-		}
-		if commitPolicy == nil {
-			// the commit hasn't been seen in any refs in the repository, use
-			// specified policy
-			commitPolicy = policy
-		}
-
 		pathsVerified := make([]bool, len(paths))
 		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
 		for j, path := range paths {
-			verifiers, err := commitPolicy.FindVerifiersForPath(ctx, fmt.Sprintf("%s:%s", fileRuleScheme, path))
+			verifiers, err := policy.FindVerifiersForPath(ctx, fmt.Sprintf("%s:%s", fileRuleScheme, path))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously, we were trying to identify when a commit was first introduced into the RSL to use the file policies applicable at the time. This makes sense for handling cases such as a commit creator leaving an organization prior to it being merged into a branch. However, this goes against expectations: when a policy is changed, the expectation is that all future changes use that policy.

We can solve the earlier issue with policy rotations invalidating prior changes being merged now using attestation signatures. Now, the commit creator's signature does not matter as long as it is approved via an attestation by whoever is trusted in the current policy.