### PR TITLE
ci: Enable `get-started` tester on certain docs changes

### DIFF
--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -4,9 +4,13 @@ on:
     branches: ['main']
     paths-ignore:
       - "docs/*"
+      - "!docs/testing/*"
+      - "!docs/get-started.md"
   pull_request:
     paths-ignore:
       - "docs/*"
+      - "!docs/testing/*"
+      - "!docs/get-started.md"
 jobs:
   test:
     strategy:
@@ -26,6 +30,6 @@ jobs:
       with:
         python-version: '3.10'
     - name: Build gittuf
-      run: make
+      run: make just-install
     - name: Test Getting Started
       run: python3 docs/testing/test-get-started-md.py

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ default : install
 build : test
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)"  -o dist/gittuf .
 
-install : test
+install : test just-install
+
+just-install :
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
 
 test :


### PR DESCRIPTION
We should run the `get-started` CI tests if there are changes to the `get-started.md` doc or testing data.