### PR TITLE
Refactoring and testing policy/verify.go

### DIFF
--- a/internal/cmd/verifytag/verifytag.go
+++ b/internal/cmd/verifytag/verifytag.go
@@ -21,8 +21,8 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 
 	status := repo.VerifyTag(cmd.Context(), args)
 
-	for _, id := range args {
-		fmt.Printf("%s: %s\n", id, status[id])
+	for _, tagName := range args {
+		fmt.Printf("%s: %s\n", tagName, status[tagName])
 	}
 
 	return nil

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -92,6 +92,36 @@ func createTestStateWithOnlyRoot(t *testing.T) *State {
 	}
 }
 
+func createTestStateWithOnlyBadRoot(t *testing.T) *State {
+	t.Helper()
+
+	signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targets1KeyBytes) //nolint:staticcheck
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := tuf.LoadKeyFromBytes(targets1PubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata := InitializeRootMetadata(key)
+
+	rootEnv, err := dsse.CreateEnvelope(rootMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootEnv, err = dsse.SignEnvelope(context.Background(), rootEnv, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &State{
+		RootPublicKeys: []*tuf.Key{key},
+		RootEnvelope:   rootEnv,
+	}
+}
+
 func createTestStateWithPolicy(t *testing.T) *State {
 	t.Helper()
 

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -92,36 +92,6 @@ func createTestStateWithOnlyRoot(t *testing.T) *State {
 	}
 }
 
-func createTestStateWithOnlyBadRoot(t *testing.T) *State {
-	t.Helper()
-
-	signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targets1KeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	key, err := tuf.LoadKeyFromBytes(targets1PubKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rootMetadata := InitializeRootMetadata(key)
-
-	rootEnv, err := dsse.CreateEnvelope(rootMetadata)
-	if err != nil {
-		t.Fatal(err)
-	}
-	rootEnv, err = dsse.SignEnvelope(context.Background(), rootEnv, signer)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return &State{
-		RootPublicKeys: []*tuf.Key{key},
-		RootEnvelope:   rootEnv,
-	}
-}
-
 func createTestStateWithPolicy(t *testing.T) *State {
 	t.Helper()
 

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -196,7 +196,6 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 			switch entry.RefName {
 			case PolicyStagingRef:
 				slog.Debug("Entry is for the policy staging reference...")
-				continue
 			case PolicyRef:
 				slog.Debug("Entry is for the policy reference...")
 				// TODO: this is repetition if the firstEntry is for policy

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -39,13 +39,13 @@ const (
 )
 
 var (
-	ErrUnauthorizedSignature             = errors.New("unauthorized signature")
-	ErrInvalidEntryNotSkipped            = errors.New("invalid entry found not marked as skipped")
-	ErrLastGoodEntryIsSkipped            = errors.New("entry expected to be unskipped is marked as skipped")
-	ErrUnknownObjectType                 = errors.New("unknown object type passed to verify signature")
-	ErrInvalidVerifier                   = errors.New("verifier has invalid parameters (is threshold 0?)")
-	ErrVerifierConditionsUnmet           = errors.New("verifier's key and threshold constraints not met")
-	ErrMultipleTagRSLEntriesFoundMessage = errors.New("multiple RSL entries found for tag")
+	ErrUnauthorizedSignature      = errors.New("unauthorized signature")
+	ErrInvalidEntryNotSkipped     = errors.New("invalid entry found not marked as skipped")
+	ErrLastGoodEntryIsSkipped     = errors.New("entry expected to be unskipped is marked as skipped")
+	ErrUnknownObjectType          = errors.New("unknown object type passed to verify signature")
+	ErrInvalidVerifier            = errors.New("verifier has invalid parameters (is threshold 0?)")
+	ErrVerifierConditionsUnmet    = errors.New("verifier's key and threshold constraints not met")
+	ErrMultipleTagRSLEntriesFound = errors.New("multiple RSL entries found for tag")
 )
 
 // VerifyRef verifies the signature on the latest RSL entry for the target ref
@@ -194,7 +194,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 	}
 
 	if strings.HasPrefix(target, gitinterface.TagRefPrefix) && targetRefEntiresCount > 1 {
-		return ErrMultipleTagRSLEntriesFoundMessage
+		return ErrMultipleTagRSLEntriesFound
 	}
 
 	for len(entries) != 0 {
@@ -208,6 +208,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 
 			switch entry.RefName {
 			case PolicyStagingRef:
+				// If we encounter a policy-staging entry, we alert the user, but ignore it for gittuf verification
 				slog.Debug("Entry is for the policy staging reference...")
 			case PolicyRef:
 				slog.Debug("Entry is for the policy reference...")
@@ -272,7 +273,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *git.Repository, initialPoli
 	return nil
 }
 
-// findFixEntry is only reached when we have an invalid state.
+// findFixEntry is only used when we have an invalid state.
 // First, findFixEntry determines the last good state for
 // the ref. This is needed to evaluate whether a fix for the invalid
 // state is available. After this is found, the workflow looks through

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -879,9 +879,11 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		}
 
 		initialPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		repo, _ = createTestRepository(t, createTestStateWithPolicy)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -938,7 +940,6 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 
 		initialPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -965,7 +966,6 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 
 		initialPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -995,7 +995,6 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 
 		initialPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1088,7 +1087,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyEntry(context.Background(), repo, state, nil, entry)
+		err := verifyEntry(context.Background(), repo, state, nil, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -1142,7 +1141,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+		err = verifyEntry(testCtx, repo, state, currentAttestations, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -1195,7 +1194,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = verifyEntry(context.Background(), repo, state, nil, entry)
+		err = verifyEntry(context.Background(), repo, state, nil, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -1207,7 +1206,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
-		err := verifyEntry(context.Background(), repo, state, nil, entry)
+		err := verifyEntry(context.Background(), repo, state, nil, entry, refName)
 		assert.Equal(t, err.Error(), fmt.Sprintf("verifying Git namespace policies failed, %s", ErrUnauthorizedSignature.Error()))
 	})
 
@@ -1258,7 +1257,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
-		err = verifyEntry(context.Background(), repo, state, nil, entry)
+		err = verifyEntry(context.Background(), repo, state, nil, entry, refName)
 		assert.Equal(t, fmt.Sprintf("verifying file namespace policies failed, %s", ErrUnauthorizedSignature.Error()), err.Error())
 	})
 }
@@ -1280,7 +1279,7 @@ func TestVerifyTagEntry(t *testing.T) {
 		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyTagEntry(context.Background(), repo, policy, entry)
+		err := verifyTagEntry(context.Background(), repo, policy, entry, tagName)
 		assert.Nil(t, err)
 	})
 
@@ -1300,7 +1299,7 @@ func TestVerifyTagEntry(t *testing.T) {
 		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyTagEntry(context.Background(), repo, policy, entry)
+		err := verifyTagEntry(context.Background(), repo, policy, entry, tagName)
 		assert.Nil(t, err)
 	})
 
@@ -1320,7 +1319,7 @@ func TestVerifyTagEntry(t *testing.T) {
 		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err := verifyTagEntry(context.Background(), repo, policy, entry)
+		err := verifyTagEntry(context.Background(), repo, policy, entry, tagName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 }

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -1019,7 +1019,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		err = VerifyRelativeForRef(context.Background(), repo, initialPolicyEntry, nil, initialPolicyEntry, entry, string(plumbing.NewTagReferenceName(tagName)))
-		assert.ErrorIs(t, err, ErrMultipleTagRSLEntriesFoundMessage)
+		assert.ErrorIs(t, err, ErrMultipleTagRSLEntriesFound)
 	})
 }
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -809,6 +809,9 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		}
 
 		initialPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		repo, _ = createTestRepository(t, createTestStateWithPolicy)
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -814,7 +814,11 @@ func TestVerifyRelativeForRef(t *testing.T) {
 
 		state := createTestStateWithOnlyBadRoot(t)
 
-		if err := state.Commit(context.Background(), repo, "Create test state", false); err != nil {
+		if err := state.Commit(repo, "Create test state", false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Apply(context.Background(), repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -851,7 +855,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		s, err := LoadCurrentState(context.Background(), repo)
+		s, err := LoadCurrentState(context.Background(), repo, PolicyRef)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -882,7 +886,11 @@ func TestVerifyRelativeForRef(t *testing.T) {
 
 		s.TargetsEnvelope = env
 
-		if err := s.Commit(context.Background(), repo, "revoke key", false); err != nil {
+		if err := s.Commit(repo, "revoke key", false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := Apply(context.Background(), repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1120,7 +1128,7 @@ func TestVerifyEntry(t *testing.T) {
 		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		s, err := LoadCurrentState(context.Background(), repo)
+		s, err := LoadCurrentState(context.Background(), repo, PolicyStagingRef)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1151,7 +1159,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		s.TargetsEnvelope = env
 
-		if err := s.Commit(context.Background(), repo, "revoke key", false); err != nil {
+		if err := s.Commit(repo, "revoke key", false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1209,7 +1217,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		state.TargetsEnvelope = env
 
-		if err := state.Commit(context.Background(), repo, "protect-1", false); err != nil {
+		if err := state.Commit(repo, "protect-1", false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -88,9 +88,14 @@ func (r *Repository) VerifyCommit(ctx context.Context, ids ...string) map[string
 	return policy.VerifyCommit(ctx, r.r, ids...)
 }
 
-func (r *Repository) VerifyTag(ctx context.Context, ids []string) map[string]string {
+func (r *Repository) VerifyTag(ctx context.Context, tags []string) map[string]string {
 	slog.Debug("Verifying tag signature...")
-	return policy.VerifyTag(ctx, r.r, ids)
+	result := map[string]string{}
+	for _, tagName := range tags {
+		result[tagName] = r.VerifyRef(ctx, tagName, false).Error()
+	}
+
+	return result
 }
 
 func (r *Repository) verifyRefTip(target string, expectedTip plumbing.Hash) error {


### PR DESCRIPTION
- VerifyRelativeForRef
- [x] Refactor into helper functions
- [x] Test with attestations 
- [x] Test when failing `currentPolicy.VerifyNewState`
- [x] Test with key revocation
- [x] Move VerifyTag's functionalty into VerifyRelativeForRef
- verifyEntry
- [x] Refactor into helper functions
- [x] Test with attestations 
- [x] Test when failing both types of ref rules 
- [x] Test with key revocation


In this PR, I am trying to clean up the core functionality of policy/verify.go which primarily runs through VerifyRelativeForRef and verifyEntry. I am also adding test to complete code coverage of these two functions.

In addition I am trying to figure out a clean way to merge the functionality of VerifyTag with VerifyRelativeForRef. This should be possible since at the end tags are refs themselves, just with different ways to verify them. 
