### PR TITLE
Fix goreleaser and prepare v0.5.1

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: gittuf
 
 builds:
@@ -30,7 +32,7 @@ gomod:
   proxy: true
 
 changelog:
-  skip: true
+  disable: true
 
 signs:
 - cmd: cosign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## v0.5.1
+
+- Updated release workflow to support GoReleaser v2
+
 ## v0.5.0
 
 - Added support for `ssh-keygen` based signer and verifier


### PR DESCRIPTION
We don't have release assets for v0.5.0 due to a breaking change in goreleaser. I propose we go directly to v0.5.1 with binaries, I don't want us to re-tag nor do I want to have binaries that are not signed by the release workflow's identity.