### PR TITLE
release: Add transport to goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,28 @@ builds:
   - "-extldflags=-znow"
   - "-buildid= -X github.com/gittuf/gittuf/internal/version.gitVersion={{ .Version }}"
 
+- id: git-remote-gittuf
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  main: ./internal/git-remote-gittuf
+  binary: git-remote-gittuf
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  goos:
+  - linux
+  - darwin
+  - freebsd
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ldflags:
+  - "-s -w"
+  - "-extldflags=-zrelro"
+  - "-extldflags=-znow"
+  - "-buildid= -X github.com/gittuf/gittuf/internal/version.gitVersion={{ .Version }}"
+
 archives:
 - id: binary
   format: binary

--- a/internal/git-remote-gittuf/README.md
+++ b/internal/git-remote-gittuf/README.md
@@ -18,13 +18,16 @@ takes care of the following common operations for you:
 
 The gittuf transport supports both HTTPS and SSH remotes.
 
-## How to Obtain
+## How to Install
 
-Currently, the transport must be built from source. Running `go install` will
-compile the transport and place it in your `GOBIN`, which is the same location
-that the `gittuf` binary is installed into. As it matures, we will update our
-release configuration and the packaging of gittuf (e.g., on Homebrew) to include
-this binary.
+This repository provides pre-built binaries for the transport that are signed
+and published using [GoReleaser]. The signature for these binaries are generated
+using [Sigstore], using the release workflow's identity. Refer to the
+instructions in the [get started guide] to verify the signature for the
+transport binary.
+
+Alternatively, the transport can be built from source. Running `go install` will
+compile the transport and place it in your `GOBIN`.
 
 ## How to Use
 
@@ -52,3 +55,7 @@ git remote set-url origin gittuf::git@github.com:gittuf/gittuf
 # For HTTPS
 git remote set-url origin gittuf::https://github.com/gittuf/gittuf
 ```
+
+[Sigstore]: https://www.sigstore.dev/
+[GoReleaser]: https://goreleaser.com/
+[get started guide]: /docs/get-started.md


### PR DESCRIPTION
Add git-remote-gittuf to releaser. We don't need to add it to brew install just yet, but it'll make piloting the transport easier with folks who don't work with Go / have older OS-es with versions of Go we can't use.