### PR TITLE
Refactor policy state verification

### DIFF
--- a/internal/policy/root.go
+++ b/internal/policy/root.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCannotMeetThreshold = errors.New("removing key will drop authorized keys below threshold")
 	ErrRootMetadataNil     = errors.New("rootMetadata is nil")
+	ErrRootKeyNil          = errors.New("root key not found")
 	ErrTargetsKeyNil       = errors.New("targetsKey is nil")
 	ErrKeyIDEmpty          = errors.New("keyID is empty")
 )

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -983,7 +983,7 @@ func TestStateVerifyNewState(t *testing.T) {
 		}
 
 		err = currentPolicy.VerifyNewState(context.Background(), newPolicy)
-		assert.ErrorContains(t, err, "do not match threshold")
+		assert.ErrorIs(t, err, ErrVerifierConditionsUnmet)
 	})
 }
 

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -137,18 +137,12 @@ func TestRemoveRootKey(t *testing.T) {
 	err = dsse.VerifyEnvelope(testCtx, state.RootEnvelope, []sslibdsse.Verifier{originalSigner}, 1)
 	assert.Nil(t, err)
 
-	err = r.RemoveRootKey(testCtx, originalSigner, rootKey.KeyID, false)
-	// Self root revocation currently is not supported
-	// This is linked to the policy package comment about using prior state for
-	// getRootVerifier
-	assert.ErrorIs(t, err, policy.ErrVerifierConditionsUnmet)
-
 	newSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targetsKeyBytes) //nolint:staticcheck
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// We can use the newly added root key to revoke the old one though
+	// We can use the newly added root key to revoke the old one
 	err = r.RemoveRootKey(testCtx, newSigner, rootKey.KeyID, false)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
Since rule names are unique across all metadata in a policy state, we don't have to worry about diamond delegations. So, we can verify all signatures on policy metadata as well as check if some file is not reachable. With this change, FindVerifiersForPath no longer needs to verify delegated metadata signatures.

Separately, state.Verify is now limited to internal consistency checks. So, it verifies that root keys in the state match, followed by checking all the targets role signatures as discussed above.

Finally, LoadCurrentState now inspects all policy states to verify root role on each state using the previous one. The very first one is still TOFU, but this can be bootstrapped using other mechanisms.

Blocked by #304.