### PR TITLE
increasing test coverage on policy.go

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -298,7 +298,9 @@ func TestStateKeys(t *testing.T) {
 }
 
 func TestStateVerify(t *testing.T) {
+	t.Parallel()
 	t.Run("only root", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithOnlyRoot(t)
 
 		err := state.Verify(testCtx)
@@ -306,6 +308,7 @@ func TestStateVerify(t *testing.T) {
 	})
 
 	t.Run("only root, remove root keys", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithOnlyRoot(t)
 
 		state.RootPublicKeys = nil
@@ -314,6 +317,7 @@ func TestStateVerify(t *testing.T) {
 	})
 
 	t.Run("with policy", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithPolicy(t)
 
 		err := state.Verify(testCtx)
@@ -321,6 +325,7 @@ func TestStateVerify(t *testing.T) {
 	})
 
 	t.Run("with delegated policy", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithDelegatedPolicies(t)
 
 		err := state.Verify(testCtx)
@@ -347,6 +352,7 @@ func TestStateCommit(t *testing.T) {
 }
 
 func TestStateGetRootMetadata(t *testing.T) {
+	t.Parallel()
 	state := createTestStateWithOnlyRoot(t)
 
 	rootMetadata, err := state.GetRootMetadata()
@@ -355,7 +361,9 @@ func TestStateGetRootMetadata(t *testing.T) {
 }
 
 func TestStateFindVerifiersForPath(t *testing.T) {
+	t.Parallel()
 	t.Run("with policy", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithPolicy(t)
 
 		gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
@@ -401,6 +409,7 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 	})
 
 	t.Run("without policy", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithOnlyRoot(t)
 
 		verifiers, err := state.FindVerifiersForPath("test-path")
@@ -410,6 +419,7 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 }
 
 func TestGetStateForCommit(t *testing.T) {
+	t.Parallel()
 	repo, firstState := createTestRepository(t, createTestStateWithPolicy)
 
 	// Create some commits
@@ -612,7 +622,9 @@ func TestListRules(t *testing.T) {
 }
 
 func TestStateHasFileRule(t *testing.T) {
+	t.Parallel()
 	t.Run("with file rules", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithPolicy(t)
 
 		hasFileRule, err := state.hasFileRule()
@@ -621,6 +633,7 @@ func TestStateHasFileRule(t *testing.T) {
 	})
 
 	t.Run("with no file rules", func(t *testing.T) {
+		t.Parallel()
 		state := createTestStateWithOnlyRoot(t)
 
 		hasFileRule, err := state.hasFileRule()

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -34,13 +34,6 @@ var (
 // using the latest policy. The expected Git ID for the ref in the latest RSL
 // entry is returned if the policy verification is successful.
 func VerifyRef(ctx context.Context, repo *gitinterface.Repository, target string) (gitinterface.Hash, error) {
-	// Get latest policy entry
-	slog.Debug("Loading policy...")
-	policyState, err := LoadCurrentState(ctx, repo, PolicyRef)
-	if err != nil {
-		return gitinterface.ZeroHash, err
-	}
-
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceEntryForRef(repo, target)
@@ -48,15 +41,7 @@ func VerifyRef(ctx context.Context, repo *gitinterface.Repository, target string
 		return gitinterface.ZeroHash, err
 	}
 
-	// Find latest set of attestations
-	slog.Debug("Loading current set of attestations...")
-	attestationsState, err := attestations.LoadCurrentAttestations(repo)
-	if err != nil {
-		return gitinterface.ZeroHash, err
-	}
-
-	slog.Debug("Verifying entry...")
-	return latestEntry.TargetID, verifyEntry(ctx, repo, policyState, attestationsState, latestEntry)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, latestEntry, latestEntry, target)
 }
 
 // VerifyRefFull verifies the entire RSL for the target ref from the first
@@ -77,10 +62,8 @@ func VerifyRefFull(ctx context.Context, repo *gitinterface.Repository, target st
 		return gitinterface.ZeroHash, err
 	}
 
-	// Do a relative verify from start entry to the latest entry (firstEntry here == policyEntry)
-	// Also, attestations is initially nil because we haven't seen any yet
 	slog.Debug("Verifying all entries...")
-	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, nil, firstEntry, latestEntry, target)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, firstEntry, latestEntry, target)
 }
 
 // VerifyRefFromEntry performs verification for the reference from a specific
@@ -94,11 +77,11 @@ func VerifyRefFromEntry(ctx context.Context, repo *gitinterface.Repository, targ
 		return gitinterface.ZeroHash, err
 	}
 
-	// TODO: we should instead find the latest ref entry before the entryID and
-	// use that
 	fromEntry, isRefEntry := fromEntryT.(*rsl.ReferenceEntry)
 	if !isRefEntry {
-		return gitinterface.ZeroHash, err
+		// TODO: we should instead find the latest reference entry
+		// before the entryID and use that
+		return gitinterface.ZeroHash, fmt.Errorf("starting entry is not an RSL reference entry")
 	}
 
 	// Find latest entry for target
@@ -108,52 +91,57 @@ func VerifyRefFromEntry(ctx context.Context, repo *gitinterface.Repository, targ
 		return gitinterface.ZeroHash, err
 	}
 
-	// Find policy entry before the starting point entry
-	slog.Debug("Identifying applicable policy entry...")
-	policyEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, fromEntry.GetID())
-	if err != nil {
-		return gitinterface.ZeroHash, err
-	}
-
-	slog.Debug("Identifying applicable attestations entry...")
-	var attestationsEntry *rsl.ReferenceEntry
-	attestationsEntry, _, err = rsl.GetLatestReferenceEntryForRefBefore(repo, attestations.Ref, fromEntry.GetID())
-	if err != nil {
-		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
-			return gitinterface.ZeroHash, err
-		}
-	}
-
 	// Do a relative verify from start entry to the latest entry
 	slog.Debug("Verifying all entries...")
-	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, policyEntry, attestationsEntry, fromEntry, latestEntry, target)
+	return latestEntry.TargetID, VerifyRelativeForRef(ctx, repo, fromEntry, latestEntry, target)
 }
 
 // VerifyRelativeForRef verifies the RSL between specified start and end entries
 // using the provided policy entry for the first entry.
-//
-// TODO: should the policy entry be inferred from the specified first entry?
-func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, initialPolicyEntry, initialAttestationsEntry, firstEntry, lastEntry *rsl.ReferenceEntry, target string) error {
+func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, firstEntry, lastEntry *rsl.ReferenceEntry, target string) error {
 	var (
 		currentPolicy       *State
 		currentAttestations *attestations.Attestations
+		err                 error
 	)
 
 	// Load policy applicable at firstEntry
-	slog.Debug("Loading initial policy...")
-	state, err := LoadState(ctx, repo, initialPolicyEntry)
-	if err != nil {
-		return err
+	// If firstEntry is for policy, we don't walk the RSL here
+	slog.Debug(fmt.Sprintf("Loading policy applicable at first entry '%s'...", firstEntry.ID.String()))
+	var initialPolicyEntry *rsl.ReferenceEntry
+	if firstEntry.RefName == PolicyRef {
+		slog.Debug(fmt.Sprintf("First entry '%s' is for gittuf policy, setting that as current policy...", firstEntry.ID.String()))
+		initialPolicyEntry = firstEntry
+	} else {
+		initialPolicyEntry, _, err = rsl.GetLatestReferenceEntryForRefBefore(repo, PolicyRef, firstEntry.ID)
+		if err != nil {
+			if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+				slog.Debug(fmt.Sprintf("No policy found before first entry '%s'", firstEntry.ID.String()))
+			} else {
+				return err
+			}
+		}
 	}
-	currentPolicy = state
+	if initialPolicyEntry != nil {
+		state, err := LoadState(ctx, repo, initialPolicyEntry)
+		if err != nil {
+			return err
+		}
+		currentPolicy = state
+	}
 
-	if initialAttestationsEntry != nil {
-		slog.Debug("Loading attestations...")
+	slog.Debug(fmt.Sprintf("Loading attestations applicable at first entry '%s'...", firstEntry.ID.String()))
+	initialAttestationsEntry, _, err := rsl.GetLatestReferenceEntryForRefBefore(repo, attestations.Ref, firstEntry.ID)
+	if err == nil {
 		attestationsState, err := attestations.LoadAttestationsForEntry(repo, initialAttestationsEntry)
 		if err != nil {
 			return err
 		}
 		currentAttestations = attestationsState
+	} else if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+		// Attestations may not be used yet, they're not
+		// compulsory like policies are
+		return err
 	}
 
 	// Enumerate RSL entries between firstEntry and lastEntry, ignoring irrelevant ones
@@ -180,18 +168,30 @@ func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, in
 			}
 			slog.Debug("Checking if entry is for policy reference...")
 			if entry.RefName == PolicyRef {
-				// TODO: this is repetition if the firstEntry is for policy
+				if entry.ID.Equal(firstEntry.ID) {
+					// We've already loaded this policy
+					continue
+				}
+
 				newPolicy, err := loadStateForEntry(repo, entry)
 				if err != nil {
 					return err
 				}
 
-				slog.Debug("Verifying new policy using current policy...")
-				if err := currentPolicy.VerifyNewState(ctx, newPolicy); err != nil {
-					return err
+				if currentPolicy != nil {
+					// currentPolicy can be nil when
+					// verifying from the beginning of the
+					// RSL entry and we only have staging
+					// refs
+					slog.Debug("Verifying new policy using current policy...")
+					if err := currentPolicy.VerifyNewState(ctx, newPolicy); err != nil {
+						return err
+					}
+					slog.Debug("Updating current policy...")
+				} else {
+					slog.Debug("Setting current policy...")
 				}
 
-				slog.Debug("Updating current policy...")
 				currentPolicy = newPolicy
 				continue
 			}
@@ -208,6 +208,9 @@ func VerifyRelativeForRef(ctx context.Context, repo *gitinterface.Repository, in
 			}
 
 			slog.Debug("Verifying changes...")
+			if currentPolicy == nil {
+				return ErrPolicyNotFound
+			}
 			if err := verifyEntry(ctx, repo, currentPolicy, currentAttestations, entry); err != nil {
 				slog.Debug("Violation found, checking if entry has been revoked...")
 				// If the invalid entry is never marked as skipped, we return err

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -1006,7 +1006,9 @@ func TestGetCommits(t *testing.T) {
 }
 
 func TestStateVerifyNewState(t *testing.T) {
+	t.Parallel()
 	t.Run("valid policy transition", func(t *testing.T) {
+		t.Parallel()
 		currentPolicy := createTestStateWithOnlyRoot(t)
 		newPolicy := createTestStateWithOnlyRoot(t)
 
@@ -1015,6 +1017,7 @@ func TestStateVerifyNewState(t *testing.T) {
 	})
 
 	t.Run("invalid policy transition", func(t *testing.T) {
+		t.Parallel()
 		currentPolicy := createTestStateWithOnlyRoot(t)
 
 		// Create invalid state
@@ -1050,6 +1053,7 @@ func TestStateVerifyNewState(t *testing.T) {
 }
 
 func TestVerifier(t *testing.T) {
+	t.Parallel()
 	tmpDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -514,6 +514,7 @@ func TestGetNonGittufParentReferenceEntryForEntry(t *testing.T) {
 }
 
 func TestGetFirstEntry(t *testing.T) {
+	t.Parallel()
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
@@ -1097,6 +1098,7 @@ func TestGetReferenceEntriesInRangeForRef(t *testing.T) {
 }
 
 func TestGetLatestUnskippedReferenceEntryForRef(t *testing.T) {
+	t.Parallel()
 	refName := "refs/heads/main"
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
Increased coverage from ~72% -> 79.7% on policy.go

## Summary of changes:
* Changed test state creation from one Policy to creating test state with delegated policies to increase coverage
* Added a case for `TestStateKeys` where one test runs as a state with delegated policies and the other with the state having only the root - to increase test coverage on the `state.PublicKeys()` method.