### PR TITLE
Switch authorizations to use merge tree target

### DIFF
--- a/docs/cli/gittuf_dev_authorize.md
+++ b/docs/cli/gittuf_dev_authorize.md
@@ -9,6 +9,7 @@ gittuf dev authorize [flags]
 ### Options
 
 ```
+  -f, --from-ref string      ref to authorize merging changes from
   -h, --help                 help for authorize
   -r, --revoke               revoke existing authorization
   -k, --signing-key string   signing key to use for creating or revoking an authorization

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -27,17 +27,17 @@ func TestNewReferenceAuthorization(t *testing.T) {
 
 	// Check subject contents
 	assert.Equal(t, 1, len(authorization.Subject))
-	assert.Contains(t, authorization.Subject[0].Digest, digestGitCommitKey)
-	assert.Equal(t, authorization.Subject[0].Digest[digestGitCommitKey], testID)
+	assert.Contains(t, authorization.Subject[0].Digest, digestGitTreeKey)
+	assert.Equal(t, authorization.Subject[0].Digest[digestGitTreeKey], testID)
 
 	// Check predicate type
 	assert.Equal(t, ReferenceAuthorizationPredicateType, authorization.PredicateType)
 
 	// Check predicate
 	predicate := authorization.Predicate.AsMap()
-	assert.Equal(t, predicate["targetRef"], testRef)
-	assert.Equal(t, predicate["toTargetID"], testID)
-	assert.Equal(t, predicate["fromTargetID"], testID)
+	assert.Equal(t, predicate[targetRefKey], testRef)
+	assert.Equal(t, predicate[targetTreeIDKey], testID)
+	assert.Equal(t, predicate[fromRevisionIDKey], testID)
 }
 
 func TestSetReferenceAuthorization(t *testing.T) {

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -5,10 +5,12 @@ package gitinterface
 import (
 	"errors"
 	"io"
+	"os/exec"
 	"path"
 	"sort"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
@@ -75,6 +77,21 @@ func GetAllFilesInTree(tree *object.Tree) (map[string]plumbing.Hash, error) {
 	}
 
 	return files, nil
+}
+
+func GetMergeTree(_ *git.Repository, commitAID, commitBID string) (string, error) {
+	if !dev.InDevMode() {
+		return "", dev.ErrNotInDevMode
+	}
+
+	command := exec.Command("git", "merge-tree", commitAID, commitBID) //nolint:gosec
+	stdOut, err := command.Output()
+	if err != nil {
+		return "", err
+	}
+
+	stdOutString := strings.TrimSpace(string(stdOut))
+	return stdOutString, nil
 }
 
 // TreeBuilder is used to create multi-level trees in a repository.

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -792,7 +792,12 @@ func getAuthorizationAttestation(repo *git.Repository, attestationsState *attest
 		fromID = priorRefEntry.TargetID
 	}
 
-	attestation, err := attestationsState.GetReferenceAuthorizationFor(repo, entry.RefName, fromID.String(), entry.TargetID.String())
+	currentCommit, err := gitinterface.GetCommit(repo, entry.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	attestation, err := attestationsState.GetReferenceAuthorizationFor(repo, entry.RefName, fromID.String(), currentCommit.TreeHash.String())
 	if err != nil {
 		if errors.Is(err, attestations.ErrAuthorizationNotFound) {
 			return nil, nil

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -856,11 +856,13 @@ func TestVerifyEntry(t *testing.T) {
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
 
+		commit, err := gitinterface.GetCommit(repo, commitIDs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		// Create authorization for this change
-		// TODO: determine authorization format, this requires the target commit
-		// ID instead of something that could be determined ahead of time like
-		// the tree ID
-		authorization, err := attestations.NewReferenceAuthorization(refName, plumbing.ZeroHash.String(), commitIDs[0].String())
+		authorization, err := attestations.NewReferenceAuthorization(refName, plumbing.ZeroHash.String(), commit.TreeHash.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -878,7 +880,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, plumbing.ZeroHash.String(), commitIDs[0].String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, plumbing.ZeroHash.String(), commit.TreeHash.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", false); err != nil {

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -4,135 +4,130 @@ package repository
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/attestations"
+	"github.com/gittuf/gittuf/internal/common"
 	"github.com/gittuf/gittuf/internal/dev"
+	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier"
-	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAddReferenceAuthorization(t *testing.T) {
+func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 	t.Setenv(dev.DevModeKey, "1")
 
-	refName := "main"
-	absRefName := "refs/heads/main"
-	commitID := plumbing.ZeroHash.String()
+	testDir := t.TempDir()
 
-	r, err := git.Init(memory.NewStorage(), memfs.New())
+	currentDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(absRefName), plumbing.ZeroHash)); err != nil {
+	if err := os.Chdir(testDir); err != nil {
 		t.Fatal(err)
 	}
+	defer os.Chdir(currentDir) //nolint:errcheck
 
+	r, err := git.PlainInit(testDir, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	repo := &Repository{r: r}
-
-	rootSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	targetsSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targetsKeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if err := repo.InitializeNamespaces(); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := repo.RecordRSLEntryForReference(absRefName, false); err != nil {
+	// Create main branch as the target branch with a Git commit
+	targetRef := "main"
+	absTargetRef := "refs/heads/main"
+	// Add a single commit
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
+	fromCommitID := commitIDs[0].String()
+	if err := repo.RecordRSLEntryForReference(targetRef, false); err != nil {
 		t.Fatal(err)
 	}
 
-	err = repo.AddReferenceAuthorization(context.Background(), rootSigner, absRefName, false)
+	// Create feature branch with two Git commits
+	featureRef := "feature"
+	absFeatureRef := "refs/heads/feature"
+	// Add two commits
+	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
+	featureCommitID := commitIDs[1].String()
+	if err := repo.RecordRSLEntryForReference(featureRef, false); err != nil {
+		t.Fatal(err)
+	}
+
+	targetTreeID, err := gitinterface.GetMergeTree(r, fromCommitID, featureCommitID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create signers
+	firstSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstKeyID, err := firstSigner.KeyID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targetsKeyBytes) //nolint:staticcheck
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondKeyID, err := secondSigner.KeyID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First authorization attestation signature
+	err = repo.AddReferenceAuthorization(context.Background(), firstSigner, absTargetRef, absFeatureRef, false)
 	assert.Nil(t, err)
 
-	allAttestations, err := attestations.LoadCurrentAttestations(repo.r)
+	allAttestations, err := attestations.LoadCurrentAttestations(r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, absRefName, commitID, commitID)
+	env, err := allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID, targetTreeID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, len(env.Signatures))
+	assert.Len(t, env.Signatures, 1)
+	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
 
-	// Add authorization using the short ref name and different signer
-	err = repo.AddReferenceAuthorization(context.Background(), targetsSigner, refName, false)
+	// Second authorization attestation signature
+	err = repo.AddReferenceAuthorization(context.Background(), secondSigner, absTargetRef, absFeatureRef, false)
 	assert.Nil(t, err)
 
-	allAttestations, err = attestations.LoadCurrentAttestations(repo.r)
+	allAttestations, err = attestations.LoadCurrentAttestations(r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	env, err = allAttestations.GetReferenceAuthorizationFor(repo.r, absRefName, commitID, commitID)
+	env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID, targetTreeID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 2, len(env.Signatures))
-}
+	assert.Len(t, env.Signatures, 2)
+	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
+	assert.Equal(t, secondKeyID, env.Signatures[1].KeyID)
 
-func TestRemoveReferenceAuthorization(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
-	absRefName := "refs/heads/main"
-	commitID := plumbing.ZeroHash.String()
-
-	rootSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r, err := git.Init(memory.NewStorage(), memfs.New())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := r.Storer.SetReference(plumbing.NewHashReference(plumbing.ReferenceName(absRefName), plumbing.ZeroHash)); err != nil {
-		t.Fatal(err)
-	}
-
-	repo := &Repository{r: r}
-
-	if err := repo.InitializeNamespaces(); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := repo.RecordRSLEntryForReference(absRefName, false); err != nil {
-		t.Fatal(err)
-	}
-
-	err = repo.AddReferenceAuthorization(context.Background(), rootSigner, absRefName, false)
+	// Remove second authorization attestation signature
+	err = repo.RemoveReferenceAuthorization(context.Background(), secondSigner, absTargetRef, fromCommitID, targetTreeID, false)
 	assert.Nil(t, err)
 
-	allAttestations, err := attestations.LoadCurrentAttestations(repo.r)
+	allAttestations, err = attestations.LoadCurrentAttestations(r)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, absRefName, commitID, commitID)
+	env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID, targetTreeID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, len(env.Signatures))
-
-	err = repo.RemoveReferenceAuthorization(context.Background(), rootSigner, absRefName, commitID, commitID, false)
-	assert.Nil(t, err)
-
-	allAttestations, err = attestations.LoadCurrentAttestations(repo.r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	env, err = allAttestations.GetReferenceAuthorizationFor(repo.r, absRefName, commitID, commitID)
-	assert.ErrorIs(t, err, attestations.ErrAuthorizationNotFound)
-	assert.Nil(t, env)
+	assert.Len(t, env.Signatures, 1)
+	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
 }


### PR DESCRIPTION
This PR updates the authorization attestation to use the merge tree as the target for the attestation. This better allows for ahead of time merges. For example, if the main branch has commit A and feature branch has commit B, previously, we required the merge to be a fast forward merge in the context of the authorization attestation. Specifically, the attestation recorded commit B as the target. Now, the target is the result of `git merge-tree <commitA> <commitB>`.