### PR TITLE
cmd: Drop devmode requirement for root and policy thresholds

### DIFF
--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -33,6 +33,6 @@ Tools for gittuf's root of trust
 * [gittuf trust remove-policy-key](gittuf_trust_remove-policy-key.md)	 - Remove Policy key from gittuf root of trust
 * [gittuf trust remove-root-key](gittuf_trust_remove-root-key.md)	 - Remove Root key from gittuf root of trust
 * [gittuf trust sign](gittuf_trust_sign.md)	 - Sign root of trust
-* [gittuf trust update-policy-threshold](gittuf_trust_update-policy-threshold.md)	 - Update Policy threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
-* [gittuf trust update-root-threshold](gittuf_trust_update-root-threshold.md)	 - Update Root threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust update-policy-threshold](gittuf_trust_update-policy-threshold.md)	 - Update Policy threshold in the gittuf root of trust
+* [gittuf trust update-root-threshold](gittuf_trust_update-root-threshold.md)	 - Update Root threshold in the gittuf root of trust
 

--- a/docs/cli/gittuf_trust_update-policy-threshold.md
+++ b/docs/cli/gittuf_trust_update-policy-threshold.md
@@ -1,13 +1,10 @@
 ## gittuf trust update-policy-threshold
 
-Update Policy threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+Update Policy threshold in the gittuf root of trust
 
 ### Synopsis
 
 This command allows users to update the threshold of valid signatures required for the policy.
-
-DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
-Until then, this command is available in developer mode only, set GITTUF_DEV=1 to use.
 
 ```
 gittuf trust update-policy-threshold [flags]

--- a/docs/cli/gittuf_trust_update-root-threshold.md
+++ b/docs/cli/gittuf_trust_update-root-threshold.md
@@ -1,13 +1,10 @@
 ## gittuf trust update-root-threshold
 
-Update Root threshold in the gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+Update Root threshold in the gittuf root of trust
 
 ### Synopsis
 
 This command allows users to update the threshold of valid signatures required for the root of trust.
-
-DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
-Until then, this command is available in developer mode only, set GITTUF_DEV=1 to use.
 
 ```
 gittuf trust update-root-threshold [flags]

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -4,11 +4,8 @@
 package updatepolicythreshold
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
 )
@@ -29,10 +26,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err
@@ -49,12 +42,9 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "update-policy-threshold",
-		Short: fmt.Sprintf("Update Policy threshold in the gittuf root of trust (developer mode only, set %s=1)", dev.DevModeKey),
-		Long: fmt.Sprintf(`This command allows users to update the threshold of valid signatures required for the policy.
-
-DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
-Until then, this command is available in developer mode only, set %s=1 to use.`, dev.DevModeKey),
+		Use:     "update-policy-threshold",
+		Short:   "Update Policy threshold in the gittuf root of trust",
+		Long:    "This command allows users to update the threshold of valid signatures required for the policy.",
 		PreRunE: common.CheckIfSigningViableWithFlag,
 		RunE:    o.Run,
 	}

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
@@ -4,11 +4,8 @@
 package updaterootthreshold
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/repository"
 	"github.com/spf13/cobra"
 )
@@ -29,10 +26,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err
@@ -49,12 +42,9 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "update-root-threshold",
-		Short: fmt.Sprintf("Update Root threshold in the gittuf root of trust (developer mode only, set %s=1)", dev.DevModeKey),
-		Long: fmt.Sprintf(`This command allows users to update the threshold of valid signatures required for the root of trust.
-
-DO NOT USE until policy-staging is working, so that multiple developers can sequentially sign the policy metadata.
-Until then, this command is available in developer mode only, set %s=1 to use.`, dev.DevModeKey),
+		Use:     "update-root-threshold",
+		Short:   "Update Root threshold in the gittuf root of trust",
+		Long:    "This command allows users to update the threshold of valid signatures required for the root of trust.",
 		PreRunE: common.CheckIfSigningViableWithFlag,
 		RunE:    o.Run,
 	}


### PR DESCRIPTION
This PR removes the devmode requirement for updating the thresholds for the root of trust and policy.