### PR TITLE
Added basic authentication attestation support

### DIFF
--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -312,8 +312,9 @@ func TestAttestationsCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, len(rootTree.Entries))
-	assert.Equal(t, referenceAuthorizationsTreeEntryName, rootTree.Entries[0].Name)
+	assert.Equal(t, 2, len(rootTree.Entries))
+	assert.Equal(t, authenticationEvidenceTreeEntryName, rootTree.Entries[0].Name)
+	assert.Equal(t, referenceAuthorizationsTreeEntryName, rootTree.Entries[1].Name)
 
 	// We don't need to check every level of the tree because we do it in the
 	// tree builder API

--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	ReferenceAuthorizationPredicateType = "https://gittuf.dev/reference-authorization/v0.1"
+	AuthenticationEvidencePredicateType = "https://gittuf.dev/authentication-evidence/v0.1"
 	digestGitCommitKey                  = "gitCommit"
 	toTargetIDKey                       = "toTargetID"
 	fromTargetIDKey                     = "fromTargetID"
@@ -146,7 +147,147 @@ func ReferenceAuthorizationPath(refName, fromID, toID string) string {
 	return path.Join(refName, fmt.Sprintf("%s-%s", fromID, toID))
 }
 
+// AuthenticationEvidence is a  record linked to a range of Reference State Log entries in a gittuf repository,
+// and changes the authentication workflows to use the PushActor instead of the signature of the RSl entry.
+// It is meant to be used as a "predicate" in an in-toto attestation.
+type AuthenticationEvidence struct {
+	TargetRef    string `json:"targetRef"`
+	FromTargetID string `json:"fromTargetID"`
+	ToTargetID   string `json:"toTargetID"`
+	PushActor    string `json:"pushActor"`
+}
+
+// NewAuthenticationEvidence creates a new reference authorization for the
+// provided information. The authentication evidence is embedded in an in-toto "statement"
+// and returned with the appropriate "predicate type" set. The `fromTargetID`
+// and `toTargetID` specify the change to `targetRef` that is the ref the target range lies on.
+// by invoking this function. The pushActor is added into the predicate of the statement,
+// and can be retrieved for later use.
+
+func NewAuthenticationEvidence(targetRef, fromTargetID, toTargetID, pushActor string) (*ita.Statement, error) {
+	predicate := &AuthenticationEvidence{
+		TargetRef:    targetRef,
+		FromTargetID: fromTargetID,
+		ToTargetID:   toTargetID,
+		PushActor:    pushActor,
+	}
+
+	predicateBytes, err := json.Marshal(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	predicateInterface := &map[string]any{}
+	if err := json.Unmarshal(predicateBytes, predicateInterface); err != nil {
+		return nil, err
+	}
+
+	predicateStruct, err := structpb.NewStruct(*predicateInterface)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitCommitKey: toTargetID},
+			},
+		},
+		PredicateType: AuthenticationEvidencePredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+// SetAuthenticationEvidence writes the new authentication evidence attestation
+// to the object store and tracks it in the current attestations state.
+func (a *Attestations) SetAuthenticationEvidence(repo *git.Repository, env *sslibdsse.Envelope, refName, fromID, toID string) error {
+	if err := validateAuthenticationEvidence(env, refName, fromID, toID); err != nil {
+		return err
+	}
+
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := gitinterface.WriteBlob(repo, envBytes)
+	if err != nil {
+		return err
+	}
+
+	if a.referenceAuthorizations == nil {
+		a.referenceAuthorizations = map[string]plumbing.Hash{}
+	}
+
+	a.referenceAuthorizations[AuthenticationEvidencePath(refName, fromID, toID)] = blobID
+	return nil
+}
+
+// GetAuthenticationEvidenceFor returns the requested authentication evidence
+// attestation (with its signatures).
+func (a *Attestations) GetAuthenticationEvidenceFor(repo *git.Repository, refName, fromID, toID string) (*sslibdsse.Envelope, error) {
+	blobID, has := a.referenceAuthorizations[AuthenticationEvidencePath(refName, fromID, toID)]
+	if !has {
+		return nil, ErrAuthorizationNotFound
+	}
+
+	envBytes, err := gitinterface.ReadBlob(repo, blobID)
+	if err != nil {
+		return nil, err
+	}
+
+	env := &sslibdsse.Envelope{}
+	if err := json.Unmarshal(envBytes, env); err != nil {
+		return nil, err
+	}
+
+	if err := validateAuthenticationEvidence(env, refName, fromID, toID); err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// AuthenticationEvidencePath constructs the expected path on-disk for the
+// authentication evidence attestation.
+func AuthenticationEvidencePath(refName, fromID, toID string) string {
+	return path.Join(refName, fmt.Sprintf("%s-%s", fromID, toID))
+}
+
 func validateReferenceAuthorization(env *sslibdsse.Envelope, refName, fromID, toID string) error {
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	attestation := &ita.Statement{}
+	if err := json.Unmarshal(payload, attestation); err != nil {
+		return err
+	}
+
+	if attestation.Subject[0].Digest[digestGitCommitKey] != toID {
+		return ErrInvalidAuthorization
+	}
+
+	predicate := attestation.Predicate.AsMap()
+
+	if predicate[toTargetIDKey] != toID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[fromTargetIDKey] != fromID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[targetRefKey] != refName {
+		return ErrInvalidAuthorization
+	}
+
+	return nil
+}
+
+func validateAuthenticationEvidence(env *sslibdsse.Envelope, refName, fromID, toID string) error {
 	payload, err := env.DecodeB64Payload()
 	if err != nil {
 		return err

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -200,14 +200,14 @@ func TestSetAuthenticationEvidence(t *testing.T) {
 	// Add auth for first branch
 	err = attestations.SetAuthenticationEvidence(repo, mainZeroZero, testRef, testID, testID)
 	assert.Nil(t, err)
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.NotContains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.NotContains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 
 	// Add auth for the other branch
 	err = attestations.SetAuthenticationEvidence(repo, featureZeroZero, testAnotherRef, testID, testID)
 	assert.Nil(t, err)
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 }
 
 func TestRemoveAuthenticationEvidence(t *testing.T) {
@@ -227,23 +227,23 @@ func TestRemoveAuthenticationEvidence(t *testing.T) {
 
 	err = attestations.SetAuthenticationEvidence(repo, mainZeroZero, testRef, testID, testID)
 	assert.Nil(t, err)
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.NotContains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.NotContains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 
 	err = attestations.SetAuthenticationEvidence(repo, featureZeroZero, testAnotherRef, testID, testID)
 	assert.Nil(t, err)
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 
 	err = attestations.RemoveAuthenticationEvidence(testAnotherRef, testID, testID)
 	assert.Nil(t, err)
-	assert.Contains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.NotContains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.Contains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.NotContains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 
 	err = attestations.RemoveAuthenticationEvidence(testRef, testID, testID)
 	assert.Nil(t, err)
-	assert.NotContains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testRef, testID, testID))
-	assert.NotContains(t, attestations.referenceAuthorizations, AuthenticationEvidencePath(testAnotherRef, testID, testID))
+	assert.NotContains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testRef, testID, testID))
+	assert.NotContains(t, attestations.authenticationEvidence, AuthenticationEvidencePath(testAnotherRef, testID, testID))
 }
 
 func TestGetAuthenticationEvidenceFor(t *testing.T) {
@@ -294,8 +294,9 @@ func TestValidateAuthorizationEvidence(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = validateAuthenticationEvidence(mainZeroZero, testAnotherRef, testID, testID)
-	assert.ErrorIs(t, err, ErrInvalidAuthorization)
+	assert.ErrorIs(t, err, ErrInvalidEvidence)
 }
+
 func createReferenceAuthorizationAttestationEnvelopes(t *testing.T, refName, fromID, toID string) *sslibdsse.Envelope {
 	t.Helper()
 
@@ -310,6 +311,7 @@ func createReferenceAuthorizationAttestationEnvelopes(t *testing.T, refName, fro
 
 	return env
 }
+
 func createAuthenticationEvidenceAttestationEnvelopes(t *testing.T, refName, fromID, toID, pushActor string) *sslibdsse.Envelope {
 	t.Helper()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -406,7 +406,7 @@ func (s *State) Verify(ctx context.Context) error {
 		return err
 	}
 
-	if err := targetsVerifier.Verify(ctx, nil, s.TargetsEnvelope); err != nil {
+	if err := targetsVerifier.Verify(ctx, nil, s.TargetsEnvelope, ""); err != nil {
 		return err
 	}
 
@@ -448,7 +448,7 @@ func (s *State) Verify(ctx context.Context) error {
 				threshold: delegation.Threshold,
 			}
 
-			if err := verifier.Verify(ctx, nil, env); err != nil {
+			if err := verifier.Verify(ctx, nil, env, ""); err != nil {
 				return err
 			}
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -1199,7 +1199,7 @@ func TestVerifier(t *testing.T) {
 
 	for name, test := range tests {
 		verifier := Verifier{name: "test-verifier", keys: test.keys, threshold: test.threshold}
-		err := verifier.Verify(context.Background(), test.gitObject, test.attestation)
+		err := verifier.Verify(context.Background(), test.gitObject, test.attestation, "")
 		if test.expectedError == nil {
 			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -791,7 +791,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyEntry(context.Background(), repo, state, nil, entry)
+		err := verifyEntry(context.Background(), repo, state, nil, "", entry)
 		assert.Nil(t, err)
 	})
 
@@ -834,6 +834,11 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		attentionLatestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, attestations.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		currentAttestations, err = attestations.LoadCurrentAttestations(repo)
 		if err != nil {
 			t.Fatal(err)
@@ -843,7 +848,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+		err = verifyEntry(testCtx, repo, state, currentAttestations, attentionLatestEntry.TargetID.String(), entry)
 		assert.Nil(t, err)
 	})
 

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -17,6 +17,7 @@ import (
 const (
 	GittufNamespacePrefix      = "refs/gittuf/"
 	Ref                        = "refs/gittuf/reference-state-log"
+	attestationRef             = "refs/gittuf/attestations"
 	ReferenceEntryHeader       = "RSL Reference Entry"
 	RefKey                     = "ref"
 	TargetIDKey                = "targetID"
@@ -287,7 +288,7 @@ func GetNonGittufParentReferenceEntryForEntry(repo *git.Repository, entry Entry)
 	for {
 		switch iterator := it.(type) {
 		case *ReferenceEntry:
-			if !strings.HasPrefix(iterator.RefName, GittufNamespacePrefix) {
+			if !strings.HasPrefix(iterator.RefName, GittufNamespacePrefix) || strings.HasPrefix(iterator.RefName, attestationRef) {
 				targetEntry = iterator
 			}
 		case *AnnotationEntry:
@@ -339,7 +340,7 @@ func GetLatestNonGittufReferenceEntry(repo *git.Repository) (*ReferenceEntry, []
 	for {
 		switch iterator := it.(type) {
 		case *ReferenceEntry:
-			if !strings.HasPrefix(iterator.RefName, GittufNamespacePrefix) {
+			if !strings.HasPrefix(iterator.RefName, GittufNamespacePrefix) || strings.HasPrefix(iterator.RefName, attestationRef) {
 				targetEntry = iterator
 			}
 		case *AnnotationEntry:


### PR DESCRIPTION
- In this current feature implementation, anyone can add an authentication attestation, with the pusher being anyone. Without evidence, as defined in the design document https://github.com/gittuf/gittuf/blob/main/docs/design-document.md#authentication-evidence-attestations, this feature is fraught with security holes.
- I do not know what format the evidence should take; I was thinking about somthing like a push event ID (for example, https://api.github.com/events) where verification could call the GitHub API, go through the push events, and try to find this ID. If found, it would check if the pusher is the pusher that the creator of the attestation says it is. The problem with this approach is that Github only allows access to the last 90 days of Push Events, so if we were to make a recording like this. If verification were run two years later, we would not be able to find that event, and the tool would mark it as failing verification, even if it were a valid attestation.