### PR TITLE
*: Support multiple versions of predicates

### DIFF
--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -17,7 +17,7 @@ import (
 func TestLoadCurrentAttestations(t *testing.T) {
 	testRef := "refs/heads/main"
 	testID := gitinterface.ZeroHash.String()
-	testAttestation, err := NewReferenceAuthorization(testRef, testID, testID)
+	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +64,7 @@ func TestLoadCurrentAttestations(t *testing.T) {
 func TestLoadAttestationsForEntry(t *testing.T) {
 	testRef := "refs/heads/main"
 	testID := gitinterface.ZeroHash.String()
-	testAttestation, err := NewReferenceAuthorization(testRef, testID, testID)
+	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +128,7 @@ func TestLoadAttestationsForEntry(t *testing.T) {
 func TestAttestationsCommit(t *testing.T) {
 	testRef := "refs/heads/main"
 	testID := gitinterface.ZeroHash.String()
-	testAttestation, err := NewReferenceAuthorization(testRef, testID, testID)
+	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -8,22 +8,42 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"testing"
+
+	// this is imported without versioning because we can just bump the version
+	// in the import for the creation flow when there's a new default version
+	authorizations "github.com/gittuf/gittuf/internal/attestations/authorizations/v02" //nolint:stylecheck
 
 	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	authorizationsv02 "github.com/gittuf/gittuf/internal/attestations/authorizations/v02" //nolint:stylecheck
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	ita "github.com/in-toto/attestation/go/v1"
 )
 
-var ErrAuthorizationNotFound = errors.New("requested authorization not found")
+var (
+	ErrAuthorizationNotFound       = errors.New("requested authorization not found")
+	ErrUnknownAuthorizationVersion = errors.New("unknown authorizations version (do you need to update your gittuf client?)")
+)
 
-// NewReferenceAuthorization creates a new reference authorization for the
+// NewReferenceAuthorizationForCommit creates a new reference authorization for
+// the provided information. The authorization is embedded in an in-toto
+// "statement" and returned with the appropriate "predicate type" set. The
+// `fromID` and `targetID` specify the change to `targetRef` that is to be
+// authorized by invoking this function. The targetID is expected to be the Git
+// tree ID of the resultant commit.
+func NewReferenceAuthorizationForCommit(targetRef, fromID, targetID string) (*ita.Statement, error) {
+	return authorizations.NewReferenceAuthorizationForCommit(targetRef, fromID, targetID)
+}
+
+// NewReferenceAuthorizationForTag creates a new reference authorization for the
 // provided information. The authorization is embedded in an in-toto "statement"
 // and returned with the appropriate "predicate type" set. The `fromID` and
-// `targetID` specify the change to `targetRef` that is to be authorized by invoking
-// this function.
-func NewReferenceAuthorization(targetRef, fromID, targetID string) (*ita.Statement, error) {
-	return authorizationsv01.NewReferenceAuthorization(targetRef, fromID, targetID)
+// `targetID` specify the change to `targetRef` that is to be authorized by
+// invoking this function. The targetID is expected to be the ID of the commit
+// the tag will point to.
+func NewReferenceAuthorizationForTag(targetRef, fromID, targetID string) (*ita.Statement, error) {
+	return authorizations.NewReferenceAuthorizationForTag(targetRef, fromID, targetID)
 }
 
 // SetReferenceAuthorization writes the new reference authorization attestation
@@ -31,7 +51,7 @@ func NewReferenceAuthorization(targetRef, fromID, targetID string) (*ita.Stateme
 func (a *Attestations) SetReferenceAuthorization(repo *gitinterface.Repository, env *sslibdsse.Envelope, refName, fromID, targetID string) error {
 	// We assume that since we're setting a new authorization, it's the latest
 	// version
-	if err := authorizationsv01.Validate(env, refName, fromID, targetID); err != nil {
+	if err := authorizations.Validate(env, refName, fromID, targetID); err != nil {
 		return err
 	}
 
@@ -51,6 +71,31 @@ func (a *Attestations) SetReferenceAuthorization(repo *gitinterface.Repository, 
 
 	a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromID, targetID)] = blobID
 	return nil
+}
+
+// SetReferenceAuthorizationWithoutValidating writes the new reference
+// authorization attestation to the object store and tracks it in the current
+// attestations state. It skips validation of the attestation, and is therefore
+// only meant for use during testing to check we support older versions
+// correctly.
+func (a *Attestations) SetReferenceAuthorizationWithoutValidating(t *testing.T, repo *gitinterface.Repository, env *sslibdsse.Envelope, refName, fromID, targetID string) {
+	t.Helper()
+
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobID, err := repo.WriteBlob(envBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a.referenceAuthorizations == nil {
+		a.referenceAuthorizations = map[string]gitinterface.Hash{}
+	}
+
+	a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromID, targetID)] = blobID
 }
 
 // RemoveReferenceAuthorization removes a set reference authorization
@@ -84,9 +129,31 @@ func (a *Attestations) GetReferenceAuthorizationFor(repo *gitinterface.Repositor
 		return nil, err
 	}
 
-	// Inspect predicate type to use appropriate validator
-	if err := authorizationsv01.Validate(env, refName, fromID, targetID); err != nil {
+	payloadBytes, err := env.DecodeB64Payload()
+	if err != nil {
 		return nil, err
+	}
+
+	type tmpStmt struct {
+		PredicateType string `json:"predicate_type"`
+	}
+	stmt := new(tmpStmt)
+	if err := json.Unmarshal(payloadBytes, stmt); err != nil {
+		return nil, err
+	}
+
+	// Inspect predicate type to use appropriate validator
+	switch stmt.PredicateType {
+	case authorizationsv01.ReferenceAuthorizationPredicateType:
+		if err := authorizationsv01.Validate(env, refName, fromID, targetID); err != nil {
+			return nil, err
+		}
+	case authorizationsv02.ReferenceAuthorizationPredicateType:
+		if err := authorizationsv02.Validate(env, refName, fromID, targetID); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, ErrUnknownAuthorizationVersion
 	}
 
 	return env, nil

--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -9,66 +9,29 @@ import (
 	"fmt"
 	"path"
 
+	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	ita "github.com/in-toto/attestation/go/v1"
 )
 
-const (
-	ReferenceAuthorizationPredicateType = "https://gittuf.dev/reference-authorization/v0.1"
-	digestGitTreeKey                    = "gitTree"
-	targetRefKey                        = "targetRef"
-	fromRevisionIDKey                   = "fromRevisionID"
-	targetTreeIDKey                     = "targetTreeID"
-)
-
-var (
-	ErrInvalidAuthorization  = errors.New("authorization attestation does not match expected details")
-	ErrAuthorizationNotFound = errors.New("requested authorization not found")
-)
-
-// ReferenceAuthorization is a lightweight record of a detached authorization in
-// a gittuf repository. It is meant to be used as a "predicate" in an in-toto
-// attestation.
-type ReferenceAuthorization struct {
-	TargetRef      string `json:"targetRef"`
-	FromRevisionID string `json:"fromRevisionID"`
-	TargetTreeID   string `json:"targetTreeID"`
-}
+var ErrAuthorizationNotFound = errors.New("requested authorization not found")
 
 // NewReferenceAuthorization creates a new reference authorization for the
 // provided information. The authorization is embedded in an in-toto "statement"
-// and returned with the appropriate "predicate type" set. The `fromTargetID`
-// and `toTargetID` specify the change to `targetRef` that is to be authorized
-// by invoking this function.
-func NewReferenceAuthorization(targetRef, fromRevisionID, targetTreeID string) (*ita.Statement, error) {
-	predicate := &ReferenceAuthorization{
-		TargetRef:      targetRef,
-		FromRevisionID: fromRevisionID,
-		TargetTreeID:   targetTreeID,
-	}
-
-	predicateStruct, err := predicateToPBStruct(predicate)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ita.Statement{
-		Type: ita.StatementTypeUri,
-		Subject: []*ita.ResourceDescriptor{
-			{
-				Digest: map[string]string{digestGitTreeKey: targetTreeID},
-			},
-		},
-		PredicateType: ReferenceAuthorizationPredicateType,
-		Predicate:     predicateStruct,
-	}, nil
+// and returned with the appropriate "predicate type" set. The `fromID` and
+// `targetID` specify the change to `targetRef` that is to be authorized by invoking
+// this function.
+func NewReferenceAuthorization(targetRef, fromID, targetID string) (*ita.Statement, error) {
+	return authorizationsv01.NewReferenceAuthorization(targetRef, fromID, targetID)
 }
 
 // SetReferenceAuthorization writes the new reference authorization attestation
 // to the object store and tracks it in the current attestations state.
-func (a *Attestations) SetReferenceAuthorization(repo *gitinterface.Repository, env *sslibdsse.Envelope, refName, fromRevisionID, targetTreeID string) error {
-	if err := validateReferenceAuthorization(env, refName, fromRevisionID, targetTreeID); err != nil {
+func (a *Attestations) SetReferenceAuthorization(repo *gitinterface.Repository, env *sslibdsse.Envelope, refName, fromID, targetID string) error {
+	// We assume that since we're setting a new authorization, it's the latest
+	// version
+	if err := authorizationsv01.Validate(env, refName, fromID, targetID); err != nil {
 		return err
 	}
 
@@ -86,7 +49,7 @@ func (a *Attestations) SetReferenceAuthorization(repo *gitinterface.Repository, 
 		a.referenceAuthorizations = map[string]gitinterface.Hash{}
 	}
 
-	a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromRevisionID, targetTreeID)] = blobID
+	a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromID, targetID)] = blobID
 	return nil
 }
 
@@ -105,8 +68,8 @@ func (a *Attestations) RemoveReferenceAuthorization(refName, fromRevisionID, tar
 
 // GetReferenceAuthorizationFor returns the requested reference authorization
 // attestation (with its signatures).
-func (a *Attestations) GetReferenceAuthorizationFor(repo *gitinterface.Repository, refName, fromRevisionID, targetTreeID string) (*sslibdsse.Envelope, error) {
-	blobID, has := a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromRevisionID, targetTreeID)]
+func (a *Attestations) GetReferenceAuthorizationFor(repo *gitinterface.Repository, refName, fromID, targetID string) (*sslibdsse.Envelope, error) {
+	blobID, has := a.referenceAuthorizations[ReferenceAuthorizationPath(refName, fromID, targetID)]
 	if !has {
 		return nil, ErrAuthorizationNotFound
 	}
@@ -121,7 +84,8 @@ func (a *Attestations) GetReferenceAuthorizationFor(repo *gitinterface.Repositor
 		return nil, err
 	}
 
-	if err := validateReferenceAuthorization(env, refName, fromRevisionID, targetTreeID); err != nil {
+	// Inspect predicate type to use appropriate validator
+	if err := authorizationsv01.Validate(env, refName, fromID, targetID); err != nil {
 		return nil, err
 	}
 
@@ -132,36 +96,4 @@ func (a *Attestations) GetReferenceAuthorizationFor(repo *gitinterface.Repositor
 // reference authorization attestation.
 func ReferenceAuthorizationPath(refName, fromID, toID string) string {
 	return path.Join(refName, fmt.Sprintf("%s-%s", fromID, toID))
-}
-
-func validateReferenceAuthorization(env *sslibdsse.Envelope, targetRef, fromRevisionID, targetTreeID string) error {
-	payload, err := env.DecodeB64Payload()
-	if err != nil {
-		return err
-	}
-
-	attestation := &ita.Statement{}
-	if err := json.Unmarshal(payload, attestation); err != nil {
-		return err
-	}
-
-	if attestation.Subject[0].Digest[digestGitTreeKey] != targetTreeID {
-		return ErrInvalidAuthorization
-	}
-
-	predicate := attestation.Predicate.AsMap()
-
-	if predicate[targetTreeIDKey] != targetTreeID {
-		return ErrInvalidAuthorization
-	}
-
-	if predicate[fromRevisionIDKey] != fromRevisionID {
-		return ErrInvalidAuthorization
-	}
-
-	if predicate[targetRefKey] != targetRef {
-		return ErrInvalidAuthorization
-	}
-
-	return nil
 }

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -6,35 +6,54 @@ package attestations
 import (
 	"testing"
 
-	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	authorizations "github.com/gittuf/gittuf/internal/attestations/authorizations/v02"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	ita "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewReferenceAuthorization(t *testing.T) {
-	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	t.Run("for commit", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
 
-	authorization, err := NewReferenceAuthorization(testRef, testID, testID)
-	assert.Nil(t, err)
+		authorization, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
+		assert.Nil(t, err)
 
-	// Check value of statement type
-	assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+		// Check value of statement type
+		assert.Equal(t, ita.StatementTypeUri, authorization.Type)
 
-	// Check subject contents
-	assert.Equal(t, 1, len(authorization.Subject))
+		// Check subject contents
+		assert.Equal(t, 1, len(authorization.Subject))
 
-	// Check predicate type
-	assert.Equal(t, authorizationsv01.ReferenceAuthorizationPredicateType, authorization.PredicateType)
+		// Check predicate type
+		assert.Equal(t, authorizations.ReferenceAuthorizationPredicateType, authorization.PredicateType)
+	})
+
+	t.Run("for tag", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+
+		authorization, err := NewReferenceAuthorizationForTag(testRef, testID, testID)
+		assert.Nil(t, err)
+
+		// Check value of statement type
+		assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+
+		// Check subject contents
+		assert.Equal(t, 1, len(authorization.Subject))
+
+		// Check predicate type
+		assert.Equal(t, authorizations.ReferenceAuthorizationPredicateType, authorization.PredicateType)
+	})
 }
 
 func TestSetReferenceAuthorization(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
 	testID := gitinterface.ZeroHash.String()
-	mainZeroZero := authorizationsv01.CreateTestEnvelope(t, testRef, testID, testID)
-	featureZeroZero := authorizationsv01.CreateTestEnvelope(t, testAnotherRef, testID, testID)
+	mainZeroZero := authorizations.CreateTestEnvelope(t, testRef, testID, testID, false)
+	featureZeroZero := authorizations.CreateTestEnvelope(t, testAnotherRef, testID, testID, false)
 
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
@@ -58,8 +77,8 @@ func TestRemoveReferenceAuthorization(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
 	testID := gitinterface.ZeroHash.String()
-	mainZeroZero := authorizationsv01.CreateTestEnvelope(t, testRef, testID, testID)
-	featureZeroZero := authorizationsv01.CreateTestEnvelope(t, testAnotherRef, testID, testID)
+	mainZeroZero := authorizations.CreateTestEnvelope(t, testRef, testID, testID, false)
+	featureZeroZero := authorizations.CreateTestEnvelope(t, testAnotherRef, testID, testID, false)
 
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
@@ -95,8 +114,8 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
 	testID := gitinterface.ZeroHash.String()
-	mainZeroZero := authorizationsv01.CreateTestEnvelope(t, testRef, testID, testID)
-	featureZeroZero := authorizationsv01.CreateTestEnvelope(t, testAnotherRef, testID, testID)
+	mainZeroZero := authorizations.CreateTestEnvelope(t, testRef, testID, testID, false)
+	featureZeroZero := authorizations.CreateTestEnvelope(t, testAnotherRef, testID, testID, false)
 
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)

--- a/internal/attestations/authorizations/authorizations.go
+++ b/internal/attestations/authorizations/authorizations.go
@@ -1,0 +1,10 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package authorizations
+
+type ReferenceAuthorization interface {
+	GetRef() string
+	GetFromID() string
+	GetTargetID() string
+}

--- a/internal/attestations/authorizations/v01/v01.go
+++ b/internal/attestations/authorizations/v01/v01.go
@@ -1,0 +1,125 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/attestations/common"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	ita "github.com/in-toto/attestation/go/v1"
+)
+
+const (
+	ReferenceAuthorizationPredicateType = "https://gittuf.dev/reference-authorization/v0.1"
+
+	digestGitTreeKey  = "gitTree"
+	targetRefKey      = "targetRef"
+	fromRevisionIDKey = "fromRevisionID"
+	targetTreeIDKey   = "targetTreeID"
+)
+
+var ErrInvalidAuthorization = errors.New("authorization attestation does not match expected details")
+
+// ReferenceAuthorization is a lightweight record of a detached authorization in
+// a gittuf repository. It is meant to be used as a "predicate" in an in-toto
+// attestation.
+type ReferenceAuthorization struct {
+	TargetRef      string `json:"targetRef"`
+	FromRevisionID string `json:"fromRevisionID"`
+	TargetTreeID   string `json:"targetTreeID"`
+}
+
+func (r *ReferenceAuthorization) GetRef() string {
+	return r.TargetRef
+}
+
+func (r *ReferenceAuthorization) GetFromID() string {
+	return r.FromRevisionID
+}
+
+func (r *ReferenceAuthorization) GetTargetID() string {
+	return r.TargetTreeID
+}
+
+// NewReferenceAuthorization creates a new reference authorization for the
+// provided information. The authorization is embedded in an in-toto "statement"
+// and returned with the appropriate "predicate type" set. The `fromTargetID`
+// and `toTargetID` specify the change to `targetRef` that is to be authorized
+// by invoking this function.
+func NewReferenceAuthorization(targetRef, fromRevisionID, targetTreeID string) (*ita.Statement, error) {
+	predicate := &ReferenceAuthorization{
+		TargetRef:      targetRef,
+		FromRevisionID: fromRevisionID,
+		TargetTreeID:   targetTreeID,
+	}
+
+	predicateStruct, err := common.PredicateToPBStruct(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitTreeKey: targetTreeID},
+			},
+		},
+		PredicateType: ReferenceAuthorizationPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+// Validate checks that the returned envelope contains the expected in-toto
+// attestation and predicate contents.
+func Validate(env *sslibdsse.Envelope, targetRef, fromRevisionID, targetTreeID string) error {
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	attestation := &ita.Statement{}
+	if err := json.Unmarshal(payload, attestation); err != nil {
+		return err
+	}
+
+	if attestation.Subject[0].Digest[digestGitTreeKey] != targetTreeID {
+		return ErrInvalidAuthorization
+	}
+
+	predicate := attestation.Predicate.AsMap()
+
+	if predicate[targetTreeIDKey] != targetTreeID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[fromRevisionIDKey] != fromRevisionID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[targetRefKey] != targetRef {
+		return ErrInvalidAuthorization
+	}
+
+	return nil
+}
+
+func CreateTestEnvelope(t *testing.T, refName, fromID, toID string) *sslibdsse.Envelope {
+	t.Helper()
+
+	authorization, err := NewReferenceAuthorization(refName, fromID, toID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}

--- a/internal/attestations/authorizations/v01/v01_test.go
+++ b/internal/attestations/authorizations/v01/v01_test.go
@@ -1,0 +1,54 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	ita "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewReferenceAuthorization(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := gitinterface.ZeroHash.String()
+
+	authorization, err := NewReferenceAuthorization(testRef, testID, testID)
+	assert.Nil(t, err)
+
+	// Check value of statement type
+	assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+
+	// Check subject contents
+	assert.Equal(t, 1, len(authorization.Subject))
+	assert.Contains(t, authorization.Subject[0].Digest, digestGitTreeKey)
+	assert.Equal(t, authorization.Subject[0].Digest[digestGitTreeKey], testID)
+
+	// Check predicate type
+	assert.Equal(t, ReferenceAuthorizationPredicateType, authorization.PredicateType)
+
+	// Check predicate
+	predicate := authorization.Predicate.AsMap()
+	assert.Equal(t, predicate[targetRefKey], testRef)
+	assert.Equal(t, predicate[targetTreeIDKey], testID)
+	assert.Equal(t, predicate[fromRevisionIDKey], testID)
+}
+
+func TestValidate(t *testing.T) {
+	testRef := "refs/heads/main"
+	testAnotherRef := "refs/heads/feature"
+	testID := gitinterface.ZeroHash.String()
+	mainZeroZero := CreateTestEnvelope(t, testRef, testID, testID)
+	featureZeroZero := CreateTestEnvelope(t, testAnotherRef, testID, testID)
+
+	err := Validate(mainZeroZero, testRef, testID, testID)
+	assert.Nil(t, err)
+
+	err = Validate(featureZeroZero, testAnotherRef, testID, testID)
+	assert.Nil(t, err)
+
+	err = Validate(mainZeroZero, testAnotherRef, testID, testID)
+	assert.ErrorIs(t, err, ErrInvalidAuthorization)
+}

--- a/internal/attestations/authorizations/v02/v02.go
+++ b/internal/attestations/authorizations/v02/v02.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	v01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	"github.com/gittuf/gittuf/internal/attestations/common"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	ita "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	ReferenceAuthorizationPredicateType = "https://gittuf.dev/reference-authorization/v0.2"
+
+	digestGitTreeKey   = "gitTree"
+	digestGitCommitKey = "gitCommit"
+	targetRefKey       = "targetRef"
+	fromIDKey          = "fromID"
+	targetIDKey        = "targetID"
+)
+
+var ErrInvalidAuthorization = v01.ErrInvalidAuthorization
+
+// ReferenceAuthorization is a lightweight record of a detached authorization in
+// a gittuf repository. It is meant to be used as a "predicate" in an in-toto
+// attestation.
+type ReferenceAuthorization struct {
+	TargetRef string `json:"targetRef"`
+	FromID    string `json:"fromID"`
+	TargetID  string `json:"targetID"`
+}
+
+func (r *ReferenceAuthorization) GetRef() string {
+	return r.TargetRef
+}
+
+func (r *ReferenceAuthorization) GetFromID() string {
+	return r.FromID
+}
+
+func (r *ReferenceAuthorization) GetTargetID() string {
+	return r.TargetID
+}
+
+// NewReferenceAuthorizationForCommit creates a new reference authorization for
+// the provided information. The authorization is embedded in an in-toto
+// "statement" and returned with the appropriate "predicate type" set. The
+// `fromID` and `targetID` specify the change to `targetRef` that is to be
+// authorized by invoking this function. The targetID is expected to be the Git
+// tree ID of the resultant commit.
+func NewReferenceAuthorizationForCommit(targetRef, fromID, targetID string) (*ita.Statement, error) {
+	predicateStruct, err := newReferenceAuthorizationStruct(targetRef, fromID, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitTreeKey: targetID},
+			},
+		},
+		PredicateType: ReferenceAuthorizationPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+// NewReferenceAuthorizationForTag creates a new reference authorization for the
+// provided information. The authorization is embedded in an in-toto "statement"
+// and returned with the appropriate "predicate type" set. The `fromID` and
+// `targetID` specify the change to `targetRef` that is to be authorized by
+// invoking this function. The targetID is expected to be the ID of the commit
+// the tag will point to.
+func NewReferenceAuthorizationForTag(targetRef, fromID, targetID string) (*ita.Statement, error) {
+	predicateStruct, err := newReferenceAuthorizationStruct(targetRef, fromID, targetID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitCommitKey: targetID},
+			},
+		},
+		PredicateType: ReferenceAuthorizationPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+// Validate checks that the returned envelope contains the expected in-toto
+// attestation and predicate contents.
+func Validate(env *sslibdsse.Envelope, targetRef, fromID, targetID string) error {
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	attestation := &ita.Statement{}
+	if err := json.Unmarshal(payload, attestation); err != nil {
+		return err
+	}
+
+	subjectDigest, hasGitTree := attestation.Subject[0].Digest[digestGitTreeKey]
+	if hasGitTree {
+		if subjectDigest != targetID {
+			return ErrInvalidAuthorization
+		}
+	} else {
+		subjectDigest, hasGitCommit := attestation.Subject[0].Digest[digestGitCommitKey]
+		if !hasGitCommit {
+			return ErrInvalidAuthorization
+		}
+
+		if subjectDigest != targetID {
+			return ErrInvalidAuthorization
+		}
+
+		if !strings.HasPrefix(targetRef, gitinterface.TagRefPrefix) {
+			return ErrInvalidAuthorization
+		}
+	}
+
+	predicate := attestation.Predicate.AsMap()
+
+	if predicate[targetIDKey] != targetID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[fromIDKey] != fromID {
+		return ErrInvalidAuthorization
+	}
+
+	if predicate[targetRefKey] != targetRef {
+		return ErrInvalidAuthorization
+	}
+
+	return nil
+}
+
+func CreateTestEnvelope(t *testing.T, refName, fromID, toID string, tag bool) *sslibdsse.Envelope {
+	t.Helper()
+
+	var (
+		authorization *ita.Statement
+		err           error
+	)
+
+	if tag {
+		authorization, err = NewReferenceAuthorizationForTag(refName, fromID, toID)
+	} else {
+		authorization, err = NewReferenceAuthorizationForCommit(refName, fromID, toID)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}
+
+func newReferenceAuthorizationStruct(targetRef, fromID, targetID string) (*structpb.Struct, error) {
+	predicate := &ReferenceAuthorization{
+		TargetRef: targetRef,
+		FromID:    fromID,
+		TargetID:  targetID,
+	}
+
+	return common.PredicateToPBStruct(predicate)
+}

--- a/internal/attestations/authorizations/v02/v02_test.go
+++ b/internal/attestations/authorizations/v02/v02_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	ita "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewReferenceAuthorization(t *testing.T) {
+	t.Run("for commit", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+
+		authorization, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
+		assert.Nil(t, err)
+
+		// Check value of statement type
+		assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+
+		// Check subject contents
+		assert.Equal(t, 1, len(authorization.Subject))
+		assert.Contains(t, authorization.Subject[0].Digest, digestGitTreeKey)
+		assert.Equal(t, authorization.Subject[0].Digest[digestGitTreeKey], testID)
+
+		// Check predicate type
+		assert.Equal(t, ReferenceAuthorizationPredicateType, authorization.PredicateType)
+
+		// Check predicate
+		predicate := authorization.Predicate.AsMap()
+		assert.Equal(t, predicate[targetRefKey], testRef)
+		assert.Equal(t, predicate[targetIDKey], testID)
+		assert.Equal(t, predicate[fromIDKey], testID)
+	})
+
+	t.Run("for tag", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+
+		authorization, err := NewReferenceAuthorizationForTag(testRef, testID, testID)
+		assert.Nil(t, err)
+
+		// Check value of statement type
+		assert.Equal(t, ita.StatementTypeUri, authorization.Type)
+
+		// Check subject contents
+		assert.Equal(t, 1, len(authorization.Subject))
+		assert.Contains(t, authorization.Subject[0].Digest, digestGitCommitKey)
+		assert.Equal(t, authorization.Subject[0].Digest[digestGitCommitKey], testID)
+
+		// Check predicate type
+		assert.Equal(t, ReferenceAuthorizationPredicateType, authorization.PredicateType)
+
+		// Check predicate
+		predicate := authorization.Predicate.AsMap()
+		assert.Equal(t, predicate[targetRefKey], testRef)
+		assert.Equal(t, predicate[targetIDKey], testID)
+		assert.Equal(t, predicate[fromIDKey], testID)
+	})
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("for commit", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testAnotherRef := "refs/heads/feature"
+		testID := gitinterface.ZeroHash.String()
+		mainZeroZero := CreateTestEnvelope(t, testRef, testID, testID, false)
+		featureZeroZero := CreateTestEnvelope(t, testAnotherRef, testID, testID, false)
+
+		err := Validate(mainZeroZero, testRef, testID, testID)
+		assert.Nil(t, err)
+
+		err = Validate(featureZeroZero, testAnotherRef, testID, testID)
+		assert.Nil(t, err)
+
+		err = Validate(mainZeroZero, testAnotherRef, testID, testID)
+		assert.ErrorIs(t, err, ErrInvalidAuthorization)
+	})
+
+	t.Run("for tag", func(t *testing.T) {
+		testRef := "refs/tags/v1"
+		testID := gitinterface.ZeroHash.String()
+		authorization := CreateTestEnvelope(t, testRef, testID, testID, true)
+
+		err := Validate(authorization, testRef, testID, testID)
+		assert.Nil(t, err)
+	})
+
+	t.Run("invalid subject", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+
+		authorization, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		authorization.Subject[0].Digest["garbage"] = authorization.Subject[0].Digest[digestGitTreeKey]
+		delete(authorization.Subject[0].Digest, digestGitTreeKey)
+		env, err := dsse.CreateEnvelope(authorization)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = Validate(env, testRef, testID, testID)
+		assert.ErrorIs(t, err, ErrInvalidAuthorization)
+	})
+
+	t.Run("mismatch ref (non tag) and subject digest key (commit)", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+		authorization := CreateTestEnvelope(t, testRef, testID, testID, true)
+
+		err := Validate(authorization, testRef, testID, testID)
+		assert.ErrorIs(t, err, ErrInvalidAuthorization)
+	})
+}

--- a/internal/attestations/common/common.go
+++ b/internal/attestations/common/common.go
@@ -1,7 +1,7 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package attestations
+package common
 
 import (
 	"encoding/json"
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func predicateToPBStruct(predicate any) (*structpb.Struct, error) {
+func PredicateToPBStruct(predicate any) (*structpb.Struct, error) {
 	predicateBytes, err := json.Marshal(predicate)
 	if err != nil {
 		return nil, err

--- a/internal/attestations/github.go
+++ b/internal/attestations/github.go
@@ -10,56 +10,22 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"sort"
 
-	"github.com/gittuf/gittuf/internal/common/set"
+	githubv01 "github.com/gittuf/gittuf/internal/attestations/github/v01"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/google/go-github/v61/github"
 	ita "github.com/in-toto/attestation/go/v1"
-	"google.golang.org/protobuf/types/known/structpb"
-)
-
-const (
-	GitHubPullRequestPredicateType         = "https://gittuf.dev/github-pull-request/v0.1"
-	GitHubPullRequestApprovalPredicateType = "https://gittuf.dev/github-pull-request-approval/v0.1"
-	digestGitCommitKey                     = "gitCommit"
 )
 
 var (
-	ErrInvalidGitHubPullRequestApprovalAttestation  = errors.New("the GitHub pull request approval attestation does not match expected details or has no approvers and dismissed approvers")
 	ErrGitHubPullRequestApprovalAttestationNotFound = errors.New("requested GitHub pull request approval attestation not found")
 	ErrGitHubReviewIDNotFound                       = errors.New("requested GitHub review ID does not exist in index")
 )
 
 func NewGitHubPullRequestAttestation(owner, repository string, pullRequestNumber int, commitID string, pullRequest *github.PullRequest) (*ita.Statement, error) {
-	pullRequestBytes, err := json.Marshal(pullRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	predicate := map[string]any{}
-	if err := json.Unmarshal(pullRequestBytes, &predicate); err != nil {
-		return nil, err
-	}
-
-	predicateStruct, err := structpb.NewStruct(predicate)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ita.Statement{
-		Type: ita.StatementTypeUri,
-		Subject: []*ita.ResourceDescriptor{
-			{
-				Uri:    fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repository, pullRequestNumber),
-				Digest: map[string]string{digestGitCommitKey: commitID},
-			},
-		},
-		PredicateType: GitHubPullRequestPredicateType,
-		Predicate:     predicateStruct,
-	}, nil
+	return githubv01.NewGitHubPullRequestAttestation(owner, repository, pullRequestNumber, commitID, pullRequest)
 }
 
 func (a *Attestations) SetGitHubPullRequestAuthorization(repo *gitinterface.Repository, env *sslibdsse.Envelope, targetRefName, commitID string) error {
@@ -87,58 +53,13 @@ func GitHubPullRequestAttestationPath(refName, commitID string) string {
 	return path.Join(refName, commitID)
 }
 
-// GitHubPullRequestApprovalAttestation is similar to a
-// `ReferenceAuthorization`, except that it records a pull request's approvers
-// inside the predicate (defined here).
-type GitHubPullRequestApprovalAttestation struct {
-	// Approvers contains the list of currently applicable approvers.
-	Approvers []*tuf.Key `json:"approvers"`
-
-	// DismissedApprovers contains the list of approvers who then dismissed
-	// their approval.
-	DismissedApprovers []*tuf.Key `json:"dismissedApprovers"`
-
-	*ReferenceAuthorization
-}
-
 // NewGitHubPullRequestApprovalAttestation creates a new GitHub pull request
 // approval attestation for the provided information. The attestation is
 // embedded in an in-toto "statement" and returned with the appropriate
-// "predicate type" set. The `fromTargetID` and `toTargetID` specify the change
-// to `targetRef` that is approved on the corresponding GitHub pull request.
-func NewGitHubPullRequestApprovalAttestation(targetRef, fromRevisionID, targetTreeID string, approvers []*tuf.Key, dismissedApprovers []*tuf.Key) (*ita.Statement, error) {
-	if len(approvers) == 0 && len(dismissedApprovers) == 0 {
-		return nil, ErrInvalidGitHubPullRequestApprovalAttestation
-	}
-
-	approvers = getFilteredSetOfApprovers(approvers)
-	dismissedApprovers = getFilteredSetOfApprovers(dismissedApprovers)
-
-	predicate := &GitHubPullRequestApprovalAttestation{
-		ReferenceAuthorization: &ReferenceAuthorization{
-			TargetRef:      targetRef,
-			FromRevisionID: fromRevisionID,
-			TargetTreeID:   targetTreeID,
-		},
-		Approvers:          approvers,
-		DismissedApprovers: dismissedApprovers,
-	}
-
-	predicateStruct, err := predicateToPBStruct(predicate)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ita.Statement{
-		Type: ita.StatementTypeUri,
-		Subject: []*ita.ResourceDescriptor{
-			{
-				Digest: map[string]string{digestGitTreeKey: targetTreeID},
-			},
-		},
-		PredicateType: GitHubPullRequestApprovalPredicateType,
-		Predicate:     predicateStruct,
-	}, nil
+// "predicate type" set. The `fromID` and `targetID` specify the change to
+// `targetRef` that is approved on the corresponding GitHub pull request.
+func NewGitHubPullRequestApprovalAttestation(targetRef, fromID, targetID string, approvers []*tuf.Key, dismissedApprovers []*tuf.Key) (*ita.Statement, error) {
+	return githubv01.NewGitHubPullRequestApprovalAttestation(targetRef, fromID, targetID, approvers, dismissedApprovers)
 }
 
 // SetGitHubPullRequestApprovalAttestation writes the new GitHub pull request
@@ -148,8 +69,8 @@ func NewGitHubPullRequestApprovalAttestation(targetRef, fromRevisionID, targetTr
 // to the indexPath so that if the review is dismissed later, the corresponding
 // attestation can be updated.
 func (a *Attestations) SetGitHubPullRequestApprovalAttestation(repo *gitinterface.Repository, env *sslibdsse.Envelope, hostURL string, reviewID int64, appName, refName, fromRevisionID, targetTreeID string) error {
-	if err := validateGitHubPullRequestApprovalAttestation(env, refName, fromRevisionID, targetTreeID); err != nil {
-		return errors.Join(ErrInvalidGitHubPullRequestApprovalAttestation, err)
+	if err := githubv01.ValidatePullRequestApproval(env, refName, fromRevisionID, targetTreeID); err != nil {
+		return errors.Join(githubv01.ErrInvalidGitHubPullRequestApprovalAttestation, err)
 	}
 
 	envBytes, err := json.Marshal(env)
@@ -188,7 +109,7 @@ func (a *Attestations) SetGitHubPullRequestApprovalAttestation(repo *gitinterfac
 	}
 	if existingIndexPath, has := a.codeReviewApprovalIndex[githubReviewID]; has {
 		if existingIndexPath != indexPath {
-			return ErrInvalidGitHubPullRequestApprovalAttestation
+			return githubv01.ErrInvalidGitHubPullRequestApprovalAttestation
 		}
 	} else {
 		a.codeReviewApprovalIndex[githubReviewID] = indexPath // only use indexPath as the same review ID can be observed by more than one app
@@ -243,6 +164,8 @@ func (a *Attestations) GetGitHubPullRequestApprovalAttestationForIndexPath(repo 
 		return nil, err
 	}
 
+	// TODO: Inspect predicate type to use appropriate validator
+
 	return env, nil
 }
 
@@ -277,29 +200,4 @@ func GitHubReviewID(hostURL string, reviewID int64) (string, error) {
 	}
 
 	return fmt.Sprintf("%s::%d", u.Host, reviewID), nil
-}
-
-func validateGitHubPullRequestApprovalAttestation(env *sslibdsse.Envelope, targetRef, fromRevisionID, targetTreeID string) error {
-	return validateReferenceAuthorization(env, targetRef, fromRevisionID, targetTreeID)
-}
-
-func getFilteredSetOfApprovers(approvers []*tuf.Key) []*tuf.Key {
-	if approvers == nil {
-		return nil
-	}
-	approversSet := set.NewSet[string]()
-	approversFiltered := make([]*tuf.Key, 0, len(approvers))
-	for _, approver := range approvers {
-		if approversSet.Has(approver.KeyID) {
-			continue
-		}
-		approversSet.Add(approver.KeyID)
-		approversFiltered = append(approversFiltered, approver)
-	}
-
-	sort.Slice(approversFiltered, func(i, j int) bool {
-		return approversFiltered[i].KeyID < approversFiltered[j].KeyID
-	})
-
-	return approversFiltered
 }

--- a/internal/attestations/github/github.go
+++ b/internal/attestations/github/github.go
@@ -1,0 +1,15 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"github.com/gittuf/gittuf/internal/attestations/authorizations"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+type PullRequestApprovalAttestation interface {
+	GetApprovers() []*tuf.Key
+	GetDismissedApprovers() []*tuf.Key
+	authorizations.ReferenceAuthorization
+}

--- a/internal/attestations/github/v01/approval.go
+++ b/internal/attestations/github/v01/approval.go
@@ -1,0 +1,128 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"errors"
+	"sort"
+	"testing"
+
+	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	"github.com/gittuf/gittuf/internal/attestations/common"
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	ita "github.com/in-toto/attestation/go/v1"
+)
+
+const (
+	GitHubPullRequestApprovalPredicateType = "https://gittuf.dev/github-pull-request-approval/v0.1"
+
+	digestGitTreeKey = "gitTree"
+)
+
+var ErrInvalidGitHubPullRequestApprovalAttestation = errors.New("the GitHub pull request approval attestation does not match expected details or has no approvers and dismissed approvers")
+
+// GitHubPullRequestApprovalAttestation is similar to a
+// `ReferenceAuthorization`, except that it records a pull request's approvers
+// inside the predicate (defined here).
+type GitHubPullRequestApprovalAttestation struct {
+	// Approvers contains the list of currently applicable approvers.
+	Approvers []*tuf.Key `json:"approvers"`
+
+	// DismissedApprovers contains the list of approvers who then dismissed
+	// their approval.
+	DismissedApprovers []*tuf.Key `json:"dismissedApprovers"`
+
+	*authorizationsv01.ReferenceAuthorization
+}
+
+func (g *GitHubPullRequestApprovalAttestation) GetApprovers() []*tuf.Key {
+	return g.Approvers
+}
+
+func (g *GitHubPullRequestApprovalAttestation) GetDismissedApprovers() []*tuf.Key {
+	return g.DismissedApprovers
+}
+
+// NewGitHubPullRequestApprovalAttestation creates a new GitHub pull request
+// approval attestation for the provided information. The attestation is
+// embedded in an in-toto "statement" and returned with the appropriate
+// "predicate type" set. The `fromTargetID` and `toTargetID` specify the change
+// to `targetRef` that is approved on the corresponding GitHub pull request.
+func NewGitHubPullRequestApprovalAttestation(targetRef, fromRevisionID, targetTreeID string, approvers []*tuf.Key, dismissedApprovers []*tuf.Key) (*ita.Statement, error) {
+	if len(approvers) == 0 && len(dismissedApprovers) == 0 {
+		return nil, ErrInvalidGitHubPullRequestApprovalAttestation
+	}
+
+	approvers = getFilteredSetOfApprovers(approvers)
+	dismissedApprovers = getFilteredSetOfApprovers(dismissedApprovers)
+
+	predicate := &GitHubPullRequestApprovalAttestation{
+		ReferenceAuthorization: &authorizationsv01.ReferenceAuthorization{
+			TargetRef:      targetRef,
+			FromRevisionID: fromRevisionID,
+			TargetTreeID:   targetTreeID,
+		},
+		Approvers:          approvers,
+		DismissedApprovers: dismissedApprovers,
+	}
+
+	predicateStruct, err := common.PredicateToPBStruct(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitTreeKey: targetTreeID},
+			},
+		},
+		PredicateType: GitHubPullRequestApprovalPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+func ValidatePullRequestApproval(env *sslibdsse.Envelope, targetRef, fromRevisionID, targetTreeID string) error {
+	return authorizationsv01.Validate(env, targetRef, fromRevisionID, targetTreeID)
+}
+
+func getFilteredSetOfApprovers(approvers []*tuf.Key) []*tuf.Key {
+	if approvers == nil {
+		return nil
+	}
+	approversSet := set.NewSet[string]()
+	approversFiltered := make([]*tuf.Key, 0, len(approvers))
+	for _, approver := range approvers {
+		if approversSet.Has(approver.KeyID) {
+			continue
+		}
+		approversSet.Add(approver.KeyID)
+		approversFiltered = append(approversFiltered, approver)
+	}
+
+	sort.Slice(approversFiltered, func(i, j int) bool {
+		return approversFiltered[i].KeyID < approversFiltered[j].KeyID
+	})
+
+	return approversFiltered
+}
+
+func CreateTestPullRequestApprovalEnvelope(t *testing.T, refName, fromID, toID string, approvers []*tuf.Key) *sslibdsse.Envelope {
+	t.Helper()
+
+	authorization, err := NewGitHubPullRequestApprovalAttestation(refName, fromID, toID, approvers, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}

--- a/internal/attestations/github/v01/approval_test.go
+++ b/internal/attestations/github/v01/approval_test.go
@@ -1,0 +1,93 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"testing"
+
+	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/signerverifier"
+	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
+	ita "github.com/in-toto/attestation/go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	targetRefKey      = "targetRef"
+	fromRevisionIDKey = "fromRevisionID"
+	targetTreeIDKey   = "targetTreeID"
+)
+
+func TestNewGitHubPullRequestApprovalAttestation(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := gitinterface.ZeroHash.String()
+
+	approvers := []*sslibsv.SSLibKey{
+		{
+			KeyID:   "jane.doe@example.com::https://oidc.example.com",
+			KeyType: signerverifier.FulcioKeyType,
+			Scheme:  signerverifier.FulcioKeyScheme,
+			KeyVal: sslibsv.KeyVal{
+				Identity: "jane.doe@example.com",
+				Issuer:   "https://oidc.example.com",
+			},
+		},
+	}
+
+	_, err := NewGitHubPullRequestApprovalAttestation(testRef, testID, testID, nil, nil)
+	assert.ErrorIs(t, err, ErrInvalidGitHubPullRequestApprovalAttestation)
+
+	approvalAttestation, err := NewGitHubPullRequestApprovalAttestation(testRef, testID, testID, approvers, nil)
+	assert.Nil(t, err)
+
+	// Check value of statement type
+	assert.Equal(t, ita.StatementTypeUri, approvalAttestation.Type)
+
+	// Check subject contents
+	assert.Equal(t, 1, len(approvalAttestation.Subject))
+	assert.Contains(t, approvalAttestation.Subject[0].Digest, digestGitTreeKey)
+	assert.Equal(t, approvalAttestation.Subject[0].Digest[digestGitTreeKey], testID)
+
+	// Check predicate type
+	assert.Equal(t, GitHubPullRequestApprovalPredicateType, approvalAttestation.PredicateType)
+
+	// Check predicate
+	predicate := approvalAttestation.Predicate.AsMap()
+	assert.Equal(t, predicate[targetRefKey], testRef)
+	assert.Equal(t, predicate[targetTreeIDKey], testID)
+	assert.Equal(t, predicate[fromRevisionIDKey], testID)
+	// FIXME: this is a really messy assertion
+	assert.Equal(t, approvers[0].KeyID, predicate["approvers"].([]any)[0].(map[string]any)["keyid"])
+}
+
+func TestValidatePullRequestApproval(t *testing.T) {
+	testRef := "refs/heads/main"
+	testAnotherRef := "refs/heads/feature"
+	testID := gitinterface.ZeroHash.String()
+
+	approvers := []*sslibsv.SSLibKey{
+		{
+			KeyID:   "jane.doe@example.com::https://oidc.example.com",
+			KeyType: signerverifier.FulcioKeyType,
+			Scheme:  signerverifier.FulcioKeyScheme,
+			KeyVal: sslibsv.KeyVal{
+				Identity: "jane.doe@example.com",
+				Issuer:   "https://oidc.example.com",
+			},
+		},
+	}
+
+	mainZeroZero := CreateTestPullRequestApprovalEnvelope(t, testRef, testID, testID, approvers)
+	featureZeroZero := CreateTestPullRequestApprovalEnvelope(t, testAnotherRef, testID, testID, approvers)
+
+	err := ValidatePullRequestApproval(mainZeroZero, testRef, testID, testID)
+	assert.Nil(t, err)
+
+	err = ValidatePullRequestApproval(featureZeroZero, testAnotherRef, testID, testID)
+	assert.Nil(t, err)
+
+	err = ValidatePullRequestApproval(mainZeroZero, testAnotherRef, testID, testID)
+	assert.ErrorIs(t, err, authorizationsv01.ErrInvalidAuthorization)
+}

--- a/internal/attestations/github/v01/pr.go
+++ b/internal/attestations/github/v01/pr.go
@@ -1,0 +1,48 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/go-github/v61/github"
+	ita "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	GitHubPullRequestPredicateType = "https://gittuf.dev/github-pull-request/v0.1"
+
+	digestGitCommitKey = "gitCommit"
+)
+
+func NewGitHubPullRequestAttestation(owner, repository string, pullRequestNumber int, commitID string, pullRequest *github.PullRequest) (*ita.Statement, error) {
+	pullRequestBytes, err := json.Marshal(pullRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	predicate := map[string]any{}
+	if err := json.Unmarshal(pullRequestBytes, &predicate); err != nil {
+		return nil, err
+	}
+
+	predicateStruct, err := structpb.NewStruct(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Uri:    fmt.Sprintf("https://github.com/%s/%s/pull/%d", owner, repository, pullRequestNumber),
+				Digest: map[string]string{digestGitCommitKey: commitID},
+			},
+		},
+		PredicateType: GitHubPullRequestPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}

--- a/internal/repository/attestations.go
+++ b/internal/repository/attestations.go
@@ -64,9 +64,18 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 		toID            gitinterface.Hash
 	)
 
+	isTag := false
+	if strings.HasPrefix(targetRef, gitinterface.TagRefPrefix) {
+		isTag = true
+	}
+
 	slog.Debug("Identifying current status of target Git reference...")
 	latestTargetEntry, _, err := rsl.GetLatestReferenceEntry(r.r, rsl.ForReference(targetRef))
 	if err == nil {
+		if isTag {
+			return fmt.Errorf("cannot approve a tag that already exists: %w", gitinterface.ErrTagAlreadyExists)
+		}
+
 		fromID = latestTargetEntry.TargetID
 	} else {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
@@ -84,12 +93,17 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 	}
 	featureCommitID = latestFeatureEntry.TargetID
 
-	slog.Debug("Computing expected merge tree...")
-	mergeTreeID, err := r.r.GetMergeTree(fromID, featureCommitID)
-	if err != nil {
-		return err
+	if isTag {
+		// for tags, the toID is the commitID the tag will point to
+		toID = featureCommitID
+	} else {
+		slog.Debug("Computing expected merge tree...")
+		mergeTreeID, err := r.r.GetMergeTree(fromID, featureCommitID)
+		if err != nil {
+			return err
+		}
+		toID = mergeTreeID
 	}
-	toID = mergeTreeID
 
 	slog.Debug("Loading current set of attestations...")
 	allAttestations, err := attestations.LoadCurrentAttestations(r.r)
@@ -110,7 +124,12 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 	if !hasAuthorization {
 		// Create a new reference authorization and embed in env
 		slog.Debug("Creating new reference authorization...")
-		statement, err := attestations.NewReferenceAuthorization(targetRef, fromID.String(), toID.String())
+		var statement *ita.Statement
+		if isTag {
+			statement, err = attestations.NewReferenceAuthorizationForTag(targetRef, fromID.String(), toID.String())
+		} else {
+			statement, err = attestations.NewReferenceAuthorizationForCommit(targetRef, fromID.String(), toID.String())
+		}
 		if err != nil {
 			return err
 		}
@@ -136,7 +155,10 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 		return err
 	}
 
-	commitMessage := fmt.Sprintf("Add reference authorization for '%s' from '%s' to '%s'", targetRef, fromID, toID)
+	commitMessage := fmt.Sprintf("Add reference authorization for '%s' from '%s' to '%s'", targetRef, fromID.String(), toID.String())
+	if isTag {
+		commitMessage = fmt.Sprintf("Add reference authorization for '%s' at '%s'", targetRef, toID.String())
+	}
 
 	slog.Debug("Committing attestations...")
 	return allAttestations.Commit(r.r, commitMessage, signCommit)

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -9,6 +9,9 @@ import (
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/attestations"
+	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
+	"github.com/gittuf/gittuf/internal/attestations/github"
+	githubv01 "github.com/gittuf/gittuf/internal/attestations/github/v01"
 	"github.com/gittuf/gittuf/internal/common"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
@@ -150,7 +153,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 	tests := map[string]struct {
 		envelope          *dsse.Envelope
-		expectedPredicate *attestations.GitHubPullRequestApprovalAttestation
+		expectedPredicate github.PullRequestApprovalAttestation
 	}{
 		"one approver, no dismissals": {
 			envelope: &dsse.Envelope{
@@ -163,7 +166,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 					},
 				},
 			},
-			expectedPredicate: &attestations.GitHubPullRequestApprovalAttestation{
+			expectedPredicate: &githubv01.GitHubPullRequestApprovalAttestation{
 				Approvers: []*tuf.Key{
 					{
 						KeyType: signerverifier.FulcioKeyType,
@@ -175,7 +178,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 						Scheme: signerverifier.FulcioKeyScheme,
 					},
 				},
-				ReferenceAuthorization: &attestations.ReferenceAuthorization{
+				ReferenceAuthorization: &authorizationsv01.ReferenceAuthorization{
 					FromRevisionID: "2f593e3195a59983423f45fe6d4335f148ffeecf",
 					TargetRef:      "refs/heads/main",
 					TargetTreeID:   "ee25b1b6c27862ea1cc419c144127123fd6f47d3",
@@ -193,7 +196,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 					},
 				},
 			},
-			expectedPredicate: &attestations.GitHubPullRequestApprovalAttestation{
+			expectedPredicate: &githubv01.GitHubPullRequestApprovalAttestation{
 				Approvers: []*tuf.Key{
 					{
 						KeyType: signerverifier.FulcioKeyType,
@@ -216,7 +219,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 						Scheme: signerverifier.FulcioKeyScheme,
 					},
 				},
-				ReferenceAuthorization: &attestations.ReferenceAuthorization{
+				ReferenceAuthorization: &authorizationsv01.ReferenceAuthorization{
 					FromRevisionID: "2f593e3195a59983423f45fe6d4335f148ffeecf",
 					TargetRef:      "refs/heads/main",
 					TargetTreeID:   "ee25b1b6c27862ea1cc419c144127123fd6f47d3",
@@ -234,7 +237,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 					},
 				},
 			},
-			expectedPredicate: &attestations.GitHubPullRequestApprovalAttestation{
+			expectedPredicate: &githubv01.GitHubPullRequestApprovalAttestation{
 				DismissedApprovers: []*tuf.Key{
 					{
 						KeyType: signerverifier.FulcioKeyType,
@@ -246,7 +249,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 						Scheme: signerverifier.FulcioKeyScheme,
 					},
 				},
-				ReferenceAuthorization: &attestations.ReferenceAuthorization{
+				ReferenceAuthorization: &authorizationsv01.ReferenceAuthorization{
 					FromRevisionID: "2f593e3195a59983423f45fe6d4335f148ffeecf",
 					TargetRef:      "refs/heads/main",
 					TargetTreeID:   "ee25b1b6c27862ea1cc419c144127123fd6f47d3",
@@ -264,7 +267,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 					},
 				},
 			},
-			expectedPredicate: &attestations.GitHubPullRequestApprovalAttestation{
+			expectedPredicate: &githubv01.GitHubPullRequestApprovalAttestation{
 				Approvers: []*tuf.Key{
 					{
 						KeyType: signerverifier.FulcioKeyType,
@@ -305,7 +308,7 @@ func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {
 						Scheme: signerverifier.FulcioKeyScheme,
 					},
 				},
-				ReferenceAuthorization: &attestations.ReferenceAuthorization{
+				ReferenceAuthorization: &authorizationsv01.ReferenceAuthorization{
 					FromRevisionID: "2f593e3195a59983423f45fe6d4335f148ffeecf",
 					TargetRef:      "refs/heads/main",
 					TargetTreeID:   "ee25b1b6c27862ea1cc419c144127123fd6f47d3",

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -6,6 +6,7 @@ package repository
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/attestations"
@@ -16,6 +17,7 @@ import (
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
@@ -25,129 +27,215 @@ import (
 func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 	t.Setenv(dev.DevModeKey, "1")
 
-	testDir := t.TempDir()
-	r := gitinterface.CreateTestGitRepository(t, testDir, false)
+	t.Run("for commits", func(t *testing.T) {
+		testDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, testDir, false)
 
-	// We meed to change the directory for this test because we `checkout`
-	// for older Git versions, modifying the worktree. This chdir ensures
-	// that the temporary directory is used as the worktree.
-	pwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(testDir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(pwd) //nolint:errcheck
+		// We meed to change the directory for this test because we `checkout`
+		// for older Git versions, modifying the worktree. This chdir ensures
+		// that the temporary directory is used as the worktree.
+		pwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(testDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(pwd) //nolint:errcheck
 
-	repo := &Repository{r: r}
+		repo := &Repository{r: r}
 
-	targetRef := "main"
-	absTargetRef := "refs/heads/main"
-	featureRef := "feature"
-	absFeatureRef := "refs/heads/feature"
+		targetRef := "main"
+		absTargetRef := "refs/heads/main"
+		featureRef := "feature"
+		absFeatureRef := "refs/heads/feature"
 
-	// Create common base for main and feature branches
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-	emptyTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	initialCommitID, err := repo.r.Commit(emptyTreeID, absTargetRef, "Initial commit\n", false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := repo.r.SetReference(absFeatureRef, initialCommitID); err != nil {
-		t.Fatal(err)
-	}
+		// Create common base for main and feature branches
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		initialCommitID, err := repo.r.Commit(emptyTreeID, absTargetRef, "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.r.SetReference(absFeatureRef, initialCommitID); err != nil {
+			t.Fatal(err)
+		}
 
-	// Create main branch as the target branch with a Git commit
-	// Add a single commit
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
-	fromCommitID := commitIDs[0]
-	if err := repo.RecordRSLEntryForReference(targetRef, false); err != nil {
-		t.Fatal(err)
-	}
+		// Create main branch as the target branch with a Git commit
+		// Add a single commit
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
+		fromCommitID := commitIDs[0]
+		if err := repo.RecordRSLEntryForReference(targetRef, false); err != nil {
+			t.Fatal(err)
+		}
 
-	// Create feature branch with two Git commits
-	// Add two commits
-	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
-	featureCommitID := commitIDs[1]
-	if err := repo.RecordRSLEntryForReference(featureRef, false); err != nil {
-		t.Fatal(err)
-	}
+		// Create feature branch with two Git commits
+		// Add two commits
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
+		featureCommitID := commitIDs[1]
+		if err := repo.RecordRSLEntryForReference(featureRef, false); err != nil {
+			t.Fatal(err)
+		}
 
-	targetTreeID, err := r.GetMergeTree(fromCommitID, featureCommitID)
-	if err != nil {
-		t.Fatal(err)
-	}
+		targetTreeID, err := r.GetMergeTree(fromCommitID, featureCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// Create signers
-	firstSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-	firstKeyID, err := firstSigner.KeyID()
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targetsKeyBytes) //nolint:staticcheck
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondKeyID, err := secondSigner.KeyID()
-	if err != nil {
-		t.Fatal(err)
-	}
+		// Create signers
+		firstSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+		if err != nil {
+			t.Fatal(err)
+		}
+		firstKeyID, err := firstSigner.KeyID()
+		if err != nil {
+			t.Fatal(err)
+		}
+		secondSigner, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(targetsKeyBytes) //nolint:staticcheck
+		if err != nil {
+			t.Fatal(err)
+		}
+		secondKeyID, err := secondSigner.KeyID()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// First authorization attestation signature
-	err = repo.AddReferenceAuthorization(testCtx, firstSigner, absTargetRef, absFeatureRef, false)
-	assert.Nil(t, err)
+		// First authorization attestation signature
+		err = repo.AddReferenceAuthorization(testCtx, firstSigner, absTargetRef, absFeatureRef, false)
+		assert.Nil(t, err)
 
-	allAttestations, err := attestations.LoadCurrentAttestations(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+		allAttestations, err := attestations.LoadCurrentAttestations(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	env, err := allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Len(t, env.Signatures, 1)
-	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
+		env, err := allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, env.Signatures, 1)
+		assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
 
-	// Second authorization attestation signature
-	err = repo.AddReferenceAuthorization(testCtx, secondSigner, absTargetRef, absFeatureRef, false)
-	assert.Nil(t, err)
+		// Second authorization attestation signature
+		err = repo.AddReferenceAuthorization(testCtx, secondSigner, absTargetRef, absFeatureRef, false)
+		assert.Nil(t, err)
 
-	allAttestations, err = attestations.LoadCurrentAttestations(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+		allAttestations, err = attestations.LoadCurrentAttestations(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Len(t, env.Signatures, 2)
-	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
-	assert.Equal(t, secondKeyID, env.Signatures[1].KeyID)
+		env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, env.Signatures, 2)
+		assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
+		assert.Equal(t, secondKeyID, env.Signatures[1].KeyID)
 
-	// Remove second authorization attestation signature
-	err = repo.RemoveReferenceAuthorization(testCtx, secondSigner, absTargetRef, fromCommitID.String(), targetTreeID.String(), false)
-	assert.Nil(t, err)
+		// Remove second authorization attestation signature
+		err = repo.RemoveReferenceAuthorization(testCtx, secondSigner, absTargetRef, fromCommitID.String(), targetTreeID.String(), false)
+		assert.Nil(t, err)
 
-	allAttestations, err = attestations.LoadCurrentAttestations(r)
-	if err != nil {
-		t.Fatal(err)
-	}
+		allAttestations, err = attestations.LoadCurrentAttestations(r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
-	if err != nil {
-		t.Fatal(err)
-	}
-	assert.Len(t, env.Signatures, 1)
-	assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
+		env, err = allAttestations.GetReferenceAuthorizationFor(r, absTargetRef, fromCommitID.String(), targetTreeID.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, env.Signatures, 1)
+		assert.Equal(t, firstKeyID, env.Signatures[0].KeyID)
+	})
+
+	t.Run("for tag", func(t *testing.T) {
+		testDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, testDir, false)
+
+		// We meed to change the directory for this test because we `checkout`
+		// for older Git versions, modifying the worktree. This chdir ensures
+		// that the temporary directory is used as the worktree.
+		pwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(testDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(pwd) //nolint:errcheck
+
+		repo := &Repository{r: r}
+
+		fromRef := "refs/heads/main"
+		targetTagRef := "refs/tags/v1"
+
+		// Create common base for main and feature branches
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		initialCommitID, err := repo.r.Commit(emptyTreeID, fromRef, "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.RecordRSLEntryForReference(fromRef, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create signer
+		signer, err := signerverifier.NewSignerVerifierFromSecureSystemsLibFormat(rootKeyBytes) //nolint:staticcheck
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyID, err := signer.KeyID()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = repo.AddReferenceAuthorization(testCtx, signer, targetTagRef, fromRef, false)
+		assert.Nil(t, err)
+
+		allAttestations, err := attestations.LoadCurrentAttestations(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+		assert.Nil(t, err)
+		assert.Len(t, env.Signatures, 1)
+		assert.Equal(t, keyID, env.Signatures[0].KeyID)
+
+		// Create tag
+		_, err = repo.r.TagUsingSpecificKey(initialCommitID, strings.TrimPrefix(targetTagRef, gitinterface.TagRefPrefix), "v1", artifacts.SSHRSAPrivate)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Add it to RSL
+		if err := repo.RecordRSLEntryForReference(targetTagRef, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Trying to approve it now fails as we're approving a tag already seen in the RSL
+		err = repo.AddReferenceAuthorization(testCtx, signer, targetTagRef, fromRef, false)
+		assert.ErrorIs(t, err, gitinterface.ErrTagAlreadyExists)
+
+		err = repo.RemoveReferenceAuthorization(testCtx, signer, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String(), false)
+		assert.Nil(t, err)
+
+		allAttestations, err = attestations.LoadCurrentAttestations(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+		assert.ErrorIs(t, err, attestations.ErrAuthorizationNotFound)
+	})
 }
 
 func TestGetGitHubPullRequestApprovalPredicateFromEnvelope(t *testing.T) {


### PR DESCRIPTION
The first commit restructures the attestations package (and dependents) to support multiple versions of attestation predicates simultaneously.


The second one builds on it to introduce v0.2 of the ref authorization predicate which better supports tag approvals.

Closes #554