### PR TITLE
Make rule names unique in gittuf policy

### DIFF
--- a/internal/common/set/set.go
+++ b/internal/common/set/set.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package set
+
+type Set[T comparable] struct {
+	contents map[T]bool
+}
+
+func NewSet[T comparable]() *Set[T] {
+	return &Set[T]{contents: map[T]bool{}}
+}
+
+func (s *Set[T]) Contents() []T {
+	items := []T{}
+	for item := range s.contents {
+		items = append(items, item)
+	}
+	return items
+}
+
+func (s *Set[T]) Add(item T) {
+	s.contents[item] = true
+}
+
+func (s *Set[T]) Remove(item T) {
+	delete(s.contents, item)
+}
+
+func (s *Set[T]) Extend(set *Set[T]) {
+	items := set.Contents()
+	for _, item := range items {
+		s.Add(item)
+	}
+}
+
+func (s *Set[T]) Has(item T) bool {
+	return s.contents[item]
+}
+
+func (s *Set[T]) Len() int {
+	return len(s.contents)
+}

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -139,11 +139,17 @@ func createTestStateWithPolicy(t *testing.T) *State {
 		t.Fatal(err)
 	}
 
-	return &State{
+	state := &State{
 		RootEnvelope:    rootEnv,
 		TargetsEnvelope: targetsEnv,
 		RootPublicKeys:  []*tuf.Key{key},
 	}
+
+	if err := state.loadRuleNames(); err != nil {
+		t.Fatal(err)
+	}
+
+	return state
 }
 
 func createTestStateWithDelegatedPolicies(t *testing.T) *State {
@@ -244,6 +250,10 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	//   /\
 	//  3  4
 
+	if err := curState.loadRuleNames(); err != nil {
+		t.Fatal(err)
+	}
+
 	return curState
 }
 
@@ -278,6 +288,10 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 	}
 	state.TargetsEnvelope = targetsEnv
 
+	if err := state.loadRuleNames(); err != nil {
+		t.Fatal(err)
+	}
+
 	return state
 }
 
@@ -311,6 +325,10 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 		t.Fatal(err)
 	}
 	state.TargetsEnvelope = targetsEnv
+
+	if err := state.loadRuleNames(); err != nil {
+		t.Fatal(err)
+	}
 
 	return state
 }

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -88,6 +88,13 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 	if err != nil {
 		return err
 	}
+
+	slog.Debug("Checking if rule with same name exists...")
+	if state.HasRuleName(ruleName) {
+		return policy.ErrDuplicatedRuleName
+	}
+
+	slog.Debug("Loading current rule file...")
 	if !state.HasTargetsRole(targetsRoleName) {
 		return policy.ErrMetadataNotFound
 	}
@@ -97,7 +104,6 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 	// assume which role is the delegating role (diamond delegations are legal).
 	// See: https://github.com/gittuf/gittuf/issues/246.
 
-	slog.Debug("Loading current rule file...")
 	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows us to avoid diamond delegations in policy and provide more guardrails to users.