### PR TITLE
Store GitHub PR data as an attestation

### DIFF
--- a/docs/cli/gittuf_dev.md
+++ b/docs/cli/gittuf_dev.md
@@ -24,6 +24,7 @@ These commands are meant to be used to aid gittuf development, and are not expec
 ### SEE ALSO
 
 * [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
+* [gittuf dev attest-github](gittuf_dev_attest-github.md)	 - Record GitHub pull request information as an attestation (developer mode only, set GITTUF_DEV=1)
 * [gittuf dev authorize](gittuf_dev_authorize.md)	 - Add or revoke reference authorization (developer mode only, set GITTUF_DEV=1)
 * [gittuf dev rsl-record](gittuf_dev_rsl-record.md)	 - Record explicit state of a Git reference in the RSL, signed with specified key (developer mode only, set GITTUF_DEV=1)
 

--- a/docs/cli/gittuf_dev_attest-github.md
+++ b/docs/cli/gittuf_dev_attest-github.md
@@ -1,0 +1,32 @@
+## gittuf dev attest-github
+
+Record GitHub pull request information as an attestation (developer mode only, set GITTUF_DEV=1)
+
+```
+gittuf dev attest-github [flags]
+```
+
+### Options
+
+```
+      --base-branch string        base branch for pull request, used with --commit
+      --commit string             commit to record pull request attestation for
+  -h, --help                      help for attest-github
+      --pull-request-number int   pull request number to record in attestation (default -1)
+      --repository string         path to base GitHub repository the pull request is opened against, of form {owner}/{repo}
+  -k, --signing-key string        signing key to use for signing attestation
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf dev](gittuf_dev.md)	 - Developer mode commands
+

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ProtonMail/go-crypto v1.0.0
 	github.com/go-git/go-billy/v5 v5.5.0
 	github.com/go-git/go-git/v5 v5.12.0
+	github.com/google/go-github/v61 v61.0.0
 	github.com/hiddeco/sshsig v0.1.0
 	github.com/in-toto/attestation v1.0.2
 	github.com/jonboulle/clockwork v0.4.0
@@ -59,6 +60,7 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/certificate-transparency-go v1.1.8 // indirect
 	github.com/google/go-containerregistry v0.19.1 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/trillian v1.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -294,6 +294,7 @@ github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49/go.mod h1:
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -302,6 +303,8 @@ github.com/google/go-containerregistry v0.19.1 h1:yMQ62Al6/V0Z7CqIrrS1iYoA5/oQCm
 github.com/google/go-containerregistry v0.19.1/go.mod h1:YCMFNQeeXeLF+dnhhWkqDItx/JSkH01j1Kis4PsjzFI=
 github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLNb9x9cg=
 github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
+github.com/google/go-github/v61 v61.0.0 h1:VwQCBwhyE9JclCI+22/7mLB1PuU9eowCXKY5pNlu1go=
+github.com/google/go-github/v61 v61.0.0/go.mod h1:0WR+KmsWX75G2EbpyGsGmradjo3IiciuI4BmdVCobQY=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=

--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -312,8 +312,9 @@ func TestAttestationsCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, 1, len(rootTree.Entries))
-	assert.Equal(t, referenceAuthorizationsTreeEntryName, rootTree.Entries[0].Name)
+	assert.Equal(t, 2, len(rootTree.Entries))
+	assert.Equal(t, githubPullRequestAttestationsTreeEntryName, rootTree.Entries[0].Name)
+	assert.Equal(t, referenceAuthorizationsTreeEntryName, rootTree.Entries[1].Name)
 
 	// We don't need to check every level of the tree because we do it in the
 	// tree builder API

--- a/internal/attestations/github.go
+++ b/internal/attestations/github.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/go-github/v61/github"
+	ita "github.com/in-toto/attestation/go/v1"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	GitHubPullRequestPredicateType = "https://gittuf.dev/github-pull-request/v0.1"
+	digestGitCommitKey             = "gitCommit"
+)
+
+func NewGitHubPullRequestAttestation(owner, repository string, pullRequestNumber int, commitID string, pullRequest *github.PullRequest) (*ita.Statement, error) {
+	pullRequestBytes, err := json.Marshal(pullRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	predicate := map[string]any{}
+	if err := json.Unmarshal(pullRequestBytes, &predicate); err != nil {
+		return nil, err
+	}
+
+	predicateStruct, err := structpb.NewStruct(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Uri:    fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repository, pullRequestNumber),
+				Digest: map[string]string{digestGitCommitKey: commitID},
+			},
+		},
+		PredicateType: GitHubPullRequestPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+func (a *Attestations) SetGitHubPullRequestAuthorization(repo *git.Repository, env *sslibdsse.Envelope, targetRefName, commitID string) error {
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := gitinterface.WriteBlob(repo, envBytes)
+	if err != nil {
+		return err
+	}
+
+	if a.githubPullRequestAttestations == nil {
+		a.githubPullRequestAttestations = map[string]plumbing.Hash{}
+	}
+
+	a.githubPullRequestAttestations[GitHubPullRequestAttestationPath(targetRefName, commitID)] = blobID
+	return nil
+}
+
+// GitHubPullRequestAttestationPath constructs the expected path on-disk for the
+// GitHub pull request attestation.
+func GitHubPullRequestAttestationPath(refName, commitID string) string {
+	return path.Join(refName, commitID)
+}

--- a/internal/cmd/dev/attestgithub/attestgithub.go
+++ b/internal/cmd/dev/attestgithub/attestgithub.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestgithub
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/dev"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	signingKey        string
+	repository        string
+	pullRequestNumber int
+	commitID          string
+	baseBranch        string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(
+		&o.signingKey,
+		"signing-key",
+		"k",
+		"",
+		"signing key to use for signing attestation",
+	)
+	cmd.MarkFlagRequired("signing-key") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.repository,
+		"repository",
+		"",
+		"path to base GitHub repository the pull request is opened against, of form {owner}/{repo}",
+	)
+	cmd.MarkFlagRequired("repository") //nolint:errcheck
+
+	cmd.Flags().IntVar(
+		&o.pullRequestNumber,
+		"pull-request-number",
+		-1,
+		"pull request number to record in attestation",
+	)
+
+	cmd.Flags().StringVar(
+		&o.commitID,
+		"commit",
+		"",
+		"commit to record pull request attestation for",
+	)
+
+	cmd.Flags().StringVar(
+		&o.baseBranch,
+		"base-branch",
+		"",
+		"base branch for pull request, used with --commit",
+	)
+
+	// When we're using commit, we need the base branch to filter through nested
+	// pull requests
+	cmd.MarkFlagsRequiredTogether("commit", "base-branch")
+
+	cmd.MarkFlagsOneRequired("pull-request-number", "commit")
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repositoryParts := strings.Split(o.repository, "/")
+	if len(repositoryParts) != 2 {
+		return fmt.Errorf("invalid format for repository, must be {owner}/{repo}")
+	}
+
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	keyBytes, err := os.ReadFile(o.signingKey)
+	if err != nil {
+		return err
+	}
+	signer, err := common.LoadSigner(keyBytes)
+	if err != nil {
+		return err
+	}
+
+	if o.commitID != "" {
+		return repo.AddGitHubPullRequestAttestationForCommit(cmd.Context(), signer, repositoryParts[0], repositoryParts[1], o.commitID, o.baseBranch, true)
+	}
+
+	return repo.AddGitHubPullRequestAttestationForNumber(cmd.Context(), signer, repositoryParts[0], repositoryParts[1], o.pullRequestNumber, true)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:   "attest-github",
+		Short: fmt.Sprintf("Record GitHub pull request information as an attestation (developer mode only, set %s=1)", dev.DevModeKey),
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/dev/dev.go
+++ b/internal/cmd/dev/dev.go
@@ -5,6 +5,7 @@ package dev
 import (
 	"fmt"
 
+	"github.com/gittuf/gittuf/internal/cmd/dev/attestgithub"
 	"github.com/gittuf/gittuf/internal/cmd/dev/authorize"
 	"github.com/gittuf/gittuf/internal/cmd/dev/rslrecordat"
 	"github.com/gittuf/gittuf/internal/dev"
@@ -20,6 +21,7 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddCommand(authorize.New())
+	cmd.AddCommand(attestgithub.New())
 	cmd.AddCommand(rslrecordat.New())
 
 	return cmd


### PR DESCRIPTION
In developer mode, this records a GitHub PR's information as an attestation (using the GitHub API).

Note: I want to examine and incorporate work by @neilnaveen from #320 as well.