### PR TITLE
Remove TUF fields that don't apply to gittuf

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -366,7 +366,6 @@ func TestStateGetRootMetadata(t *testing.T) {
 
 	rootMetadata, err := state.GetRootMetadata()
 	assert.Nil(t, err)
-	assert.Equal(t, 1, rootMetadata.Version)
 	assert.Equal(t, "52e3b8e73279d6ebdd62a5016e2725ff284f569665eb92ccb145d83817a02997", rootMetadata.Roles[RootRoleName].KeyIDs[0])
 }
 

--- a/internal/policy/root.go
+++ b/internal/policy/root.go
@@ -23,7 +23,6 @@ var (
 // expiry date set to one year from now, and the provided key is added.
 func InitializeRootMetadata(key *tuf.Key) *tuf.RootMetadata {
 	rootMetadata := tuf.NewRootMetadata()
-	rootMetadata.SetVersion(1)
 	rootMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 	rootMetadata.AddKey(key)
 

--- a/internal/policy/root_test.go
+++ b/internal/policy/root_test.go
@@ -16,7 +16,6 @@ func TestInitializeRootMetadata(t *testing.T) {
 	}
 
 	rootMetadata := InitializeRootMetadata(key)
-	assert.Equal(t, 1, rootMetadata.Version)
 	assert.Equal(t, key, rootMetadata.Keys[key.KeyID])
 	assert.Equal(t, 1, rootMetadata.Roles[RootRoleName].Threshold)
 	assert.Equal(t, []string{key.KeyID}, rootMetadata.Roles[RootRoleName].KeyIDs)

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -16,7 +16,6 @@ var ErrCannotManipulateAllowRule = errors.New("cannot change in-built gittuf-all
 // InitializeTargetsMetadata creates a new instance of TargetsMetadata.
 func InitializeTargetsMetadata() *tuf.TargetsMetadata {
 	targetsMetadata := tuf.NewTargetsMetadata()
-	targetsMetadata.SetVersion(1)
 	targetsMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 	targetsMetadata.Delegations.AddDelegation(AllowRule())
 	return targetsMetadata

--- a/internal/policy/targets_test.go
+++ b/internal/policy/targets_test.go
@@ -15,7 +15,6 @@ import (
 func TestInitializeTargetsMetadata(t *testing.T) {
 	targetsMetadata := InitializeTargetsMetadata()
 
-	assert.Equal(t, 1, targetsMetadata.Version)
 	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
 }
 

--- a/internal/repository/root.go
+++ b/internal/repository/root.go
@@ -289,7 +289,6 @@ func (r *Repository) loadRootMetadata(state *policy.State, keyID string) (*tuf.R
 }
 
 func (r *Repository) updateRootMetadata(ctx context.Context, state *policy.State, signer sslibdsse.SignerVerifier, rootMetadata *tuf.RootMetadata, commitMessage string, signCommit bool) error {
-	rootMetadata.SetVersion(rootMetadata.Version + 1)
 	rootMetadataBytes, err := json.Marshal(rootMetadata)
 	if err != nil {
 		return err

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -70,7 +70,6 @@ func TestAddRootKey(t *testing.T) {
 
 	rootMetadata, err := state.GetRootMetadata()
 	assert.Nil(t, err)
-	assert.Equal(t, 2, rootMetadata.Version)
 	assert.Equal(t, []string{originalKeyID, newRootKey.KeyID}, rootMetadata.Roles[policy.RootRoleName].KeyIDs)
 	assert.Equal(t, originalKeyID, state.RootEnvelope.Signatures[0].KeyID)
 	assert.Equal(t, 2, len(state.RootPublicKeys))
@@ -107,7 +106,6 @@ func TestRemoveRootKey(t *testing.T) {
 	}
 
 	// We should have no additions as we tried to add the same key
-	assert.Equal(t, 2, rootMetadata.Version)
 	assert.Equal(t, 1, len(state.RootPublicKeys))
 	assert.Equal(t, 1, len(rootMetadata.Roles[policy.RootRoleName].KeyIDs))
 
@@ -130,7 +128,6 @@ func TestRemoveRootKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 3, rootMetadata.Version)
 	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, rootKey.KeyID)
 	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, newRootKey.KeyID)
 	assert.Equal(t, 2, len(state.RootPublicKeys))
@@ -157,7 +154,6 @@ func TestRemoveRootKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 4, rootMetadata.Version)
 	assert.Contains(t, rootMetadata.Roles[policy.RootRoleName].KeyIDs, newRootKey.KeyID)
 	assert.Equal(t, 1, len(rootMetadata.Roles[policy.RootRoleName].KeyIDs))
 	assert.Equal(t, 1, len(state.RootPublicKeys))
@@ -188,7 +184,6 @@ func TestAddTopLevelTargetsKey(t *testing.T) {
 
 	rootMetadata, err := state.GetRootMetadata()
 	assert.Nil(t, err)
-	assert.Equal(t, 2, rootMetadata.Version)
 	assert.Equal(t, key.KeyID, rootMetadata.Roles[policy.RootRoleName].KeyIDs[0])
 	assert.Equal(t, key.KeyID, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs[0])
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
@@ -234,7 +229,6 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 3, rootMetadata.Version)
 	assert.Equal(t, rootKey.KeyID, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs[0])
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, rootKey.KeyID)
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, targetsKey.KeyID)
@@ -254,7 +248,6 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, 4, rootMetadata.Version)
 	assert.Contains(t, rootMetadata.Roles[policy.TargetsRoleName].KeyIDs, targetsKey.KeyID)
 	err = dsse.VerifyEnvelope(testCtx, state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -115,8 +115,6 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 		return err
 	}
 
-	targetsMetadata.SetVersion(targetsMetadata.Version + 1)
-
 	env, err := dsse.CreateEnvelope(targetsMetadata)
 	if err != nil {
 		return nil
@@ -179,8 +177,6 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 		return err
 	}
 
-	targetsMetadata.SetVersion(targetsMetadata.Version + 1)
-
 	env, err := dsse.CreateEnvelope(targetsMetadata)
 	if err != nil {
 		return nil
@@ -238,8 +234,6 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.Sign
 	if err != nil {
 		return err
 	}
-
-	targetsMetadata.SetVersion(targetsMetadata.Version + 1)
 
 	env, err := dsse.CreateEnvelope(targetsMetadata)
 	if err != nil {
@@ -302,8 +296,6 @@ func (r *Repository) AddKeyToTargets(ctx context.Context, signer sslibdsse.Signe
 	if err != nil {
 		return err
 	}
-
-	targetsMetadata.SetVersion(targetsMetadata.Version + 1)
 
 	env, err := dsse.CreateEnvelope(targetsMetadata)
 	if err != nil {

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -48,7 +48,6 @@ func TestInitializeTargets(t *testing.T) {
 
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
 		assert.Nil(t, err)
-		assert.Equal(t, 1, targetsMetadata.Version)
 		assert.Empty(t, targetsMetadata.Targets)
 		assert.Contains(t, targetsMetadata.Delegations.Roles, policy.AllowRule())
 	})

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -24,7 +24,7 @@ func TestCreateEnvelope(t *testing.T) {
 	env, err := CreateEnvelope(rootMetadata)
 	assert.Nil(t, err)
 	assert.Equal(t, PayloadType, env.PayloadType)
-	assert.Equal(t, "eyJ0eXBlIjoicm9vdCIsInNwZWNfdmVyc2lvbiI6IjEuMCIsImNvbnNpc3RlbnRfc25hcHNob3QiOnRydWUsInZlcnNpb24iOjAsImV4cGlyZXMiOiIiLCJrZXlzIjpudWxsLCJyb2xlcyI6bnVsbH0=", env.Payload)
+	assert.Equal(t, "eyJ0eXBlIjoicm9vdCIsImV4cGlyZXMiOiIiLCJrZXlzIjpudWxsLCJyb2xlcyI6bnVsbH0=", env.Payload)
 }
 
 func TestSignEnvelope(t *testing.T) {

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -17,8 +17,6 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
 
-const specVersion = "1.0"
-
 var (
 	ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
 )
@@ -83,27 +81,17 @@ type Role struct {
 
 // RootMetadata defines the schema of TUF's Root role.
 type RootMetadata struct {
-	Type               string          `json:"type"`
-	SpecVersion        string          `json:"spec_version"`
-	ConsistentSnapshot bool            `json:"consistent_snapshot"` // TODO: how do we handle this?
-	Version            int             `json:"version"`
-	Expires            string          `json:"expires"`
-	Keys               map[string]*Key `json:"keys"`
-	Roles              map[string]Role `json:"roles"`
+	Type    string          `json:"type"`
+	Expires string          `json:"expires"`
+	Keys    map[string]*Key `json:"keys"`
+	Roles   map[string]Role `json:"roles"`
 }
 
 // NewRootMetadata returns a new instance of RootMetadata.
 func NewRootMetadata() *RootMetadata {
 	return &RootMetadata{
-		Type:               "root",
-		SpecVersion:        specVersion,
-		ConsistentSnapshot: true,
+		Type: "root",
 	}
-}
-
-// SetVersion sets the version of the RootMetadata to the value passed in.
-func (r *RootMetadata) SetVersion(version int) {
-	r.Version = version
 }
 
 // SetExpires sets the expiry date of the RootMetadata to the value passed in.
@@ -133,8 +121,6 @@ func (r *RootMetadata) AddRole(roleName string, role Role) {
 // TargetsMetadata defines the schema of TUF's Targets role.
 type TargetsMetadata struct {
 	Type        string         `json:"type"`
-	SpecVersion string         `json:"spec_version"`
-	Version     int            `json:"version"`
 	Expires     string         `json:"expires"`
 	Targets     map[string]any `json:"targets"`
 	Delegations *Delegations   `json:"delegations"`
@@ -144,14 +130,8 @@ type TargetsMetadata struct {
 func NewTargetsMetadata() *TargetsMetadata {
 	return &TargetsMetadata{
 		Type:        "targets",
-		SpecVersion: specVersion,
 		Delegations: &Delegations{},
 	}
-}
-
-// SetVersion sets the version of the TargetsMetadata to the value passed in.
-func (t *TargetsMetadata) SetVersion(version int) {
-	t.Version = version
 }
 
 // SetExpires sets the expiry date of the TargetsMetadata to the value passed

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -55,16 +55,6 @@ Y3eV5jJqu4dWvCMmwbCLSfCJJOF9dryMwkqjpcpWUuPlAgMBAAE=
 func TestRootMetadata(t *testing.T) {
 	rootMetadata := NewRootMetadata()
 
-	t.Run("test NewRootMetadata", func(t *testing.T) {
-		assert.Equal(t, specVersion, rootMetadata.SpecVersion)
-		assert.Equal(t, 0, rootMetadata.Version)
-	})
-
-	t.Run("test SetVersion", func(t *testing.T) {
-		rootMetadata.SetVersion(10)
-		assert.Equal(t, 10, rootMetadata.Version)
-	})
-
 	t.Run("test SetExpires", func(t *testing.T) {
 		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)
 		rootMetadata.SetExpires(d.Format(time.RFC3339))
@@ -92,16 +82,6 @@ func TestRootMetadata(t *testing.T) {
 
 func TestTargetsMetadataAndDelegations(t *testing.T) {
 	targetsMetadata := NewTargetsMetadata()
-
-	t.Run("test NewTargetsMetadata", func(t *testing.T) {
-		assert.Equal(t, specVersion, targetsMetadata.SpecVersion)
-		assert.Equal(t, 0, targetsMetadata.Version)
-	})
-
-	t.Run("test SetVersion", func(t *testing.T) {
-		targetsMetadata.SetVersion(10)
-		assert.Equal(t, 10, targetsMetadata.Version)
-	})
 
 	t.Run("test SetExpires", func(t *testing.T) {
 		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)


### PR DESCRIPTION
The original root and targets metadata schemas were taken directly from the TUF specification. As such, they include fields that we don't use in gittuf.

Removed Fields:

1. SpecVersion: this field identifies the version of the TUF specification the metadata conforms to. We don't conform to the TUF specification.

2. ConsistentSnapshot: this boolean field indicates if the repository uses consistent snapshots as defined in the TUF specification. We don't use this (and in fact we don't use snapshot metadata at all as the RSL effectively serves the snapshot role).

3. Version: this field is an incrementing integer that identifies the version of the metadata for the specific role. In TUF, this is used to ensure we have a consistent set of metadata via the snapshot role. As before, the RSL gives us this property naturally.

Note that we still don't use the Expires field in gittuf verification. We need to explore what it means for policy metadata to expire in a Git repository and whether the expiry check (for the latest policy metadata) applies the same way it does in TUF.