### PR TITLE
Ignore generated CLI docs in PR diff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/cli/*.md linguist-generated=true


### PR DESCRIPTION
From: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

They render as follows now:
![image](https://github.com/gittuf/gittuf/assets/8928778/95b3e44c-8409-4d87-ab63-54513f48623e)

So we can still opt in to see specific changes, but IMO this makes reviewing bigger changes easier.