### PR TITLE
Rework policy signing-key flag check

### DIFF
--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -84,6 +84,21 @@ func LoadSigner(keyBytes []byte) (sslibdsse.SignerVerifier, error) {
 	return signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(keyBytes) //nolint:staticcheck
 }
 
+// CheckIfSigningViableWithFlag checks if a signing key was specified via the
+// "signing-key" flag, and then calls CheckIfSigningViable
+func CheckIfSigningViableWithFlag(cmd *cobra.Command, _ []string) error {
+	signingKeyFlag := cmd.Flags().Lookup("signing-key")
+
+	// Check if a signing key was specified via the "signing-key" flag
+	if signingKeyFlag.Value.String() == "" {
+		return fmt.Errorf("required flag \"signing-key\" not set")
+	}
+
+	return CheckIfSigningViable(cmd, []string{""})
+}
+
+// CheckIfSigningViable checks if we are able to sign RSL entries given the
+// current environment
 func CheckIfSigningViable(_ *cobra.Command, _ []string) error {
 	_, _, err := gitinterface.GetSigningCommand()
 

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -70,7 +70,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-key",
 		Short:             "Add a trusted key to a policy file",
 		Long:              `This command allows users to add a trusted key to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -96,7 +96,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-rule",
 		Short:             "Add a new rule to a policy file",
 		Long:              `This command allows users to add a new rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -49,7 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize policy file",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/persistent/persistent.go
+++ b/internal/cmd/policy/persistent/persistent.go
@@ -16,5 +16,4 @@ func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
 		"",
 		"signing key to use to sign policy file",
 	)
-	cmd.MarkPersistentFlagRequired("signing-key") //nolint:errcheck
 }

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -28,14 +28,10 @@ func New() *cobra.Command {
 	cmd.AddCommand(addkey.New(o))
 	cmd.AddCommand(addrule.New(o))
 	cmd.AddCommand(listrules.New())
+	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removerule.New(o))
 	cmd.AddCommand(sign.New(o))
 	cmd.AddCommand(updaterule.New(o))
-
-	remoteCmd := remote.New()
-	cmd.AddCommand(remoteCmd)
-	// set signing-key as not required for remote command
-	remoteCmd.InheritedFlags().SetAnnotation("signing-key", cobra.BashCompOneRequiredFlag, []string{"false"}) // nolint:errcheck
 
 	return cmd
 }

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -58,7 +58,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-rule",
 		Short:             "Remove rule from a policy file",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/sign/sign.go
+++ b/internal/cmd/policy/sign/sign.go
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "sign",
 		Short:             "Sign policy file",
 		Long:              "This command allows users to add their signature to the specified policy file.",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -96,7 +96,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "update-rule",
 		Short:             "Update an existing rule in a policy file",
 		Long:              `This command allows users to update an existing rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -55,7 +55,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-policy-key",
 		Short:             "Add Policy key to gittuf root of trust",
 		Long:              `This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -54,7 +54,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-root-key",
 		Short:             "Add Root key to gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -40,7 +40,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize gittuf root of trust for repository",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/persistent/persistent.go
+++ b/internal/cmd/trust/persistent/persistent.go
@@ -16,5 +16,4 @@ func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
 		"",
 		"signing key to use to sign root of trust",
 	)
-	cmd.MarkPersistentFlagRequired("signing-key") //nolint:errcheck
 }

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-policy-key",
 		Short:             "Remove Policy key from gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removerootkey/removerootkey.go
+++ b/internal/cmd/trust/removerootkey/removerootkey.go
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-root-key",
 		Short:             "Remove Root key from gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/sign/sign.go
+++ b/internal/cmd/trust/sign/sign.go
@@ -41,7 +41,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "sign",
 		Short:             "Sign root of trust",
 		Long:              "This command allows users to add their signature to the root of trust file.",
-		PreRunE:           common.CheckIfSigningViable,
+		PreRunE:           common.CheckIfSigningViableWithFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -28,16 +28,12 @@ func New() *cobra.Command {
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(addpolicykey.New(o))
 	cmd.AddCommand(addrootkey.New(o))
+	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removepolicykey.New(o))
 	cmd.AddCommand(removerootkey.New(o))
 	cmd.AddCommand(sign.New(o))
 	cmd.AddCommand(updatepolicythreshold.New(o))
 	cmd.AddCommand(updaterootthreshold.New(o))
-
-	remoteCmd := remote.New()
-	cmd.AddCommand(remoteCmd)
-	// set signing-key as not required for remote command
-	remoteCmd.InheritedFlags().SetAnnotation("signing-key", cobra.BashCompOneRequiredFlag, []string{"false"}) // nolint:errcheck
 
 	return cmd
 }

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -59,7 +59,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 
 DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
 Until then, this command is available in developer mode only, set %s=1 to use.`, dev.DevModeKey),
-		PreRunE: common.CheckIfSigningViable,
+		PreRunE: common.CheckIfSigningViableWithFlag,
 		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
@@ -59,7 +59,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 
 DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
 Until then, this command is available in developer mode only, set %s=1 to use.`, dev.DevModeKey),
-		PreRunE: common.CheckIfSigningViable,
+		PreRunE: common.CheckIfSigningViableWithFlag,
 		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
Invoking gittuf's policy commands that require a signing key without the `-k` flag to specify said signing key does not raise an error.

Currently, this check is performed by setting an attribute on the flag via cobra. Unfortunately, it appears that disabling this requirement for subcommands that do not need a signing key (i.e. `list-rules`) _also_ disables the flag for subcommands that _do_ need it.

 This PR recreates the required flag check in the `CheckIfSigningViable` function.

A minor note: As this is done in PreRunE, the signing key flag check will run before other flag checks. Run `gittuf policy add-rule` without any flags before and after this PR change to see what I mean. Unsure if we care about this.