### PR TITLE
rsl: Add incrementing number to RSL entry

### DIFF
--- a/internal/attestations/attestations.go
+++ b/internal/attestations/attestations.go
@@ -72,7 +72,7 @@ type Attestations struct {
 // LoadCurrentAttestations inspects the repository's attestations namespace and
 // loads the current attestations.
 func LoadCurrentAttestations(repo *gitinterface.Repository) (*Attestations, error) {
-	entry, _, err := rsl.GetLatestReferenceEntryForRef(repo, Ref)
+	entry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(Ref))
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return nil, err

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -3,9 +3,7 @@
 package common
 
 import (
-	"encoding/pem"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -37,84 +35,44 @@ var (
 // **signed** reference entry using the specified GPG key. It is used to
 // substitute for the default RSL entry creation and signing mechanism which
 // relies on the user's Git config.
+//
+// Update: This helper just wraps around CommitUsingSpecificKey in the rsl
+// package. We can probably get rid of it, but it's a pretty big delta.
 func CreateTestRSLReferenceEntryCommit(t *testing.T, repo *gitinterface.Repository, entry *rsl.ReferenceEntry, signingKeyBytes []byte) gitinterface.Hash {
 	t.Helper()
 
-	// We do this manually because rsl.Commit() will not sign using our test key
-
-	lines := []string{
-		rsl.ReferenceEntryHeader,
-		"",
-		fmt.Sprintf("%s: %s", rsl.RefKey, entry.RefName),
-		fmt.Sprintf("%s: %s", rsl.TargetIDKey, entry.TargetID.String()),
+	if err := entry.CommitUsingSpecificKey(repo, signingKeyBytes); err != nil {
+		t.Fatal(err)
 	}
 
-	commitMessage := strings.Join(lines, "\n")
-
-	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+	entryID, err := repo.GetReference(rsl.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	commitIDHash, err := repo.CommitUsingSpecificKey(emptyTreeHash, rsl.Ref, commitMessage, signingKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return commitIDHash
+	return entryID
 }
 
 // CreateTestRSLAnnotationEntryCommit is a test helper used to create a
 // **signed** RSL annotation using the specified GPG key. It is used to
 // substitute for the default RSL annotation creation and signing mechanism
 // which relies on the user's Git config.
+//
+// Update: This helper just wraps around CommitUsingSpecificKey in the rsl
+// package. We can probably get rid of it, but it's a pretty big delta.
 func CreateTestRSLAnnotationEntryCommit(t *testing.T, repo *gitinterface.Repository, annotation *rsl.AnnotationEntry, signingKeyBytes []byte) gitinterface.Hash {
 	t.Helper()
 
-	// We do this manually because rsl.Commit() will not sign using our test key
-
-	lines := []string{
-		rsl.AnnotationEntryHeader,
-		"",
+	if err := annotation.CommitUsingSpecificKey(repo, signingKeyBytes); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, entry := range annotation.RSLEntryIDs {
-		lines = append(lines, fmt.Sprintf("%s: %s", rsl.EntryIDKey, entry.String()))
-	}
-
-	if annotation.Skip {
-		lines = append(lines, fmt.Sprintf("%s: true", rsl.SkipKey))
-	} else {
-		lines = append(lines, fmt.Sprintf("%s: false", rsl.SkipKey))
-	}
-
-	if len(annotation.Message) != 0 {
-		var message strings.Builder
-		messageBlock := pem.Block{
-			Type:  rsl.AnnotationMessageBlockType,
-			Bytes: []byte(annotation.Message),
-		}
-		if err := pem.Encode(&message, &messageBlock); err != nil {
-			t.Fatal(err)
-		}
-		lines = append(lines, strings.TrimSpace(message.String()))
-	}
-
-	commitMessage := strings.Join(lines, "\n")
-
-	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+	entryID, err := repo.GetReference(rsl.Ref)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	commitIDHash, err := repo.CommitUsingSpecificKey(emptyTreeHash, rsl.Ref, commitMessage, signingKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return commitIDHash
+	return entryID
 }
 
 // AddNTestCommitsToSpecifiedRef is a test helper that adds test commits to the

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -15,14 +15,17 @@ entry <entryID> (skipped)
 
   Ref:    <refName>
   Target: <targetID>
+  Number: <number>
 
     Annotation ID: <annotationID>
     Skip:          <yes/no>
+    Number:        <number>
     Message:
       <message>
 
     Annotation ID: <annotationID>
     Skip:          <yes/no>
+    Number:        <number>
     Message:
       <message>
 */
@@ -49,6 +52,9 @@ func PrepareRSLLogOutput(entries []*rsl.ReferenceEntry, annotationMap map[string
 
 		log += fmt.Sprintf("\n  Ref:    %s", entry.RefName)
 		log += fmt.Sprintf("\n  Target: %s", entry.TargetID.String())
+		if entry.Number != 0 {
+			log += fmt.Sprintf("\n  Number: %d", entry.Number)
+		}
 
 		if annotations, ok := annotationMap[entry.ID.String()]; ok {
 			for _, annotation := range annotations {
@@ -58,6 +64,9 @@ func PrepareRSLLogOutput(entries []*rsl.ReferenceEntry, annotationMap map[string
 					log += "\n    Skip:          yes"
 				} else {
 					log += "\n    Skip:          no"
+				}
+				if annotation.Number != 0 {
+					log += fmt.Sprintf("\n    Number:        %d", annotation.Number)
 				}
 				log += fmt.Sprintf("\n    Message:\n      %s", annotation.Message)
 			}

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -69,11 +69,11 @@ entry 0000000000000000000000000000000000000000
 			t.Fatal(err)
 		}
 
-		branchEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, "refs/heads/main")
+		branchEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference("refs/heads/main"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		tagEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, "refs/tags/v1")
+		tagEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference("refs/tags/v1"))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPrepareRSLLogOutput(t *testing.T) {
-	t.Run("simple", func(t *testing.T) {
+	t.Run("simple without number", func(t *testing.T) {
 		branchEntry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
 		branchEntry.ID = gitinterface.ZeroHash
 		tagEntry := rsl.NewReferenceEntry("refs/tags/v1", gitinterface.ZeroHash)
@@ -27,6 +27,31 @@ entry 0000000000000000000000000000000000000000
 
   Ref:    refs/tags/v1
   Target: 0000000000000000000000000000000000000000
+`
+
+		logOutput := PrepareRSLLogOutput([]*rsl.ReferenceEntry{branchEntry, tagEntry}, nil)
+		assert.Equal(t, expectedOutput, logOutput)
+	})
+
+	t.Run("simple with number", func(t *testing.T) {
+		branchEntry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+		branchEntry.ID = gitinterface.ZeroHash
+		branchEntry.Number = 1
+		tagEntry := rsl.NewReferenceEntry("refs/tags/v1", gitinterface.ZeroHash)
+		tagEntry.ID = gitinterface.ZeroHash
+		tagEntry.Number = 2
+
+		expectedOutput := `entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+
+entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/tags/v1
+  Target: 0000000000000000000000000000000000000000
+  Number: 2
 `
 
 		logOutput := PrepareRSLLogOutput([]*rsl.ReferenceEntry{branchEntry, tagEntry}, nil)
@@ -65,14 +90,17 @@ entry 0000000000000000000000000000000000000000
 
   Ref:    refs/tags/v1
   Target: 0000000000000000000000000000000000000000
+  Number: 2
 
 entry %s (skipped)
 
   Ref:    refs/heads/main
   Target: 0000000000000000000000000000000000000000
+  Number: 1
 
     Annotation ID: %s
     Skip:          yes
+    Number:        3
     Message:
       msg
 `, tagEntry.ID.String(), branchEntry.ID.String(), annotationEntry.GetID().String())

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -114,7 +114,7 @@ func LoadState(ctx context.Context, repo *gitinterface.Repository, entry *rsl.Re
 // active policy. It verifies the root of trust for the state starting from the
 // initial policy entry in the RSL.
 func LoadCurrentState(ctx context.Context, repo *gitinterface.Repository, ref string) (*State, error) {
-	entry, _, err := rsl.GetLatestReferenceEntryForRef(repo, ref)
+	entry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(ref))
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func GetStateForCommit(ctx context.Context, repo *gitinterface.Repository, commi
 		return nil, err
 	}
 
-	commitPolicyEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, firstSeenEntry.ID)
+	commitPolicyEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(PolicyRef), rsl.BeforeEntryID(firstSeenEntry.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -858,7 +858,7 @@ func verifySuccessiveRootsAndLoadLatestPolicyState(ctx context.Context, repo *gi
 		return nil, err
 	}
 
-	latestPolicyEntryBeforeSpecifiedEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, entry.ID)
+	latestPolicyEntryBeforeSpecifiedEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(PolicyRef), rsl.BeforeEntryID(entry.ID))
 	if err != nil {
 		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			// we have a single policy entry

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -263,7 +263,7 @@ func TestLoadFirstState(t *testing.T) {
 func TestLoadStateForEntry(t *testing.T) {
 	repo, state := createTestRepository(t, createTestStateWithOnlyRoot)
 
-	entry, _, err := rsl.GetLatestReferenceEntryForRef(repo, PolicyRef)
+	entry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(PolicyRef))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -36,7 +36,7 @@ var (
 func VerifyRef(ctx context.Context, repo *gitinterface.Repository, target string) (gitinterface.Hash, error) {
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
-	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
+	latestEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(target))
 	if err != nil {
 		return gitinterface.ZeroHash, err
 	}
@@ -57,7 +57,7 @@ func VerifyRefFull(ctx context.Context, repo *gitinterface.Repository, target st
 
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
-	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
+	latestEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(target))
 	if err != nil {
 		return gitinterface.ZeroHash, err
 	}
@@ -86,7 +86,7 @@ func VerifyRefFromEntry(ctx context.Context, repo *gitinterface.Repository, targ
 
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
-	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
+	latestEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(target))
 	if err != nil {
 		return gitinterface.ZeroHash, err
 	}
@@ -113,7 +113,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, fi
 		slog.Debug(fmt.Sprintf("First entry '%s' is for gittuf policy, setting that as current policy...", firstEntry.ID.String()))
 		initialPolicyEntry = firstEntry
 	} else {
-		initialPolicyEntry, _, err = rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, firstEntry.ID)
+		initialPolicyEntry, _, err = rsl.GetLatestReferenceEntry(repo, rsl.ForReference(PolicyRef), rsl.BeforeEntryID(firstEntry.ID))
 		if err != nil {
 			if errors.Is(err, rsl.ErrRSLEntryNotFound) {
 				slog.Debug(fmt.Sprintf("No policy found before first entry '%s'", firstEntry.ID.String()))
@@ -131,7 +131,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, fi
 	}
 
 	slog.Debug(fmt.Sprintf("Loading attestations applicable at first entry '%s'...", firstEntry.ID.String()))
-	initialAttestationsEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, attestations.Ref, firstEntry.ID)
+	initialAttestationsEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(attestations.Ref), rsl.BeforeEntryID(firstEntry.ID))
 	if err == nil {
 		attestationsState, err := attestations.LoadAttestationsForEntry(repo, initialAttestationsEntry)
 		if err != nil {
@@ -250,7 +250,7 @@ func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, fi
 
 		// 1. What's the last good state?
 		slog.Debug("Identifying last valid state...")
-		lastGoodEntry, lastGoodEntryAnnotations, err := rsl.GetLatestUnskippedReferenceEntryForRefBefore(repo, invalidEntry.RefName, invalidEntry.ID)
+		lastGoodEntry, lastGoodEntryAnnotations, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(invalidEntry.RefName), rsl.BeforeEntryID(invalidEntry.ID), rsl.IsUnskipped())
 		if err != nil {
 			return err
 		}
@@ -505,7 +505,7 @@ func getApproverAttestationAndKeyIDs(ctx context.Context, repo *gitinterface.Rep
 	}
 
 	firstEntry := false
-	priorRefEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, entry.RefName, entry.ID)
+	priorRefEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(entry.RefName), rsl.BeforeEntryID(entry.ID))
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return nil, nil, err
@@ -591,7 +591,7 @@ func getApproverAttestationAndKeyIDs(ctx context.Context, repo *gitinterface.Rep
 func getCommits(repo *gitinterface.Repository, entry *rsl.ReferenceEntry) ([]gitinterface.Hash, error) {
 	firstEntry := false
 
-	priorRefEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, entry.RefName, entry.ID)
+	priorRefEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(entry.RefName), rsl.BeforeEntryID(entry.ID))
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return nil, err

--- a/internal/repository/attestations.go
+++ b/internal/repository/attestations.go
@@ -62,7 +62,7 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 	)
 
 	slog.Debug("Identifying current status of target Git reference...")
-	latestTargetEntry, _, err := rsl.GetLatestReferenceEntryForRef(r.r, targetRef)
+	latestTargetEntry, _, err := rsl.GetLatestReferenceEntry(r.r, rsl.ForReference(targetRef))
 	if err == nil {
 		fromID = latestTargetEntry.TargetID
 	} else {
@@ -73,7 +73,7 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 	}
 
 	slog.Debug("Identifying current status of feature Git reference...")
-	latestFeatureEntry, _, err := rsl.GetLatestReferenceEntryForRef(r.r, featureRef)
+	latestFeatureEntry, _, err := rsl.GetLatestReferenceEntry(r.r, rsl.ForReference(featureRef))
 	if err != nil {
 		// We don't have an RSL entry for the feature ref to use to approve the
 		// merge

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -235,7 +235,7 @@ func (r *Repository) PullRSL(remoteName string) error {
 // same target ID Note that it's legal for the RSL to have target A, then B,
 // then A again, this is not considered a duplicate entry
 func (r *Repository) isDuplicateEntry(refName string, targetID gitinterface.Hash) (bool, error) {
-	latestUnskippedEntry, _, err := rsl.GetLatestUnskippedReferenceEntryForRef(r.r, refName)
+	latestUnskippedEntry, _, err := rsl.GetLatestReferenceEntry(r.r, rsl.ForReference(refName), rsl.IsUnskipped())
 	if err != nil {
 		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return false, nil

--- a/internal/rsl/cache_test.go
+++ b/internal/rsl/cache_test.go
@@ -10,43 +10,38 @@ import (
 )
 
 func TestRSLCache(t *testing.T) {
-	// Create repo to add test entries to
-	tmpDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-
 	// Add test entries
-	// Note: We want to be careful in identifying their IDs not to use a method
-	// that populates the cache
-	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
-	entry1ID, err := repo.GetReference(Ref)
+	// Using fake hashes (these are commits in the gittuf repo itself)
+	entry1 := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+	entry1.Number = 1
+	hash, err := gitinterface.NewHash("4dcd174e182cedf597b8a84f24ea5a53dae7e1e7")
 	if err != nil {
 		t.Fatal(err)
 	}
+	entry1.ID = hash
 
-	if err := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
-	entry2ID, err := repo.GetReference(Ref)
+	entry2 := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash)
+	entry2.Number = 2
+	hash, err = gitinterface.NewHash("5bf80ffecacfde7e6b8281e65223b139a76160e1")
 	if err != nil {
 		t.Fatal(err)
 	}
+	entry2.ID = hash
 
 	// Nothing yet in the parent cache
 	assert.Empty(t, cache.parentCache)
 
 	// Test set and get for parent-child cache
-	cache.setParent(entry2ID, entry1ID)
-	assert.Equal(t, entry1ID.String(), cache.parentCache[entry2ID.String()])
+	cache.setParent(entry2.ID, entry1.ID)
+	assert.Equal(t, entry1.ID.String(), cache.parentCache[entry2.ID.String()])
 	assert.Equal(t, 1, len(cache.parentCache))
 
-	parentID, has, err := cache.getParent(entry2ID)
+	parentID, has, err := cache.getParent(entry2.ID)
 	assert.Nil(t, err)
-	assert.Equal(t, entry1ID.String(), parentID.String())
+	assert.Equal(t, entry1.ID.String(), parentID.String())
 	assert.True(t, has)
 
-	_, has, err = cache.getParent(entry1ID) // not in cache
+	_, has, err = cache.getParent(entry1.ID) // not in cache
 	assert.Nil(t, err)
 	assert.False(t, has)
 
@@ -54,22 +49,11 @@ func TestRSLCache(t *testing.T) {
 	assert.Empty(t, cache.entryCache)
 
 	// Test set and get for entry cache
-	// Note: As before, we want to be careful not to populate the cache when we
-	// load the entries
-	message, err := repo.GetCommitMessage(entry1ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	entry1, err := parseRSLEntryText(entry1ID, message)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cache.setEntry(entry1ID, entry1)
-	assert.Equal(t, entry1, cache.entryCache[entry1ID.String()])
+	cache.setEntry(entry1.ID, entry1)
+	assert.Equal(t, entry1, cache.entryCache[entry1.ID.String()])
 	assert.Equal(t, 1, len(cache.entryCache))
 
-	entry, has := cache.getEntry(entry1ID)
+	entry, has := cache.getEntry(entry1.ID)
 	assert.Equal(t, entry1, entry)
 	assert.True(t, has)
 }

--- a/internal/rsl/options.go
+++ b/internal/rsl/options.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+import "github.com/gittuf/gittuf/internal/gitinterface"
+
+type GetLatestReferenceEntryOptions struct {
+	Reference string
+
+	BeforeEntryID     gitinterface.Hash
+	BeforeEntryNumber uint64
+
+	UntilEntryID     gitinterface.Hash
+	UntilEntryNumber uint64
+
+	Unskipped bool
+
+	NonGittuf bool
+}
+
+type GetLatestReferenceEntryOption func(*GetLatestReferenceEntryOptions)
+
+// ForReference indicates that the reference entry returned must be for a
+// specific Git reference.
+func ForReference(reference string) GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.Reference = reference
+	}
+}
+
+// BeforeEntryID searches for the matching reference entry before the specified
+// entry ID. It cannot be used in combination with BeforeEntryNumber.
+// BeforeEntryID is exclusive: the returned entry cannot be the reference entry
+// that matches the specified ID.
+func BeforeEntryID(entryID gitinterface.Hash) GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.BeforeEntryID = entryID
+	}
+}
+
+// BeforeEntryNumber searches for the matching reference entry before the
+// specified entry number. It cannot be used in combination with BeforeEntryID.
+// BeforeEntryNumber is exclusive: the returned entry cannot be the reference
+// entry that matches the specified number.
+func BeforeEntryNumber(number uint64) GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.BeforeEntryNumber = number
+	}
+}
+
+// UntilEntryID terminates the search for the desired reference entry when an
+// entry with the specified ID is encountered. It cannot be used in combination
+// with UntilEntryNumber. UntilEntryID is inclusive: the returned entry can be
+// the entry that matches the specified ID.
+func UntilEntryID(entryID gitinterface.Hash) GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.UntilEntryID = entryID
+	}
+}
+
+// UntilEntryNumber terminates the search for the desired reference entry when
+// an entry with the specified number is encountered. It cannot be used in
+// combination with UntilEntryID. UntilEntryNumber is inclusive: the returned
+// entry can be the entry that matches the specified number.
+func UntilEntryNumber(number uint64) GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.UntilEntryNumber = number
+	}
+}
+
+// IsUnskipped ensures that the returned reference entry has not been skipped by
+// a subsequent annotation entry.
+func IsUnskipped() GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.Unskipped = true
+	}
+}
+
+// ForNonGittufReference ensures that the returned reference entry is not for a
+// gittuf-specific reference.
+func ForNonGittufReference() GetLatestReferenceEntryOption {
+	return func(o *GetLatestReferenceEntryOptions) {
+		o.NonGittuf = true
+	}
+}


### PR DESCRIPTION
This commit adds a uint64 Number field to RSL entries. This allows us to determine the ordering of distinct RSL entries, enabling optimizations such as knowing which policy to use for an entry without always walking the RSL.

The implementation maintains backwards compatibility, so the numbering can start from whenever this is enabled. This is made easy by the fact that we can guarantee gittuf is updated everywhere it is currently used.