### PR TITLE
Re-design ssh Key as Verifier only

### DIFF
--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -59,7 +59,7 @@ func TestVerifyEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Nil(t, VerifyEnvelope(context.Background(), env, []sslibdsse.Verifier{signer.Key}, 1))
+	assert.Nil(t, VerifyEnvelope(context.Background(), env, []sslibdsse.Verifier{signer.Verifier}, 1))
 }
 
 func loadSSHSigner(keyPath string) (*ssh.Signer, error) {
@@ -67,13 +67,14 @@ func loadSSHSigner(keyPath string) (*ssh.Signer, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	signer := &ssh.Signer{
-		Key:  key,
-		Path: keyPath,
+	verifier, err := ssh.NewVerifierFromKey(key)
+	if err != nil {
+		return nil, err
 	}
-
-	return signer, nil
+	return &ssh.Signer{
+		Verifier: verifier,
+		Path:     keyPath,
+	}, nil
 }
 
 func createSignedEnvelope(signer *ssh.Signer) (*sslibdsse.Envelope, error) {

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -63,7 +63,7 @@ func TestVerifyEnvelope(t *testing.T) {
 }
 
 func loadSSHSigner(keyPath string) (*ssh.Signer, error) {
-	key, err := ssh.Import(keyPath)
+	key, err := ssh.NewKeyFromFile(keyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-const SSHSigNamespace = "git"
-
 // Key is a container and dsse.Verifier implementation for SSH keys.
 type Key struct {
 	KeyType string
@@ -23,6 +21,11 @@ type Key struct {
 	Scheme  string
 	keyID   string
 }
+
+const (
+	SSHSigNamespace = "git"
+	SSHKeyType      = "ssh"
+)
 
 // KeyVal is a container for public key material for SSH keys.
 type KeyVal struct {
@@ -113,7 +116,7 @@ func Import(path string) (*Key, error) {
 
 	return &Key{
 		keyID:   ssh.FingerprintSHA256(sshPub),
-		KeyType: "ssh",
+		KeyType: SSHKeyType,
 		Scheme:  sshPub.Type(),
 		KeyVal: KeyVal{
 			Public: base64.StdEncoding.EncodeToString(sshPub.Marshal()),

--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -10,35 +10,24 @@ import (
 	"os/exec"
 	"strings"
 
+	sv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/hiddeco/sshsig"
 	"golang.org/x/crypto/ssh"
 )
-
-// Key is a container and dsse.Verifier implementation for SSH keys.
-type Key struct {
-	KeyType string
-	KeyVal  KeyVal
-	Scheme  string
-	keyID   string
-}
 
 const (
 	SSHSigNamespace = "git"
 	SSHKeyType      = "ssh"
 )
 
-// KeyVal is a container for public key material for SSH keys.
-type KeyVal struct {
-	Public string
+// Verifier is a dsse.Verifier implementation for SSH keys.
+type Verifier struct {
+	keyID  string
+	sshKey ssh.PublicKey
 }
 
 // Verify implements the dsse.Verifier.Verify interface for SSH keys.
-func (k *Key) Verify(_ context.Context, data []byte, sig []byte) error {
-	pub, err := parseSSH2Body(k.KeyVal.Public)
-	if err != nil {
-		return fmt.Errorf("failed to parse ssh public key material: %w", err)
-	}
-
+func (v *Verifier) Verify(_ context.Context, data []byte, sig []byte) error {
 	signature, err := sshsig.Unarmor(sig)
 	if err != nil {
 		return fmt.Errorf("failed to parse ssh signature: %w", err)
@@ -48,7 +37,7 @@ func (k *Key) Verify(_ context.Context, data []byte, sig []byte) error {
 
 	// ssh-keygen uses sha512 to sign with **any*** key
 	hash := sshsig.HashSHA512
-	if err = sshsig.Verify(message, signature, pub, hash, SSHSigNamespace); err != nil {
+	if err := sshsig.Verify(message, signature, v.sshKey, hash, SSHSigNamespace); err != nil {
 		return fmt.Errorf("failed to verify ssh signature: %w", err)
 	}
 
@@ -57,21 +46,20 @@ func (k *Key) Verify(_ context.Context, data []byte, sig []byte) error {
 
 // KeyID implements the dsse.Verifier.KeyID interface for SSH keys.
 // FIXME: consider removing error in interface; a dsse.Verifier needs a keyid
-func (k *Key) KeyID() (string, error) {
-	return k.keyID, nil
+func (v *Verifier) KeyID() (string, error) {
+	return v.keyID, nil
 }
 
 // Public implements the dsse.Verifier.Public interface for SSH keys.
 // FIXME: consider removing in interface, "Verify()" is all that's needed
-func (k *Key) Public() crypto.PublicKey {
-	sshKey, _ := parseSSH2Body(k.KeyVal.Public)
-	return sshKey.(ssh.CryptoPublicKey).CryptoPublicKey()
+func (v *Verifier) Public() crypto.PublicKey {
+	return v.sshKey.(ssh.CryptoPublicKey).CryptoPublicKey()
 }
 
 // Signer is a dsse.Signer implementation for SSH keys.
 type Signer struct {
-	Key  *Key
-	Path string
+	Verifier *Verifier
+	Path     string
 }
 
 // Sign implements the dsse.Signer.Sign interface for SSH keys.
@@ -94,33 +82,47 @@ func (s *Signer) Sign(_ context.Context, data []byte) ([]byte, error) {
 
 // KeyID implements the dsse.Signer.KeyID interface for SSH keys.
 func (s *Signer) KeyID() (string, error) {
-	return s.Key.KeyID()
+	return s.Verifier.KeyID()
 }
 
-// NewKeyFromFile imports an SSH public key from the passed path.
+// NewKeyFromFile imports an ssh SSlibKey from the passed path.
 // The path can point to a public or private, encrypted or plaintext, rsa,
 // ecdsa or ed25519 key file in a format supported by "ssh-keygen". This aligns
 // with the git "user.signingKey" option.
 // https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
-func NewKeyFromFile(path string) (*Key, error) {
+func NewKeyFromFile(path string) (*sv.SSLibKey, error) {
 	cmd := exec.Command("ssh-keygen", "-m", "rfc4716", "-e", "-f", path)
 	output, err := cmd.Output()
 	if err != nil {
 		return nil, fmt.Errorf("failed to run command %v: %w", cmd, err)
 	}
-
 	sshPub, err := parseSSH2Key(string(output))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse SSH2 key: %w", err)
 	}
 
-	return &Key{
-		keyID:   ssh.FingerprintSHA256(sshPub),
+	return &sv.SSLibKey{
+		KeyID:   ssh.FingerprintSHA256(sshPub),
 		KeyType: SSHKeyType,
 		Scheme:  sshPub.Type(),
-		KeyVal: KeyVal{
+		KeyVal: sv.KeyVal{
 			Public: base64.StdEncoding.EncodeToString(sshPub.Marshal()),
 		},
+	}, nil
+}
+
+// NewVerifierFromKey creates a new Verifier from SSlibKey of type ssh.
+func NewVerifierFromKey(key *sv.SSLibKey) (*Verifier, error) {
+	if key.KeyType != SSHKeyType {
+		return nil, fmt.Errorf("wrong keyType: %s", key.KeyType)
+	}
+	sshKey, err := parseSSH2Body(key.KeyVal.Public)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ssh public key material: %w", err)
+	}
+	return &Verifier{
+		keyID:  key.KeyID,
+		sshKey: sshKey,
 	}, nil
 }
 

--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -97,12 +97,12 @@ func (s *Signer) KeyID() (string, error) {
 	return s.Key.KeyID()
 }
 
-// Import imports an SSH public key from the passed path.
+// NewKeyFromFile imports an SSH public key from the passed path.
 // The path can point to a public or private, encrypted or plaintext, rsa,
 // ecdsa or ed25519 key file in a format supported by "ssh-keygen". This aligns
 // with the git "user.signingKey" option.
 // https://git-scm.com/docs/git-config#Documentation/git-config.txt-usersigningKey
-func Import(path string) (*Key, error) {
+func NewKeyFromFile(path string) (*Key, error) {
 	cmd := exec.Command("ssh-keygen", "-m", "rfc4716", "-e", "-f", path)
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/signerverifier/ssh/ssh_test.go
+++ b/internal/signerverifier/ssh/ssh_test.go
@@ -70,7 +70,7 @@ func TestSSH(t *testing.T) {
 
 			keyPath := filepath.Join(tmpDir, test.keyName)
 
-			key, err := Import(keyPath)
+			key, err := NewKeyFromFile(keyPath)
 			if err != nil {
 				t.Fatalf("%s: %v", test.keyName, err)
 			}


### PR DESCRIPTION
Previously, ssh `Key` satisfied both the `dsse.Verifier` interface and served as TUF metadata key container. Unfortunately, it didn't seem feasible to wire up the key container with the current TUF metadata implementation, which uses `SSlibKey`.

This commit re-designs the ssh key implementation to use SSlibKey as key container and a separate Verifier for verification.

See https://github.com/gittuf/gittuf/pull/429#issuecomment-2151588628 for more detailed design considerations.

Change details:

* Add an SSHKeyTypeConstant
* Rename Import to NewKeyFromFile
* Replace ssh Key with ssh Verifier, which satisfies the dsse.Verifier interface, but is otherwise a black box (no key details exposed).
* Change NewKeyFromFile to return an SSlibKey, to be included in TUF metadata.
* Add NewVerifierFromKey function to create an ssh Verifier from a  corresponding SSlibKey, e.g. included in TUF metadata, to verify  a signature from an ssh Signer.
* Add TUF metadata integration POC / usage example in tuf_test.go (see [comment in #429](https://github.com/gittuf/gittuf/pull/429#discussion_r1628103131)).