### PR TITLE
Support Go 1.22.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,13 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: '1.22'
     - name: Checkout code
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
     - name: Test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: '1.21.x'
+          go-version: '1.22'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - run: ./.github/workflows/check-docs.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: '1.21.x'
+          go-version: '1.22'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:
-          go-version: '1.21.x'
+          go-version: '1.22'
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0 # fetch full history for previous tag information

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -48,7 +48,7 @@ gittuf version
 
 **Building from source.** To build from source, clone the repository and run
 `make`. This will also run the test suite prior to installing gittuf. Note that
-Go 1.21 or higher is necessary to build gittuf.
+Go 1.22 or higher is necessary to build gittuf.
 
 ```bash
 $ git clone https://github.com/gittuf/gittuf

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gittuf/gittuf
 
-go 1.21.5
+go 1.22
 
 require (
 	github.com/ProtonMail/go-crypto v1.0.0


### PR DESCRIPTION
Trying to fix the CI failures in #317, I think it may be because of go.mod's Go version. Note that in the process, I'm adding 1.22.x to the CI workflow.