### PR TITLE
Verify file rules in specified branches only

### DIFF
--- a/internal/cmd/policy/listrules/listrules.go
+++ b/internal/cmd/policy/listrules/listrules.go
@@ -41,10 +41,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		fmt.Printf(strings.Repeat("    ", curRule.Depth)+"Rule %s:\n", curRule.Delegation.Name)
 		gitpaths, filepaths := []string{}, []string{}
 		for _, path := range curRule.Delegation.Paths {
-			if strings.HasPrefix(path, "git:") {
-				gitpaths = append(gitpaths, path)
+			if path.PathType() == 0 {
+				gitpaths = append(gitpaths, path.GetPath())
 			} else {
-				filepaths = append(filepaths, path)
+				filepaths = append(filepaths, path.GetPath())
 			}
 		}
 		if len(filepaths) > 0 {

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -112,12 +112,12 @@ func createTestStateWithPolicy(t *testing.T) *State {
 	}
 
 	targetsMetadata := InitializeTargetsMetadata()
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	// Add a file protection rule. When used with common.AddNTestCommitsToSpecifiedRef, we have files with names 1, 2, 3,...n.
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []string{"file:1", "file:2"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-files-1-and-2", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.FilePath{FilePath: "file:1"}, &tuf.FilePath{FilePath: "file:2"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,12 +181,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	// Create the root targets metadata
 	targetsMetadata := InitializeTargetsMetadata()
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "1", []*tuf.Key{key}, []string{"file:1/*"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "1", []*tuf.Key{key}, []tuf.Path{&tuf.FilePath{FilePath: "file:1/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "2", []*tuf.Key{key}, []string{"file:2/*"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "2", []*tuf.Key{key}, []tuf.Path{&tuf.FilePath{FilePath: "file:2/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,12 +203,12 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 
 	// Create the second level of delegations
 	delegation1Metadata := InitializeTargetsMetadata()
-	delegation1Metadata, err = AddDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []string{"file:1/subpath1/*"}, 1)
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "3", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.FilePath{FilePath: "file:1/subpath1/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	delegation1Metadata, err = AddDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []string{"file:1/subpath2/*"}, 1)
+	delegation1Metadata, err = AddDelegation(delegation1Metadata, "4", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.FilePath{FilePath: "file:1/subpath2/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +269,7 @@ func createTestStateWithThresholdPolicy(t *testing.T) *State {
 	}
 
 	// Set threshold = 2 for existing rule with the added key
-	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []string{"git:refs/heads/main"}, 2)
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,7 +346,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 	}
 
 	// Set threshold = 2 for existing rule with the added key
-	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []string{"git:refs/heads/main"}, 2)
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approverKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -423,7 +423,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 	}
 
 	// Set threshold = 2 for existing rule with the added key
-	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approver1Key, approver2Key}, []string{"git:refs/heads/main"}, 3)
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "protect-main", []*tuf.Key{gpgKey, approver1Key, approver2Key}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -454,7 +454,7 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []string{"git:refs/tags/*"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/tags/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +492,7 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []string{"git:refs/tags/*"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "protect-tags", []*tuf.Key{rootKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/tags/*"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -37,7 +37,7 @@ func TestLoadState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-1", []*tuf.Key{}, []string{""}, 1)
+		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-1", []*tuf.Key{}, []tuf.Path{&tuf.BranchPath{BranchName: ""}}, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -68,7 +68,7 @@ func TestLoadState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-2", []*tuf.Key{}, []string{""}, 1)
+		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-2", []*tuf.Key{}, []tuf.Path{&tuf.BranchPath{BranchName: ""}}, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -127,7 +127,7 @@ func TestLoadState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-1", []*tuf.Key{}, []string{""}, 1)
+		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-1", []*tuf.Key{}, []tuf.Path{&tuf.BranchPath{BranchName: ""}}, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -158,7 +158,7 @@ func TestLoadState(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-2", []*tuf.Key{}, []string{""}, 1)
+		targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule-2", []*tuf.Key{}, []tuf.Path{&tuf.BranchPath{BranchName: ""}}, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -231,7 +231,7 @@ func TestLoadFirstState(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{}, []string{"*"}, 1) // just a dummy rule
+	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{}, []tuf.Path{&tuf.BranchPath{BranchName: "*"}}, 1) // just a dummy rule
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +394,7 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 		}
 
 		for name, test := range tests {
-			verifiers, err := state.FindVerifiersForPath(test.path)
+			verifiers, err := state.FindVerifiersForPath([]string{test.path})
 			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
 			assert.Equal(t, test.verifiers, verifiers, fmt.Sprintf("policy verifiers for path '%s' don't match expected verifiers in test '%s'", test.path, name))
 		}
@@ -403,7 +403,7 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 	t.Run("without policy", func(t *testing.T) {
 		state := createTestStateWithOnlyRoot(t)
 
-		verifiers, err := state.FindVerifiersForPath("test-path")
+		verifiers, err := state.FindVerifiersForPath([]string{"test-path"})
 		assert.Nil(t, verifiers)
 		assert.ErrorIs(t, err, ErrMetadataNotFound)
 	})
@@ -469,7 +469,7 @@ func TestGetStateForCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{key}, []string{"*"}, 1) // just a dummy rule
+	targetsMetadata, err = AddDelegation(targetsMetadata, "new-rule", []*tuf.Key{key}, []tuf.Path{&tuf.BranchPath{BranchName: "*"}}, 1) // just a dummy rule
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -520,7 +520,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "protect-main",
-					Paths:       []string{"git:refs/heads/main"},
+					Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "refs/heads/main"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{
@@ -533,7 +533,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "protect-files-1-and-2",
-					Paths:       []string{"file:1", "file:2"},
+					Paths:       []tuf.Path{&tuf.FilePath{FilePath: "file:1"}, &tuf.FilePath{FilePath: "file:2"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{
@@ -556,7 +556,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "1",
-					Paths:       []string{"file:1/*"},
+					Paths:       []tuf.Path{&tuf.FilePath{FilePath: "file:1/*"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{
@@ -569,7 +569,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "3",
-					Paths:       []string{"file:1/subpath1/*"},
+					Paths:       []tuf.Path{&tuf.FilePath{FilePath: "file:1/subpath1/*"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{
@@ -582,7 +582,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "4",
-					Paths:       []string{"file:1/subpath2/*"},
+					Paths:       []tuf.Path{&tuf.FilePath{FilePath: "file:1/subpath2/*"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{
@@ -596,7 +596,7 @@ func TestListRules(t *testing.T) {
 			{
 				Delegation: tuf.Delegation{
 					Name:        "2",
-					Paths:       []string{"file:2/*"},
+					Paths:       []tuf.Path{&tuf.FilePath{FilePath: "file:2/*"}},
 					Terminating: false,
 					Custom:      nil,
 					Role: tuf.Role{

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -22,7 +22,7 @@ func InitializeTargetsMetadata() *tuf.TargetsMetadata {
 }
 
 // AddDelegation adds a new delegation to TargetsMetadata.
-func AddDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int) (*tuf.TargetsMetadata, error) {
+func AddDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []tuf.Path, threshold int) (*tuf.TargetsMetadata, error) {
 	if ruleName == AllowRuleName {
 		return nil, ErrCannotManipulateAllowRule
 	}
@@ -52,7 +52,7 @@ func AddDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string, author
 }
 
 // UpdateDelegation is used to amend a delegation in TargetsMetadata.
-func UpdateDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int) (*tuf.TargetsMetadata, error) {
+func UpdateDelegation(targetsMetadata *tuf.TargetsMetadata, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []tuf.Path, threshold int) (*tuf.TargetsMetadata, error) {
 	if ruleName == AllowRuleName {
 		return nil, ErrCannotManipulateAllowRule
 	}
@@ -128,7 +128,7 @@ func AddKeyToTargets(targetsMetadata *tuf.TargetsMetadata, authorizedKeys []*tuf
 func AllowRule() tuf.Delegation {
 	return tuf.Delegation{
 		Name:        AllowRuleName,
-		Paths:       []string{"*"},
+		Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "*"}},
 		Terminating: true,
 		Role: tuf.Role{
 			KeyIDs:    []string{},

--- a/internal/policy/targets_test.go
+++ b/internal/policy/targets_test.go
@@ -30,7 +30,7 @@ func TestAddDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []tuf.Path{&tuf.BranchPath{BranchName: "test/"}}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Keys[key1.KeyID])
@@ -39,7 +39,7 @@ func TestAddDelegation(t *testing.T) {
 	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
 	assert.Equal(t, tuf.Delegation{
 		Name:        "test-rule",
-		Paths:       []string{"test/"},
+		Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "test/"}},
 		Terminating: false,
 		Role:        tuf.Role{KeyIDs: []string{key1.KeyID, key2.KeyID}, Threshold: 1},
 	}, targetsMetadata.Delegations.Roles[0])
@@ -57,7 +57,7 @@ func TestUpdateDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1}, []string{"test/"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1}, []tuf.Path{&tuf.BranchPath{BranchName: "test/"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,12 +66,12 @@ func TestUpdateDelegation(t *testing.T) {
 	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
 	assert.Equal(t, tuf.Delegation{
 		Name:        "test-rule",
-		Paths:       []string{"test/"},
+		Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "test/"}},
 		Terminating: false,
 		Role:        tuf.Role{KeyIDs: []string{key1.KeyID}, Threshold: 1},
 	}, targetsMetadata.Delegations.Roles[0])
 
-	targetsMetadata, err = UpdateDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []string{"test/"}, 1)
+	targetsMetadata, err = UpdateDelegation(targetsMetadata, "test-rule", []*tuf.Key{key1, key2}, []tuf.Path{&tuf.BranchPath{BranchName: "test/"}}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Keys[key1.KeyID])
@@ -80,7 +80,7 @@ func TestUpdateDelegation(t *testing.T) {
 	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
 	assert.Equal(t, tuf.Delegation{
 		Name:        "test-rule",
-		Paths:       []string{"test/"},
+		Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "test/"}},
 		Terminating: false,
 		Role:        tuf.Role{KeyIDs: []string{key1.KeyID, key2.KeyID}, Threshold: 1},
 	}, targetsMetadata.Delegations.Roles[0])
@@ -94,7 +94,7 @@ func TestRemoveDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key}, []string{"test/"}, 1)
+	targetsMetadata, err = AddDelegation(targetsMetadata, "test-rule", []*tuf.Key{key}, []tuf.Path{&tuf.BranchPath{BranchName: "test/"}}, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -400,7 +400,7 @@ func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *Sta
 
 		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
 		for _, path := range paths {
-			verifiers, err := policy.FindVerifiersForPath(fmt.Sprintf("%s:%s", fileRuleScheme, path))
+			verifiers, err := policy.FindVerifiersForPath([]string{fmt.Sprintf("%s:%s", fileRuleScheme, path), fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName)})
 			if err != nil {
 				return err
 			}
@@ -455,7 +455,7 @@ func verifyTagEntry(ctx context.Context, repo *gitinterface.Repository, policy *
 	}
 
 	// Find authorized verifiers for tag's RSL entry
-	verifiers, err := policy.FindVerifiersForPath(fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName))
+	verifiers, err := policy.FindVerifiersForPath([]string{fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName)})
 	if err != nil {
 		return err
 	}
@@ -605,7 +605,7 @@ func getCommits(repo *gitinterface.Repository, entry *rsl.ReferenceEntry) ([]git
 }
 
 func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target string, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, approverKeyIDs *set.Set[string]) (string, error) {
-	verifiers, err := policy.FindVerifiersForPath(target)
+	verifiers, err := policy.FindVerifiersForPath([]string{target})
 	if err != nil {
 		return "", err
 	}

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -97,7 +97,7 @@ func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
 		t.Fatal(err)
 	}
 
-	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey}, []string{"git:refs/heads/main"}, 1, false); err != nil {
+	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 1, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -73,7 +73,7 @@ func (r *Repository) InitializeTargets(ctx context.Context, signer sslibdsse.Sig
 
 // AddDelegation is the interface for the user to add a new rule to gittuf
 // policy.
-func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int, signCommit bool) error {
+func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []tuf.Path, threshold int, signCommit bool) error {
 	if ruleName == policy.RootRoleName {
 		return ErrInvalidPolicyName
 	}
@@ -140,7 +140,7 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 
 // UpdateDelegation is the interface for the user to update a rule to gittuf
 // policy.
-func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []string, threshold int, signCommit bool) error {
+func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedKeys []*tuf.Key, rulePatterns []tuf.Path, threshold int, signCommit bool) error {
 	if ruleName == policy.RootRoleName {
 		return ErrInvalidPolicyName
 	}

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -79,7 +79,7 @@ func TestAddDelegation(t *testing.T) {
 
 		ruleName := "test-rule"
 		authorizedKeyBytes := []*tuf.Key{targetsPubKey}
-		rulePatterns := []string{"git:branch=main"}
+		rulePatterns := []tuf.Path{&tuf.BranchPath{BranchName: "git:branch=main"}}
 
 		state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
 		if err != nil {
@@ -145,7 +145,7 @@ func TestUpdateDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = r.UpdateDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey, targetsKey}, []string{"git:refs/heads/main"}, 1, false)
+	err = r.UpdateDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []*tuf.Key{gpgKey, targetsKey}, []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}}, 1, false)
 	assert.Nil(t, err)
 
 	state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
@@ -161,7 +161,7 @@ func TestUpdateDelegation(t *testing.T) {
 	assert.Equal(t, 2, len(targetsMetadata.Delegations.Roles))
 	assert.Contains(t, targetsMetadata.Delegations.Roles, tuf.Delegation{
 		Name:        "protect-main",
-		Paths:       []string{"git:refs/heads/main"},
+		Paths:       []tuf.Path{&tuf.BranchPath{BranchName: "git:refs/heads/main"}},
 		Terminating: false,
 		Role:        tuf.Role{KeyIDs: []string{gpgKey.KeyID, targetsKey.KeyID}, Threshold: 1},
 	})
@@ -182,7 +182,7 @@ func TestRemoveDelegation(t *testing.T) {
 
 	ruleName := "test-rule"
 	authorizedKeyBytes := []*tuf.Key{targetsPubKey}
-	rulePatterns := []string{"git:branch=main"}
+	rulePatterns := []tuf.Path{&tuf.BranchPath{BranchName: "git:branch=main"}}
 
 	err = r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, ruleName, authorizedKeyBytes, rulePatterns, 1, false)
 	assert.Nil(t, err)

--- a/internal/tuf/paths.go
+++ b/internal/tuf/paths.go
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tuf
+
+import (
+	"errors"
+
+	"github.com/danwakefield/fnmatch"
+)
+
+// The paths.go file contains the definitions and logic for rule paths in
+// gittuf. This is in its own file for neatness purposes.
+
+var (
+	ErrBranchPathScope = errors.New("branch paths cannot have branch scopes")
+)
+
+const (
+	INTERNAL_PATH = 0
+	BRANCH_PATH   = 1
+	FILE_PATH     = 2
+)
+
+// Path serves as a container for the different path types we can have in a
+// gittuf rule: branch or file paths.
+type Path interface {
+	PathType() int // 0: reserved, 1: branch, 2: file
+	Matches(target []string) bool
+}
+
+// // InternalPath is used to store any arbitrary path, preserving the old
+// // functionality prior to the addition of BranchPath and FilePath
+// type InternalPath struct {
+// 	Path string
+// }
+
+// // PathType for InternalPath returns 0.
+// func (p *InternalPath) PathType() int {
+// 	return INTERNAL_PATH
+// }
+
+// func (p *InternalPath) GetPath() string {
+// 	return p.Path
+// }
+
+// BranchPath represents a branch path. There is only one value: the branch it
+// represents.
+type BranchPath struct {
+	BranchName string
+}
+
+// PathType for BranchPath returns 1.
+func (b *BranchPath) PathType() int {
+	return BRANCH_PATH // 0: branch
+}
+
+// GetPath for BranchPath returns the branch name.
+func (b *BranchPath) GetPath() string {
+	return b.BranchName
+}
+
+// Matches for BranchPath returns whether the branch pattern matches the input
+// target. In this case, the input array is always expected to be of size 1.
+func (b *BranchPath) Matches(target []string) bool {
+	return fnmatch.Match(b.BranchName, target[0], 0)
+}
+
+// FilePath represents a file path. There are two values: the file(s) it
+// represents, and any branches that this rule is scoped to.
+type FilePath struct {
+	FilePath    string
+	BranchScope []string
+}
+
+// PathType for FilePath returns 2.
+func (f *FilePath) PathType() int {
+	return FILE_PATH // 1: file
+}
+
+// GetPath for FilePath returns the file path.
+func (f *FilePath) GetPath() string {
+	return f.FilePath
+}
+
+// GetBranchScope for FilePath returns the set of branches that this file path
+// applies to.
+func (f *FilePath) GetBranchScope() []string {
+	return f.BranchScope
+}
+
+// Matches for FilePath returns whether the file pattern and any scope match the
+// input target. The input array may be either of size 1 for only a file path to
+// match against, or of size 2, where the second element is the branch that this
+// rule applies to.
+func (f *FilePath) Matches(target []string) bool {
+	// First, check if the file path itself matches the input one
+	if matches := fnmatch.Match(f.FilePath, target[0], 0); matches {
+		// Check if the path has a scope.
+
+		// Note that if the path does have a scope, then this means that this
+		// path only applies in certain branches. If the path does not have one,
+		// then it is assumed to apply in all branches.
+		if len(f.BranchScope) > 0 {
+			// If so, iterate over each branch specified, and check if it maches
+			// the one in the input array.
+			for _, scope := range f.BranchScope {
+				if matches := fnmatch.Match(scope, target[1], 0); matches {
+					return true
+				}
+			}
+		} else {
+			// If the path does not have any scope information, return true.
+			return true
+		}
+	}
+	return false
+}

--- a/internal/tuf/paths_test.go
+++ b/internal/tuf/paths_test.go
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tuf
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBranchPathMatches(t *testing.T) {
+	tests := map[string]struct {
+		pattern  string
+		target   string
+		expected bool
+	}{
+		"full path, matches": {
+			pattern:  "foo",
+			target:   "foo",
+			expected: true,
+		},
+		"artifact in directory, matches": {
+			pattern:  "foo/*",
+			target:   "foo/bar",
+			expected: true,
+		},
+		"artifact in directory, does not match": {
+			pattern:  "foo/*.txt",
+			target:   "foo/bar.tgz",
+			expected: false,
+		},
+		"artifact in subdirectory, matches": {
+			pattern:  "foo/*",
+			target:   "foo/bar/foobar",
+			expected: true,
+		},
+		"artifact in subdirectory with specified extension, matches": {
+			pattern:  "foo/*.tgz",
+			target:   "foo/bar/foobar.tgz",
+			expected: true,
+		},
+		"pattern with single character selector, matches": {
+			pattern:  "foo/?.tgz",
+			target:   "foo/a.tgz",
+			expected: true,
+		},
+		"pattern with character sequence, matches": {
+			pattern:  "foo/[abc].tgz",
+			target:   "foo/a.tgz",
+			expected: true,
+		},
+		"pattern with character sequence, does not match": {
+			pattern:  "foo/[abc].tgz",
+			target:   "foo/x.tgz",
+			expected: false,
+		},
+		"pattern with negative character sequence, matches": {
+			pattern:  "foo/[!abc].tgz",
+			target:   "foo/x.tgz",
+			expected: true,
+		},
+		"pattern with negative character sequence, does not match": {
+			pattern:  "foo/[!abc].tgz",
+			target:   "foo/a.tgz",
+			expected: false,
+		},
+		"artifact in arbitrary directory, matches": {
+			pattern:  "*/*.txt",
+			target:   "foo/bar/foobar.txt",
+			expected: true,
+		},
+		"artifact with specific name in arbitrary directory, matches": {
+			pattern:  "*/foobar.txt",
+			target:   "foo/bar/foobar.txt",
+			expected: true,
+		},
+		"artifact with arbitrary subdirectories, matches": {
+			pattern:  "foo/*/foobar.txt",
+			target:   "foo/bar/baz/foobar.txt",
+			expected: true,
+		},
+		"artifact in arbitrary directory, does not match": {
+			pattern:  "*.txt",
+			target:   "foo/bar/foobar.txtfile",
+			expected: false,
+		},
+		"arbitrary directory, does not match": {
+			pattern:  "*_test",
+			target:   "foo/bar_test/foobar",
+			expected: false,
+		},
+		"no pattern": {
+			pattern:  "",
+			target:   "foo",
+			expected: false,
+		},
+		"pattern with multiple consecutive wildcards, matches": {
+			pattern:  "foo/*/*/*.txt",
+			target:   "foo/bar/baz/qux.txt",
+			expected: true,
+		},
+		"pattern with multiple non-consecutive wildcards, matches": {
+			pattern:  "foo/*/baz/*.txt",
+			target:   "foo/bar/baz/qux.txt",
+			expected: true,
+		},
+		"pattern with gittuf git prefix, matches": {
+			pattern:  "git:refs/heads/*",
+			target:   "git:refs/heads/main",
+			expected: true,
+		},
+		"pattern with gittuf file prefix for all recursive contents, matches": {
+			pattern:  "file:src/signatures/*",
+			target:   "file:src/signatures/rsa/rsa.go",
+			expected: true,
+		},
+	}
+
+	for name, test := range tests {
+		branchPath := BranchPath{BranchName: test.pattern}
+		got := branchPath.Matches([]string{test.target})
+		assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
+func TestFilePathMatches(t *testing.T) {
+	t.Run("without branch scope", func(t *testing.T) {
+		tests := map[string]struct {
+			pattern  string
+			target   string
+			expected bool
+		}{
+			"full path, matches": {
+				pattern:  "foo",
+				target:   "foo",
+				expected: true,
+			},
+			"artifact in directory, matches": {
+				pattern:  "foo/*",
+				target:   "foo/bar",
+				expected: true,
+			},
+			"artifact in directory, does not match": {
+				pattern:  "foo/*.txt",
+				target:   "foo/bar.tgz",
+				expected: false,
+			},
+			"artifact in subdirectory, matches": {
+				pattern:  "foo/*",
+				target:   "foo/bar/foobar",
+				expected: true,
+			},
+			"artifact in subdirectory with specified extension, matches": {
+				pattern:  "foo/*.tgz",
+				target:   "foo/bar/foobar.tgz",
+				expected: true,
+			},
+			"pattern with single character selector, matches": {
+				pattern:  "foo/?.tgz",
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, matches": {
+				pattern:  "foo/[abc].tgz",
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, does not match": {
+				pattern:  "foo/[abc].tgz",
+				target:   "foo/x.tgz",
+				expected: false,
+			},
+			"pattern with negative character sequence, matches": {
+				pattern:  "foo/[!abc].tgz",
+				target:   "foo/x.tgz",
+				expected: true,
+			},
+			"pattern with negative character sequence, does not match": {
+				pattern:  "foo/[!abc].tgz",
+				target:   "foo/a.tgz",
+				expected: false,
+			},
+			"artifact in arbitrary directory, matches": {
+				pattern:  "*/*.txt",
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with specific name in arbitrary directory, matches": {
+				pattern:  "*/foobar.txt",
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with arbitrary subdirectories, matches": {
+				pattern:  "foo/*/foobar.txt",
+				target:   "foo/bar/baz/foobar.txt",
+				expected: true,
+			},
+			"artifact in arbitrary directory, does not match": {
+				pattern:  "*.txt",
+				target:   "foo/bar/foobar.txtfile",
+				expected: false,
+			},
+			"arbitrary directory, does not match": {
+				pattern:  "*_test",
+				target:   "foo/bar_test/foobar",
+				expected: false,
+			},
+			"no pattern": {
+				pattern:  "",
+				target:   "foo",
+				expected: false,
+			},
+			"pattern with multiple consecutive wildcards, matches": {
+				pattern:  "foo/*/*/*.txt",
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with multiple non-consecutive wildcards, matches": {
+				pattern:  "foo/*/baz/*.txt",
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with gittuf git prefix, matches": {
+				pattern:  "git:refs/heads/*",
+				target:   "git:refs/heads/main",
+				expected: true,
+			},
+			"pattern with gittuf file prefix for all recursive contents, matches": {
+				pattern:  "file:src/signatures/*",
+				target:   "file:src/signatures/rsa/rsa.go",
+				expected: true,
+			},
+		}
+
+		for name, test := range tests {
+			filePath := FilePath{FilePath: test.pattern}
+			got := filePath.Matches([]string{test.target})
+			assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+		}
+	})
+
+	t.Run("with branch scope", func(t *testing.T) {
+		tests := map[string]struct {
+			pattern  string
+			scope    []string
+			target   []string
+			expected bool
+		}{
+			"full path, main branch, matches": {
+				pattern:  "foo",
+				scope:    []string{"refs/heads/main"},
+				target:   []string{"foo", "refs/heads/main"},
+				expected: true,
+			},
+			"full path, feature branch, does not match": {
+				pattern:  "foo",
+				scope:    []string{"refs/heads/main"},
+				target:   []string{"foo", "refs/heads/feature"},
+				expected: false,
+			},
+			"artifact in directory, main branch, matches": {
+				pattern:  "foo/*",
+				scope:    []string{"refs/heads/main"},
+				target:   []string{"foo/bar", "refs/heads/main"},
+				expected: true,
+			},
+			"artifact in directory, feature branch, does not match": {
+				pattern:  "foo/*",
+				scope:    []string{"refs/heads/main"},
+				target:   []string{"foo/bar", "refs/heads/feature"},
+				expected: false,
+			},
+		}
+
+		for name, test := range tests {
+			filePath := FilePath{FilePath: test.pattern, BranchScope: test.scope}
+			got := filePath.Matches(test.target)
+			assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+		}
+	})
+}

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -12,8 +12,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/danwakefield/fnmatch"
-
 	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
@@ -180,17 +178,16 @@ func (d *Delegations) AddDelegation(delegation Delegation) {
 // pertaining to the delegation.
 type Delegation struct {
 	Name        string           `json:"name"`
-	Paths       []string         `json:"paths"`
+	Paths       []Path           `json:"paths"`
 	Terminating bool             `json:"terminating"`
 	Custom      *json.RawMessage `json:"custom,omitempty"`
 	Role
 }
 
 // Matches checks if any of the delegation's patterns match the target.
-func (d *Delegation) Matches(target string) bool {
+func (d *Delegation) Matches(target []string) bool {
 	for _, pattern := range d.Paths {
-		// We validate pattern when it's added to / updated in the metadata
-		if matches := fnmatch.Match(pattern, target, 0); matches {
+		if matches := pattern.Matches(target); matches {
 			return true
 		}
 	}

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -133,125 +133,125 @@ func TestTargetsMetadataAndDelegations(t *testing.T) {
 	})
 }
 
-func TestDelegationMatches(t *testing.T) {
-	tests := map[string]struct {
-		patterns []string
-		target   string
-		expected bool
-	}{
-		"full path, matches": {
-			patterns: []string{"foo"},
-			target:   "foo",
-			expected: true,
-		},
-		"artifact in directory, matches": {
-			patterns: []string{"foo/*"},
-			target:   "foo/bar",
-			expected: true,
-		},
-		"artifact in directory, does not match": {
-			patterns: []string{"foo/*.txt"},
-			target:   "foo/bar.tgz",
-			expected: false,
-		},
-		"artifact in directory, one pattern matches": {
-			patterns: []string{"foo/*.txt", "foo/*.tgz"},
-			target:   "foo/bar.tgz",
-			expected: true,
-		},
-		"artifact in subdirectory, matches": {
-			patterns: []string{"foo/*"},
-			target:   "foo/bar/foobar",
-			expected: true,
-		},
-		"artifact in subdirectory with specified extension, matches": {
-			patterns: []string{"foo/*.tgz"},
-			target:   "foo/bar/foobar.tgz",
-			expected: true,
-		},
-		"pattern with single character selector, matches": {
-			patterns: []string{"foo/?.tgz"},
-			target:   "foo/a.tgz",
-			expected: true,
-		},
-		"pattern with character sequence, matches": {
-			patterns: []string{"foo/[abc].tgz"},
-			target:   "foo/a.tgz",
-			expected: true,
-		},
-		"pattern with character sequence, does not match": {
-			patterns: []string{"foo/[abc].tgz"},
-			target:   "foo/x.tgz",
-			expected: false,
-		},
-		"pattern with negative character sequence, matches": {
-			patterns: []string{"foo/[!abc].tgz"},
-			target:   "foo/x.tgz",
-			expected: true,
-		},
-		"pattern with negative character sequence, does not match": {
-			patterns: []string{"foo/[!abc].tgz"},
-			target:   "foo/a.tgz",
-			expected: false,
-		},
-		"artifact in arbitrary directory, matches": {
-			patterns: []string{"*/*.txt"},
-			target:   "foo/bar/foobar.txt",
-			expected: true,
-		},
-		"artifact with specific name in arbitrary directory, matches": {
-			patterns: []string{"*/foobar.txt"},
-			target:   "foo/bar/foobar.txt",
-			expected: true,
-		},
-		"artifact with arbitrary subdirectories, matches": {
-			patterns: []string{"foo/*/foobar.txt"},
-			target:   "foo/bar/baz/foobar.txt",
-			expected: true,
-		},
-		"artifact in arbitrary directory, does not match": {
-			patterns: []string{"*.txt"},
-			target:   "foo/bar/foobar.txtfile",
-			expected: false,
-		},
-		"arbitrary directory, does not match": {
-			patterns: []string{"*_test"},
-			target:   "foo/bar_test/foobar",
-			expected: false,
-		},
-		"no patterns": {
-			patterns: nil,
-			target:   "foo",
-			expected: false,
-		},
-		"pattern with multiple consecutive wildcards, matches": {
-			patterns: []string{"foo/*/*/*.txt"},
-			target:   "foo/bar/baz/qux.txt",
-			expected: true,
-		},
-		"pattern with multiple non-consecutive wildcards, matches": {
-			patterns: []string{"foo/*/baz/*.txt"},
-			target:   "foo/bar/baz/qux.txt",
-			expected: true,
-		},
-		"pattern with gittuf git prefix, matches": {
-			patterns: []string{"git:refs/heads/*"},
-			target:   "git:refs/heads/main",
-			expected: true,
-		},
-		"pattern with gittuf file prefix for all recursive contents, matches": {
-			patterns: []string{"file:src/signatures/*"},
-			target:   "file:src/signatures/rsa/rsa.go",
-			expected: true,
-		},
-	}
+// func TestDelegationMatches(t *testing.T) {
+// 	tests := map[string]struct {
+// 		patterns []string
+// 		target   string
+// 		expected bool
+// 	}{
+// 		"full path, matches": {
+// 			patterns: []string{"foo"},
+// 			target:   "foo",
+// 			expected: true,
+// 		},
+// 		"artifact in directory, matches": {
+// 			patterns: []string{"foo/*"},
+// 			target:   "foo/bar",
+// 			expected: true,
+// 		},
+// 		"artifact in directory, does not match": {
+// 			patterns: []string{"foo/*.txt"},
+// 			target:   "foo/bar.tgz",
+// 			expected: false,
+// 		},
+// 		"artifact in directory, one pattern matches": {
+// 			patterns: []string{"foo/*.txt", "foo/*.tgz"},
+// 			target:   "foo/bar.tgz",
+// 			expected: true,
+// 		},
+// 		"artifact in subdirectory, matches": {
+// 			patterns: []string{"foo/*"},
+// 			target:   "foo/bar/foobar",
+// 			expected: true,
+// 		},
+// 		"artifact in subdirectory with specified extension, matches": {
+// 			patterns: []string{"foo/*.tgz"},
+// 			target:   "foo/bar/foobar.tgz",
+// 			expected: true,
+// 		},
+// 		"pattern with single character selector, matches": {
+// 			patterns: []string{"foo/?.tgz"},
+// 			target:   "foo/a.tgz",
+// 			expected: true,
+// 		},
+// 		"pattern with character sequence, matches": {
+// 			patterns: []string{"foo/[abc].tgz"},
+// 			target:   "foo/a.tgz",
+// 			expected: true,
+// 		},
+// 		"pattern with character sequence, does not match": {
+// 			patterns: []string{"foo/[abc].tgz"},
+// 			target:   "foo/x.tgz",
+// 			expected: false,
+// 		},
+// 		"pattern with negative character sequence, matches": {
+// 			patterns: []string{"foo/[!abc].tgz"},
+// 			target:   "foo/x.tgz",
+// 			expected: true,
+// 		},
+// 		"pattern with negative character sequence, does not match": {
+// 			patterns: []string{"foo/[!abc].tgz"},
+// 			target:   "foo/a.tgz",
+// 			expected: false,
+// 		},
+// 		"artifact in arbitrary directory, matches": {
+// 			patterns: []string{"*/*.txt"},
+// 			target:   "foo/bar/foobar.txt",
+// 			expected: true,
+// 		},
+// 		"artifact with specific name in arbitrary directory, matches": {
+// 			patterns: []string{"*/foobar.txt"},
+// 			target:   "foo/bar/foobar.txt",
+// 			expected: true,
+// 		},
+// 		"artifact with arbitrary subdirectories, matches": {
+// 			patterns: []string{"foo/*/foobar.txt"},
+// 			target:   "foo/bar/baz/foobar.txt",
+// 			expected: true,
+// 		},
+// 		"artifact in arbitrary directory, does not match": {
+// 			patterns: []string{"*.txt"},
+// 			target:   "foo/bar/foobar.txtfile",
+// 			expected: false,
+// 		},
+// 		"arbitrary directory, does not match": {
+// 			patterns: []string{"*_test"},
+// 			target:   "foo/bar_test/foobar",
+// 			expected: false,
+// 		},
+// 		"no patterns": {
+// 			patterns: nil,
+// 			target:   "foo",
+// 			expected: false,
+// 		},
+// 		"pattern with multiple consecutive wildcards, matches": {
+// 			patterns: []string{"foo/*/*/*.txt"},
+// 			target:   "foo/bar/baz/qux.txt",
+// 			expected: true,
+// 		},
+// 		"pattern with multiple non-consecutive wildcards, matches": {
+// 			patterns: []string{"foo/*/baz/*.txt"},
+// 			target:   "foo/bar/baz/qux.txt",
+// 			expected: true,
+// 		},
+// 		"pattern with gittuf git prefix, matches": {
+// 			patterns: []string{"git:refs/heads/*"},
+// 			target:   "git:refs/heads/main",
+// 			expected: true,
+// 		},
+// 		"pattern with gittuf file prefix for all recursive contents, matches": {
+// 			patterns: []string{"file:src/signatures/*"},
+// 			target:   "file:src/signatures/rsa/rsa.go",
+// 			expected: true,
+// 		},
+// 	}
 
-	for name, test := range tests {
-		delegation := Delegation{Paths: test.patterns}
-		got := delegation.Matches(test.target)
-		assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
-	}
-}
+// 	for name, test := range tests {
+// 		delegation := Delegation{Paths: test.patterns}
+// 		got := delegation.Matches(test.target)
+// 		assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+// 	}
+// }
 
 func TestRootMetadataWithSSHKey(t *testing.T) {
 	// Setup test key pair


### PR DESCRIPTION
This PR adds functionality to verify file rules in specified branches only. Specifically,

- `add-branch-rule` and `add-file-rule` are new commands which take care of building their respective type of rules for the user. These are in addition to the existing workflow provided by `add-rule`, which allows unrestricted input.
- The `Matches` method in the `tuf` package now supports passing in branches in addition to a file pattern, enabling the namesake functionality of this PR.

**Note**: The changes in this PR now treat file rules without branch information as applying to all branches. For example, `file:README.md` will apply to `README.md` in **all** branches, while `file:README.md;git:refs/heads/main` will only apply to `README.md` in the `main` branch.

~~Still WIP, need to add some tests.~~

**Edit**: `add-branch-rule` and `add-file-rule` postponed to a future PR.

Closes #355.