### PR TITLE
ci: Run gittuf workflows only on gittuf/gittuf

### DIFF
--- a/.github/workflows/gittuf-rsl-main.yml
+++ b/.github/workflows/gittuf-rsl-main.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
 jobs:
   create-rsl-entry:
+    if: github.repository == 'gittuf/gittuf'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/gittuf-rsl-non-main.yml
+++ b/.github/workflows/gittuf-rsl-non-main.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
 jobs:
   create-rsl-entry:
+    if: github.repository == 'gittuf/gittuf'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -7,6 +7,7 @@ on:
       - completed
 jobs:
   gittuf-verify:
+    if: github.repository == 'gittuf/gittuf'
     runs-on: ubuntu-latest
     steps:
       - name: Install gittuf


### PR DESCRIPTION
This avoids failures of gittuf workflows for forks that may not have the gittuf refs.