### PR TITLE
ci: Don't run CI on changes to only docs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,12 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - "docs/**"
   schedule:
     - cron: '28 17 * * 6'
 permissions: read-all

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: ['main']
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
   pull_request:
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -3,13 +3,13 @@ on:
   push:
     branches: ['main']
     paths-ignore:
-      - "docs/*"
-      - "!docs/testing/*"
+      - "docs/**"
+      - "!docs/testing/**"
       - "!docs/get-started.md"
   pull_request:
     paths-ignore:
-      - "docs/*"
-      - "!docs/testing/*"
+      - "docs/**"
+      - "!docs/testing/**"
       - "!docs/get-started.md"
 permissions: read-all
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: ['main']
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
   pull_request:
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
 permissions: read-all
 jobs:
   golangci:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,6 +13,8 @@ on:
     - cron: '15 10 * * 3'
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - "docs/**"
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -3,10 +3,10 @@ on:
   push:
     branches: ["main"]
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
   pull_request:
     paths-ignore:
-      - "docs/*"
+      - "docs/**"
 permissions: read-all
 jobs:
   test:


### PR DESCRIPTION
This PR prevents most CI from running when there are only changes to the `docs` directory.

Turns out we needed to use `**` instead of just `*`: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet