### PR TITLE
Change how test coverage is calculated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,7 @@ jobs:
         go-version: '1.22'
         cache: true
     - name: Test
-      run: go test -covermode atomic ./...
+      run: go test ./...
+    - name: Test Coverage
+      if: matrix.os == 'ubuntu-latest'
+      run: go test -covermode=atomic `go list ./... | grep -v -f .test_ignore.txt`

--- a/.test_ignore.txt
+++ b/.test_ignore.txt
@@ -1,0 +1,16 @@
+github.com/gittuf/gittuf/docs/cli
+github.com/gittuf/gittuf/internal/cmd/addhooks
+github.com/gittuf/gittuf/internal/cmd/clone
+github.com/gittuf/gittuf/internal/cmd/dev
+github.com/gittuf/gittuf/internal/cmd/policy
+github.com/gittuf/gittuf/internal/cmd/profile
+github.com/gittuf/gittuf/internal/cmd/root
+github.com/gittuf/gittuf/internal/cmd/rsl
+github.com/gittuf/gittuf/internal/cmd/trust
+github.com/gittuf/gittuf/internal/cmd/verifycommit
+github.com/gittuf/gittuf/internal/cmd/verifyref
+github.com/gittuf/gittuf/internal/cmd/verifytag
+github.com/gittuf/gittuf/internal/cmd/version
+github.com/gittuf/gittuf/internal/dev
+github.com/gittuf/gittuf/internal/testartifacts
+github.com/gittuf/gittuf/internal/version


### PR DESCRIPTION
This PR prevents files that don't need / have tests from cluttering up our testing coverage results. By default, it looks like go includes everything in coverage, including things like `docs/cli`, which is irrelevant. This allows us to select what should be included.

This will probably need improvement for windows due to the use of `grep`...