### PR TITLE
Expand CONTRIBUTING.md to cover Slack + community meetings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ Contributions to gittuf can be of several types:
   enhancements to the implementation
 * new issues or feature requests
 
-You can also join our community in #gittuf in [OpenSSF Slack](https://openssf.slack.com/) and/or our monthly gittuf Community Meetings, which take place the first Friday of the month at 17:00 UTC ([your timezone](https://time.is/1700_UTC)). Here are the prior [meeting notes](https://docs.google.com/document/d/1tXFCVUHsICLpLKxcGvhzBDUWmpsY1LQvysFaX6AJRkk/edit#heading=h.9m0zi4b0wnne) to get oriented.
+[Join our community](https://github.com/gittuf/community/?tab=readme-ov-file#join-us)
+to get started!
 
 ## Contributor Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Contributions to gittuf can be of several types:
   enhancements to the implementation
 * new issues or feature requests
 
+You can also join our community in #gittuf in [OpenSSF Slack](https://openssf.slack.com/) and/or our monthly gittuf Community Meetings, which take place the first Friday of the month at 17:00 UTC ([your timezone](https://time.is/1700_UTC)). Here are the prior [meeting notes](https://docs.google.com/document/d/1tXFCVUHsICLpLKxcGvhzBDUWmpsY1LQvysFaX6AJRkk/edit#heading=h.9m0zi4b0wnne) to get oriented.
+
 ## Contributor Workflow
 
 When submitting changes to the gittuf docs or implementation, contributors must


### PR DESCRIPTION
Doing my homework for https://github.com/ossf/DevRel-community/issues/35 required a bit of spelunking because there wasn't mention of either the Slack channel or the monthly community meetings in either README.md or CONTRIBUTING.md (first two places I looked).

This is a simple PR to just add a reference to those in, in order to help the next person.