### PR TITLE
gitignore: Ignore vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/*
 *.prof
+vendor*


### PR DESCRIPTION
I sometimes vendor via `go mod vendor` when I need to debug something. I don't want to accidentally check it in...