### PR TITLE
policy, attestations: Add Searcher interfaces

### DIFF
--- a/internal/attestations/searcher.go
+++ b/internal/attestations/searcher.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+)
+
+var ErrAttestationsNotFound = errors.New("attestations not found")
+
+// Searcher defines the interface for identifying the applicable attestations
+// entry in the RSL for some entry.
+type Searcher interface {
+	FindAttestationsEntryFor(rsl.Entry) (*rsl.ReferenceEntry, error)
+}
+
+// RegularSearcher implements the Searcher interface. It walks back the RSL from
+// the specified entry to find the latest attestations entry.
+type RegularSearcher struct {
+	repo *gitinterface.Repository
+}
+
+func (r *RegularSearcher) FindAttestationsEntryFor(entry rsl.Entry) (*rsl.ReferenceEntry, error) {
+	// If the requested entry itself is for the attestations ref, return as is
+	if entry, isReferenceEntry := entry.(*rsl.ReferenceEntry); isReferenceEntry && entry.RefName == Ref {
+		slog.Debug(fmt.Sprintf("Initial entry '%s' is for attestations, setting that as current set of attestations...", entry.GetID().String()))
+		return entry, nil
+	}
+
+	attestationsEntry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(Ref), rsl.BeforeEntryID(entry.GetID()))
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			// Attestations may not be used yet, they're not
+			// compulsory
+			slog.Debug(fmt.Sprintf("No attestations found before initial entry '%s'", entry.GetID().String()))
+			return nil, ErrAttestationsNotFound
+		}
+
+		return nil, err
+	}
+
+	return attestationsEntry, nil
+}
+
+func NewRegularSearcher(repo *gitinterface.Repository) *RegularSearcher {
+	return &RegularSearcher{repo: repo}
+}

--- a/internal/attestations/searcher_test.go
+++ b/internal/attestations/searcher_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegularSearcher(t *testing.T) {
+	t.Run("attestations exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		attestations := &Attestations{}
+		if err := attestations.Commit(repo, "Initial attestations\n", false); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedAttestationsEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Add an entry after
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := NewRegularSearcher(repo)
+		attestationsEntry, err := searcher.FindAttestationsEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
+
+		// Try with annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, false, "Annotation\n").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		attestationsEntry, err = searcher.FindAttestationsEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
+
+		// Requested entry is annotations entry
+		if err := rsl.NewReferenceEntry(Ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err = rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		attestationsEntry, err = searcher.FindAttestationsEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, entry.GetID(), attestationsEntry.GetID())
+	})
+
+	t.Run("attestations do not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		// Add an entry after
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := NewRegularSearcher(repo)
+		attestationsEntry, err := searcher.FindAttestationsEntryFor(entry)
+		assert.ErrorIs(t, err, ErrAttestationsNotFound)
+		assert.Nil(t, attestationsEntry)
+	})
+}

--- a/internal/policy/searcher.go
+++ b/internal/policy/searcher.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+)
+
+// Searcher defines the interface for identifying the applicable policy entry in
+// the RSL for some entry.
+type Searcher interface {
+	FindPolicyEntryFor(rsl.Entry) (*rsl.ReferenceEntry, error)
+}
+
+// RegularSearcher implements the Searcher interface. It walks back the RSL from
+// the specified entry to find the latest policy entry.
+type RegularSearcher struct {
+	repo *gitinterface.Repository
+}
+
+func (r *RegularSearcher) FindPolicyEntryFor(entry rsl.Entry) (*rsl.ReferenceEntry, error) {
+	// If the requested entry itself is for the policy ref, return as is
+	if entry, isReferenceEntry := entry.(*rsl.ReferenceEntry); isReferenceEntry && entry.RefName == PolicyRef {
+		slog.Debug(fmt.Sprintf("Initial entry '%s' is for gittuf policy, setting that as current policy...", entry.GetID().String()))
+		return entry, nil
+	}
+
+	policyEntry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(PolicyRef), rsl.BeforeEntryID(entry.GetID()))
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			slog.Debug(fmt.Sprintf("No policy found before initial entry '%s'", entry.GetID().String()))
+			return nil, ErrPolicyNotFound
+		}
+
+		// Any other err must be returned
+		return nil, err
+	}
+
+	return policyEntry, nil
+}
+
+func NewRegularSearcher(repo *gitinterface.Repository) *RegularSearcher {
+	return &RegularSearcher{repo: repo}
+}

--- a/internal/policy/searcher_test.go
+++ b/internal/policy/searcher_test.go
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegularSearcher(t *testing.T) {
+	t.Run("policy exists", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithOnlyRoot)
+
+		expectedPolicyEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Add an entry after
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := NewRegularSearcher(repo)
+		policyEntry, err := searcher.FindPolicyEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
+
+		// Try with annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, false, "Annotation\n").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		policyEntry, err = searcher.FindPolicyEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
+
+		// Requested entry is annotations entry
+		if err := rsl.NewReferenceEntry(PolicyRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err = rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		policyEntry, err = searcher.FindPolicyEntryFor(entry)
+		assert.Nil(t, err)
+		assert.Equal(t, entry.GetID(), policyEntry.GetID())
+	})
+
+	t.Run("policy does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		// Add an entry after
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := NewRegularSearcher(repo)
+		policyEntry, err := searcher.FindPolicyEntryFor(entry)
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+		assert.Nil(t, policyEntry)
+	})
+}


### PR DESCRIPTION
This commit adds Searcher interfaces for the policy and attestations refs, which are used by VerifyRelativeForRef.