### PR TITLE
transport: Fix discovery of old RSL tip on remote

### DIFF
--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -428,7 +428,10 @@ func handleSSH(_, url string) (map[string]string, bool, error) {
 					return nil, false, err
 				}
 
-				oldTip := remoteRefTips[rsl.Ref]
+				oldTip, has := remoteRefTips[rsl.Ref]
+				if !has {
+					oldTip = zeroHash
+				}
 				newTip := string(bytes.TrimSpace(output))
 
 				pushCmd := fmt.Sprintf("%s %s %s\n", oldTip, newTip, rsl.Ref)


### PR DESCRIPTION
We had a mistaken assumption that if the remote didn't already have the RSL ref, the oldTip variable would be set to zero.