### PR TITLE
Split up add and update rule flows

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -28,4 +28,5 @@ Tools to manage gittuf policies
 * [gittuf policy remote](gittuf_policy_remote.md)	 - Tools for managing remote policies
 * [gittuf policy remove-rule](gittuf_policy_remove-rule.md)	 - Remove rule from a policy file
 * [gittuf policy sign](gittuf_policy_sign.md)	 - Sign policy file
+* [gittuf policy update-rule](gittuf_policy_update-rule.md)	 - Update an existing rule in a policy file
 

--- a/docs/cli/gittuf_policy_update-rule.md
+++ b/docs/cli/gittuf_policy_update-rule.md
@@ -1,0 +1,36 @@
+## gittuf policy update-rule
+
+Update an existing rule in a policy file
+
+### Synopsis
+
+This command allows users to update an existing rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+
+```
+gittuf policy update-rule [flags]
+```
+
+### Options
+
+```
+      --authorize-key stringArray   authorized public key for rule
+  -h, --help                        help for update-rule
+      --policy-name string          name of policy file to add rule to (default "targets")
+      --rule-name string            name of rule
+      --rule-pattern stringArray    patterns used to identify namespaces rule applies to
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign policy file
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/policy/removerule"
 	"github.com/gittuf/gittuf/internal/cmd/policy/sign"
+	"github.com/gittuf/gittuf/internal/cmd/policy/updaterule"
 	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/remote"
 	"github.com/spf13/cobra"
 )
@@ -29,6 +30,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(listrules.New())
 	cmd.AddCommand(removerule.New(o))
 	cmd.AddCommand(sign.New(o))
+	cmd.AddCommand(updaterule.New(o))
 
 	remoteCmd := remote.New()
 	cmd.AddCommand(remoteCmd)

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterule
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p              *persistent.Options
+	policyName     string
+	ruleName       string
+	authorizedKeys []string
+	rulePatterns   []string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		policy.TargetsRoleName,
+		"name of policy file to add rule to",
+	)
+
+	cmd.Flags().StringVar(
+		&o.ruleName,
+		"rule-name",
+		"",
+		"name of rule",
+	)
+	cmd.MarkFlagRequired("rule-name") //nolint:errcheck
+
+	cmd.Flags().StringArrayVar(
+		&o.authorizedKeys,
+		"authorize-key",
+		[]string{},
+		"authorized public key for rule",
+	)
+	cmd.MarkFlagRequired("authorize-key") //nolint:errcheck
+
+	cmd.Flags().StringArrayVar(
+		&o.rulePatterns,
+		"rule-pattern",
+		[]string{},
+		"patterns used to identify namespaces rule applies to",
+	)
+	cmd.MarkFlagRequired("rule-pattern") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	signer, err := common.LoadSigner(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	authorizedKeys := []*tuf.Key{}
+	for _, key := range o.authorizedKeys {
+		key, err := common.LoadPublicKey(key)
+		if err != nil {
+			return err
+		}
+
+		authorizedKeys = append(authorizedKeys, key)
+	}
+
+	return repo.UpdateDelegation(cmd.Context(), signer, o.policyName, o.ruleName, authorizedKeys, o.rulePatterns, true)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "update-rule",
+		Short:             "Update an existing rule in a policy file",
+		Long:              `This command allows users to update an existing rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		PreRunE:           common.CheckIfSigningViable,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -120,12 +120,12 @@ func createTestStateWithPolicy(t *testing.T) *State {
 	}
 
 	targetsMetadata := InitializeTargetsMetadata()
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"})
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Add a file protection rule. When used with common.AddNTestCommitsToSpecifiedRef, we have files with names 1, 2, 3,...n.
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []string{"file:1", "file:2"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []string{"file:1", "file:2"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,12 +183,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	// Create the root targets metadata
 	targetsMetadata := InitializeTargetsMetadata()
 
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "1", []*tuf.Key{key}, []string{"file:1/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "1", []*tuf.Key{key}, []string{"file:1/*"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "2", []*tuf.Key{key}, []string{"file:2/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "2", []*tuf.Key{key}, []string{"file:2/*"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,12 +205,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 
 	// Create the second level of delegations
 	delegation1Metadata := InitializeTargetsMetadata()
-	delegation1Metadata, err = AddOrUpdateDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []string{"file:1/subpath1/*"})
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []string{"file:1/subpath1/*"})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	delegation1Metadata, err = AddOrUpdateDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []string{"file:1/subpath2/*"})
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []string{"file:1/subpath2/*"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []string{"git:refs/tags/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []string{"git:refs/tags/*"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []string{"git:refs/tags/*"})
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []string{"git:refs/tags/*"})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -344,7 +344,7 @@ func TestGetStateForCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddOrUpdateDelegation(targetsMetadata, "new-rule", []*tuf.Key{}, []string{"*"}) // just a dummy rule
+	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{}, []string{"*"}) // just a dummy rule
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Earlier, add-rule was also (silently) the command to update an existing rule. This PR makes these separate flows as a first step in making rule names unique in policy. Now, we can check during add-rule that a rule with the same name doesn't already exist.

Part of #304.