### PR TITLE
Add functions and a command for reorder rules in a policy file

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -28,6 +28,7 @@ Tools to manage gittuf policies
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state
 * [gittuf policy remote](gittuf_policy_remote.md)	 - Tools for managing remote policies
 * [gittuf policy remove-rule](gittuf_policy_remove-rule.md)	 - Remove rule from a policy file
+* [gittuf policy reorder-rules](gittuf_policy_reorder-rules.md)	 - Reorder rules in the specified policy file
 * [gittuf policy sign](gittuf_policy_sign.md)	 - Sign policy file
 * [gittuf policy update-rule](gittuf_policy_update-rule.md)	 - Update an existing rule in a policy file
 

--- a/docs/cli/gittuf_policy_reorder-rules.md
+++ b/docs/cli/gittuf_policy_reorder-rules.md
@@ -1,0 +1,33 @@
+## gittuf policy reorder-rules
+
+Reorder rules in the specified policy file
+
+### Synopsis
+
+This command allows users to reorder rules in the specified policy file. By default, the main policy file is selected. The rule names need to be passed as arguments, in the new order they must appear in, starting from the first to the last rule. Rule names may contain spaces, so they should be enclosed in quotes if necessary.
+
+```
+gittuf policy reorder-rules [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for reorder-rules
+      --policy-name string   name of policy file to reorder rules in (default "targets")
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign policy file
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/listrules"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/policy/removerule"
+	"github.com/gittuf/gittuf/internal/cmd/policy/reorderrules"
 	"github.com/gittuf/gittuf/internal/cmd/policy/sign"
 	"github.com/gittuf/gittuf/internal/cmd/policy/updaterule"
 	"github.com/gittuf/gittuf/internal/cmd/trustpolicy/apply"
@@ -32,6 +33,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(listrules.New())
 	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removerule.New(o))
+	cmd.AddCommand(reorderrules.New(o))
 	cmd.AddCommand(sign.New(o))
 	cmd.AddCommand(updaterule.New(o))
 

--- a/internal/cmd/policy/reorderrules/reorderrules.go
+++ b/internal/cmd/policy/reorderrules/reorderrules.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package reorderrules
+
+import (
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p          *persistent.Options
+	policyName string
+	ruleNames  []string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		"targets",
+		"name of policy file to reorder rules in",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	o.ruleNames = append(o.ruleNames, args...)
+
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	signer, err := common.LoadSigner(o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	err = repo.ReorderDelegations(cmd.Context(), signer, o.policyName, o.ruleNames, true)
+	return err
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "reorder-rules",
+		Short:             "Reorder rules in the specified policy file",
+		Long:              "This command allows users to reorder rules in the specified policy file. By default, the main policy file is selected. The rule names need to be passed as arguments, in the new order they must appear in, starting from the first to the last rule. Rule names may contain spaces, so they should be enclosed in quotes if necessary.",
+		PreRunE:           common.CheckIfSigningViableWithFlag,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/common/set/set.go
+++ b/internal/common/set/set.go
@@ -62,3 +62,29 @@ func (s *Set[T]) Intersection(set *Set[T]) *Set[T] {
 
 	return intersection
 }
+
+func (s *Set[T]) Minus(set *Set[T]) *Set[T] {
+	minus := NewSet[T]()
+
+	for item := range s.contents {
+		if !set.Has(item) {
+			minus.Add(item)
+		}
+	}
+
+	return minus
+}
+
+func (s *Set[T]) Equal(set *Set[T]) bool {
+	if s.Len() != set.Len() {
+		return false
+	}
+
+	for item := range s.contents {
+		if !set.Has(item) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -200,6 +200,59 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 	return state.Commit(r.r, commitMessage, signCommit)
 }
 
+// ReorderDelegations is the interface for the user to reorder rules in gittuf
+// policy.
+func (r *Repository) ReorderDelegations(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleNames []string, signCommit bool) error {
+	keyID, err := signer.KeyID()
+	if err != nil {
+		return nil
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyStagingRef)
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Loading current rule file...")
+	if !state.HasTargetsRole(targetsRoleName) {
+		return policy.ErrMetadataNotFound
+	}
+
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Reordering rules in rule file...")
+	targetsMetadata, err = policy.ReorderDelegations(targetsMetadata, ruleNames)
+	if err != nil {
+		return err
+	}
+
+	env, err := dsse.CreateEnvelope(targetsMetadata)
+	if err != nil {
+		return nil
+	}
+
+	slog.Debug(fmt.Sprintf("Signing updated rule file using '%s'...", keyID))
+	env, err = dsse.SignEnvelope(ctx, env, signer)
+	if err != nil {
+		return nil
+	}
+
+	if targetsRoleName == policy.TargetsRoleName {
+		state.TargetsEnvelope = env
+	} else {
+		state.DelegationEnvelopes[targetsRoleName] = env
+	}
+
+	commitMessage := fmt.Sprintf("Reorder rules in policy '%s'", targetsRoleName)
+
+	slog.Debug("Committing policy...")
+	return state.Commit(r.r, commitMessage, signCommit)
+}
+
 // RemoveDelegation is the interface for a user to remove a rule from gittuf
 // policy.
 func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, signCommit bool) error {


### PR DESCRIPTION
1. Add a function ReorderDelegations() to handle rule reordering from backend
2. Add a command ```gittuf policy reorder-rules [flags]``` to reorder rules from CLI