### PR TITLE
*: Add copyright notice to code files

### DIFF
--- a/internal/attestations/attestations.go
+++ b/internal/attestations/attestations.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/github.go
+++ b/internal/attestations/github.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/github_test.go
+++ b/internal/attestations/github_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/attestations/helpers.go
+++ b/internal/attestations/helpers.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestations

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addhooks

--- a/internal/cmd/addhooks/prepush.go
+++ b/internal/cmd/addhooks/prepush.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addhooks

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package clone

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package common

--- a/internal/cmd/common/common_test.go
+++ b/internal/cmd/common/common_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package common

--- a/internal/cmd/dev/addgithubapproval/addgithubapproval.go
+++ b/internal/cmd/dev/addgithubapproval/addgithubapproval.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addgithubapproval

--- a/internal/cmd/dev/attestgithub/attestgithub.go
+++ b/internal/cmd/dev/attestgithub/attestgithub.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package attestgithub

--- a/internal/cmd/dev/authorize/authorize.go
+++ b/internal/cmd/dev/authorize/authorize.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package authorize

--- a/internal/cmd/dev/dev.go
+++ b/internal/cmd/dev/dev.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dev

--- a/internal/cmd/dev/dismissgithubapproval/dismissgithubapproval.go
+++ b/internal/cmd/dev/dismissgithubapproval/dismissgithubapproval.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dismissgithubapproval

--- a/internal/cmd/dev/rslrecordat/rslrecordat.go
+++ b/internal/cmd/dev/rslrecordat/rslrecordat.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rslrecordat

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addkey

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addrule

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package init

--- a/internal/cmd/policy/listrules/listrules.go
+++ b/internal/cmd/policy/listrules/listrules.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package listrules

--- a/internal/cmd/policy/persistent/persistent.go
+++ b/internal/cmd/policy/persistent/persistent.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package persistent

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package removerule

--- a/internal/cmd/policy/reorderrules/reorderrules.go
+++ b/internal/cmd/policy/reorderrules/reorderrules.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package reorderrules

--- a/internal/cmd/policy/sign/sign.go
+++ b/internal/cmd/policy/sign/sign.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package sign

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package updaterule

--- a/internal/cmd/profile/profile.go
+++ b/internal/cmd/profile/profile.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package profile

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package root

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package annotate

--- a/internal/cmd/rsl/log/log.go
+++ b/internal/cmd/rsl/log/log.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package log

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package record

--- a/internal/cmd/rsl/remote/check/check.go
+++ b/internal/cmd/rsl/remote/check/check.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package check

--- a/internal/cmd/rsl/remote/pull/pull.go
+++ b/internal/cmd/rsl/remote/pull/pull.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package pull

--- a/internal/cmd/rsl/remote/push/push.go
+++ b/internal/cmd/rsl/remote/push/push.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package push

--- a/internal/cmd/rsl/remote/reconcile/reconcile.go
+++ b/internal/cmd/rsl/remote/reconcile/reconcile.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package reconcile

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package remote

--- a/internal/cmd/rsl/rsl.go
+++ b/internal/cmd/rsl/rsl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/cmd/rsl/skiprewritten/skiprewritten.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package skiprewritten

--- a/internal/cmd/trust/addgithubappkey/addgithubappkey.go
+++ b/internal/cmd/trust/addgithubappkey/addgithubappkey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addgithubappkey

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addpolicykey

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package addrootkey

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package disablegithubappapprovals

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package enablegithubappapprovals

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package init

--- a/internal/cmd/trust/persistent/persistent.go
+++ b/internal/cmd/trust/persistent/persistent.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package persistent

--- a/internal/cmd/trust/removegithubappkey/removegithubappkey.go
+++ b/internal/cmd/trust/removegithubappkey/removegithubappkey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package removegithubappkey

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package removepolicykey

--- a/internal/cmd/trust/removerootkey/removerootkey.go
+++ b/internal/cmd/trust/removerootkey/removerootkey.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package removerootkey

--- a/internal/cmd/trust/sign/sign.go
+++ b/internal/cmd/trust/sign/sign.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package sign

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package trust

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package updatepolicythreshold

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package updaterootthreshold

--- a/internal/cmd/trustpolicy/apply/apply.go
+++ b/internal/cmd/trustpolicy/apply/apply.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package apply

--- a/internal/cmd/trustpolicy/remote/pull/pull.go
+++ b/internal/cmd/trustpolicy/remote/pull/pull.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package pull

--- a/internal/cmd/trustpolicy/remote/push/push.go
+++ b/internal/cmd/trustpolicy/remote/push/push.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package push

--- a/internal/cmd/trustpolicy/remote/remote.go
+++ b/internal/cmd/trustpolicy/remote/remote.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package remote

--- a/internal/cmd/verifyref/verifyref.go
+++ b/internal/cmd/verifyref/verifyref.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package verifyref

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package version

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package common

--- a/internal/common/set/set.go
+++ b/internal/common/set/set.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package set

--- a/internal/dev/dev.go
+++ b/internal/dev/dev.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dev

--- a/internal/display/display.go
+++ b/internal/display/display.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package display

--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package display

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package display

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package display

--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/git-remote-gittuf/helpers.go
+++ b/internal/git-remote-gittuf/helpers.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/git-remote-gittuf/main.go
+++ b/internal/git-remote-gittuf/main.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/git-remote-gittuf/split.go
+++ b/internal/git-remote-gittuf/split.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main

--- a/internal/gitinterface/blob.go
+++ b/internal/gitinterface/blob.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/blob_test.go
+++ b/internal/gitinterface/blob_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/changes.go
+++ b/internal/gitinterface/changes.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/commit.go
+++ b/internal/gitinterface/commit.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/common.go
+++ b/internal/gitinterface/common.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/config.go
+++ b/internal/gitinterface/config.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/config_test.go
+++ b/internal/gitinterface/config_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/hash.go
+++ b/internal/gitinterface/hash.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/hash_test.go
+++ b/internal/gitinterface/hash_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/log.go
+++ b/internal/gitinterface/log.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/log_test.go
+++ b/internal/gitinterface/log_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/references.go
+++ b/internal/gitinterface/references.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/references_test.go
+++ b/internal/gitinterface/references_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/remote.go
+++ b/internal/gitinterface/remote.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/remote_test.go
+++ b/internal/gitinterface/remote_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/repository.go
+++ b/internal/gitinterface/repository.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/signature.go
+++ b/internal/gitinterface/signature.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/signature_test.go
+++ b/internal/gitinterface/signature_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/sync.go
+++ b/internal/gitinterface/sync.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/sync_test.go
+++ b/internal/gitinterface/sync_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/tag.go
+++ b/internal/gitinterface/tag.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/tag_test.go
+++ b/internal/gitinterface/tag_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/tree_test.go
+++ b/internal/gitinterface/tree_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/gitinterface/utils.go
+++ b/internal/gitinterface/utils.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gitinterface

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/root.go
+++ b/internal/policy/root.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/root_test.go
+++ b/internal/policy/root_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/searcher.go
+++ b/internal/policy/searcher.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/searcher_test.go
+++ b/internal/policy/searcher_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/targets_test.go
+++ b/internal/policy/targets_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package policy

--- a/internal/repository/attestations.go
+++ b/internal/repository/attestations.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/common_test.go
+++ b/internal/repository/common_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/helpers_test.go
+++ b/internal/repository/helpers_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/hook.go
+++ b/internal/repository/hook.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/hook_test.go
+++ b/internal/repository/hook_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/options/rsl/rsl.go
+++ b/internal/repository/options/rsl/rsl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/repository/options/verify/verify.go
+++ b/internal/repository/options/verify/verify.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package verify

--- a/internal/repository/policy.go
+++ b/internal/repository/policy.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/policy_test.go
+++ b/internal/repository/policy_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/root.go
+++ b/internal/repository/root.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/rsl.go
+++ b/internal/repository/rsl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/rsl_test.go
+++ b/internal/repository/rsl_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/sync.go
+++ b/internal/repository/sync.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/sync_test.go
+++ b/internal/repository/sync_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/targets_test.go
+++ b/internal/repository/targets_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/verify.go
+++ b/internal/repository/verify.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/repository/verify_test.go
+++ b/internal/repository/verify_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package repository

--- a/internal/rsl/cache.go
+++ b/internal/rsl/cache.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/rsl/cache_test.go
+++ b/internal/rsl/cache_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/rsl/options.go
+++ b/internal/rsl/options.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package rsl

--- a/internal/signerverifier/common/common.go
+++ b/internal/signerverifier/common/common.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package common

--- a/internal/signerverifier/dsse/dsse.go
+++ b/internal/signerverifier/dsse/dsse.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dsse

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package dsse

--- a/internal/signerverifier/gpg/gpg.go
+++ b/internal/signerverifier/gpg/gpg.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gpg

--- a/internal/signerverifier/gpg/gpg_test.go
+++ b/internal/signerverifier/gpg/gpg_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package gpg

--- a/internal/signerverifier/signerverifier.go
+++ b/internal/signerverifier/signerverifier.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package signerverifier

--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 package ssh
 

--- a/internal/signerverifier/ssh/ssh_test.go
+++ b/internal/signerverifier/ssh/ssh_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 package ssh
 

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package tuf

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package tuf

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package version

--- a/main.go
+++ b/main.go
@@ -1,3 +1,4 @@
+// Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
 package main


### PR DESCRIPTION
This PR adds copyright notices to gittuf's code files.

Based on https://www.linuxfoundation.org/blog/blog/copyright-notices-in-open-source-software-projects

cc @adityasaky