### PR TITLE
Support older Git versions

### DIFF
--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -1,0 +1,24 @@
+name: git 2.34.1 on ubuntu-22.04
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "docs/*"
+  pull_request:
+    paths-ignore:
+      - "docs/*"
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Downgrade Git
+        run: sudo apt-get update && sudo apt-get install -y --allow-downgrades git=1:2.34.1-1ubuntu1.11 git-man=1:2.34.1-1ubuntu1.11
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+      - name: Install Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
+        with:
+          go-version: "1.22"
+          cache: true
+      - name: Test
+        run: go test ./...

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -4,7 +4,6 @@ package gitinterface
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -340,8 +339,4 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, []string{"a"}, diffs)
 	})
-}
-
-func testNameToRefName(testName string) string {
-	return BranchReferenceName(strings.ReplaceAll(testName, " ", "__"))
 }

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -26,7 +26,12 @@ func (r *Repository) EmptyTree() (Hash, error) {
 // GetAllFilesInTree returns all filepaths and the corresponding blob hashes in
 // the specified tree.
 func (r *Repository) GetAllFilesInTree(treeID Hash) (map[string]Hash, error) {
-	stdOut, err := r.executor("ls-tree", "-r", "--format=%(path) %(objectname)", treeID.String()).executeString()
+	// From Git 2.36, we can use --format here. However, it appears a not
+	// insignificant number of developers are still on Git 2.34.1, a side effect
+	// of being on Ubuntu 22.04. 22.04 is still widely used in WSL2 environments.
+	// So, we're removing --format and parsing the output differently to handle
+	// the extra information for each entry we don't need.
+	stdOut, err := r.executor("ls-tree", "-r", treeID.String()).executeString()
 	if err != nil {
 		return nil, fmt.Errorf("unable to enumerate all files in tree: %w", err)
 	}
@@ -42,16 +47,23 @@ func (r *Repository) GetAllFilesInTree(treeID Hash) (map[string]Hash, error) {
 
 	files := map[string]Hash{}
 	for _, entry := range entries {
-		// we control entry's format in --format above, so no need to check
-		// length of split
-		entrySplit := strings.Split(entry, " ")
+		// Without --format, the output is in the following format:
+		// <mode> SP <type> SP <object> TAB <file>
+		// From: https://git-scm.com/docs/git-ls-tree/2.34.1#_output_format
 
-		hash, err := NewHash(entrySplit[1])
+		entrySplit := strings.Split(entry, " ")
+		// entrySplit[0] is <mode> -- discard
+		// entrySplit[1] is <type> -- discard
+		// entrySplit[2] is <object> TAB <file> -- keep
+		entrySplit = strings.Split(entrySplit[2], "\t")
+
+		// <object> is really the object ID
+		hash, err := NewHash(entrySplit[0])
 		if err != nil {
-			return nil, fmt.Errorf("invalid Git ID '%s' for path '%s': %w", entrySplit[1], entrySplit[0], err)
+			return nil, fmt.Errorf("invalid Git ID '%s' for path '%s': %w", entrySplit[0], entrySplit[1], err)
 		}
 
-		files[entrySplit[0]] = hash
+		files[entrySplit[1]] = hash
 	}
 
 	return files, nil

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -3,6 +3,7 @@
 package gitinterface
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,175 @@ func TestRepositoryEmptyTree(t *testing.T) {
 	// SHA-1 ID used by Git to denote an empty tree
 	// $ git hash-object -t tree --stdin < /dev/null
 	assert.Equal(t, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", hash.String())
+}
+
+func TestGetMergeTree(t *testing.T) {
+	t.Run("no conflict", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		// We meed to change the directory for this test because we `checkout`
+		// for older Git versions, modifying the worktree. This chdir ensures
+		// that the temporary directory is used as the worktree.
+		pwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(pwd) //nolint:errcheck
+
+		emptyBlobID, err := repo.WriteBlob(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeBuilder := NewTreeBuilder(repo)
+		emptyTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeAID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]Hash{"a": emptyBlobID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		treeBID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]Hash{"b": emptyBlobID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		combinedTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]Hash{
+			"a": emptyBlobID,
+			"b": emptyBlobID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mainRef := "refs/heads/main"
+		featureRef := "refs/heads/feature"
+
+		// Add commits to the main branch
+		baseCommitID, err := repo.Commit(emptyTreeID, mainRef, "Initial commit", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitAID, err := repo.Commit(treeAID, mainRef, "Commit A", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Add commits to the feature branch
+		if err := repo.SetReference(featureRef, baseCommitID); err != nil {
+			t.Fatal(err)
+		}
+		commitBID, err := repo.Commit(treeBID, featureRef, "Commit B", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// fix up checked out worktree
+		if _, err := repo.executor("restore", "--staged", ".").executeString(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := repo.executor("checkout", "--", ".").executeString(); err != nil {
+			t.Fatal(err)
+		}
+
+		mergeTreeID, err := repo.GetMergeTree(commitAID, commitBID)
+		assert.Nil(t, err)
+		if !combinedTreeID.Equal(mergeTreeID) {
+			mergeTreeContents, err := repo.GetAllFilesInTree(mergeTreeID)
+			if err != nil {
+				t.Fatalf("unexpected error when debugging non-matched merge trees: %s", err.Error())
+			}
+			t.Log("merge tree contents:", mergeTreeContents)
+			t.Error("merge trees don't match")
+		}
+	})
+
+	t.Run("merge conflict", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		// We meed to change the directory for this test because we `checkout`
+		// for older Git versions, modifying the worktree. This chdir ensures
+		// that the temporary directory is used as the worktree.
+		pwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(pwd) //nolint:errcheck
+
+		emptyBlobID, err := repo.WriteBlob(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeBuilder := NewTreeBuilder(repo)
+		emptyTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		blobAID, err := repo.WriteBlob([]byte("a"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		blobBID, err := repo.WriteBlob([]byte("b"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		treeAID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]Hash{"a": blobAID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		treeBID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]Hash{
+			"a": blobBID,
+			"b": emptyBlobID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		mainRef := "refs/heads/main"
+		featureRef := "refs/heads/feature"
+
+		// Add commits to the main branch
+		baseCommitID, err := repo.Commit(emptyTreeID, mainRef, "Initial commit", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		commitAID, err := repo.Commit(treeAID, mainRef, "Commit A", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Add commits to the feature branch
+		if err := repo.SetReference(featureRef, baseCommitID); err != nil {
+			t.Fatal(err)
+		}
+		commitBID, err := repo.Commit(treeBID, featureRef, "Commit B", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// fix up checked out worktree
+		if _, err := repo.executor("restore", "--staged", ".").executeString(); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := repo.executor("checkout", "--", ".").executeString(); err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = repo.GetMergeTree(commitAID, commitBID)
+		assert.NotNil(t, err)
+	})
 }
 
 func TestTreeBuilder(t *testing.T) {

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -4,6 +4,7 @@ package gitinterface
 
 import (
 	"fmt"
+	"os/exec"
 	"path"
 	"strings"
 )
@@ -36,4 +37,29 @@ func RemoteRef(refName, remoteName string) string {
 	}
 
 	return remotePath
+}
+
+// IsNiceGitVersion determines whether the version of git is "nice". Certain Git
+// subcommands that gittuf uses were added in newer versions than some common
+// client versions. Instead of using a workaround for all clients, we determine
+// if we can use the newer features or instead need to use workarounds.
+func isNiceGitVersion() (bool, error) {
+	cmd := exec.Command("git", "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return false, err
+	}
+
+	versionString := strings.TrimPrefix(strings.TrimSpace(string(output)), "git version ")
+
+	var major, minor, patch int
+	_, err = fmt.Sscanf(versionString, "%d.%d.%d", &major, &minor, &patch)
+	if err != nil {
+		return false, err
+	}
+
+	if major >= 2 && minor >= 38 {
+		return true, nil
+	}
+	return false, nil
 }

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -63,3 +63,7 @@ func isNiceGitVersion() (bool, error) {
 	}
 	return false, nil
 }
+
+func testNameToRefName(testName string) string {
+	return BranchReferenceName(strings.ReplaceAll(testName, " ", "__"))
+}

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -3,6 +3,7 @@
 package repository
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/attestations"
@@ -18,6 +19,18 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 
 	testDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, testDir, false)
+
+	// We meed to change the directory for this test because we `checkout`
+	// for older Git versions, modifying the worktree. This chdir ensures
+	// that the temporary directory is used as the worktree.
+	pwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(pwd) //nolint:errcheck
 
 	repo := &Repository{r: r}
 


### PR DESCRIPTION
This allows us to support Git < 2.36, needed for users still on Ubuntu 22.04.

Closes #434 