### PR TITLE
gitinterface: Make user.signingkey optional

### DIFF
--- a/internal/gitinterface/keys_test.go
+++ b/internal/gitinterface/keys_test.go
@@ -21,7 +21,6 @@ var (
 	testConfig2 = artifacts.GitConfig2
 	testConfig3 = artifacts.GitConfig3
 	testConfig4 = artifacts.GitConfig4
-	testConfig5 = artifacts.GitConfig5
 )
 
 func TestGetSigningInfo(t *testing.T) {
@@ -119,25 +118,6 @@ func TestGetSigningInfo(t *testing.T) {
 			wantedKeyInfo:       "abcdef",
 			wantedProgram:       "gpgsm",
 		},
-		"unknown signing key": {
-			c: &config.Config{
-				Raw: &format.Config{
-					Sections: format.Sections{
-						&format.Section{
-							Name: "user",
-							Options: format.Options{
-								&format.Option{
-									Key:   "foo",
-									Value: "bar",
-								},
-							},
-						},
-					},
-				},
-			},
-			configFile:    testConfig4,
-			expectedError: ErrSigningKeyNotSpecified,
-		},
 		"unknown signing method": {
 			c: &config.Config{
 				Raw: &format.Config{
@@ -163,7 +143,7 @@ func TestGetSigningInfo(t *testing.T) {
 					},
 				},
 			},
-			configFile:    testConfig5,
+			configFile:    testConfig4,
 			expectedError: ErrUnknownSigningMethod,
 		},
 	}

--- a/internal/testartifacts/gitconfig.go
+++ b/internal/testartifacts/gitconfig.go
@@ -15,6 +15,3 @@ var GitConfig3 []byte
 
 //go:embed testdata/gitconfigs/config-4
 var GitConfig4 []byte
-
-//go:embed testdata/gitconfigs/config-5
-var GitConfig5 []byte

--- a/internal/testartifacts/testdata/gitconfigs/config-4
+++ b/internal/testartifacts/testdata/gitconfigs/config-4
@@ -1,1 +1,2 @@
-user.foo bar
+user.signingkey abcdef
+gpg.format abcdef

--- a/internal/testartifacts/testdata/gitconfigs/config-5
+++ b/internal/testartifacts/testdata/gitconfigs/config-5
@@ -1,2 +1,0 @@
-user.signingkey abcdef
-gpg.format abcdef


### PR DESCRIPTION
Now, user.signingkey is required only when the signing format is ssh. I suspect we can loosen this too?