### PR TITLE
Replace path.Join -> filepath.Join

### DIFF
--- a/internal/repository/hook.go
+++ b/internal/repository/hook.go
@@ -8,7 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 )
 
 type ErrHookExists struct {
@@ -42,12 +42,12 @@ func (r *Repository) UpdateHook(hookType HookType, content []byte, force bool) e
 	}
 
 	repoRoot := tree.Filesystem.Root()
-	hookFolder := path.Join(repoRoot, ".git", "hooks")
+	hookFolder := filepath.Join(repoRoot, ".git", "hooks")
 	if err := os.MkdirAll(hookFolder, 0o750); err != nil {
 		return fmt.Errorf("making sure folder exist: %w", err)
 	}
 
-	hookFile := path.Join(hookFolder, string(hookType))
+	hookFile := filepath.Join(hookFolder, string(hookType))
 	hookExists, err := doesFileExist(hookFile)
 	if err != nil {
 		return fmt.Errorf("checking if hookFile '%s' exists: %w", hookFile, err)

--- a/internal/repository/hook_test.go
+++ b/internal/repository/hook_test.go
@@ -4,7 +4,7 @@ package repository
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -23,7 +23,7 @@ func TestUpdatePrePushHook(t *testing.T) {
 		err = r.UpdateHook(HookPrePush, []byte("some content"), false)
 		require.NoError(t, err)
 
-		hookFile := path.Join(tmpDir, ".git", "hooks", "pre-push")
+		hookFile := filepath.Join(tmpDir, ".git", "hooks", "pre-push")
 		prepushScript, err := os.ReadFile(hookFile)
 		require.NoError(t, err)
 		assert.Equal(t, []byte("some content"), prepushScript)
@@ -36,8 +36,8 @@ func TestUpdatePrePushHook(t *testing.T) {
 		require.NoError(t, err)
 		r := &Repository{r: repo}
 
-		hookDir := path.Join(tmpDir, ".git", "hooks")
-		hookFile := path.Join(hookDir, "pre-push")
+		hookDir := filepath.Join(tmpDir, ".git", "hooks")
+		hookFile := filepath.Join(hookDir, "pre-push")
 		err = os.Mkdir(hookDir, 0o750)
 		require.NoError(t, err)
 		err = os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec
@@ -57,8 +57,8 @@ func TestUpdatePrePushHook(t *testing.T) {
 		require.NoError(t, err)
 		r := &Repository{r: repo}
 
-		hookDir := path.Join(tmpDir, ".git", "hooks")
-		hookFile := path.Join(hookDir, "pre-push")
+		hookDir := filepath.Join(tmpDir, ".git", "hooks")
+		hookFile := filepath.Join(hookDir, "pre-push")
 		err = os.Mkdir(hookDir, 0o750)
 		require.NoError(t, err)
 		err = os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec


### PR DESCRIPTION
path.Join only uses `/`.
filepath.Join will use `/` or `\` depending on the OS

Might be messing with Windows compatibility. (though not sure)