### PR TITLE
Support the local and remote ref names being different

### DIFF
--- a/.test_ignore.txt
+++ b/.test_ignore.txt
@@ -12,5 +12,6 @@ github.com/gittuf/gittuf/internal/cmd/verifyref
 github.com/gittuf/gittuf/internal/cmd/verifytag
 github.com/gittuf/gittuf/internal/cmd/version
 github.com/gittuf/gittuf/internal/dev
+github.com/gittuf/gittuf/internal/repository/options
 github.com/gittuf/gittuf/internal/testartifacts
 github.com/gittuf/gittuf/internal/version

--- a/docs/cli/gittuf_dev_rsl-record.md
+++ b/docs/cli/gittuf_dev_rsl-record.md
@@ -9,6 +9,7 @@ gittuf dev rsl-record [flags]
 ### Options
 
 ```
+      --dst-ref string       name of destination reference, if it differs from source reference
   -h, --help                 help for rsl-record
   -k, --signing-key string   path to PEM encoded SSH or GPG signing key
   -t, --target string        target ID

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -9,7 +9,8 @@ gittuf rsl record [flags]
 ### Options
 
 ```
-  -h, --help   help for record
+      --dst-ref string   name of destination reference, if it differs from source reference
+  -h, --help             help for record
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_verify-ref.md
+++ b/docs/cli/gittuf_verify-ref.md
@@ -9,9 +9,10 @@ gittuf verify-ref [flags]
 ### Options
 
 ```
-      --from-entry string   perform verification from specified RSL entry (developer mode only, set GITTUF_DEV=1)
-  -h, --help                help for verify-ref
-      --latest-only         perform verification against latest entry in the RSL
+      --from-entry string        perform verification from specified RSL entry (developer mode only, set GITTUF_DEV=1)
+  -h, --help                     help for verify-ref
+      --latest-only              perform verification against latest entry in the RSL
+      --remote-ref-name string   name of remote reference, if it differs from the local name
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/dev/rslrecordat/rslrecordat.go
+++ b/internal/cmd/dev/rslrecordat/rslrecordat.go
@@ -8,15 +8,24 @@ import (
 
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/repository"
+	rslopts "github.com/gittuf/gittuf/internal/repository/options/rsl"
 	"github.com/spf13/cobra"
 )
 
 type options struct {
 	targetID       string
 	signingKeyPath string
+	dstRef         string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.dstRef,
+		"dst-ref",
+		"",
+		"name of destination reference, if it differs from source reference",
+	)
+
 	cmd.Flags().StringVarP(
 		&o.targetID,
 		"target",
@@ -47,7 +56,7 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RecordRSLEntryForReferenceAtTarget(args[0], o.targetID, signingKeyBytes)
+	return repo.RecordRSLEntryForReferenceAtTarget(args[0], o.targetID, signingKeyBytes, rslopts.WithOverrideRefName(o.dstRef))
 }
 
 func New() *cobra.Command {

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -5,12 +5,22 @@ package record
 import (
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/repository"
+	rslopts "github.com/gittuf/gittuf/internal/repository/options/rsl"
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	dstRef string
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.dstRef,
+		"dst-ref",
+		"",
+		"name of destination reference, if it differs from source reference",
+	)
+}
 
 func (o *options) Run(_ *cobra.Command, args []string) error {
 	repo, err := repository.LoadRepository()
@@ -18,7 +28,7 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RecordRSLEntryForReference(args[0], true)
+	return repo.RecordRSLEntryForReference(args[0], true, rslopts.WithOverrideRefName(o.dstRef))
 }
 
 func New() *cobra.Command {

--- a/internal/repository/options/rsl/rsl.go
+++ b/internal/repository/options/rsl/rsl.go
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+type Options struct {
+	RefNameOverride string
+}
+
+type Option func(o *Options)
+
+func WithOverrideRefName(refNameOverride string) Option {
+	return func(o *Options) {
+		o.RefNameOverride = refNameOverride
+	}
+}

--- a/internal/repository/options/verify/verify.go
+++ b/internal/repository/options/verify/verify.go
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package verify
+
+type Options struct {
+	RefNameOverride string
+	LatestOnly      bool
+}
+
+type Option func(o *Options)
+
+func WithOverrideRefName(refNameOverride string) Option {
+	return func(o *Options) {
+		o.RefNameOverride = refNameOverride
+	}
+}
+
+func WithLatestOnly() Option {
+	return func(o *Options) {
+		o.LatestOnly = true
+	}
+}

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -98,5 +98,5 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRo
 	}
 
 	slog.Debug("Verifying HEAD...")
-	return repository, repository.VerifyRef(ctx, head, false)
+	return repository, repository.VerifyRef(ctx, head)
 }

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/policy"
+	verifyopts "github.com/gittuf/gittuf/internal/repository/options/verify"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,42 +19,70 @@ func TestVerifyRef(t *testing.T) {
 	repo := createTestRepositoryWithPolicy(t, "")
 
 	refName := "refs/heads/main"
+	remoteRefName := "refs/heads/not-main"
 
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 	entry.ID = entryID
 
+	// Add one entry for a different remote ref name
+	entry = rsl.NewReferenceEntry(remoteRefName, commitIDs[0])
+	entryID = common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
+	entry.ID = entryID
+
 	tests := map[string]struct {
-		target     string
-		latestOnly bool
-		err        error
+		localRefName  string
+		remoteRefName string
+		latestOnly    bool
+		err           error
 	}{
 		"absolute ref, not full": {
-			target:     "refs/heads/main",
-			latestOnly: true,
+			localRefName: refName,
+			latestOnly:   true,
 		},
 		"absolute ref, full": {
-			target:     "refs/heads/main",
-			latestOnly: false,
+			localRefName: refName,
+			latestOnly:   false,
 		},
 		"relative ref, not full": {
-			target:     "main",
-			latestOnly: true,
+			localRefName: "main",
+			latestOnly:   true,
 		},
 		"relative ref, full": {
-			target:     "main",
-			latestOnly: false,
+			localRefName: "main",
+			latestOnly:   false,
 		},
 		"unknown ref, full": {
-			target:     "refs/heads/unknown",
-			latestOnly: false,
-			err:        rsl.ErrRSLEntryNotFound,
+			localRefName: "refs/heads/unknown",
+			latestOnly:   false,
+			err:          rsl.ErrRSLEntryNotFound,
+		},
+		"different local and remote ref names, not full": {
+			localRefName:  refName,
+			remoteRefName: remoteRefName,
+			latestOnly:    true,
+		},
+		"different local and remote ref names, full": {
+			localRefName:  refName,
+			remoteRefName: remoteRefName,
+			latestOnly:    false,
+		},
+		"unknown remote ref, full": {
+			localRefName:  refName,
+			remoteRefName: "refs/heads/unknown",
+			latestOnly:    false,
+			err:           rsl.ErrRSLEntryNotFound,
 		},
 	}
 
 	for name, test := range tests {
-		err := repo.VerifyRef(testCtx, test.target, test.latestOnly)
+		options := []verifyopts.Option{verifyopts.WithOverrideRefName(test.remoteRefName)}
+		if test.latestOnly {
+			options = append(options, verifyopts.WithLatestOnly())
+		}
+
+		err := repo.VerifyRef(testCtx, test.localRefName, options...)
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {
@@ -63,9 +92,9 @@ func TestVerifyRef(t *testing.T) {
 
 	// Add another commit
 	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
-	err := repo.VerifyRef(testCtx, refName, true)
+	err := repo.VerifyRef(testCtx, refName, verifyopts.WithLatestOnly())
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
-	err = repo.VerifyRef(testCtx, refName, false)
+	err = repo.VerifyRef(testCtx, refName, verifyopts.WithLatestOnly())
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
 }
 
@@ -75,54 +104,77 @@ func TestVerifyRefFromEntry(t *testing.T) {
 	repo := createTestRepositoryWithPolicy(t, "")
 
 	refName := "refs/heads/main"
+	remoteRefName := "refs/heads/not-main"
 
 	// Policy violation
 	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgUnauthorizedKeyBytes)
+	// Violation for refName
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	violatingEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgUnauthorizedKeyBytes)
+	// Violation for remoteRefName
+	entry = rsl.NewReferenceEntry(remoteRefName, commitIDs[0])
+	violatingRemoteRefNameEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgUnauthorizedKeyBytes)
 
-	// No policy violation
+	// No policy violation for refName
 	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	// refName
 	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
 	goodEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
+	// remoteRefName
+	entry = rsl.NewReferenceEntry(remoteRefName, commitIDs[0])
+	goodRemoteRefNameEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 
-	// No policy violation (latest)
+	// No policy violation for refName (what we verify)
 	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
 	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
 	common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
+	// No policy violation for remoteRefName (what we verify)
+	entry = rsl.NewReferenceEntry(remoteRefName, commitIDs[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 
 	tests := map[string]struct {
-		target      string
-		fromEntryID gitinterface.Hash
-		err         error
+		localRefName  string
+		remoteRefName string
+		fromEntryID   gitinterface.Hash
+		err           error
 	}{
 		"absolute ref, from non-violating": {
-			target:      "refs/heads/main",
-			fromEntryID: goodEntryID,
+			localRefName: "refs/heads/main",
+			fromEntryID:  goodEntryID,
 		},
 		"absolute ref, from violating": {
-			target:      "refs/heads/main",
-			fromEntryID: violatingEntryID,
-			err:         policy.ErrUnauthorizedSignature,
+			localRefName: "refs/heads/main",
+			fromEntryID:  violatingEntryID,
+			err:          policy.ErrUnauthorizedSignature,
 		},
 		"relative ref, from non-violating": {
-			target:      "main",
-			fromEntryID: goodEntryID,
+			localRefName: "main",
+			fromEntryID:  goodEntryID,
 		},
 		"relative ref, from violating": {
-			target:      "main",
-			fromEntryID: violatingEntryID,
-			err:         policy.ErrUnauthorizedSignature,
+			localRefName: "main",
+			fromEntryID:  violatingEntryID,
+			err:          policy.ErrUnauthorizedSignature,
 		},
 		"unknown ref": {
-			target:      "refs/heads/unknown",
-			fromEntryID: gitinterface.ZeroHash,
-			err:         rsl.ErrRSLEntryNotFound,
+			localRefName: "refs/heads/unknown",
+			fromEntryID:  gitinterface.ZeroHash,
+			err:          rsl.ErrRSLEntryNotFound,
+		},
+		"different local and remote ref names, from non-violating": {
+			localRefName:  refName,
+			remoteRefName: remoteRefName,
+			fromEntryID:   goodRemoteRefNameEntryID,
+		},
+		"different local and remote ref names, from violating": {
+			localRefName:  refName,
+			remoteRefName: remoteRefName,
+			fromEntryID:   violatingRemoteRefNameEntryID,
 		},
 	}
 
 	for name, test := range tests {
-		err := repo.VerifyRefFromEntry(testCtx, test.target, test.fromEntryID.String())
+		err := repo.VerifyRefFromEntry(testCtx, test.localRefName, test.fromEntryID.String(), verifyopts.WithOverrideRefName(test.remoteRefName))
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))
 		} else {


### PR DESCRIPTION
Closes #413 

This PR makes two changes. First, when recording an entry in the RSL, it supports the src ref name being different from the dst ref name. For example, `git push origin local-branch-name:remote-branch-name` updates `remote-branch-name` on origin with the tip of `local-branch-name`. So, the RSL entry for this push must record `remote-branch-name` as the ref name updated, which is what everyone else sees, and use `local-branch-name` as the target ID.

Second, the verification workflow now accepts an optional `--remote-ref-name` flag. When this is set, the workflow uses the remote ref name to identify and verify the relevant RSL entries, but finally uses the local ref name to check that the tip matches. We need this for the following case:
```
git fetch origin remote-branch-name:local-branch-name
gittuf verify-ref --remote-ref-name=remote-branch-name local-branch-name
```

I debated whether the flag ought to be inverted, so we `gittuf verify-ref --local-ref-name=local-branch-name remote-branch-name`. This makes more sense from the implementation PoV because we use the remote ref name a lot more with the RSL verification, but to me it appears to be counterintuitive to the user. They ought to be providing the refname they see in their copy of the repository, I think.