### PR TITLE
Add ssh Key <-> SSlibKey conversion functions

### DIFF
--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -177,8 +177,8 @@ func parseSSH2Key(data string) (ssh.PublicKey, error) {
 	return parseSSH2Body(body)
 }
 
-// SSHKeyToSSlibKey converts an ssh Key into an SSlibKey.
-func SSHKeyToSSlibKey(key *Key) *sv.SSLibKey {
+// KeyToSSlibKey converts an ssh Key into an SSlibKey.
+func KeyToSSlibKey(key *Key) *sv.SSLibKey {
 	return &sv.SSLibKey{
 		KeyID:   key.keyID,
 		Scheme:  key.Scheme,
@@ -189,8 +189,8 @@ func SSHKeyToSSlibKey(key *Key) *sv.SSLibKey {
 	}
 }
 
-// SSHKeyToSSlibKey converts an SSlibKey into an ssh Key.
-func SSlibKeyToSSHKey(key *sv.SSLibKey) (*Key, error) {
+// KeyFromSSlibKey converts an SSlibKey into an ssh Key.
+func KeyFromSSlibKey(key *sv.SSLibKey) (*Key, error) {
 	if key.KeyType != SSHKeyType {
 		return nil, fmt.Errorf("cannot convert key of type '%s'", key.KeyType)
 	}

--- a/internal/signerverifier/ssh/ssh_test.go
+++ b/internal/signerverifier/ssh/ssh_test.go
@@ -131,12 +131,11 @@ func TestConvert(t *testing.T) {
 		KeyVal:  KeyVal{Public: "AAAAC3NzaC1lZDI1NTE5AAAAIPu3Q15xYZOCg7kzYoApSgy/fPumLVHgSQO+bjSwdGQg"},
 	}
 
-	sslibKey := SSHKeyToSSlibKey(sshKey)
-	sshKey2, _ := SSlibKeyToSSHKey(sslibKey)
+	sslibKey := KeyToSSlibKey(sshKey)
+	sshKey2, _ := KeyFromSSlibKey(sslibKey)
 	assert.Equal(t, sshKey, sshKey2)
 
 	sslibKey.KeyType = "gpg"
-	_, err := SSlibKeyToSSHKey(sslibKey)
+	_, err := KeyFromSSlibKey(sslibKey)
 	assert.NotNil(t, err)
-
 }

--- a/internal/signerverifier/ssh/ssh_test.go
+++ b/internal/signerverifier/ssh/ssh_test.go
@@ -122,3 +122,21 @@ COb1zE7zaJacJ42tNdVq7Z3x+Hik9PRfgBPt1oF41SFSCp0YRPLxLMFdTjNgV3HZXVNlq6
 	}
 	assert.Equal(t, key.Type(), "ssh-rsa")
 }
+
+func TestConvert(t *testing.T) {
+	sshKey := &Key{
+		keyID:   "SHA256:cewFulOIcROWnolPTGEQXG4q7xvLIn3kNTCMqdfoP4E",
+		KeyType: "ssh",
+		Scheme:  "ssh-ed25519",
+		KeyVal:  KeyVal{Public: "AAAAC3NzaC1lZDI1NTE5AAAAIPu3Q15xYZOCg7kzYoApSgy/fPumLVHgSQO+bjSwdGQg"},
+	}
+
+	sslibKey := SSHKeyToSSlibKey(sshKey)
+	sshKey2, _ := SSlibKeyToSSHKey(sslibKey)
+	assert.Equal(t, sshKey, sshKey2)
+
+	sslibKey.KeyType = "gpg"
+	_, err := SSlibKeyToSSHKey(sslibKey)
+	assert.NotNil(t, err)
+
+}

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -282,7 +282,7 @@ func TestRootMetadataWithSSHKey(t *testing.T) {
 
 	// Create TUF root, convert and add test key
 	rootMetadata := NewRootMetadata()
-	sslibKey := ssh.SSHKeyToSSlibKey(sshKey)
+	sslibKey := ssh.KeyToSSlibKey(sshKey)
 	rootMetadata.AddKey(sslibKey)
 	assert.Contains(t, rootMetadata.Keys, sshKeyid)
 
@@ -309,7 +309,7 @@ func TestRootMetadataWithSSHKey(t *testing.T) {
 	}
 
 	sslibKey2 := rootMetadata2.Keys[sshKeyid]
-	sshKey2, _ := ssh.SSlibKeyToSSHKey(sslibKey2)
+	sshKey2, _ := ssh.KeyFromSSlibKey(sslibKey2)
 
 	err = dsse.VerifyEnvelope(ctx, env, []sslibdsse.Verifier{sshKey2}, 1)
 	if err != nil {

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -3,11 +3,18 @@
 package tuf
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -243,5 +250,69 @@ func TestDelegationMatches(t *testing.T) {
 		delegation := Delegation{Paths: test.patterns}
 		got := delegation.Matches(test.target)
 		assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
+func TestRootMetadataWithSSHKey(t *testing.T) {
+	// Setup test key pair
+	keys := []struct {
+		name string
+		data []byte
+	}{
+		{"rsa", artifacts.SSHRSAPrivate},
+		{"rsa.pub", artifacts.SSHRSAPublicSSH},
+	}
+	tmpDir := t.TempDir()
+	for _, key := range keys {
+		keyPath := filepath.Join(tmpDir, key.name)
+		if err := os.WriteFile(keyPath, key.data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	keyPath := filepath.Join(tmpDir, "rsa")
+	sshKey, err := ssh.Import(keyPath)
+	if err != nil {
+		t.Fatal()
+	}
+	sshKeyid, _ := sshKey.KeyID()
+	signer := &ssh.Signer{
+		Key:  sshKey,
+		Path: keyPath,
+	}
+
+	// Create TUF root, convert and add test key
+	rootMetadata := NewRootMetadata()
+	sslibKey := ssh.SSHKeyToSSlibKey(sshKey)
+	rootMetadata.AddKey(sslibKey)
+	assert.Contains(t, rootMetadata.Keys, sshKeyid)
+
+	// Sign and wrap
+	ctx := context.Background()
+	env, err := dsse.CreateEnvelope(rootMetadata)
+	if err != nil {
+		t.Fatal()
+	}
+	env, err = dsse.SignEnvelope(ctx, env, signer)
+	if err != nil {
+		t.Fatal()
+	}
+	// Unwrap and verify
+	// NOTE: For the sake of testing the contained key, we unwrap before we
+	// verify. Typically, in DSSE it should be the other way around.
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		t.Fatal()
+	}
+	rootMetadata2 := &RootMetadata{}
+	if err := json.Unmarshal(payload, rootMetadata2); err != nil {
+		t.Fatal()
+	}
+
+	sslibKey2 := rootMetadata2.Keys[sshKeyid]
+	sshKey2, _ := ssh.SSlibKeyToSSHKey(sslibKey2)
+
+	err = dsse.VerifyEnvelope(ctx, env, []sslibdsse.Verifier{sshKey2}, 1)
+	if err != nil {
+		t.Fatal()
 	}
 }


### PR DESCRIPTION
Add functions to convert an ssh Key to an SSlibKey and vice versa.

This can be used to include an ssh Key in TUF metadata (which expects
an SSlibKey) and to again extract it for ssh signature verification.

A basic unit test and a TUF metadata usage example (as test) is included. 