### PR TITLE
add commit command to cmd.go and main.go

### DIFF
--- a/internal/gittuf-git/cmd/cmd.go
+++ b/internal/gittuf-git/cmd/cmd.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -56,19 +57,74 @@ func PullOrFetch(gitArgs args.Args) error {
 		return err
 	}
 
-	// Pull RSL changes
-	remote := args.DetermineRemote(gitArgs.Parameters)
+	RSLcmdArgs := []string{gitArgs.Command, gitArgs.Parameters[0]}
+	RSLcmdArgs = append(RSLcmdArgs, "refs/gittuf/reference-state-log")
+	fmt.Println(RSLcmdArgs)
+	gitPullRSLCmd := exec.Command("git", RSLcmdArgs...)
+	gitPullRSLCmd.Stdout = os.Stdout
+	gitPullRSLCmd.Stderr = os.Stderr
+
+	if err := gitPullRSLCmd.Run(); err != nil {
+		return err
+	}
+
+	policyCmdArgs := []string{gitArgs.Command, gitArgs.Parameters[0]}
+	policyCmdArgs = append(policyCmdArgs, "refs/gittuf/policy")
+	gitPullPolicyCmd := exec.Command("git", policyCmdArgs...)
+	gitPullPolicyCmd.Stdout = os.Stdout
+	gitPullPolicyCmd.Stderr = os.Stderr
+
+	// Pull policy changes
+	return gitPullRSLCmd.Run()
+}
+
+// Commit handles the commit operation for gittuf + git
+func Commit(gitArgs args.Args) error {
+	if gitArgs.ChdirIdx > 0 {
+		if err := os.Chdir(gitArgs.GlobalFlags[gitArgs.ChdirIdx]); err != nil {
+			return err
+		}
+	}
+
+	// verify policy
 	repo, err := repository.LoadRepository()
 	if err != nil {
 		return err
 	}
 
-	if err := repo.PullRSL(remote); err != nil {
+	var refName string
+	if len(gitArgs.Parameters) > 1 {
+		refParts := strings.Split(gitArgs.Parameters[1], ":")
+		if len(refParts) > 0 {
+			refName = refParts[0]
+		} else {
+			refName = gitArgs.Parameters[1]
+		}
+	} else {
+		refName = "HEAD"
+	}
+
+	if err = repo.VerifyRef(context.Background(), refName); err != nil {
+		fmt.Println("Verification unsuccessful with error: ", err)
+	} else {
+		fmt.Println("Verification success")
+	}
+
+	// Commit irrespective of failed verification. However, verification is
+	// important for debugging purposes. The user should be able to keep
+	// track of whether and why verification is failing.
+	cmdArgs := []string{gitArgs.Command}
+	cmdArgs = append(cmdArgs, gitArgs.Parameters...)
+	// TODO: Make this more robust in case of symlinks to git
+	gitPushCmd := exec.Command("git", cmdArgs...)
+	gitPushCmd.Stdout = os.Stdout
+	gitPushCmd.Stderr = os.Stderr
+
+	if err := gitPushCmd.Run(); err != nil {
 		return err
 	}
 
-	// Pull policy changes
-	return repo.PullPolicy(remote)
+	return nil
 }
 
 // Push handles the push operation for gittuf + git

--- a/internal/gittuf-git/main.go
+++ b/internal/gittuf-git/main.go
@@ -55,6 +55,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
 			os.Exit(1)
 		}
+	case gitArgs.Command == "commit":
+		err := cmd.Commit(gitArgs)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		}
 	case gitArgs.Command == "push":
 		err := cmd.Push(gitArgs)
 		if err != nil {


### PR DESCRIPTION
Added the Commit command for gittuf-git command compatibility, and changed the working of the `PullOrFetch` command to use `git` calls from the command line instead of being reliant on gittuf packages (made it more gittuf independent)

`Commit` calles `VerifyRef` before actually committing, and prints out verification status, but the Commit happens regardless of whether the verification was successful or not.