### PR TITLE
Vendor go-sslib/dsse and add support for setting a signature extension

### DIFF
--- a/internal/attestations/authorization.go
+++ b/internal/attestations/authorization.go
@@ -9,8 +9,8 @@ import (
 	"path"
 
 	"github.com/gittuf/gittuf/internal/gitinterface"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 const (

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/go-git/go-git/v5/plumbing"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/attestations/github.go
+++ b/internal/attestations/github.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/gitinterface"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/google/go-github/v61/github"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/internal/attestations/github_test.go
+++ b/internal/attestations/github_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -11,9 +11,9 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 var (

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -16,8 +16,8 @@ import (
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 const (

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -17,9 +17,9 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/common"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 var (

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/repository/attestations.go
+++ b/internal/repository/attestations.go
@@ -16,11 +16,11 @@ import (
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/google/go-github/v61/github"
 	ita "github.com/in-toto/attestation/go/v1"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 const (

--- a/internal/repository/attestations_test.go
+++ b/internal/repository/attestations_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/signerverifier"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/repository/root.go
+++ b/internal/repository/root.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 // InitializeRoot is the interface for the user to create the repository's root

--- a/internal/repository/root_test.go
+++ b/internal/repository/root_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/signerverifier"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/repository/targets.go
+++ b/internal/repository/targets.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 var ErrInvalidPolicyName = errors.New("invalid rule or policy file name, cannot be 'root'")

--- a/internal/signerverifier/dsse/dsse.go
+++ b/internal/signerverifier/dsse/dsse.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/gittuf/gittuf/internal/signerverifier/common"
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 )
 
 const PayloadType = "application/vnd.gittuf+json"

--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/third_party/go-securesystemslib/README.md
+++ b/internal/third_party/go-securesystemslib/README.md
@@ -1,5 +1,9 @@
 # Vendored secure-systems-lab/go-securesystemslib
 
+Issue: https://github.com/gittuf/gittuf/issues/266
+
+## signerverifier
+
 We have temporarily vendored go-securesystemslib's signerverifier package, a
 dependency we use for signature creation / verification workflows. The reason
 for this is to update go-securesystemslib with support for standard encoding
@@ -18,4 +22,9 @@ Note that @adityasaky, maintainer of gittuf, is also a maintainer of
 go-securesystemslib, and is part of the improvement effort. After it is
 complete, this copy will be taken out.
 
-Issue: https://github.com/gittuf/gittuf/issues/266
+## dsse
+
+The dsse package has also been vendored to experimentally add support for DSSE
+signature extensions. We're starting with support for Sigstore, and once we land
+on a reusable interface for extensions, we can upstream this to
+go-securesystemslib.

--- a/internal/third_party/go-securesystemslib/dsse/envelope.go
+++ b/internal/third_party/go-securesystemslib/dsse/envelope.go
@@ -1,0 +1,64 @@
+package dsse
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+/*
+Envelope captures an envelope as described by the DSSE specification. See here:
+https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
+*/
+type Envelope struct {
+	PayloadType string      `json:"payloadType"`
+	Payload     string      `json:"payload"`
+	Signatures  []Signature `json:"signatures"`
+}
+
+/*
+DecodeB64Payload returns the serialized body, decoded from the envelope's
+payload field. A flexible decoder is used, first trying standard base64, then
+URL-encoded base64.
+*/
+func (e *Envelope) DecodeB64Payload() ([]byte, error) {
+	return b64Decode(e.Payload)
+}
+
+/*
+Signature represents a generic in-toto signature that contains the identifier
+of the key which was used to create the signature.
+The used signature scheme has to be agreed upon by the signer and verifer
+out of band.
+The signature is a base64 encoding of the raw bytes from the signature
+algorithm.
+*/
+type Signature struct {
+	KeyID string `json:"keyid"`
+	Sig   string `json:"sig"`
+}
+
+/*
+PAE implementes the DSSE Pre-Authentic Encoding
+https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#signature-definition
+*/
+func PAE(payloadType string, payload []byte) []byte {
+	return []byte(fmt.Sprintf("DSSEv1 %d %s %d %s",
+		len(payloadType), payloadType,
+		len(payload), payload))
+}
+
+/*
+Both standard and url encoding are allowed:
+https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
+*/
+func b64Decode(s string) ([]byte, error) {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		b, err = base64.URLEncoding.DecodeString(s)
+		if err != nil {
+			return nil, fmt.Errorf("unable to base64 decode payload (is payload in the right format?)")
+		}
+	}
+
+	return b, nil
+}

--- a/internal/third_party/go-securesystemslib/dsse/envelope.go
+++ b/internal/third_party/go-securesystemslib/dsse/envelope.go
@@ -3,6 +3,8 @@ package dsse
 import (
 	"encoding/base64"
 	"fmt"
+
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 /*
@@ -33,8 +35,14 @@ The signature is a base64 encoding of the raw bytes from the signature
 algorithm.
 */
 type Signature struct {
-	KeyID string `json:"keyid"`
-	Sig   string `json:"sig"`
+	KeyID     string     `json:"keyid"`
+	Sig       string     `json:"sig"`
+	Extension *Extension `json:"extension,omitempty"`
+}
+
+type Extension struct {
+	Kind string           `json:"kind"`
+	Ext  *structpb.Struct `json:"ext"`
 }
 
 /*

--- a/internal/third_party/go-securesystemslib/dsse/sign.go
+++ b/internal/third_party/go-securesystemslib/dsse/sign.go
@@ -1,0 +1,85 @@
+/*
+Package dsse implements the Dead Simple Signing Envelope (DSSE)
+https://github.com/secure-systems-lab/dsse
+*/
+package dsse
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+)
+
+// ErrNoSigners indicates that no signer was provided.
+var ErrNoSigners = errors.New("no signers provided")
+
+// EnvelopeSigner creates signed Envelopes.
+type EnvelopeSigner struct {
+	providers []Signer
+}
+
+/*
+NewEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer algorithms to
+sign the data.
+*/
+func NewEnvelopeSigner(p ...Signer) (*EnvelopeSigner, error) {
+	var providers []Signer
+
+	for _, s := range p {
+		if s != nil {
+			providers = append(providers, s)
+		}
+	}
+
+	if len(providers) == 0 {
+		return nil, ErrNoSigners
+	}
+
+	return &EnvelopeSigner{
+		providers: providers,
+	}, nil
+}
+
+/*
+NewMultiEnvelopeSigner creates an EnvelopeSigner that uses 1+ Signer
+algorithms to sign the data. The threshold parameter is legacy and is ignored.
+
+Deprecated: This function simply calls NewEnvelopeSigner, and that function should
+be preferred.
+*/
+func NewMultiEnvelopeSigner(threshold int, p ...Signer) (*EnvelopeSigner, error) {
+	return NewEnvelopeSigner(p...)
+}
+
+/*
+SignPayload signs a payload and payload type according to DSSE.
+Returned is an envelope as defined here:
+https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
+One signature will be added for each Signer in the EnvelopeSigner.
+*/
+func (es *EnvelopeSigner) SignPayload(ctx context.Context, payloadType string, body []byte) (*Envelope, error) {
+	var e = Envelope{
+		Payload:     base64.StdEncoding.EncodeToString(body),
+		PayloadType: payloadType,
+	}
+
+	paeEnc := PAE(payloadType, body)
+
+	for _, signer := range es.providers {
+		sig, err := signer.Sign(ctx, paeEnc)
+		if err != nil {
+			return nil, err
+		}
+		keyID, err := signer.KeyID()
+		if err != nil {
+			keyID = ""
+		}
+
+		e.Signatures = append(e.Signatures, Signature{
+			KeyID: keyID,
+			Sig:   base64.StdEncoding.EncodeToString(sig),
+		})
+	}
+
+	return &e, nil
+}

--- a/internal/third_party/go-securesystemslib/dsse/signerverifier.go
+++ b/internal/third_party/go-securesystemslib/dsse/signerverifier.go
@@ -1,0 +1,43 @@
+package dsse
+
+import (
+	"context"
+	"crypto"
+)
+
+/*
+Signer defines the interface for an abstract signing algorithm. The Signer
+interface is used to inject signature algorithm implementations into the
+EnvelopeSigner. This decoupling allows for any signing algorithm and key
+management system can be used. The full message is provided as the parameter.
+If the signature algorithm depends on hashing of the message prior to signature
+calculation, the implementor of this interface must perform such hashing. The
+function must return raw bytes representing the calculated signature using the
+current algorithm, and the key used (if applicable).
+*/
+type Signer interface {
+	Sign(ctx context.Context, data []byte) ([]byte, error)
+	KeyID() (string, error)
+}
+
+/*
+Verifier verifies a complete message against a signature and key. If the message
+was hashed prior to signature generation, the verifier must perform the same
+steps. If KeyID returns successfully, only signature matching the key ID will be
+verified.
+*/
+type Verifier interface {
+	Verify(ctx context.Context, data, sig []byte) error
+	KeyID() (string, error)
+	Public() crypto.PublicKey
+}
+
+// SignerVerifier provides both the signing and verification interface.
+type SignerVerifier interface {
+	Signer
+	Verifier
+}
+
+// Deprecated: switch to renamed SignerVerifier. This is currently aliased for
+// backwards compatibility.
+type SignVerifier = SignerVerifier

--- a/internal/third_party/go-securesystemslib/dsse/signerverifier.go
+++ b/internal/third_party/go-securesystemslib/dsse/signerverifier.go
@@ -3,6 +3,8 @@ package dsse
 import (
 	"context"
 	"crypto"
+
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 /*
@@ -30,6 +32,11 @@ type Verifier interface {
 	Verify(ctx context.Context, data, sig []byte) error
 	KeyID() (string, error)
 	Public() crypto.PublicKey
+}
+
+type SupportsSignatureExtension interface {
+	SetExtension(*structpb.Struct)
+	ExpectedExtensionKind() string
 }
 
 // SignerVerifier provides both the signing and verification interface.

--- a/internal/third_party/go-securesystemslib/dsse/verify.go
+++ b/internal/third_party/go-securesystemslib/dsse/verify.go
@@ -1,0 +1,139 @@
+package dsse
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// ErrNoSignature indicates that an envelope did not contain any signatures.
+var ErrNoSignature = errors.New("no signature found")
+
+type EnvelopeVerifier struct {
+	providers []Verifier
+	threshold int
+}
+
+type AcceptedKey struct {
+	Public crypto.PublicKey
+	KeyID  string
+	Sig    Signature
+}
+
+func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]AcceptedKey, error) {
+	if e == nil {
+		return nil, errors.New("cannot verify a nil envelope")
+	}
+
+	if len(e.Signatures) == 0 {
+		return nil, ErrNoSignature
+	}
+
+	// Decode payload (i.e serialized body)
+	body, err := e.DecodeB64Payload()
+	if err != nil {
+		return nil, err
+	}
+	// Generate PAE(payloadtype, serialized body)
+	paeEnc := PAE(e.PayloadType, body)
+
+	// If *any* signature is found to be incorrect, it is skipped
+	var acceptedKeys []AcceptedKey
+	usedKeyids := make(map[string]string)
+	unverified_providers := make([]Verifier, len(ev.providers))
+	copy(unverified_providers, ev.providers)
+	for _, s := range e.Signatures {
+		sig, err := b64Decode(s.Sig)
+		if err != nil {
+			return nil, err
+		}
+
+		// Loop over the providers.
+		// If provider and signature include key IDs but do not match skip.
+		// If a provider recognizes the key, we exit
+		// the loop and use the result.
+		providers := unverified_providers
+		for i, v := range providers {
+			keyID, err := v.KeyID()
+
+			// Verifiers that do not provide a keyid will be generated one using public.
+			if err != nil || keyID == "" {
+				keyID, err = SHA256KeyID(v.Public())
+				if err != nil {
+					keyID = ""
+				}
+			}
+
+			if s.KeyID != "" && keyID != "" && err == nil && s.KeyID != keyID {
+				continue
+			}
+
+			err = v.Verify(ctx, paeEnc, sig)
+			if err != nil {
+				continue
+			}
+
+			acceptedKey := AcceptedKey{
+				Public: v.Public(),
+				KeyID:  keyID,
+				Sig:    s,
+			}
+			unverified_providers = removeIndex(providers, i)
+
+			// See https://github.com/in-toto/in-toto/pull/251
+			if _, ok := usedKeyids[keyID]; ok {
+				fmt.Printf("Found envelope signed by different subkeys of the same main key, Only one of them is counted towards the step threshold, KeyID=%s\n", keyID)
+				continue
+			}
+
+			usedKeyids[keyID] = ""
+			acceptedKeys = append(acceptedKeys, acceptedKey)
+			break
+		}
+	}
+
+	// Sanity if with some reflect magic this happens.
+	if ev.threshold <= 0 || ev.threshold > len(ev.providers) {
+		return nil, errors.New("invalid threshold")
+	}
+
+	if len(usedKeyids) < ev.threshold {
+		return acceptedKeys, fmt.Errorf("accepted signatures do not match threshold, Found: %d, Expected %d", len(acceptedKeys), ev.threshold)
+	}
+
+	return acceptedKeys, nil
+}
+
+func NewEnvelopeVerifier(v ...Verifier) (*EnvelopeVerifier, error) {
+	return NewMultiEnvelopeVerifier(1, v...)
+}
+
+func NewMultiEnvelopeVerifier(threshold int, p ...Verifier) (*EnvelopeVerifier, error) {
+	if threshold <= 0 || threshold > len(p) {
+		return nil, errors.New("invalid threshold")
+	}
+
+	ev := EnvelopeVerifier{
+		providers: p,
+		threshold: threshold,
+	}
+
+	return &ev, nil
+}
+
+func SHA256KeyID(pub crypto.PublicKey) (string, error) {
+	// Generate public key fingerprint
+	sshpk, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+	fingerprint := ssh.FingerprintSHA256(sshpk)
+	return fingerprint, nil
+}
+
+func removeIndex(v []Verifier, index int) []Verifier {
+	return append(v[:index], v[index+1:]...)
+}

--- a/internal/third_party/go-securesystemslib/dsse/verify.go
+++ b/internal/third_party/go-securesystemslib/dsse/verify.go
@@ -71,6 +71,13 @@ func (ev *EnvelopeVerifier) Verify(ctx context.Context, e *Envelope) ([]Accepted
 				continue
 			}
 
+			if v, supportsSignatureExtension := v.(SupportsSignatureExtension); supportsSignatureExtension {
+				if s.Extension == nil || s.Extension.Kind != v.ExpectedExtensionKind() {
+					continue
+				}
+				v.SetExtension(s.Extension.Ext)
+			}
+
 			err = v.Verify(ctx, paeEnc, sig)
 			if err != nil {
 				continue

--- a/internal/third_party/go-securesystemslib/signerverifier/signerverifier.go
+++ b/internal/third_party/go-securesystemslib/signerverifier/signerverifier.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 )
 
 var KeyIDHashAlgorithms = []string{"sha256", "sha512"}

--- a/internal/tuf/tuf_test.go
+++ b/internal/tuf/tuf_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
-	sslibdsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This PR prepares #524 by vendoring the dsse library and adding support for signature extensions.