### PR TITLE
ci: Use latest gittuf release

### DIFF
--- a/.github/workflows/gittuf-rsl-main.yml
+++ b/.github/workflows/gittuf-rsl-main.yml
@@ -12,9 +12,7 @@ jobs:
       id-token: write
     steps:
       - name: Install gittuf
-        uses: gittuf/gittuf-installer@8ce8fbd070477ec72678151e82b82c3d866d9fcd
-        with:
-          gittuf-version: main
+        uses: gittuf/gittuf-installer@bb2e6c13c0825057e48e931b686d61c3b6267ef8
       - name: Install gitsign
         uses: actions-go/go-install@0607b3e7a61b8f1b55e1169a884804d084db73af
         with:

--- a/.github/workflows/gittuf-rsl-non-main.yml
+++ b/.github/workflows/gittuf-rsl-non-main.yml
@@ -12,9 +12,7 @@ jobs:
       id-token: write
     steps:
       - name: Install gittuf
-        uses: gittuf/gittuf-installer@8ce8fbd070477ec72678151e82b82c3d866d9fcd
-        with:
-          gittuf-version: main
+        uses: gittuf/gittuf-installer@bb2e6c13c0825057e48e931b686d61c3b6267ef8
       - name: Install gitsign
         uses: actions-go/go-install@0607b3e7a61b8f1b55e1169a884804d084db73af
         with:

--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install gittuf
-        uses: gittuf/gittuf-installer@8ce8fbd070477ec72678151e82b82c3d866d9fcd
-        with:
-          gittuf-version: main
+        uses: gittuf/gittuf-installer@bb2e6c13c0825057e48e931b686d61c3b6267ef8
       - name: Checkout and verify repository
         run: |
           gittuf clone https://github.com/${{ github.repository }}


### PR DESCRIPTION
This uses the latest gittuf-installer version, which loads v0.4.0 of gittuf by default.