### PR TITLE
Track verified states for refs locally

### DIFF
--- a/docs/cli/gittuf.md
+++ b/docs/cli/gittuf.md
@@ -21,5 +21,6 @@ A security layer for Git repositories, powered by TUF
 * [gittuf rsl](gittuf_rsl.md)	 - Tools to manage the repository's reference state log
 * [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
 * [gittuf verify-ref](gittuf_verify-ref.md)	 - Tools for verifying gittuf policies
+* [gittuf verify-ref-cache](gittuf_verify-ref-cache.md)	 - Tools for verifying gittuf policies
 * [gittuf version](gittuf_version.md)	 - Version of gittuf
 

--- a/docs/cli/gittuf_verify-ref-cache.md
+++ b/docs/cli/gittuf_verify-ref-cache.md
@@ -1,0 +1,30 @@
+## gittuf verify-ref-cache
+
+Tools for verifying gittuf policies
+
+```
+gittuf verify-ref-cache [flags]
+```
+
+### Options
+
+```
+      --from-entry string        perform verification from specified RSL entry (developer mode only, set GITTUF_DEV=1)
+  -h, --help                     help for verify-ref-cache
+      --latest-only              perform verification against latest entry in the RSL
+      --remote-ref-name string   name of remote reference, if it differs from the local name
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
+

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"slices"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+)
+
+type persistentCacheCtxKey string
+
+const (
+	Ref                                      = "refs/local/gittuf-persistent"
+	PersistentCacheKey persistentCacheCtxKey = "persistentCache"
+
+	persistentTreeEntryName = "persistent"
+)
+
+type Persistent struct {
+	// PolicyEntryNumbers is a list of EntryNumberToID values for entries
+	// pertaining to the policy ref. The list is ordered by each entry's Number.
+	PolicyEntryNumbers []EntryNumberToID
+
+	// AttestationsEntryNumbers is a list of EntryNumberToID values for entries
+	// pertaining to the attestations ref. The list is ordered by each entry's
+	// Number.
+	AttestationsEntryNumbers []EntryNumberToID
+
+	AddedAttestationsBeforeNumber uint64
+
+	// LastVerifiedEntryForRef is a map that indicates the last verified RSL
+	// entry for a ref.
+	LastVerifiedEntryForRef map[string]EntryNumberToID
+}
+
+func (p *Persistent) Commit(repo *gitinterface.Repository) error {
+	contents, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := repo.WriteBlob(contents)
+	if err != nil {
+		return err
+	}
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+	treeID, err := treeBuilder.WriteRootTreeFromBlobIDs(map[string]gitinterface.Hash{persistentTreeEntryName: blobID})
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.Commit(treeID, Ref, "Set persistent cache\n", false)
+	return err
+}
+
+func (p *Persistent) HasPolicyEntryNumber(entryNumber uint64) (gitinterface.Hash, bool) {
+	if len(p.PolicyEntryNumbers) == 0 || entryNumber == 0 {
+		return gitinterface.ZeroHash, false
+	}
+
+	index, has := slices.BinarySearchFunc(p.PolicyEntryNumbers, EntryNumberToID{Number: entryNumber}, binarySearch)
+	if !has {
+		return gitinterface.ZeroHash, false
+	}
+
+	// Unlike Find... we're actively checking if a policy number has been
+	// inserted into the cache before, so we return the ID from that index
+	// exactly
+	return p.PolicyEntryNumbers[index].ID, true
+}
+
+func (p *Persistent) FindPolicyEntryNumberForEntry(entryNumber uint64) EntryNumberToID {
+	if len(p.PolicyEntryNumbers) == 0 {
+		return EntryNumberToID{Number: 0}
+	}
+
+	index, has := slices.BinarySearchFunc(p.PolicyEntryNumbers, EntryNumberToID{Number: entryNumber}, binarySearch)
+	if has {
+		// The entry number given to us is the first entry which happens to be
+		// the start of verification as well
+		// This can happen for full verification
+		return p.PolicyEntryNumbers[index]
+	}
+
+	// When !has, index is point of insertion, but we want the applicable entry
+	// which is index-1
+	return p.PolicyEntryNumbers[index-1]
+}
+
+func (p *Persistent) InsertPolicyEntryNumber(entryNumber uint64, entryID gitinterface.Hash) {
+	if entryNumber == 0 {
+		// For now, we don't have a way to track non-numbered entries
+		return
+	}
+
+	slog.Debug(fmt.Sprintf("Inserting policy entry with ID '%s' and number %d into persistent cache...", entryID.String(), entryNumber))
+
+	if len(p.PolicyEntryNumbers) == 0 {
+		// No entries yet, just add the current entry
+		p.PolicyEntryNumbers = []EntryNumberToID{{Number: entryNumber, ID: entryID}}
+		return
+	}
+
+	if p.PolicyEntryNumbers[len(p.PolicyEntryNumbers)-1].Number < entryNumber {
+		// Current entry clearly belongs at the very end
+		p.PolicyEntryNumbers = append(p.PolicyEntryNumbers, EntryNumberToID{Number: entryNumber, ID: entryID})
+		return
+	}
+
+	// We don't check the converse where the current entry is less than the
+	// first entry because we're inserting as entries are encountered
+	// chronologically. Worst case, binary search fallthrough below will still
+	// handle it
+
+	index, has := slices.BinarySearchFunc(p.PolicyEntryNumbers, EntryNumberToID{Number: entryNumber}, binarySearch)
+	if has {
+		// We could assume that if we've seen an entry with a number greater
+		// than this, we should have seen this one too, but for now...
+		return
+	}
+
+	newSlice := make([]EntryNumberToID, 0, len(p.PolicyEntryNumbers)+1)
+	for i := 0; i < index; i++ {
+		newSlice[i] = p.PolicyEntryNumbers[i]
+	}
+	for i := index + 1; i < len(p.PolicyEntryNumbers)+1; i++ {
+		newSlice[i] = p.PolicyEntryNumbers[i-1]
+	}
+	newSlice[index] = EntryNumberToID{Number: entryNumber, ID: entryID}
+
+	p.PolicyEntryNumbers = newSlice
+}
+
+func (p *Persistent) FindAttestationsEntryNumberForEntry(entryNumber uint64) EntryNumberToID {
+	if len(p.AttestationsEntryNumbers) == 0 {
+		return EntryNumberToID{Number: 0}
+	}
+
+	// Set entryNumber as max scanned if it's higher than what's already there
+	if p.AddedAttestationsBeforeNumber < entryNumber {
+		p.AddedAttestationsBeforeNumber = entryNumber
+	}
+
+	index, has := slices.BinarySearchFunc(p.AttestationsEntryNumbers, EntryNumberToID{Number: entryNumber}, binarySearch)
+	if has {
+		return p.AttestationsEntryNumbers[index]
+	}
+
+	return p.AttestationsEntryNumbers[index-1]
+}
+
+func (p *Persistent) InsertAttestationEntryNumber(entryNumber uint64, entryID gitinterface.Hash) {
+	if entryNumber == 0 {
+		// For now, we don't have a way to track non-numbered entries
+		return
+	}
+
+	if len(p.AttestationsEntryNumbers) == 0 {
+		// No entries yet, just add the current entry
+		p.AttestationsEntryNumbers = []EntryNumberToID{{Number: entryNumber, ID: entryID}}
+		return
+	}
+
+	if p.AttestationsEntryNumbers[len(p.AttestationsEntryNumbers)-1].Number < entryNumber {
+		// Current entry clearly belongs at the very end
+		p.AttestationsEntryNumbers = append(p.AttestationsEntryNumbers, EntryNumberToID{Number: entryNumber, ID: entryID})
+		return
+	}
+
+	// We don't check the converse where the current entry is less than the
+	// first entry because we're inserting as entries are encountered
+	// chronologically. Worst case, binary search fallthrough below will still
+	// handle it
+
+	index, has := slices.BinarySearchFunc(p.AttestationsEntryNumbers, EntryNumberToID{Number: entryNumber}, binarySearch)
+	if has {
+		// We could assume that if we've seen an entry with a number greater
+		// than this, we should have seen this one too, but for now...
+		return
+	}
+
+	newSlice := make([]EntryNumberToID, 0, len(p.AttestationsEntryNumbers)+1)
+	for i := 0; i < index; i++ {
+		newSlice[i] = p.AttestationsEntryNumbers[i]
+	}
+	for i := index + 1; i < len(p.AttestationsEntryNumbers)+1; i++ {
+		newSlice[i] = p.AttestationsEntryNumbers[i-1]
+	}
+	newSlice[index] = EntryNumberToID{Number: entryNumber, ID: entryID}
+
+	p.AttestationsEntryNumbers = newSlice
+}
+
+func NewPersistentCache() *Persistent {
+	return &Persistent{
+		PolicyEntryNumbers:       []EntryNumberToID{},
+		AttestationsEntryNumbers: []EntryNumberToID{},
+		LastVerifiedEntryForRef:  map[string]EntryNumberToID{},
+	}
+}
+
+// LoadPersistentCache loads the persistent cache from the tip of the local ref.
+// If an instance has already been loaded and a pointer has been stored in
+// memory, that instance is returned.
+func LoadPersistentCache(repo *gitinterface.Repository) (*Persistent, error) {
+	slog.Debug("Loading persistent cache from disk...")
+
+	commitID, err := repo.GetReference(Ref)
+	if err != nil {
+		if errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			// Persistent cache doesn't exist
+			slog.Debug("Persistent cache does not exist, creating new instance...")
+			return NewPersistentCache(), nil
+		}
+
+		return nil, err
+	}
+
+	treeID, err := repo.GetCommitTreeID(commitID)
+	if err != nil {
+		return nil, err
+	}
+
+	allFiles, err := repo.GetAllFilesInTree(treeID)
+	if err != nil {
+		return nil, err
+	}
+
+	blobID, has := allFiles[persistentTreeEntryName]
+	if !has {
+		// Persistent cache doesn't seem to exist? This maybe warrants an
+		// error but we may have more than one file here in future?
+		slog.Debug("Persistent cache does not exist, creating new instance...")
+		return NewPersistentCache(), nil
+	}
+
+	blob, err := repo.ReadBlob(blobID)
+	if err != nil {
+		return nil, err
+	}
+
+	persistentCache := &Persistent{}
+	if err := json.Unmarshal(blob, &persistentCache); err != nil {
+		return nil, err
+	}
+	slog.Debug("Loaded persistent cache")
+
+	return persistentCache, nil
+}
+
+type EntryNumberToID struct {
+	// Number is the RSL entry's number.
+	Number uint64
+
+	// ID is the RSL entry's Git ID.
+	ID gitinterface.Hash
+}
+
+func binarySearch(a, b EntryNumberToID) int {
+	if a.Number == b.Number {
+		// Exact match
+		return 0
+	}
+
+	if a.Number < b.Number {
+		// Precedes
+		return -1
+	}
+
+	// Succeeds
+	return 1
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package cache

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
 	"github.com/gittuf/gittuf/internal/cmd/trust"
 	"github.com/gittuf/gittuf/internal/cmd/verifyref"
+	"github.com/gittuf/gittuf/internal/cmd/verifyrefcache"
 	"github.com/gittuf/gittuf/internal/cmd/version"
 	"github.com/spf13/cobra"
 )
@@ -94,6 +95,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(policy.New())
 	cmd.AddCommand(rsl.New())
 	cmd.AddCommand(verifyref.New())
+	cmd.AddCommand(verifyrefcache.New())
 	cmd.AddCommand(version.New())
 
 	return cmd

--- a/internal/cmd/verifyrefcache/verifyrefcache.go
+++ b/internal/cmd/verifyrefcache/verifyrefcache.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package verifyrefcache
+
+import (
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/dev"
+	"github.com/gittuf/gittuf/internal/repository"
+	verifyopts "github.com/gittuf/gittuf/internal/repository/options/verify"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	latestOnly    bool
+	fromEntry     string
+	remoteRefName string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(
+		&o.latestOnly,
+		"latest-only",
+		false,
+		"perform verification against latest entry in the RSL",
+	)
+
+	cmd.Flags().StringVar(
+		&o.fromEntry,
+		"from-entry",
+		"",
+		fmt.Sprintf("perform verification from specified RSL entry (developer mode only, set %s=1)", dev.DevModeKey),
+	)
+
+	cmd.MarkFlagsMutuallyExclusive("latest-only", "from-entry")
+
+	cmd.Flags().StringVar(
+		&o.remoteRefName,
+		"remote-ref-name",
+		"",
+		"name of remote reference, if it differs from the local name",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	if o.fromEntry != "" {
+		if !dev.InDevMode() {
+			return dev.ErrNotInDevMode
+		}
+
+		return repo.VerifyRefFromEntry(cmd.Context(), args[0], o.fromEntry, verifyopts.WithOverrideRefName(o.remoteRefName))
+	}
+
+	opts := []verifyopts.Option{verifyopts.WithOverrideRefName(o.remoteRefName)}
+	if o.latestOnly {
+		opts = append(opts, verifyopts.WithLatestOnly())
+	}
+	return repo.VerifyRefCache(cmd.Context(), args[0], opts...)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "verify-ref-cache",
+		Short:             "Tools for verifying gittuf policies",
+		Args:              cobra.ExactArgs(1),
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -3,9 +3,7 @@
 package common
 
 import (
-	"encoding/pem"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,84 +35,44 @@ var (
 // **signed** reference entry using the specified GPG key. It is used to
 // substitute for the default RSL entry creation and signing mechanism which
 // relies on the user's Git config.
+//
+// Update: This helper just wraps around CommitUsingSpecificKey in the rsl
+// package. We can probably get rid of it, but it's a pretty big delta.
 func CreateTestRSLReferenceEntryCommit(t *testing.T, repo *gitinterface.Repository, entry *rsl.ReferenceEntry, signingKeyBytes []byte) gitinterface.Hash {
 	t.Helper()
 
-	// We do this manually because rsl.Commit() will not sign using our test key
-
-	lines := []string{
-		rsl.ReferenceEntryHeader,
-		"",
-		fmt.Sprintf("%s: %s", rsl.RefKey, entry.RefName),
-		fmt.Sprintf("%s: %s", rsl.TargetIDKey, entry.TargetID.String()),
+	if err := entry.CommitUsingSpecificKey(repo, signingKeyBytes); err != nil {
+		t.Fatal(err)
 	}
 
-	commitMessage := strings.Join(lines, "\n")
-
-	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+	entryID, err := repo.GetReference(rsl.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	commitIDHash, err := repo.CommitUsingSpecificKey(emptyTreeHash, rsl.Ref, commitMessage, signingKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return commitIDHash
+	return entryID
 }
 
 // CreateTestRSLAnnotationEntryCommit is a test helper used to create a
 // **signed** RSL annotation using the specified GPG key. It is used to
 // substitute for the default RSL annotation creation and signing mechanism
 // which relies on the user's Git config.
+//
+// Update: This helper just wraps around CommitUsingSpecificKey in the rsl
+// package. We can probably get rid of it, but it's a pretty big delta.
 func CreateTestRSLAnnotationEntryCommit(t *testing.T, repo *gitinterface.Repository, annotation *rsl.AnnotationEntry, signingKeyBytes []byte) gitinterface.Hash {
 	t.Helper()
 
-	// We do this manually because rsl.Commit() will not sign using our test key
-
-	lines := []string{
-		rsl.AnnotationEntryHeader,
-		"",
+	if err := annotation.CommitUsingSpecificKey(repo, signingKeyBytes); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, entry := range annotation.RSLEntryIDs {
-		lines = append(lines, fmt.Sprintf("%s: %s", rsl.EntryIDKey, entry.String()))
-	}
-
-	if annotation.Skip {
-		lines = append(lines, fmt.Sprintf("%s: true", rsl.SkipKey))
-	} else {
-		lines = append(lines, fmt.Sprintf("%s: false", rsl.SkipKey))
-	}
-
-	if len(annotation.Message) != 0 {
-		var message strings.Builder
-		messageBlock := pem.Block{
-			Type:  rsl.AnnotationMessageBlockType,
-			Bytes: []byte(annotation.Message),
-		}
-		if err := pem.Encode(&message, &messageBlock); err != nil {
-			t.Fatal(err)
-		}
-		lines = append(lines, strings.TrimSpace(message.String()))
-	}
-
-	commitMessage := strings.Join(lines, "\n")
-
-	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+	entryID, err := repo.GetReference(rsl.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	commitIDHash, err := repo.CommitUsingSpecificKey(emptyTreeHash, rsl.Ref, commitMessage, signingKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return commitIDHash
+	return entryID
 }
 
 // AddNTestCommitsToSpecifiedRef is a test helper that adds test commits to the

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -15,14 +15,17 @@ entry <entryID> (skipped)
 
   Ref:    <refName>
   Target: <targetID>
+  Number: <number>
 
     Annotation ID: <annotationID>
     Skip:          <yes/no>
+    Number:        <number>
     Message:
       <message>
 
     Annotation ID: <annotationID>
     Skip:          <yes/no>
+    Number:        <number>
     Message:
       <message>
 */
@@ -49,6 +52,9 @@ func PrepareRSLLogOutput(entries []*rsl.ReferenceEntry, annotationMap map[string
 
 		log += fmt.Sprintf("\n  Ref:    %s", entry.RefName)
 		log += fmt.Sprintf("\n  Target: %s", entry.TargetID.String())
+		if entry.Number != 0 {
+			log += fmt.Sprintf("\n  Number: %d", entry.Number)
+		}
 
 		if annotations, ok := annotationMap[entry.ID.String()]; ok {
 			for _, annotation := range annotations {
@@ -58,6 +64,9 @@ func PrepareRSLLogOutput(entries []*rsl.ReferenceEntry, annotationMap map[string
 					log += "\n    Skip:          yes"
 				} else {
 					log += "\n    Skip:          no"
+				}
+				if annotation.Number != 0 {
+					log += fmt.Sprintf("\n    Number:        %d", annotation.Number)
 				}
 				log += fmt.Sprintf("\n    Message:\n      %s", annotation.Message)
 			}

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPrepareRSLLogOutput(t *testing.T) {
-	t.Run("simple", func(t *testing.T) {
+	t.Run("simple without number", func(t *testing.T) {
 		branchEntry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
 		branchEntry.ID = gitinterface.ZeroHash
 		tagEntry := rsl.NewReferenceEntry("refs/tags/v1", gitinterface.ZeroHash)
@@ -27,6 +27,31 @@ entry 0000000000000000000000000000000000000000
 
   Ref:    refs/tags/v1
   Target: 0000000000000000000000000000000000000000
+`
+
+		logOutput := PrepareRSLLogOutput([]*rsl.ReferenceEntry{branchEntry, tagEntry}, nil)
+		assert.Equal(t, expectedOutput, logOutput)
+	})
+
+	t.Run("simple with number", func(t *testing.T) {
+		branchEntry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+		branchEntry.ID = gitinterface.ZeroHash
+		branchEntry.Number = 1
+		tagEntry := rsl.NewReferenceEntry("refs/tags/v1", gitinterface.ZeroHash)
+		tagEntry.ID = gitinterface.ZeroHash
+		tagEntry.Number = 2
+
+		expectedOutput := `entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+
+entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/tags/v1
+  Target: 0000000000000000000000000000000000000000
+  Number: 2
 `
 
 		logOutput := PrepareRSLLogOutput([]*rsl.ReferenceEntry{branchEntry, tagEntry}, nil)
@@ -65,14 +90,17 @@ entry 0000000000000000000000000000000000000000
 
   Ref:    refs/tags/v1
   Target: 0000000000000000000000000000000000000000
+  Number: 2
 
 entry %s (skipped)
 
   Ref:    refs/heads/main
   Target: 0000000000000000000000000000000000000000
+  Number: 1
 
     Annotation ID: %s
     Skip:          yes
+    Number:        3
     Message:
       msg
 `, tagEntry.ID.String(), branchEntry.ID.String(), annotationEntry.GetID().String())

--- a/internal/gitinterface/hash.go
+++ b/internal/gitinterface/hash.go
@@ -22,7 +22,6 @@ var (
 
 // Hash represents a Git object hash. It is a lightweight wrapper around the
 // standard hex encoded representation of a SHA-1 or SHA-256 hash used by Git.
-
 type Hash []byte
 
 // String returns the hex encoded hash.

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -83,20 +83,20 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, entry, policyEntry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, secondEntry, firstEntry, refName)
 		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 	})
 
@@ -104,27 +104,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -141,7 +141,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -149,27 +149,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -186,7 +186,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -194,27 +194,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -238,7 +238,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -246,27 +246,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -290,7 +290,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -298,27 +298,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs := []gitinterface.Hash{entryID}
@@ -329,7 +329,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's still in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs = append(invalidEntryIDs, entryID)
@@ -348,7 +348,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -356,27 +356,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		invalidEntryIDs := []gitinterface.Hash{entryID}
@@ -387,7 +387,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's still in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -404,7 +404,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// An invalid entry is not marked as skipped
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrInvalidEntryNotSkipped)
 	})
 
@@ -412,27 +412,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -449,7 +449,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 
 		// Send it into invalid state again
@@ -459,7 +459,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit
@@ -476,7 +476,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 	})
 
@@ -484,29 +484,28 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		// Add some commits
-		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		invalidLastGoodCommitID := commitIDs[len(commitIDs)-1]
 
 		// Add more commits, change the number of commits to have different trees
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 4, gpgKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
 		entry.ID = entryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3, gpgUnauthorizedKeyBytes)
@@ -515,7 +514,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the invalid last good commit
@@ -532,7 +531,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 
@@ -540,27 +539,27 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		validCommitID := commitIDs[0] // track this for later
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Fix using the known-good commit's tree
@@ -584,14 +583,14 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		entry.ID = entryID
 
 		// No error anymore
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.Nil(t, err)
 
 		// Skip the recovery entry as well
 		annotation = rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
 		annotationID = common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
 		annotation.ID = annotationID
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 
@@ -599,26 +598,26 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithPolicy)
 		refName := "refs/heads/main"
 
-		policyEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
-		if err != nil {
-			t.Fatal(err)
-		}
-
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
 
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		secondEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		secondEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, secondEntry, gpgKeyBytes)
+		secondEntry.ID = secondEntryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, secondEntry, refName)
 		assert.Nil(t, err)
 
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
-		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
-		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
 		entry.ID = entryID
 
 		// It's in an invalid state right now, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 
 		// Create a skip annotation for the invalid entry
@@ -627,7 +626,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 		annotation.ID = annotationID
 
 		// No fix entry, error out
-		err = VerifyRelativeForRef(testCtx, repo, policyEntry, nil, policyEntry, entry, refName)
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
 		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
 	})
 }

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -82,6 +82,7 @@ func TestVerifyRef(t *testing.T) {
 			options = append(options, verifyopts.WithLatestOnly())
 		}
 
+		fmt.Println(name)
 		err := repo.VerifyRef(testCtx, test.localRefName, options...)
 		if test.err != nil {
 			assert.ErrorIs(t, err, test.err, fmt.Sprintf("unexpected error in test '%s'", name))

--- a/internal/rsl/cache_test.go
+++ b/internal/rsl/cache_test.go
@@ -10,43 +10,38 @@ import (
 )
 
 func TestRSLCache(t *testing.T) {
-	// Create repo to add test entries to
-	tmpDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-
 	// Add test entries
-	// Note: We want to be careful in identifying their IDs not to use a method
-	// that populates the cache
-	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
-	entry1ID, err := repo.GetReference(Ref)
+	// Using fake hashes (these are commits in the gittuf repo itself)
+	entry1 := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+	entry1.Number = 1
+	hash, err := gitinterface.NewHash("4dcd174e182cedf597b8a84f24ea5a53dae7e1e7")
 	if err != nil {
 		t.Fatal(err)
 	}
+	entry1.ID = hash
 
-	if err := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
-	entry2ID, err := repo.GetReference(Ref)
+	entry2 := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash)
+	entry2.Number = 2
+	hash, err = gitinterface.NewHash("5bf80ffecacfde7e6b8281e65223b139a76160e1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	entry2.ID = hash
 
 	// Nothing yet in the parent cache
 	assert.Empty(t, cache.parentCache)
 
 	// Test set and get for parent-child cache
-	cache.setParent(entry2ID, entry1ID)
-	assert.Equal(t, entry1ID.String(), cache.parentCache[entry2ID.String()])
+	cache.setParent(entry2.ID, entry1.ID)
+	assert.Equal(t, entry1.ID.String(), cache.parentCache[entry2.ID.String()])
 	assert.Equal(t, 1, len(cache.parentCache))
 
-	parentID, has, err := cache.getParent(entry2ID)
+	parentID, has, err := cache.getParent(entry2.ID)
 	assert.Nil(t, err)
-	assert.Equal(t, entry1ID.String(), parentID.String())
+	assert.Equal(t, entry1.ID.String(), parentID.String())
 	assert.True(t, has)
 
-	_, has, err = cache.getParent(entry1ID) // not in cache
+	_, has, err = cache.getParent(entry1.ID) // not in cache
 	assert.Nil(t, err)
 	assert.False(t, has)
 
@@ -54,22 +49,11 @@ func TestRSLCache(t *testing.T) {
 	assert.Empty(t, cache.entryCache)
 
 	// Test set and get for entry cache
-	// Note: As before, we want to be careful not to populate the cache when we
-	// load the entries
-	message, err := repo.GetCommitMessage(entry1ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry1, err := parseRSLEntryText(entry1ID, message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cache.setEntry(entry1ID, entry1)
-	assert.Equal(t, entry1, cache.entryCache[entry1ID.String()])
+	cache.setEntry(entry1.ID, entry1)
+	assert.Equal(t, entry1, cache.entryCache[entry1.ID.String()])
 	assert.Equal(t, 1, len(cache.entryCache))
 
-	entry, has := cache.getEntry(entry1ID)
+	entry, has := cache.getEntry(entry1.ID)
 	assert.Equal(t, entry1, entry)
 	assert.True(t, has)
 }

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/gittuf/gittuf/internal/gitinterface"
@@ -23,6 +24,7 @@ const (
 	EndMessage                 = "-----END MESSAGE-----"
 	EntryIDKey                 = "entryID"
 	SkipKey                    = "skip"
+	NumberKey                  = "number"
 
 	remoteTrackerRef       = "refs/remotes/%s/gittuf/reference-state-log"
 	gittufNamespacePrefix  = "refs/gittuf/"
@@ -48,6 +50,7 @@ func RemoteTrackerRef(remote string) string {
 type Entry interface {
 	GetID() gitinterface.Hash
 	Commit(*gitinterface.Repository, bool) error
+	GetNumber() uint64
 	createCommitMessage() (string, error)
 }
 
@@ -62,6 +65,9 @@ type ReferenceEntry struct {
 
 	// TargetID contains the Git hash for the object expected at RefName.
 	TargetID gitinterface.Hash
+
+	// Number contains a strictly increasing number that hints at entry ordering.
+	Number uint64
 }
 
 // NewReferenceEntry returns a ReferenceEntry object for a normal RSL entry.
@@ -75,6 +81,18 @@ func (e *ReferenceEntry) GetID() gitinterface.Hash {
 
 // Commit creates a commit object in the RSL for the ReferenceEntry.
 func (e *ReferenceEntry) Commit(repo *gitinterface.Repository, sign bool) error {
+	latestEntry, err := GetLatestEntry(repo)
+	if err == nil {
+		e.Number = latestEntry.GetNumber() + 1
+	} else {
+		if errors.Is(err, ErrRSLEntryNotFound) {
+			// First entry
+			e.Number = 1
+		} else {
+			return err
+		}
+	}
+
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
 	emptyTreeID, err := repo.EmptyTree()
@@ -87,9 +105,22 @@ func (e *ReferenceEntry) Commit(repo *gitinterface.Repository, sign bool) error 
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
-// ReferenceEmpty. The commit is signed using the provided PEM encoded SSH or
-// GPG private key. This is only intended for use in gittuf's developer mode.
+// ReferenceEntry. The commit is signed using the provided PEM encoded SSH or
+// GPG private key. This is only intended for use in gittuf's developer mode or
+// in tests.
 func (e *ReferenceEntry) CommitUsingSpecificKey(repo *gitinterface.Repository, signingKeyBytes []byte) error {
+	latestEntry, err := GetLatestEntry(repo)
+	if err == nil {
+		e.Number = latestEntry.GetNumber() + 1
+	} else {
+		if errors.Is(err, ErrRSLEntryNotFound) {
+			// First entry
+			e.Number = 1
+		} else {
+			return err
+		}
+	}
+
 	message, _ := e.createCommitMessage() // we have an error return for annotations, always nil here
 
 	emptyTreeID, err := repo.EmptyTree()
@@ -99,6 +130,10 @@ func (e *ReferenceEntry) CommitUsingSpecificKey(repo *gitinterface.Repository, s
 
 	_, err = repo.CommitUsingSpecificKey(emptyTreeID, Ref, message, signingKeyBytes)
 	return err
+}
+
+func (e *ReferenceEntry) GetNumber() uint64 {
+	return e.Number
 }
 
 // Skipped returns true if any of the annotations mark the entry as
@@ -119,6 +154,7 @@ func (e *ReferenceEntry) createCommitMessage() (string, error) {
 		"",
 		fmt.Sprintf("%s: %s", RefKey, e.RefName),
 		fmt.Sprintf("%s: %s", TargetIDKey, e.TargetID.String()),
+		fmt.Sprintf("%s: %d", NumberKey, e.Number),
 	}
 	return strings.Join(lines, "\n"), nil
 }
@@ -139,6 +175,9 @@ type AnnotationEntry struct {
 
 	// Message contains any messages or notes added by a user for the annotation.
 	Message string
+
+	// Number contains a strictly increasing number that hints at entry ordering.
+	Number uint64
 }
 
 // NewAnnotationEntry returns an Annotation object that applies to one or more
@@ -160,6 +199,18 @@ func (a *AnnotationEntry) Commit(repo *gitinterface.Repository, sign bool) error
 		}
 	}
 
+	latestEntry, err := GetLatestEntry(repo)
+	if err == nil {
+		a.Number = latestEntry.GetNumber() + 1
+	} else {
+		if errors.Is(err, ErrRSLEntryNotFound) {
+			// First entry -> can an annotation actually be first? TODO
+			a.Number = 1
+		} else {
+			return err
+		}
+	}
+
 	message, err := a.createCommitMessage()
 	if err != nil {
 		return err
@@ -172,6 +223,48 @@ func (a *AnnotationEntry) Commit(repo *gitinterface.Repository, sign bool) error
 
 	_, err = repo.Commit(emptyTreeID, Ref, message, sign)
 	return err
+}
+
+// CommitUsingSpecificKey creates a commit object in the RSL for the
+// AnnotationEntry. The commit is signed using the provided PEM encoded SSH or
+// GPG private key. This is only intended for use in gittuf's developer mode or
+// in tests.
+func (a *AnnotationEntry) CommitUsingSpecificKey(repo *gitinterface.Repository, signingKeyBytes []byte) error {
+	// Check if referred entries exist in the RSL namespace.
+	for _, id := range a.RSLEntryIDs {
+		if _, err := GetEntry(repo, id); err != nil {
+			return err
+		}
+	}
+
+	latestEntry, err := GetLatestEntry(repo)
+	if err == nil {
+		a.Number = latestEntry.GetNumber() + 1
+	} else {
+		if errors.Is(err, ErrRSLEntryNotFound) {
+			// First entry -> can an annotation actually be first? TODO
+			a.Number = 1
+		} else {
+			return err
+		}
+	}
+
+	message, err := a.createCommitMessage()
+	if err != nil {
+		return err
+	}
+
+	emptyTreeID, err := repo.EmptyTree()
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.CommitUsingSpecificKey(emptyTreeID, Ref, message, signingKeyBytes)
+	return err
+}
+
+func (a *AnnotationEntry) GetNumber() uint64 {
+	return a.Number
 }
 
 // RefersTo returns true if the specified entryID is referred to by the
@@ -201,6 +294,8 @@ func (a *AnnotationEntry) createCommitMessage() (string, error) {
 	} else {
 		lines = append(lines, fmt.Sprintf("%s: false", SkipKey))
 	}
+
+	lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, a.Number))
 
 	if len(a.Message) != 0 {
 		var message strings.Builder
@@ -242,6 +337,8 @@ func GetEntry(repo *gitinterface.Repository, entryID gitinterface.Hash) (Entry, 
 func GetParentForEntry(repo *gitinterface.Repository, entry Entry) (Entry, error) {
 	parentID, has, err := cache.getParent(entry.GetID())
 	if err == nil && has {
+		// We don't need to check the parent's Number here because it was
+		// checked when this was set in the cache
 		return GetEntry(repo, parentID)
 	}
 
@@ -259,8 +356,26 @@ func GetParentForEntry(repo *gitinterface.Repository, entry Entry) (Entry, error
 	}
 
 	parentID = parentIDs[0]
+	parentEntry, err := GetEntry(repo, parentID)
+	if err != nil {
+		return nil, err
+	}
+
+	switch entry.GetNumber() {
+	case 0, 1:
+		// parent entry has to be 0
+		if parentEntry.GetNumber() != 0 {
+			return nil, ErrInvalidRSLEntry
+		}
+	default:
+		// parent entry has to be 1 less than entry
+		if parentEntry.GetNumber() != entry.GetNumber()-1 {
+			return nil, ErrInvalidRSLEntry
+		}
+	}
+
 	cache.setParent(entry.GetID(), parentID)
-	return GetEntry(repo, parentID)
+	return parentEntry, nil
 }
 
 // GetNonGittufParentReferenceEntryForEntry returns the first RSL reference
@@ -375,6 +490,76 @@ func GetLatestNonGittufReferenceEntry(repo *gitinterface.Repository) (*Reference
 // locally in the RSL for the specified refName.
 func GetLatestReferenceEntryForRef(repo *gitinterface.Repository, refName string) (*ReferenceEntry, []*AnnotationEntry, error) {
 	return GetLatestReferenceEntryForRefBefore(repo, refName, gitinterface.ZeroHash)
+}
+
+func GetLatestReferenceEntryForRefBeforeUntilNumber(repo *gitinterface.Repository, refName string, anchor gitinterface.Hash, until uint64) (*ReferenceEntry, []*AnnotationEntry, error) {
+	allAnnotations := []*AnnotationEntry{}
+
+	iteratorT, err := GetLatestEntry(repo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if !anchor.IsZero() {
+		for !iteratorT.GetID().Equal(anchor) {
+			if iteratorT.GetNumber() < until {
+				return nil, nil, fmt.Errorf("before and until conditions are incompatible")
+			}
+			if annotation, isAnnotation := iteratorT.(*AnnotationEntry); isAnnotation {
+				allAnnotations = append(allAnnotations, annotation)
+			}
+
+			iteratorT, err = GetParentForEntry(repo, iteratorT)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// If the anchor is an annotation, track that
+		if annotation, isAnnotation := iteratorT.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+		}
+
+		// We have to set the iterator to the parent. The other option is to
+		// swap the refName check and parent in the loop below but that breaks
+		// GetLatestReferenceEntryForRef's behavior. By adding this one extra
+		// GetParent here, we avoid repetition.
+		iteratorT, err = GetParentForEntry(repo, iteratorT)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	var targetEntry *ReferenceEntry
+	for {
+		switch iterator := iteratorT.(type) {
+		case *ReferenceEntry:
+			if iterator.RefName == refName {
+				targetEntry = iterator
+			}
+		case *AnnotationEntry:
+			allAnnotations = append(allAnnotations, iterator)
+		}
+
+		if targetEntry != nil {
+			// we've found the target entry, stop walking the RSL
+			break
+		}
+
+		if iteratorT.GetNumber() < until {
+			// we haven't found the target entry but we've hit the until limit
+			return nil, nil, ErrRSLEntryNotFound
+		}
+
+		iteratorT, err = GetParentForEntry(repo, iteratorT)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	annotations := filterAnnotationsForRelevantAnnotations(allAnnotations, targetEntry.ID)
+
+	return targetEntry, annotations, nil
 }
 
 // GetLatestReferenceEntryForRefBefore returns the latest reference entry
@@ -770,6 +955,14 @@ func parseReferenceEntryText(id gitinterface.Hash, text string) (*ReferenceEntry
 			}
 
 			entry.TargetID = targetHash
+
+		case NumberKey:
+			number, err := strconv.ParseUint(strings.TrimSpace(ls[1]), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			entry.Number = number
 		}
 	}
 
@@ -818,6 +1011,13 @@ func parseAnnotationEntryText(id gitinterface.Hash, text string) (*AnnotationEnt
 			} else {
 				annotation.Skip = false
 			}
+		case NumberKey:
+			number, err := strconv.ParseUint(strings.TrimSpace(ls[1]), 10, 64)
+			if err != nil {
+				return nil, err
+			}
+
+			annotation.Number = number
 		}
 	}
 


### PR DESCRIPTION
This allows us to not have to verify the full history of the repository each time.

Current status: it works but is untested and needs clean up. At the time of opening, I'm mostly just saving state to github.

ETA: looking at CI, it works _when you hold it particularly right_ seems to be a better description. :smile: 

Closes #245 

TODOS:
- [ ] Add tests for cache
- [x] Add tests for rsl.Get methods that use the entry number
- [x] Use non global cache variable
- [ ] Add tests for verifyrelativeforref that doesn't verify from the start every time
- [ ] Fix up expected user interface -> we shouldn't have verify-ref-cache by the time this will be merged
- [ ] Add tests where a repository goes from not having numbers to having numbers