### PR TITLE
gitinterface: Fix test failing on Windows

### DIFF
--- a/internal/gitinterface/common.go
+++ b/internal/gitinterface/common.go
@@ -44,11 +44,7 @@ func CreateTestGitRepository(t *testing.T, dir string) *Repository {
 
 	setupSigningKeys(t, keysDir)
 
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := exec.Command(binary, "init", "-b", "main")
+	cmd := exec.Command(binary, "init", "-b", "main", dir)
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR fixes CI on Windows failing due to a test in `gitinterface` by manually working with the temporary directory.

Addresses #407.