### PR TITLE
Add verify-mergeable

### DIFF
--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"testing"
 )
 
 // ResetDueToError reverses a change applied to a ref to the specified target
@@ -38,6 +39,21 @@ func RemoteRef(refName, remoteName string) string {
 	}
 
 	return remotePath
+}
+
+// RestoreWorktree is a test helper to fix the worktree in tests where we need
+// to operate in a checked out copy of the repository. This is primarily needed
+// for support with older Git versions.
+func (r *Repository) RestoreWorktree(t *testing.T) {
+	t.Helper()
+
+	if _, err := r.executor("restore", "--staged", ".").executeString(); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := r.executor("checkout", "--", ".").executeString(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // IsNiceGitVersion determines whether the version of git is "nice". Certain Git

--- a/internal/policy/searcher.go
+++ b/internal/policy/searcher.go
@@ -17,9 +17,11 @@ import (
 // the RSL.
 type searcher interface {
 	FindFirstPolicyEntry() (*rsl.ReferenceEntry, error)
+	FindLatestPolicyEntry() (*rsl.ReferenceEntry, error)
 	FindPolicyEntryFor(rsl.Entry) (*rsl.ReferenceEntry, error)
 	FindPolicyEntriesInRange(rsl.Entry, rsl.Entry) ([]*rsl.ReferenceEntry, error)
 	FindAttestationsEntryFor(rsl.Entry) (*rsl.ReferenceEntry, error)
+	FindLatestAttestationsEntry() (*rsl.ReferenceEntry, error)
 }
 
 func newSearcher(repo *gitinterface.Repository) searcher {
@@ -44,6 +46,11 @@ func (r *regularSearcher) FindFirstPolicyEntry() (*rsl.ReferenceEntry, error) {
 	}
 
 	return entry, nil
+}
+
+func (r *regularSearcher) FindLatestPolicyEntry() (*rsl.ReferenceEntry, error) {
+	entry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(PolicyRef))
+	return entry, err
 }
 
 // FindPolicyEntryFor identifies the latest policy entry for the specified
@@ -106,4 +113,9 @@ func (r *regularSearcher) FindAttestationsEntryFor(entry rsl.Entry) (*rsl.Refere
 
 func newRegularSearcher(repo *gitinterface.Repository) *regularSearcher {
 	return &regularSearcher{repo: repo}
+}
+
+func (r *regularSearcher) FindLatestAttestationsEntry() (*rsl.ReferenceEntry, error) {
+	entry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(attestations.Ref))
+	return entry, err
 }


### PR DESCRIPTION
~Depends on #439~

~A bunch of comments for verify-mergeable were left there, will cross reference.~

I've applied the comments in threads inline for discussion. The idea of verify-mergeable is to be able to say "this PR can be merged as it has reached the required number of approvals" or "this PR can be merged as long as the merge is by someone with approval powers". I want to plug this into gittuf/github-app to add checkruns to a repository.