### PR TITLE
Improvements to Windows installation guidelines

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -74,7 +74,8 @@ gittuf version
 To build from source, clone the repository and run
 `make`. This will also run the test suite prior to installing gittuf. Note that Go 1.22 or higher is necessary to build gittuf.
 
-> [!NOTE] `make` needs to be installed externally on Windows, it is not packaged with the OS. You may install it from [chocolatey] or from the [GNU website].
+> [!NOTE]
+> `make` needs to be installed externally on Windows, it is not packaged with the OS. You may install it from [chocolatey] or from the [GNU website].
 
 ```sh
 git clone https://github.com/gittuf/gittuf
@@ -87,7 +88,8 @@ make
 First, create some keys that are used for the gittuf root of trust, policies, as
 well as for commits created while following this guide.
 
-> [!NOTE] If running on Windows, do not use the `-N ""` flag for the `ssh-keygen` commands.
+> [!NOTE]
+> If running on Windows, do not use the `-N ""` flag for the `ssh-keygen` commands.
 ```bash
 mkdir gittuf-get-started && cd gittuf-get-started
 mkdir keys && cd keys


### PR DESCRIPTION
This PR adds more explicit and updated instructions for the Windows installation process.  The current version does not address the differences in Unix terminal commands and Windows PowerShell commands. This PR attempts to address those. 

## Summary of Changes
* Made the instructions in the second [!Note] quote box about Windows .exe files clearer.
* Added a Windows-specific shell script box, titled "Windows" (and titled the first one as Unix-based operating systems).
* Added explicit information about unavailability of `make` in Windows and how to install it.
* Added a note to address the `-N ""` flag not throwing a "too many arguments" error while running `ssh-keygen` on Windows PowerShell. This is due to PowerShell interpreting quotation marks differently than Unix-based terminals.
* minor change: made "building from source" an H3 field instead of just boldface.