### PR TITLE
transport: Fetch refs/gittuf/* before creating entries

### DIFF
--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -158,6 +158,15 @@ func handleCurl(remoteName, url string) (map[string]string, bool, error) {
 
 						// }
 
+						log("fetching remote gittuf refs")
+						cmd := exec.Command("git", "fetch", url, "refs/gittuf/*:refs/gittuf/*")
+						cmd.Stderr = os.Stderr
+						cmd.Stdout = os.Stderr
+						cmd.Stdin = os.Stdin
+						if err := cmd.Run(); err != nil {
+							return nil, false, err
+						}
+
 						for _, pushCommand := range pushCommands {
 							if len(gittufRefsTips) != 0 {
 								refSpec := string(bytes.Split(bytes.TrimSpace(pushCommand), []byte{' '})[1])

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -356,6 +356,15 @@ func handleSSH(_, url string) (map[string]string, bool, error) {
 					command = stdInScanner.Bytes()
 				}
 
+				log("fetching remote gittuf refs")
+				cmd := exec.Command("git", "fetch", url, "refs/gittuf/*:refs/gittuf/*")
+				cmd.Stderr = os.Stderr
+				cmd.Stdout = os.Stderr
+				cmd.Stdin = os.Stdin
+				if err := cmd.Run(); err != nil {
+					return nil, false, err
+				}
+
 				pushObjects := set.NewSet[string]()
 				log("adding gittuf RSL entries")
 				for i, refSpec := range pushRefSpecs {
@@ -426,7 +435,7 @@ func handleSSH(_, url string) (map[string]string, bool, error) {
 				// TODO: gittuf verify-ref for each dstRef; abort if
 				// verification fails
 
-				cmd := exec.Command("git", "rev-parse", rsl.Ref) //nolint:gosec
+				cmd = exec.Command("git", "rev-parse", rsl.Ref) //nolint:gosec
 				output, err := cmd.Output()
 				if err != nil {
 					return nil, false, err


### PR DESCRIPTION
Fetch remote gittuf refs to ensure new RSL entries are appened at the end