### PR TITLE
ci: Bump go version to 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['1.22', '1.23']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
@@ -20,7 +21,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
       with:
-        go-version: '1.22'
+        go-version: ${{ matrix.go-version }}
         cache: true
     - name: Test
       run: go test -timeout 20m ./...

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
       - run: ./.github/workflows/check-docs.sh

--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        go-version: ['1.22', '1.23']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
@@ -24,7 +25,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
       with:
-        go-version: '1.22'
+        go-version: ${{ matrix.go-version }}
         cache: true
     - name: Install Python
       uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0 # fetch full history for previous tag information
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache: true
       - uses: sigstore/cosign-installer@4959ce089c160fddf62f7b42464195ba1a56d382
       - uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -10,6 +10,9 @@ on:
 permissions: read-all
 jobs:
   test:
+    strategy:
+      matrix:
+        go-version: ['1.22', '1.23']
     runs-on: ubuntu-22.04
     steps:
       - name: Downgrade Git
@@ -19,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: "1.22"
+          go-version: ${{ matrix.go-version }}
           cache: true
       - name: Test
         run: go test ./...


### PR DESCRIPTION
This PR bumps the go version for our tests workflow to `1.23`.

Most notably, this changes our testing coverage results:

`1.22` (https://github.com/gittuf/gittuf/actions/runs/10819478695/job/30017444897):
```
Run go test -covermode=atomic `go list ./... | grep -v -f .test_ignore.txt`
	github.com/gittuf/gittuf		coverage: 0.0% of statements
ok  	github.com/gittuf/gittuf/internal/attestations	0.267s	coverage: 27.4% of statements
ok  	github.com/gittuf/gittuf/internal/cmd/common	0.037s	coverage: 2.3% of statements
	github.com/gittuf/gittuf/internal/common/set		coverage: 0.0% of statements
	github.com/gittuf/gittuf/internal/common		coverage: 0.0% of statements
ok  	github.com/gittuf/gittuf/internal/display	0.060s	coverage: 15.5% of statements
ok  	github.com/gittuf/gittuf/internal/gitinterface	2.156s	coverage: 50.6% of statements
ok  	github.com/gittuf/gittuf/internal/policy	9.846s	coverage: 67.8% of statements
?   	github.com/gittuf/gittuf/internal/signerverifier/common	[no test files]
	github.com/gittuf/gittuf/internal/signerverifier		coverage: 0.0% of statements
	github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier		coverage: 0.0% of statements
ok  	github.com/gittuf/gittuf/internal/repository	15.255s	coverage: 55.7% of statements
ok  	github.com/gittuf/gittuf/internal/rsl	2.521s	coverage: 53.5% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/dsse	0.038s	coverage: 9.3% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/gpg	0.007s	coverage: 2.6% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/ssh	1.323s	coverage: 19.0% of statements
ok  	github.com/gittuf/gittuf/internal/tuf	0.023s	coverage: 30.7% of statements
```


`1.23` (https://github.com/gittuf/gittuf/actions/runs/10945101864/job/30388530890) :
```
Run go test -covermode=atomic `go list ./... | grep -v -f .test_ignore.txt`
	github.com/gittuf/gittuf		coverage: 0.0% of statements
	github.com/gittuf/gittuf/internal/common		coverage: 0.0% of statements
	github.com/gittuf/gittuf/internal/common/set		coverage: 0.0% of statements
ok  	github.com/gittuf/gittuf/internal/attestations	0.556s	coverage: 59.1% of statements
ok  	github.com/gittuf/gittuf/internal/cmd/common	0.059s	coverage: 14.6% of statements
ok  	github.com/gittuf/gittuf/internal/display	0.147s	coverage: 82.7% of statements
ok  	github.com/gittuf/gittuf/internal/gitinterface	2.636s	coverage: 65.0% of statements
	github.com/gittuf/gittuf/internal/signerverifier		coverage: 0.0% of statements
?   	github.com/gittuf/gittuf/internal/signerverifier/common	[no test files]
	github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier		coverage: 0.0% of statements
ok  	github.com/gittuf/gittuf/internal/policy	11.529s	coverage: 78.4% of statements
ok  	github.com/gittuf/gittuf/internal/repository	14.845s	coverage: 63.0% of statements
ok  	github.com/gittuf/gittuf/internal/rsl	2.671s	coverage: 88.2% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/dsse	0.035s	coverage: 75.0% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/gpg	0.008s	coverage: 85.7% of statements
ok  	github.com/gittuf/gittuf/internal/signerverifier/ssh	1.352s	coverage: 80.3% of statements
ok  	github.com/gittuf/gittuf/internal/tuf	0.024s	coverage: 92.7% of statements
```