### PR TITLE
Add missing SPDX header

### DIFF
--- a/internal/cmd/addhooks/prepush.go
+++ b/internal/cmd/addhooks/prepush.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package addhooks
 
 var prePushScript = []byte(`#!/bin/sh


### PR DESCRIPTION
Noticed a missing SPDX header in `prepush.go`.