### PR TITLE
repository: Verify full history on clone

### DIFF
--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -65,5 +65,5 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string) (*Reposito
 	repository := &Repository{r: r}
 
 	slog.Debug("Verifying HEAD...")
-	return repository, repository.VerifyRef(ctx, head.Target().String(), true)
+	return repository, repository.VerifyRef(ctx, head.Target().String(), false)
 }


### PR DESCRIPTION
This is needed when actual recovery flows have happened.