### PR TITLE
Add reconciliation workflow to update local RSL against remote RSL

### DIFF
--- a/docs/cli/gittuf_rsl_remote.md
+++ b/docs/cli/gittuf_rsl_remote.md
@@ -20,7 +20,7 @@ Tools for managing remote RSLs
 ### SEE ALSO
 
 * [gittuf rsl](gittuf_rsl.md)	 - Tools to manage the repository's reference state log
-* [gittuf rsl remote check](gittuf_rsl_remote_check.md)	 - Check remote RSL for updates, for development use only
 * [gittuf rsl remote pull](gittuf_rsl_remote_pull.md)	 - Pull RSL from the specified remote
 * [gittuf rsl remote push](gittuf_rsl_remote_push.md)	 - Push RSL to the specified remote
+* [gittuf rsl remote reconcile](gittuf_rsl_remote_reconcile.md)	 - Reconcile local RSL with remote RSL
 

--- a/docs/cli/gittuf_rsl_remote_reconcile.md
+++ b/docs/cli/gittuf_rsl_remote_reconcile.md
@@ -1,0 +1,31 @@
+## gittuf rsl remote reconcile
+
+Reconcile local RSL with remote RSL
+
+### Synopsis
+
+This command checks the local RSL against the specified remote and reconciles the local RSL if needed. If the local RSL doesn't exist or is strictly behind the remote RSL, then the local RSL is updated to match the remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated. Finally, if the local and remote RSLs have diverged, then the local only RSL entries are reapplied over the latest entries in the remote if the local only RSL entries and remote only entries are for different Git references.
+
+```
+gittuf rsl remote reconcile <remote> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for reconcile
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf rsl remote](gittuf_rsl_remote.md)	 - Tools for managing remote RSLs
+

--- a/internal/cmd/rsl/remote/check/check.go
+++ b/internal/cmd/rsl/remote/check/check.go
@@ -18,7 +18,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	hasUpdates, hasDiverged, err := repo.CheckRemoteRSLForUpdates(cmd.Context(), args[0])
+	hasUpdates, hasDiverged, err := repo.CheckRemoteRSLForUpdates(cmd.Context(), args[0]) //nolint:staticcheck
 	if err != nil {
 		return err
 	}
@@ -44,6 +44,7 @@ func New() *cobra.Command {
 		Short:             "Check remote RSL for updates, for development use only",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
+		Deprecated:        "This command will be replaced soon with the new reconciliation workflow",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/rsl/remote/reconcile/reconcile.go
+++ b/internal/cmd/rsl/remote/reconcile/reconcile.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"github.com/gittuf/gittuf/internal/repository"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) Run(cmd *cobra.Command, args []string) error {
+	repo, err := repository.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.ReconcileLocalRSLWithRemote(cmd.Context(), args[0], true)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "reconcile <remote>",
+		Short:             "Reconcile local RSL with remote RSL",
+		Long:              `This command checks the local RSL against the specified remote and reconciles the local RSL if needed. If the local RSL doesn't exist or is strictly behind the remote RSL, then the local RSL is updated to match the remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated. Finally, if the local and remote RSLs have diverged, then the local only RSL entries are reapplied over the latest entries in the remote if the local only RSL entries and remote only entries are for different Git references.`,
+		Args:              cobra.ExactArgs(1),
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/check"
 	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/pull"
 	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/push"
+	"github.com/gittuf/gittuf/internal/cmd/rsl/remote/reconcile"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +20,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(check.New())
 	cmd.AddCommand(pull.New())
 	cmd.AddCommand(push.New())
+	cmd.AddCommand(reconcile.New())
 
 	return cmd
 }

--- a/internal/gitinterface/commit.go
+++ b/internal/gitinterface/commit.go
@@ -288,6 +288,28 @@ func (r *Repository) KnowsCommit(testCommitID, ancestorCommitID Hash) (bool, err
 	return err == nil, nil
 }
 
+// GetCommonAncestor finds the common ancestor commit for the two supplied
+// commits.
+func (r *Repository) GetCommonAncestor(commitAID, commitBID Hash) (Hash, error) {
+	if err := r.ensureIsCommit(commitAID); err != nil {
+		return nil, err
+	}
+	if err := r.ensureIsCommit(commitBID); err != nil {
+		return nil, err
+	}
+
+	mergeBase, err := r.executor("merge-base", commitAID.String(), commitBID.String()).executeString()
+	if err != nil {
+		return nil, err
+	}
+
+	mergeBaseID, err := NewHash(mergeBase)
+	if err != nil {
+		return nil, fmt.Errorf("received invalid commit ID: %w", err)
+	}
+	return mergeBaseID, nil
+}
+
 // ensureIsCommit is a helper to check that the ID represents a Git commit
 // object.
 func (r *Repository) ensureIsCommit(commitID Hash) error {

--- a/internal/gitinterface/remote.go
+++ b/internal/gitinterface/remote.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitinterface
+
+func (r *Repository) AddRemote(remoteName, url string) error {
+	_, err := r.executor("remote", "add", remoteName, url).executeString()
+	return err
+}
+
+func (r *Repository) RemoveRemote(remoteName string) error {
+	_, err := r.executor("remote", "remove", remoteName).executeString()
+	return err
+}
+
+func (r *Repository) GetRemoteURL(remoteName string) (string, error) {
+	return r.executor("remote", "get-url", remoteName).executeString()
+}

--- a/internal/gitinterface/remote_test.go
+++ b/internal/gitinterface/remote_test.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package gitinterface
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemote(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tmpDir, false)
+
+	output, err := repo.executor("remote").executeString()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "", output) // no output because there are no remotes
+
+	remoteName := "origin"
+	remoteURL := "git@example.com:repo.git"
+
+	// Test AddRemote
+	err = repo.AddRemote(remoteName, remoteURL)
+	assert.Nil(t, err)
+
+	output, err = repo.executor("remote", "-v").executeString()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput := fmt.Sprintf("%s\t%s (fetch)\n%s\t%s (push)", remoteName, remoteURL, remoteName, remoteURL)
+	assert.Equal(t, expectedOutput, output)
+
+	// Test GetRemoteURL
+	returnedRemoteURL, err := repo.GetRemoteURL(remoteName)
+	assert.Nil(t, err)
+	assert.Equal(t, remoteURL, returnedRemoteURL)
+
+	_, err = repo.GetRemoteURL("does-not-exist")
+	assert.ErrorContains(t, err, "No such remote")
+
+	// Test RemoveRemote
+	err = repo.RemoveRemote(remoteName)
+	assert.Nil(t, err)
+
+	output, err = repo.executor("remote").executeString()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "", output) // no output because there are no remotes
+}

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	rslopts "github.com/gittuf/gittuf/internal/repository/options/rsl"
@@ -142,6 +143,206 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 	return rsl.NewAnnotationEntry(rslEntryHashes, skip, message).Commit(r.r, signCommit)
 }
 
+// ReconcileLocalRSLWithRemote checks the local RSL against the specified remote
+// and reconciles the local RSL if needed. If the local RSL doesn't exist or is
+// strictly behind the remote RSL, then the local RSL is updated to match the
+// remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated.
+// Finally, if the local and remote RSLs have diverged, then the local only RSL
+// entries are reapplied over the latest entries in the remote if the local only
+// RSL entries and remote only entries are for different Git references.
+func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName string, sign bool) error {
+	remoteURL, err := r.r.GetRemoteURL(remoteName)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(remoteURL, gittufTransportPrefix) {
+		slog.Debug("Creating new remote to avoid using gittuf transport...")
+		remoteName = fmt.Sprintf("check-remote-%s", remoteName)
+		if err := r.r.AddRemote(remoteName, strings.TrimPrefix(remoteURL, gittufTransportPrefix)); err != nil {
+			return err
+		}
+		defer r.r.RemoveRemote(remoteName) //nolint:errcheck
+	}
+
+	// Fetch status of RSL on the remote
+	trackerRef := rsl.RemoteTrackerRef(remoteName)
+	rslRemoteRefSpec := []string{fmt.Sprintf("%s:%s", rsl.Ref, trackerRef)}
+
+	slog.Debug(fmt.Sprintf("Updating remote RSL tracker (%s)...", rslRemoteRefSpec))
+	if err := r.r.FetchRefSpec(remoteName, rslRemoteRefSpec); err != nil {
+		return err
+	}
+
+	remoteRefState, err := r.r.GetReference(trackerRef)
+	if err != nil {
+		return err
+	}
+	slog.Debug(fmt.Sprintf("Remote RSL is at '%s'", remoteRefState.String()))
+
+	// Load status of the local RSL for comparison
+	localRefState, err := r.r.GetReference(rsl.Ref)
+	if err != nil {
+		return err
+	}
+	slog.Debug(fmt.Sprintf("Local RSL is at '%s'", localRefState.String()))
+
+	// Check if local is nil and exit appropriately
+	if localRefState.IsZero() {
+		// Local RSL has not been populated but remote is not zero
+		// Fetch updates to the local RSL
+		slog.Debug("Local RSL has not been initialized but remote RSL exists, fetching remote RSL...")
+		if err := r.r.Fetch(remoteName, []string{rsl.Ref}, true); err != nil {
+			return err
+		}
+
+		slog.Debug("Updated local RSL!")
+		return nil
+	}
+
+	// Check if equal and exit early if true
+	if remoteRefState.Equal(localRefState) {
+		slog.Debug("Local and remote RSLs have same state, nothing to do")
+		return nil
+	}
+
+	// Next, check if remote is ahead of local
+	knows, err := r.r.KnowsCommit(remoteRefState, localRefState)
+	if err != nil {
+		return err
+	}
+	if knows {
+		slog.Debug("Remote RSL is ahead of local RSL, fetching remote RSL...")
+		if err := r.r.Fetch(remoteName, []string{rsl.Ref}, true); err != nil {
+			return err
+		}
+
+		slog.Debug("Updated local RSL!")
+		return nil
+	}
+
+	// If not ancestor, local may be ahead or they may have diverged
+	// If remote is ancestor, only local is ahead, no updates
+	// If remote is not ancestor, the two have diverged, local needs to pull updates
+	knows, err = r.r.KnowsCommit(localRefState, remoteRefState)
+	if err != nil {
+		return err
+	}
+	if knows {
+		// We don't push to the remote RSL, that's handled alongside
+		// other pushes (eg. via the transport) or explicitly
+		slog.Debug("Local RSL is ahead of remote RSL, nothing to do")
+		return nil
+	}
+
+	// This is the tricky one
+	// First, we find a common ancestor for the two
+	// Second, we identify all the entries in the local that is not in the
+	// remote
+	// Third, we set local to the remote's tip
+	// Fourth, we apply all the entries that we identified over the new tip
+	slog.Debug("Local and remote RSLs have diverged, identifying common ancestor to reconcile local RSL...")
+	commonAncestor, err := r.r.GetCommonAncestor(localRefState, remoteRefState)
+	if err != nil {
+		return err
+	}
+	slog.Debug(fmt.Sprintf("Found common ancestor entry '%s'", commonAncestor.String()))
+
+	localOnlyEntries, err := getRSLEntriesUntil(r.r, localRefState, commonAncestor)
+	if err != nil {
+		return err
+	}
+	remoteOnlyEntries, err := getRSLEntriesUntil(r.r, remoteRefState, commonAncestor)
+	if err != nil {
+		return err
+	}
+
+	localUpdatedRefs := set.NewSet[string]()
+	for _, entry := range localOnlyEntries {
+		slog.Debug(fmt.Sprintf("Identified local only entry that must be reapplied '%s'", entry.GetID().String()))
+		if entry, isRefEntry := entry.(*rsl.ReferenceEntry); isRefEntry {
+			localUpdatedRefs.Add(entry.RefName)
+		}
+	}
+
+	remoteUpdatedRefs := set.NewSet[string]()
+	for _, entry := range remoteOnlyEntries {
+		slog.Debug(fmt.Sprintf("Identified remote only entry '%s'", entry.GetID().String()))
+		if entry, isRefEntry := entry.(*rsl.ReferenceEntry); isRefEntry {
+			remoteUpdatedRefs.Add(entry.RefName)
+		}
+	}
+
+	// Check if remote has entries for refs that are also updated locally
+	// We don't want to do conflict resolution right now
+	intersection := localUpdatedRefs.Intersection(remoteUpdatedRefs)
+	if intersection.Len() != 0 {
+		return fmt.Errorf("unable to reconcile local RSL with remote; both RSLs contain changes to the same refs [%s]", strings.Join(intersection.Contents(), ", "))
+	}
+
+	// Set local RSL to match the remote state
+	if err := r.r.SetReference(rsl.Ref, remoteRefState); err != nil {
+		return fmt.Errorf("unable to update local RSL: %w", err)
+	}
+
+	// Apply local only entries on top of the new local RSL
+	// localOnlyEntries is in reverse order
+	for i := len(localOnlyEntries) - 1; i >= 0; i-- {
+		slog.Debug(fmt.Sprintf("Reapplying entry '%s'...", localOnlyEntries[i].GetID().String()))
+
+		// We create a new object so as to apply anything the
+		// entry may contain that is inferred at commit time
+		// For example, an incrementing number inferred from the
+		// parent entry
+		switch entry := localOnlyEntries[i].(type) {
+		case *rsl.ReferenceEntry:
+			if err := rsl.NewReferenceEntry(entry.RefName, entry.TargetID).Commit(r.r, sign); err != nil {
+				return fmt.Errorf("unable to reapply reference entry '%s': %w", entry.ID.String(), err)
+			}
+		case *rsl.AnnotationEntry:
+			if err := rsl.NewAnnotationEntry(entry.RSLEntryIDs, entry.Skip, entry.Message).Commit(r.r, sign); err != nil {
+				return fmt.Errorf("unable to reapply annotation entry '%s': %w", entry.ID.String(), err)
+			}
+		}
+
+		if slog.Default().Enabled(ctx, slog.LevelDebug) {
+			currentTip, err := r.r.GetReference(rsl.Ref)
+			if err != nil {
+				return fmt.Errorf("unable to get current tip of the RSL: %w", err)
+			}
+			slog.Debug("New entry ID for '%s' is '%s'", localOnlyEntries[i].GetID().String(), currentTip.String())
+		}
+	}
+
+	slog.Debug("Updated local RSL!")
+	return nil
+}
+
+func getRSLEntriesUntil(repo *gitinterface.Repository, start, until gitinterface.Hash) ([]rsl.Entry, error) {
+	entries := []rsl.Entry{}
+
+	iterator, err := rsl.GetEntry(repo, start)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load entry '%s': %w", start.String(), err)
+	}
+
+	for {
+		entries = append(entries, iterator)
+
+		parent, err := rsl.GetParentForEntry(repo, iterator)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load parent of entry '%s': %w", iterator.GetID().String(), err)
+		}
+
+		if parent.GetID().Equal(until) {
+			break
+		}
+
+		iterator = parent
+	}
+
+	return entries, nil
+}
+
 // CheckRemoteRSLForUpdates checks if the RSL at the specified remote
 // repository has updated in comparison with the local repository's RSL. This is
 // done by fetching the remote RSL to the local repository's remote RSL tracker.
@@ -149,6 +350,9 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 // remote RSLs have diverged. In summary, the first return value indicates if
 // there is an update and the second return value indicates if the two RSLs have
 // diverged and need to be reconciled.
+//
+// Deprecated: this was a precursor to ReconcileLocalRSLWithRemote, we probably
+// don't need both of them.
 func (r *Repository) CheckRemoteRSLForUpdates(_ context.Context, remoteName string) (bool, bool, error) {
 	remoteURL, err := r.r.GetRemoteURL(remoteName)
 	if err != nil {


### PR DESCRIPTION
When checking the status of the remote RSL against the local RSL, we must not use the transport, as that will also update the local RSL (in addition to the remote tracker). With this commit, a separate temporary remote is created and used.

Part of #525 