### PR TITLE
increasing policy.go test coverage

### DIFF
--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -121,9 +121,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	commitID, err = repo.CommitUsingSpecificKey(treeWithContentsID, refName, "Add README\n", key)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedSecondCommitID, commitID.String())
-
 }
-
 func TestRepositoryVerifyCommit(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tempDir, false)
@@ -184,11 +182,8 @@ func TestRepositoryVerifyCommit(t *testing.T) {
 	t.Run("gitsign signed commit, verify with ssh key", func(t *testing.T) {
 		err = repo.verifyCommitSignature(context.Background(), gitsignSignedCommitID, sshKey)
 		assert.ErrorIs(t, err, ErrIncorrectVerificationKey)
-		//assert.Nil(t, err)
 	})
-
 }
-
 func TestKnowsCommit(t *testing.T) {
 	tmpDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tmpDir, false)
@@ -307,7 +302,6 @@ func createTestGPGSignedCommit(t *testing.T, repo *Repository) Hash {
 
 	return commitHash
 }
-
 func createTestSigstoreSignedCommit(t *testing.T, repo *Repository) Hash {
 	t.Helper()
 
@@ -315,7 +309,6 @@ func createTestSigstoreSignedCommit(t *testing.T, repo *Repository) Hash {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	testCommit := &object.Commit{
 		Hash: plumbing.NewHash("d6b230478965e25477263aa65f1ca6d23d0c0d97"),
 		Author: object.Signature{

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -199,6 +199,7 @@ func TestRepositoryVerifyCommit(t *testing.T) {
 		assert.ErrorIs(t, err, ErrIncorrectVerificationKey)
 	})
 }
+
 func TestKnowsCommit(t *testing.T) {
 	tmpDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tmpDir, false)
@@ -317,6 +318,7 @@ func createTestGPGSignedCommit(t *testing.T, repo *Repository) Hash {
 
 	return commitHash
 }
+
 func createTestSigstoreSignedCommit(t *testing.T, repo *Repository) Hash {
 	t.Helper()
 

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -129,11 +129,11 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	// Create second commit with tree
 	expectedSecondCommitID := "11020a7c78c4f903d0592ec2e8f73d00a17ec47e"
 	commitID, err = repo.CommitUsingSpecificKey(treeWithContentsID, refName, "Add README\n", privateKey)
+	assert.Nil(t, err)
 
 	// Verify commit signature using publicKey
-	verificationErr := repo.verifyCommitSignature(context.Background(), commitID, publicKey)
+	err = repo.verifyCommitSignature(context.Background(), commitID, publicKey)
 	assert.Nil(t, err)
-	assert.Nil(t, verificationErr)
 	assert.Equal(t, expectedSecondCommitID, commitID.String())
 }
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -308,7 +308,6 @@ func TestStateKeys(t *testing.T) {
 		assert.Nil(t, err, keys)
 		assert.Equal(t, expectedKeys, keys)
 	})
-
 }
 func TestStateVerify(t *testing.T) {
 	t.Parallel()

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -277,26 +277,39 @@ func TestLoadStateForEntry(t *testing.T) {
 }
 
 func TestStateKeys(t *testing.T) {
-	state := createTestStateWithPolicy(t)
+	t.Run("state with delegated policies", func(t *testing.T) {
+		state := createTestStateWithDelegatedPolicies(t) // changed from createTestStateWithPolicies to increase test
+		// coverage to cover s.DelegationEnvelopes in PublicKeys()
 
-	expectedKeys := map[string]*tuf.Key{}
-	rootKey, err := tuf.LoadKeyFromBytes(rootKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedKeys[rootKey.KeyID] = rootKey
+		expectedKeys := map[string]*tuf.Key{}
+		rootKey, err := tuf.LoadKeyFromBytes(rootKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedKeys[rootKey.KeyID] = rootKey
 
-	gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedKeys[gpgKey.KeyID] = gpgKey
+		gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectedKeys[gpgKey.KeyID] = gpgKey
 
-	keys, err := state.PublicKeys()
-	assert.Nil(t, err, keys)
-	assert.Equal(t, expectedKeys, keys)
+		keys, err := state.PublicKeys()
+		assert.Nil(t, err, keys)
+		assert.Equal(t, expectedKeys, keys)
+	})
+
+	t.Run("state with only root", func(t *testing.T) {
+		state := createTestStateWithOnlyRoot(t)
+
+		expectedKeys := map[string]*tuf.Key(nil)
+
+		keys, err := state.PublicKeys()
+		assert.Nil(t, err, keys)
+		assert.Equal(t, expectedKeys, keys)
+	})
+
 }
-
 func TestStateVerify(t *testing.T) {
 	t.Parallel()
 	t.Run("only root", func(t *testing.T) {
@@ -362,11 +375,12 @@ func TestStateGetRootMetadata(t *testing.T) {
 
 func TestStateFindVerifiersForPath(t *testing.T) {
 	t.Parallel()
-	t.Run("with policy", func(t *testing.T) {
+	t.Run("with delegated policy", func(t *testing.T) {
 		t.Parallel()
-		state := createTestStateWithPolicy(t)
+		state := createTestStateWithDelegatedPolicies(t) // changed from createTestStateWithPolicies to increase test
+		// coverage to cover s.DelegationEnvelopes in PublicKeys()
 
-		gpgKey, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		key, err := tuf.LoadKeyFromBytes(rootPubKeyBytes)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -375,19 +389,19 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 			path      string
 			verifiers []*Verifier
 		}{
-			"verifiers for refs/heads/main": {
-				path: "git:refs/heads/main",
+			"verifiers for files 1": {
+				path: "file:1/*",
 				verifiers: []*Verifier{{
-					name:      "protect-main",
-					keys:      []*tuf.Key{gpgKey},
+					name:      "1",
+					keys:      []*tuf.Key{key},
 					threshold: 1,
 				}},
 			},
 			"verifiers for files": {
-				path: "file:1",
+				path: "file:2/*",
 				verifiers: []*Verifier{{
-					name:      "protect-files-1-and-2",
-					keys:      []*tuf.Key{gpgKey},
+					name:      "2",
+					keys:      []*tuf.Key{key},
 					threshold: 1,
 				}},
 			},
@@ -624,8 +638,7 @@ func TestListRules(t *testing.T) {
 func TestStateHasFileRule(t *testing.T) {
 	t.Parallel()
 	t.Run("with file rules", func(t *testing.T) {
-		t.Parallel()
-		state := createTestStateWithPolicy(t)
+		state := createTestStateWithDelegatedPolicies(t)
 
 		hasFileRule, err := state.hasFileRule()
 		assert.Nil(t, err)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -309,6 +309,7 @@ func TestStateKeys(t *testing.T) {
 		assert.Equal(t, expectedKeys, keys)
 	})
 }
+
 func TestStateVerify(t *testing.T) {
 	t.Parallel()
 	t.Run("only root", func(t *testing.T) {


### PR DESCRIPTION
Increased coverage from ~72% -> 79.7% on policy.go

## Summary of changes:
* Changed test state creation from one Policy to creating test state with delegated policies to increase coverage
* Added a case for TestStateKeys where one test runs as a state with delegated policies and the other with the state having only the root - to increase test coverage on the state.PublicKeys() method.