### PR TITLE
transport: Handle explicit refs/gittuf fetches

### DIFF
--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -209,6 +209,17 @@ func handleCurl(repo *repository.Repository, remoteName, url string) (map[string
 						wroteGittufWants = true
 					}
 					wroteWants = true
+				} else {
+					for ref, tip := range gittufRefsTips {
+						wantCmd := fmt.Sprintf("want %s", tip)
+						if bytes.Contains(input, []byte(wantCmd)) {
+							// Take out this ref as
+							// something for us to
+							// update or add wants
+							// for
+							delete(gittufRefsTips, ref)
+						}
+					}
 				}
 
 				if _, err := helperStdIn.Write(input); err != nil {
@@ -247,6 +258,17 @@ func handleCurl(repo *repository.Repository, remoteName, url string) (map[string
 							input = stdInScanner.Bytes()
 							if len(input) == 0 {
 								break
+							}
+
+							for ref, tip := range gittufRefsTips {
+								wantCmd := fmt.Sprintf("want %s", tip)
+								if bytes.Contains(input, []byte(wantCmd)) {
+									// Take out this ref as
+									// something for us to
+									// update or add wants
+									// for
+									delete(gittufRefsTips, ref)
+								}
 							}
 
 							// Having scanned already, we must write prior

--- a/internal/git-remote-gittuf/main.go
+++ b/internal/git-remote-gittuf/main.go
@@ -167,7 +167,9 @@ func run() error {
 				return err
 			}
 			if err := repo.GetGitRepository().SetReference(ref, tipH); err != nil {
-				return err
+				msg := fmt.Sprintf("Unable to set reference '%s': '%s'", ref, err.Error())
+				log(msg)
+				os.Stderr.Write([]byte(fmt.Sprintf("git-remote-gittuf: %s\n", msg))) //nolint:errcheck
 			}
 		}
 

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -316,6 +316,17 @@ func handleSSH(repo *repository.Repository, remoteName, url string) (map[string]
 						wroteGittufWants = true
 					}
 					wroteWants = true
+				} else {
+					for ref, tip := range gittufRefsTips {
+						wantCmd := fmt.Sprintf("want %s", tip)
+						if bytes.Contains(input, []byte(wantCmd)) {
+							// Take out this ref as
+							// something for us to
+							// update or add wants
+							// for
+							delete(gittufRefsTips, ref)
+						}
+					}
 				}
 
 				if _, err := helperStdIn.Write(input); err != nil {


### PR DESCRIPTION
If we see a `want <>` statement for a gittuf ref, we now know:
a) not to request it ourselves (not really a problem if we do but cleaner)
b) not to update the ref using a set-reference after the fetch is complete since our caller will handle it for us

This gets rid of pesky errors but isn't perfect when two gittuf refs have the same ID but the user requests only one. We skip updating both refs but overall we can probably make it easier with another sync command for folks to use when they're actually updating gittuf policy etc.