### PR TITLE
ci: Don't run most of CI on changes to Markdown files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
     branches: ['main']
     paths-ignore:
       - "docs/*"
+      - "**.md"
   pull_request:
     paths-ignore:
       - "docs/*"
+      - "**.md"
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,10 +16,12 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - "docs/**"
+      - "**.md"
   pull_request:
     branches: [ "main" ]
     paths-ignore:
       - "docs/**"
+      - "**.md"
   schedule:
     - cron: '28 17 * * 6'
 permissions: read-all

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,9 +4,11 @@ on:
     branches: ['main']
     paths-ignore:
       - "docs/**"
+      - "**.md"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "**.md"
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -6,11 +6,13 @@ on:
       - "docs/**"
       - "!docs/testing/**"
       - "!docs/get-started.md"
+      - "*.md"
   pull_request:
     paths-ignore:
       - "docs/**"
       - "!docs/testing/**"
       - "!docs/get-started.md"
+      - "*.md"
 permissions: read-all
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,11 @@ on:
     branches: ['main']
     paths-ignore:
       - "docs/**"
+      - "**.md"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "**.md"
 permissions: read-all
 jobs:
   golangci:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,6 +15,7 @@ on:
     branches: [ "main" ]
     paths-ignore:
       - "docs/**"
+      - "**.md"
 
 # Declare default permissions as read only.
 permissions: read-all

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -4,9 +4,11 @@ on:
     branches: ["main"]
     paths-ignore:
       - "docs/**"
+      - "**.md"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "**.md"
 permissions: read-all
 jobs:
   test:


### PR DESCRIPTION
This PR prevents triggering most of CI on changes to only Markdown files.