### PR TITLE
build: Update Makefile to work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,28 @@ LDFLAGS=-buildid= -X github.com/gittuf/gittuf/internal/version.gitVersion=$(GIT_
 default : install
 
 build : test
+ifeq ($(OS),Windows_NT)
+	set CGO_ENABLED=0
+	go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
+	go build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
+	set CGO_ENABLED=
+else
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
+endif
 
 install : test just-install
 
 just-install :
+ifeq ($(OS),Windows_NT)
+	set CGO_ENABLED=0
+	go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
+	go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
+	set CGO_ENABLED=
+else
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
+endif
 
 test :
 	go test -timeout 20m -v ./...


### PR DESCRIPTION
This PR fixes building from source on Windows platforms, by changing how the `CGO_ENABLED` var is set. 