### PR TITLE
Use signerverifier/ssh for git signing / verifying

### DIFF
--- a/internal/gitinterface/commit.go
+++ b/internal/gitinterface/commit.go
@@ -176,14 +176,14 @@ func (r *Repository) verifyCommitSignature(ctx context.Context, commitID Hash, k
 		}
 
 		return nil
-	case signerverifier.RSAKeyType, signerverifier.ECDSAKeyType, signerverifier.ED25519KeyType, ssh.SSHKeyType:
+	case ssh.SSHKeyType:
 		commitContents, err := getCommitBytesWithoutSignature(commit)
 		if err != nil {
 			return errors.Join(ErrVerifyingSSHSignature, err)
 		}
 		commitSignature := []byte(commit.PGPSignature)
 
-		if err := verifySSHKeySignature(key, commitContents, commitSignature); err != nil {
+		if err := verifySSHKeySignature(ctx, key, commitContents, commitSignature); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 

--- a/internal/gitinterface/tag.go
+++ b/internal/gitinterface/tag.go
@@ -120,14 +120,14 @@ func (r *Repository) verifyTagSignature(ctx context.Context, tagID Hash, key *tu
 		}
 
 		return nil
-	case signerverifier.RSAKeyType, signerverifier.ECDSAKeyType, signerverifier.ED25519KeyType, ssh.SSHKeyType:
+	case ssh.SSHKeyType:
 		tagContents, err := getTagBytesWithoutSignature(tag)
 		if err != nil {
 			return errors.Join(ErrVerifyingSSHSignature, err)
 		}
 		tagSignature := []byte(tag.PGPSignature)
 
-		if err := verifySSHKeySignature(key, tagContents, tagSignature); err != nil {
+		if err := verifySSHKeySignature(ctx, key, tagContents, tagSignature); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 

--- a/internal/signerverifier/signerverifier.go
+++ b/internal/signerverifier/signerverifier.go
@@ -6,19 +6,14 @@ package signerverifier
 import (
 	"github.com/gittuf/gittuf/internal/signerverifier/common"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
-	sslibsv "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/signerverifier"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
 
 const (
-	ED25519KeyType  = sslibsv.ED25519KeyType
-	ECDSAKeyType    = sslibsv.ECDSAKeyType
-	RSAKeyType      = sslibsv.RSAKeyType
 	GPGKeyType      = "gpg"
 	FulcioKeyType   = "sigstore-oidc"
 	FulcioKeyScheme = "fulcio"
-	RekorServer     = "https://rekor.sigstore.dev"
 )
 
 // NewSignerVerifierFromTUFKey returns a verifier for RSA, ED25519, and ECDSA
@@ -26,13 +21,7 @@ const (
 //
 // Deprecated: Switch to upstream key loading APIs.
 func NewSignerVerifierFromTUFKey(key *tuf.Key) (dsse.Verifier, error) {
-	switch key.KeyType {
-	case ED25519KeyType:
-		return sslibsv.NewED25519SignerVerifierFromSSLibKey(key)
-	case ECDSAKeyType:
-		return sslibsv.NewECDSASignerVerifierFromSSLibKey(key)
-	case RSAKeyType:
-		return sslibsv.NewRSAPSSSignerVerifierFromSSLibKey(key)
+	switch key.KeyType { //nolint:gocritic
 	case ssh.SSHKeyType:
 		return ssh.NewVerifierFromKey(key)
 	}


### PR DESCRIPTION
Closes #448 

I ran into an import cycle when I was trying something and decided to change this. Signing flow needs changing still, and possibly careful testing to ensure we're compatible.

Edit: I don't know if we want to change the signing flow: we're working off key bytes and it's used more for tests at the moment.