### PR TITLE
docs: Add app / code review tool attestations

### DIFF
--- a/docs/gaps/5/README.md
+++ b/docs/gaps/5/README.md
@@ -1,0 +1,233 @@
+# Principals, not Keys
+
+## Metadata
+
+* **Number:** 5
+* **Title:** Principals, not Keys
+* **Implemented:** No
+* **Withdrawn/Rejected:** No
+* **Sponsors:** Aditya Sirish A Yelgundhalli (adityasaky)
+* **Last Modified:** March 25, 2025
+
+## Abstract
+
+gittuf's policy, like TUF metadata that it is inspired by, assumes that all
+actors are [represented by their signing keys](/docs/design-document.md#actors).
+This assumption leads to usability problems in Git development in contrast to
+traditional TUF deployments in packaging ecosystems and the like.
+
+## Motivation
+
+There are more contexts where a developer may sign in a Git repository protected
+by gittuf compared to a standard TUF deployment. Developers may contribute code
+from different devices or cloud based IDEs that have distinct signing keys. The
+current gittuf policy would represent these different signing keys as
+independent actors, making policy misconfigurations that allow a developer to
+meet a threshold using multiple keys they control more likely.
+
+Additionally, as gittuf may integrate multiple systems (a code forge like
+GitHub, a code review tool like Gerrit), the policy ought to be able to track a
+developer's identity across all of these systems. Doing so would reduce
+cognitive overload for maintainers who manage policies, and would enable
+integrating into metadata such as in-toto attestations produced by these other
+systems.
+
+## Specification
+
+This GAP introduces the notion of a generic "principal". A principal can be a
+single key or a more complex entity that contains more than one signing key and
+other custom metadata. A principal has the following attributes:
+* ID: A unique identifier for the principal
+* Keys: A set of public keys that can be used to verify signatures, no
+  duplicates are allowed
+* CustomMetadata: Additional custom metadata that must be associated with the
+  principal
+
+Additionally, this GAP introduces the first new principal type, to represent a
+"person". A "person" has the following schema:
+
+```
+"<id>": {
+    "personID": "<id>",
+    "publicKeys": {
+        "<keyID1>": {
+            "keyid": "<keyID1>",
+            "keyid_hash_algorithms": null,
+            "keytype": "sigstore-oidc",
+            "keyval": {
+                "identity": "<username>",
+                "issuer": "<issuer>"
+            },
+            "scheme": "fulcio"
+          },
+        "<keyid2>>": ...
+    },
+    "associatedIdentities": {
+        "<integrationID1>": "<usernameA>",
+        "<integrationID2>": "<usernameB>",
+        ...
+    }
+    "customMetadata": {...}
+}
+```
+
+Here, `personID` can be set to any unique (within the policy) identifier of a
+person such as their name or email address, similar to
+[TAP-12](https://github.com/theupdateframework/taps/blob/master/tap12.md). Each
+key associated with a person follows the schema already used by keys in gittuf's
+policy today. `associatedIdentities` records the person's identity on
+integrations. Finally, `customMetadata` allows for recording arbitrary
+attributes with each person for further extensibility. To meet the generic
+principal schema, the person type considers a combination of `customMetadata`
+and `associatedIdentities` as the principal's custom metadata.
+
+Here is an example person using this schema:
+
+```
+"aditya@example.com": {
+    "personID": "aditya@example.com",
+    "publicKeys": {
+        "B83110D012545604": {
+            "keyid": "B83110D012545604",
+            "keytype": "gpg",
+            "keyval": {
+                "public": "<pubkey>"
+            },
+            "scheme": "gpg"
+        },
+        "aditya@example.com::https://github.com/login/oauth": {
+            "keyid": "aditya@example.com::https://github.com/login/oauth",
+            "keytype": "sigstore-oidc",
+            "keyval": {
+                "identity": "aditya@example.com",
+                "issuer": "https://github.com/login/oauth"
+            },
+            "scheme": "fulcio"
+        },
+    },
+    "associatedIdentities": {
+        "https://github.com": "adityasaky+8928778",
+    }
+    "customMetadata": {}
+}
+```
+
+Each associated identity SHOULD be recorded with an immutable value. For
+example, some source control platforms allow a user to change their username,
+with the old username up for grabs for another user to claim. Here, the username
+alone is insufficient to identify the user uniquely. In the example above,
+`8928778` is a unique identifier on github.com that does not change even if the
+username is updated. For readability, the associated identity includes both the
+usename and the unchanging ID, with only the latter ensuring uniqueness.
+
+### Updating Principal Definitions
+
+When dealing directly with keys, a delegating entity must update their
+delegation when a developer must rotate their key. With principals, this remains
+the same. If `Alice` delegates to the `Bob` person in a delegation, if Bob
+updates his keys, then `Alice` must update her definition for `Bob`.
+
+See [Security](#security) for considerations with frequent updates to principal
+definitions.
+
+### Using Principal Keys For Verification
+
+During the verification workflow, each principal trusted for the specified path
+must be examined to see if they are to be counted towards the threshold. This is
+very similar to the existing verification workflow where each key is examined,
+and is in fact identical when the principal is a single key.
+
+For multiple-key principals, every key associated with the principal must be
+used to verify the signature. Even if the principal has issued multiple
+signatures using their keys, they must only be counted once towards the
+threshold.
+
+While the keys associated with a principal are unique, it's possible that
+multiple principals have the same key associated with them. For example, due to
+a misconfiguration, the policy may indicate that both Bob and Carol use key
+`abcdef`. A signature from this key MUST only count towards the threshold once.
+If the key was encountered via Bob, then in addition to counting Bob towards the
+threshold, the key must also be marked as used, so it's not trusted when the
+verification workflow checks Carol's keys.
+
+## Reasoning
+
+As noted in the [Motivation](#motivation), gittuf's deployment scenarios
+necessitate knowing more about a developer to support flexibility. The approach
+employed in this GAP is to support grouping multiple keys as a single actor, as
+well as associating other metadata with the actor. The generic principal type
+can be expanded in other ways: for now, it supports single keys and persons.
+However, this can be expanded to support other special entities such as bots.
+The principal type can also be used to represent a group of principals. For
+example, a team principal type can be defined to represent a group of
+developers, each defined using a person principal type.
+
+While this proposal introduces some complexity in gittuf's verification
+workflows (see [Security](#security)), the alternative is to move the complexity
+to repository maintainers who author policies, and have to reason about how to
+handle multiple keys for a single developer.
+
+## Backwards Compatibility
+
+The new schema is not backwards compatible with the key-based approach in the
+gittuf design. This must be introduced using a new version of the policy
+metadata schema. Additionally, the gittuf client must continue supporting
+existing policies that use keys directly.
+
+## Security
+
+This GAP introduces some concepts that have security implications.
+
+### Out of Sync Principal Definitions
+
+The delegating entity is responsible for associating a unique identifier for the
+delegatee "person". While this is unique within the context of a delegated file,
+other delegated files may use the same ID for another person. To avoid policy
+misconfiguration or confusion issues, the person definitions SHOULD be
+consistent across metadata. In other words, the definition for `Bob` SHOULD be
+the same when delegated to by `Alice` in role `foo` and when delegated to by
+`Carol` in role `bar`. This introduces a usability issue: when `Bob`'s
+definition must be changed, all delegations must be updated as well. While this
+is also the case for when a key must be rotated or revoked, storing additional
+metadata for each person makes it likely that changes are more frequent.
+
+A possible solution is to centralize (within gittuf metadata) all person
+definitions. This can be achieved with a dedicated role for person declarations,
+delegated to by the repository's root of trust. This role becomes the source of
+truth for all person definitions in the repository's rule files. The downside of
+this solution is that a developer cannot delegate to an entirely new person
+anymore, though this may be a desirable feature in some contexts. For example,
+in an enterprise context, there may be a desire to allow delegations but limit
+them to trusted developers part of the company.
+
+Centralizing person declarations could also enable each developer to manage
+their own `person` definition. The dedicated role for definitions can be sharded
+on a per-person basis, allowing each person to manage their own keys and
+associated identities.
+
+TODO: does self managed mean a developer can add themselves? Claiming an ID is
+complicated. Being too prescriptive is also not a good idea about how the ID
+ownership is verified.
+
+### Counting a Principal towards Threshold
+
+This GAP introduces some complexity in the verification workflow, specifically
+with how a principal is counted towards the threshold. The workflow must now
+track whether a key was used for another previously examined principal to avoid
+counting a single signature for two principals who both have the same key
+associated with them.
+
+However, this complexity is acceptable given the alternative. Without the
+ability to associate multiple keys with a single principal, the maintainers
+responsible for declaring policies have to write unintuitive rules, and
+misconfigurations that allow a single developer to be counted multiple times
+towards the threshold are likelier.
+
+## Prototype Implementation
+
+See v0.2 policy metadata. To use this metadata, set `GITTUF_DEV=1` and
+`GITTUF_ALLOW_V02_POLICY=1`.
+
+## References
+
+* [TAP-12](https://github.com/theupdateframework/taps/blob/master/tap12.md)

--- a/docs/gaps/6/README.md
+++ b/docs/gaps/6/README.md
@@ -1,0 +1,166 @@
+# Code Review Tool Attestations
+
+## Metadata
+
+* **Number:** 6
+* **Title:** Code Review Tool Attestations
+* **Implemented:** No
+* **Withdrawn/Rejected:** No
+* **Sponsors:** Aditya Sirish A Yelgundhalli (adityasaky)
+* **Related GAPs:** [GAP-3](/docs/gaps/3/README.md), [GAP-5](/docs/gaps/5/README.md)
+* **Last Modified:** March 25, 2025
+
+## Abstract
+
+gittuf's [reference authorization
+attestations](/docs/design-document.md#reference-authorization) can be used to
+meet a threshold of approvals for a change in a Git repository. Here, every
+approver signs the attestation themselves, minimizing the trusted entities
+during verification, but this has usability concerns. To balance usability and
+security, this extension proposes the use of special attestations created by
+popular code review tools.
+
+## Motivation
+
+While gittuf supports code review approvals using reference authorization
+attestations, issuing these attestations introduces significant overhead to
+developers. They must now issue them using their gittuf client and sync the
+attestations to the remote.
+
+To offset this usability burden, this GAP proposes using attestations to
+represent approvals performed on popular code review tools (e.g., GitHub pull
+request reviews). This enables developers to continue using existing approval
+workflows while also meeting gittuf policies.
+
+## Specification
+
+The introduction of code review tool attestations to gittuf involves changes to
+the root of trust metadata schema (to bootstrap trust for the code review tool)
+as well as the verification workflow (to make use of the attestation).
+
+### Attestation Schema
+
+The attestation is similar to the reference authorization, but also includes
+information indicating the approvers as identified by the code review tool. Each
+listed approver SHOULD include an immutable identifier for the approver.
+
+```
+TargetRef    string
+FromID string
+TargetID   string
+Approvers    []string
+```
+
+The attestation must indicate the code review tool via the predicate type, and
+it must be signed by the code review tool or a trusted integration with the
+tool. See [verification](#verification) for how these attestations are
+authenticated.
+
+Here is an example of an attestation statement (minus the signature envelope)
+for a code review approval from [@adityasaky](https://github.com/adityasaky) on
+a GitHub pull request.
+
+```json
+{
+    "_type": "https://in-toto.io/Statement/v1",
+    "subject": [{
+        "digest": {
+            "gitTree": "2f70a39ab17467b112563c1bb151470ca4e51099"
+        }
+    }],
+    "predicateType": "https://gittuf.dev/github-pull-request-approval/v0.1",
+    "predicate": {
+        "targetRef": "refs/heads/main",
+        "fromID": "8caa1161a7d5e45122f681664ab14c8ff7c03a0e",
+        "targetID": "2f70a39ab17467b112563c1bb151470ca4e51099",
+        "approvers": ["adityasaky+8928778"]
+    }
+}
+```
+
+Here, `8928778` is the immutable ID of the approver on the code review platform.
+This remains consistent even if the approver's username is changed.
+
+### Policy
+
+The root of trust metadata schema is extended to include the signing key of the
+code review tool or platform. Specifically, the root of trust metadata includes
+an additional role for code review tools. The role is associated with one or
+more signing keys used by the tool to sign the attestations.
+
+The policy schema (for rules) required for this is described in GAP-5.
+Specifically, the `associatedIdentities` map is used to record the identity of
+each person from the perspective of the code review tool.
+
+### Verification
+
+The verification workflow follows the [default
+workflow](/docs/design-document.md#verification-workflow) until the reference
+authorization is verified. If the threshold is met, then verification succeeds
+without using the code review tool attestations. If the threshold is not met,
+the verification workflow moves on to using the code review tool attestations.
+Note that during verification, the set of `personIDs` verified using reference
+authorizations is tracked even if the threshold is not met to ensure that the
+same person is not also trusted via a code review tool approval.
+
+If a threshold is not met, then code review tool approvals are used for the
+change in question. The approval attestations are loaded for apps or tools that
+are explicitly marked as trusted in the repository's root of trust metadata.
+Specifically, in `root.json`, each trusted `integrationID` must be associated
+with its signing key or identity. The attestations from the trusted apps are
+loaded and their signatures are verified using the corresponding app key from
+the `root.json`.
+
+Then, the attestations's `Approvers` are used to extend the list of `personIDs`
+verified via their signatures. Each approver is matched to a person using gittuf
+policy, and the corresponding `personID` is added to `personIDs`. Note that
+`personIDs` must contain no duplicates, to ensure the same person is not counted
+twice towards the threshold. If the threshold is met with the approvers in the
+code review tool attestation, then verification passes.
+
+## Reasoning
+
+This GAP uses the same basic semantic, that of an attestation, to track code
+review approvals. The GAP also specifies how the signer for the attestation can
+be trusted by the owners of a repository. As such, this approach maintains many
+of gittuf's core properties (forge-agnostic record of approvals, verifiability
+of source of approval claim) while improving gittuf's usability.
+
+## Backwards Compatibility
+
+This GAP introduces no backwards incompatibility.
+
+## Security
+
+The changes proposed have the following implications on gittuf's security model.
+
+### Rotating Code Review Tool's Signing Key
+
+After a code review tool's signing key is configured, rotating the key requires
+updating the root metadata of every repository that trusts the tool's
+attestations. This is a significant downside to the current approach.
+
+### Change in Trust Model
+
+Using code review tools or apps reintroduces single points of trust to gittuf
+verification. The app or tool can indicate an approval happened when the person
+in question did not actually issue an approval. One aspect of the attestations,
+however, is that it introduces non-repudiation: the code review tool cannot
+indicate a change is approved by a person and later claim otherwise, as the
+attestation cannot be amended without violating the RSL's append-only property.
+
+Another possible mitigation is to have thresholds for these attestations. This
+may be possible when the attestation issuer is some other integration into a
+code review tool (e.g., a [GitHub app](https://docs.github.com/en/apps/overview)
+that watches GitHub pull requests), where multiple, isolated integrations can be
+used. However, if the issuer is the code review tool itself, then we cannot
+employ thresholds.
+
+## Prototype Implementation
+
+See support for GitHub pull request approval attestations.
+
+## References
+
+* [GitHub pull request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews)
+* [GitHub app](https://docs.github.com/en/apps/overview)

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -28,6 +28,8 @@ the gittuf/community repository.
 | 2 | [gittuf on the Forge](/docs/gaps/2/README.md) | No | No |
 | 3 | [Authentication Evidence Attestations](/docs/gaps/3/README.md) | No | No |
 | 4 | [Supporting Global Constraints in gittuf](/docs/gaps/4/README.md) | No | No |
+| 5 | [Principals, not Keys](/docs/gaps/5/README.md) | No | No |
+| 6 | [Code Review Tool Attestations](/docs/gaps/6/README.md) | No | No |
 
 ## GAP Format
 


### PR DESCRIPTION
Adds app / code review tool attestations as an extension doc after some discussions with @wlynch re https://github.com/gittuf/github-app.