### PR TITLE
tuf: Add metadata version to gittuf metadata

### DIFF
--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -21,7 +21,7 @@ func TestCreateEnvelope(t *testing.T) {
 	env, err := CreateEnvelope(rootMetadata)
 	assert.Nil(t, err)
 	assert.Equal(t, PayloadType, env.PayloadType)
-	assert.Equal(t, "eyJ0eXBlIjoicm9vdCIsImV4cGlyZXMiOiIiLCJrZXlzIjpudWxsLCJyb2xlcyI6bnVsbCwiZ2l0aHViQXBwcm92YWxzVHJ1c3RlZCI6ZmFsc2V9", env.Payload)
+	assert.Equal(t, "eyJ0eXBlIjoicm9vdCIsIm1ldGFkYXRhX3ZlcnNpb24iOjAsImV4cGlyZXMiOiIiLCJrZXlzIjpudWxsLCJyb2xlcyI6bnVsbCwiZ2l0aHViQXBwcm92YWxzVHJ1c3RlZCI6ZmFsc2V9", env.Payload)
 }
 
 func TestSignEnvelope(t *testing.T) {

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -18,6 +18,8 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
 
+const currentMetadataVersion = 0
+
 var (
 	ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
 )
@@ -83,6 +85,7 @@ type Role struct {
 // RootMetadata defines the schema of TUF's Root role.
 type RootMetadata struct {
 	Type                   string          `json:"type"`
+	MetadataVersion        int             `json:"metadata_version"`
 	Expires                string          `json:"expires"`
 	Keys                   map[string]*Key `json:"keys"`
 	Roles                  map[string]Role `json:"roles"`
@@ -92,7 +95,8 @@ type RootMetadata struct {
 // NewRootMetadata returns a new instance of RootMetadata.
 func NewRootMetadata() *RootMetadata {
 	return &RootMetadata{
-		Type: "root",
+		Type:            "root",
+		MetadataVersion: currentMetadataVersion,
 	}
 }
 
@@ -122,17 +126,19 @@ func (r *RootMetadata) AddRole(roleName string, role Role) {
 
 // TargetsMetadata defines the schema of TUF's Targets role.
 type TargetsMetadata struct {
-	Type        string         `json:"type"`
-	Expires     string         `json:"expires"`
-	Targets     map[string]any `json:"targets"`
-	Delegations *Delegations   `json:"delegations"`
+	Type            string         `json:"type"`
+	MedadataVersion int            `json:"metadata_version"`
+	Expires         string         `json:"expires"`
+	Targets         map[string]any `json:"targets"`
+	Delegations     *Delegations   `json:"delegations"`
 }
 
 // NewTargetsMetadata returns a new instance of TargetsMetadata.
 func NewTargetsMetadata() *TargetsMetadata {
 	return &TargetsMetadata{
-		Type:        "targets",
-		Delegations: &Delegations{},
+		Type:            "targets",
+		MedadataVersion: currentMetadataVersion,
+		Delegations:     &Delegations{},
 	}
 }
 

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -62,6 +62,10 @@ Y3eV5jJqu4dWvCMmwbCLSfCJJOF9dryMwkqjpcpWUuPlAgMBAAE=
 func TestRootMetadata(t *testing.T) {
 	rootMetadata := NewRootMetadata()
 
+	t.Run("test NewRootMetadata", func(t *testing.T) {
+		assert.Equal(t, currentMetadataVersion, rootMetadata.MetadataVersion)
+	})
+
 	t.Run("test SetExpires", func(t *testing.T) {
 		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)
 		rootMetadata.SetExpires(d.Format(time.RFC3339))
@@ -89,6 +93,10 @@ func TestRootMetadata(t *testing.T) {
 
 func TestTargetsMetadataAndDelegations(t *testing.T) {
 	targetsMetadata := NewTargetsMetadata()
+
+	t.Run("test NewTargetsMetadata", func(t *testing.T) {
+		assert.Equal(t, currentMetadataVersion, targetsMetadata.MedadataVersion)
+	})
 
 	t.Run("test SetExpires", func(t *testing.T) {
 		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)


### PR DESCRIPTION
This PR adds a version field to the gittuf metadata to indicate what gittuf should expect when parsing metadata. This is useful for cases such as #326, where the underlying metadata is upgraded with a breaking change to support teams.

The TUF metadata has a `metadata_version` JSON property added for the root and targets metadata to signal what version said metadata aligns with.