### PR TITLE
tuf, policy, gittuf: Add v02 of policy metadata

### DIFF
--- a/.github/workflows/get-started-tests-policy-v02.yml
+++ b/.github/workflows/get-started-tests-policy-v02.yml
@@ -1,0 +1,42 @@
+name: get-started-tests with policy v02
+on:
+  push:
+    branches: ['main']
+    paths-ignore:
+      - "docs/**"
+      - "!docs/testing/**"
+      - "!docs/get-started.md"
+      - "*.md"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "!docs/testing/**"
+      - "!docs/get-started.md"
+      - "*.md"
+permissions: read-all
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        go-version: ['1.23']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - name: Install Go
+      uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache: true
+    - name: Install Python
+      uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+      with:
+        python-version: '3.10'
+    - name: Build gittuf
+      run: make just-install
+    - name: Test Getting Started
+      run: python3 docs/testing/test-get-started-md.py
+      env:
+        GITTUF_DEV: '1'
+        GITTUF_ALLOW_V02_POLICY: '1'

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -405,7 +405,7 @@ func (r *Repository) SignRoot(ctx context.Context, signer sslibdsse.SignerVerifi
 
 func (r *Repository) loadRootMetadata(state *policy.State, keyID string) (tuf.RootMetadata, error) {
 	slog.Debug("Loading current root metadata...")
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -31,7 +31,7 @@ func TestInitializeRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	assert.Nil(t, err)
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
 
@@ -60,7 +60,7 @@ func TestAddRootKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	assert.Nil(t, err)
 
 	assert.Equal(t, originalKeyID, state.RootEnvelope.Signatures[0].KeyID)
@@ -88,7 +88,7 @@ func TestRemoveRootKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestRemoveRootKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestRemoveRootKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +162,7 @@ func TestAddTopLevelTargetsKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	assert.Nil(t, err)
 	assert.Equal(t, key.KeyID, state.RootEnvelope.Signatures[0].KeyID)
 	assert.True(t, getRootPrincipalIDs(t, rootMetadata).Has(key.KeyID))
@@ -195,7 +195,7 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +215,7 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,7 +240,7 @@ func TestAddGitHubAppKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	assert.Nil(t, err)
 
 	appPrincipals, err := rootMetadata.GetGitHubAppPrincipals()
@@ -269,7 +269,7 @@ func TestRemoveGitHubAppKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestRemoveGitHubAppKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -329,7 +329,7 @@ func TestTrustGitHubApp(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rootMetadata, err := state.GetRootMetadata()
+		rootMetadata, err := state.GetRootMetadata(false)
 		assert.Nil(t, err)
 
 		assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted())
@@ -345,7 +345,7 @@ func TestTrustGitHubApp(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rootMetadata, err = state.GetRootMetadata()
+		rootMetadata, err = state.GetRootMetadata(false)
 		assert.Nil(t, err)
 
 		assert.True(t, rootMetadata.IsGitHubAppApprovalTrusted())
@@ -369,7 +369,7 @@ func TestUntrustGitHubApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	assert.Nil(t, err)
 
 	assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted())
@@ -385,7 +385,7 @@ func TestUntrustGitHubApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	assert.Nil(t, err)
 
 	assert.True(t, rootMetadata.IsGitHubAppApprovalTrusted())
@@ -400,7 +400,7 @@ func TestUntrustGitHubApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	assert.Nil(t, err)
 
 	assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted())
@@ -416,7 +416,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -445,7 +445,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -474,7 +474,7 @@ func TestUpdateTopLevelTargetsThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -501,7 +501,7 @@ func TestUpdateTopLevelTargetsThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rootMetadata, err = state.GetRootMetadata()
+	rootMetadata, err = state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/experimental/gittuf/targets.go
+++ b/experimental/gittuf/targets.go
@@ -105,7 +105,7 @@ func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerV
 	// assume which role is the delegating role (diamond delegations are legal).
 	// See: https://github.com/gittuf/gittuf/issues/246.
 
-	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 	// assume which role is the delegating role (diamond delegations are legal).
 	// See: https://github.com/gittuf/gittuf/issues/246.
 
-	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
 	if err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func (r *Repository) ReorderDelegations(ctx context.Context, signer sslibdsse.Si
 		return policy.ErrMetadataNotFound
 	}
 
-	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
 	if err != nil {
 		return err
 	}
@@ -275,7 +275,7 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.Sign
 	// assume which role is the delegating role (diamond delegations are legal).
 	// See: https://github.com/gittuf/gittuf/issues/246.
 
-	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
 	if err != nil {
 		return err
 	}
@@ -336,7 +336,7 @@ func (r *Repository) AddKeyToTargets(ctx context.Context, signer sslibdsse.Signe
 	}
 
 	slog.Debug("Loading current rule file...")
-	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
 	if err != nil {
 		return err
 	}

--- a/experimental/gittuf/targets_test.go
+++ b/experimental/gittuf/targets_test.go
@@ -37,7 +37,7 @@ func TestInitializeTargets(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		assert.Contains(t, targetsMetadata.GetRules(), tufv01.AllowRule())
 	})
@@ -76,7 +76,7 @@ func TestAddDelegation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		assert.Equal(t, 1, len(targetsMetadata.GetPrincipals()))
 		assert.Equal(t, 2, len(targetsMetadata.GetRules()))
@@ -90,7 +90,7 @@ func TestAddDelegation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName)
+		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		assert.Contains(t, targetsMetadata.GetPrincipals(), targetsPubKey.ID())
 		assert.Contains(t, targetsMetadata.GetPrincipals(), gpgKey.KeyID)
@@ -133,7 +133,7 @@ func TestUpdateDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +171,7 @@ func TestReorderDelegations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestRemoveDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.GetPrincipals(), targetsPubKey.ID())
 	assert.Equal(t, 3, len(targetsMetadata.GetRules()))
@@ -223,7 +223,7 @@ func TestRemoveDelegation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.GetPrincipals(), targetsPubKey.ID())
 	assert.Equal(t, 2, len(targetsMetadata.GetRules()))
@@ -249,7 +249,7 @@ func TestAddKeyToTargets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.GetPrincipals(), gpgKey.KeyID)
 	assert.Equal(t, 1, len(targetsMetadata.GetPrincipals()))
@@ -262,7 +262,7 @@ func TestAddKeyToTargets(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName)
+	targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(targetsMetadata.GetPrincipals()))
 }

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -247,7 +247,7 @@ func createTestStateWithThresholdPolicy(t *testing.T) *State {
 	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
 	approverKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 	}
 	state.RootEnvelope = rootEnv
 
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +354,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -376,7 +376,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 	}
 	state.RootEnvelope = rootEnv
 
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +409,7 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 		t.Fatal(err)
 	}
 	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +448,7 @@ func createTestStateWithThresholdTagPolicy(t *testing.T) *State {
 	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
 	approverKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 	state := createTestStateWithPolicy(t)
 
 	rootKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
-	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
-	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -339,7 +338,8 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 		state := createTestStateWithDelegatedPolicies(t) // changed from createTestStateWithPolicies to increase test
 		// coverage to cover s.DelegationEnvelopes in PublicKeys()
 
-		key := ssh.NewKeyFromBytes(t, rootPubKeyBytes)
+		keyR := ssh.NewKeyFromBytes(t, rootPubKeyBytes)
+		key := tufv01.NewKeyFromSSLibKey(keyR)
 
 		tests := map[string]struct {
 			path      string
@@ -348,17 +348,17 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 			"verifiers for files 1": {
 				path: "file:1/*",
 				verifiers: []*Verifier{{
-					name:      "1",
-					keys:      []*signerverifier.SSLibKey{key},
-					threshold: 1,
+					name:       "1",
+					principals: []tuf.Principal{key},
+					threshold:  1,
 				}},
 			},
 			"verifiers for files": {
 				path: "file:2/*",
 				verifiers: []*Verifier{{
-					name:      "2",
-					keys:      []*signerverifier.SSLibKey{key},
-					threshold: 1,
+					name:       "2",
+					principals: []tuf.Principal{key},
+					threshold:  1,
 				}},
 			},
 			"verifiers for unprotected branch": {

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +37,7 @@ func TestLoadState(t *testing.T) {
 
 		assertStatesEqual(t, state, loadedState)
 
-		targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+		targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -121,7 +122,7 @@ func TestLoadState(t *testing.T) {
 
 		assertStatesEqual(t, state, loadedState)
 
-		targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName)
+		targetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -218,7 +219,7 @@ func TestLoadFirstState(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	targetsMetadata, err := secondState.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := secondState.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -323,7 +324,7 @@ func TestStateGetRootMetadata(t *testing.T) {
 	t.Parallel()
 	state := createTestStateWithOnlyRoot(t)
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(true)
 	assert.Nil(t, err)
 
 	rootPrincipals, err := rootMetadata.GetRootPrincipals()
@@ -440,7 +441,7 @@ func TestGetStateForCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	targetsMetadata, err := secondState.GetTargetsMetadata(TargetsRoleName)
+	targetsMetadata, err := secondState.GetTargetsMetadata(TargetsRoleName, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,27 +498,27 @@ func TestListRules(t *testing.T) {
 
 		expectedRules := []*DelegationWithDepth{
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "protect-main",
 					Paths:       []string{"git:refs/heads/main"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
 					},
 				},
 				Depth: 0,
 			},
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "protect-files-1-and-2",
 					Paths:       []string{"file:1", "file:2"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
 					},
 				},
 				Depth: 0,
@@ -534,54 +535,54 @@ func TestListRules(t *testing.T) {
 
 		expectedRules := []*DelegationWithDepth{
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "1",
 					Paths:       []string{"file:1/*"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
+						Threshold:    1,
 					},
 				},
 				Depth: 0,
 			},
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "3",
 					Paths:       []string{"file:1/subpath1/*"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
 					},
 				},
 				Depth: 1,
 			},
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "4",
 					Paths:       []string{"file:1/subpath2/*"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
 					},
 				},
 				Depth: 1,
 			},
 
 			{
-				Delegation: &tufv01.Delegation{
+				Delegation: &tufv02.Delegation{
 					Name:        "2",
 					Paths:       []string{"file:2/*"},
 					Terminating: false,
 					Custom:      nil,
-					Role: tufv01.Role{
-						KeyIDs:    set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
-						Threshold: 1,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
+						Threshold:    1,
 					},
 				},
 				Depth: 0,
@@ -618,7 +619,7 @@ func TestApply(t *testing.T) {
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-	rootMetadata, err := state.GetRootMetadata()
+	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/root.go
+++ b/internal/policy/root.go
@@ -8,13 +8,20 @@ import (
 
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 )
 
 // InitializeRootMetadata initializes a new instance of tuf.RootMetadata with
 // default values and a given key. The default values are version set to 1,
 // expiry date set to one year from now, and the provided key is added.
 func InitializeRootMetadata(key tuf.Principal) (tuf.RootMetadata, error) {
-	rootMetadata := tufv01.NewRootMetadata()
+	var rootMetadata tuf.RootMetadata
+
+	if tufv02.AllowV02Metadata() {
+		rootMetadata = tufv02.NewRootMetadata()
+	} else {
+		rootMetadata = tufv01.NewRootMetadata()
+	}
 	rootMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 
 	if err := rootMetadata.AddRootPrincipal(key); err != nil {

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -8,11 +8,18 @@ import (
 
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 )
 
 // InitializeTargetsMetadata creates a new instance of TargetsMetadata.
 func InitializeTargetsMetadata() tuf.TargetsMetadata {
-	targetsMetadata := tufv01.NewTargetsMetadata()
+	var targetsMetadata tuf.TargetsMetadata
+	if tufv02.AllowV02Metadata() {
+		targetsMetadata = tufv02.NewTargetsMetadata()
+	} else {
+		targetsMetadata = tufv01.NewTargetsMetadata()
+	}
+
 	targetsMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 	return targetsMetadata
 }

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gittuf/gittuf/internal/attestations"
 	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
 	"github.com/gittuf/gittuf/internal/common"
+	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
@@ -19,6 +20,7 @@ import (
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,6 +81,614 @@ func TestVerifyRefFromEntry(t *testing.T) {
 	currentTip, err := VerifyRefFromEntry(testCtx, repo, refName, entryID)
 	assert.Nil(t, err)
 	assert.Equal(t, commitIDs[1], currentTip)
+}
+
+func TestVerifyRelativeForRefUsingPersons(t *testing.T) {
+	t.Setenv(tufv02.AllowV02MetadataKey, "1")
+	t.Setenv(dev.DevModeKey, "1")
+
+	t.Run("no recovery", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		err = VerifyRelativeForRef(testCtx, repo, entry, firstEntry, refName)
+		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
+	})
+
+	t.Run("no recovery, first entry is the very first entry", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		firstEntry, _, err := rsl.GetFirstEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		err = VerifyRelativeForRef(testCtx, repo, entry, firstEntry, refName)
+		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
+	})
+
+	t.Run("no recovery, first entry is the very first entry but policy is not applied", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		currentRSLTip, err := repo.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+		currentRSLTipParentIDs, err := repo.GetCommitParentIDs(currentRSLTip)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.SetReference(rsl.Ref, currentRSLTipParentIDs[0]); err != nil {
+			// Set to parent -> this is policy staging
+			t.Fatal(err)
+		}
+
+		refName := "refs/heads/main"
+
+		firstEntry, _, err := rsl.GetFirstEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+	})
+
+	t.Run("with recovery, commit-same, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, commit-same, recovered by unauthorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgUnauthorizedKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, tree-same, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit's tree
+		validTreeID, err := repo.GetCommitTreeID(validCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newCommitID, err := repo.CommitUsingSpecificKey(validTreeID, refName, "Revert invalid commit\n", gpgKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, newCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, tree-same, recovered by unauthorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit's tree
+		validTreeID, err := repo.GetCommitTreeID(validCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newCommitID, err := repo.CommitUsingSpecificKey(validTreeID, refName, "Revert invalid commit\n", gpgUnauthorizedKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgUnauthorizedKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, newCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, commit-same, multiple invalid entries, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		invalidEntryIDs := []gitinterface.Hash{entryID}
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's still in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		invalidEntryIDs = append(invalidEntryIDs, entryID)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entries
+		annotation := rsl.NewAnnotationEntry(invalidEntryIDs, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, commit-same, unskipped invalid entries, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		invalidEntryIDs := []gitinterface.Hash{entryID}
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's still in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for only one invalid entry
+		annotation := rsl.NewAnnotationEntry(invalidEntryIDs, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// An invalid entry is not marked as skipped
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrInvalidEntryNotSkipped)
+	})
+
+	t.Run("with recovery, commit-same, recovered by authorized user, last good state is due to recovery", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		// Send it into invalid state again
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit
+		if err := repo.SetReference(refName, validCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entry
+		annotation = rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID = common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, validCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+	})
+
+	t.Run("with recovery, error because recovery goes back too far, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		invalidLastGoodCommitID := commitIDs[len(commitIDs)-1]
+
+		// Add more commits, change the number of commits to have different trees
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 4, gpgKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 3, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the invalid last good commit
+		if err := repo.SetReference(refName, invalidLastGoodCommitID); err != nil {
+			t.Fatal(err)
+		}
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to invalid last good commit
+		entry = rsl.NewReferenceEntry(refName, invalidLastGoodCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+	})
+
+	t.Run("with recovery but recovered entry is also skipped, tree-same, recovered by authorized user", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		validCommitID := commitIDs[0] // track this for later
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Fix using the known-good commit's tree
+		validTreeID, err := repo.GetCommitTreeID(validCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		newCommitID, err := repo.CommitUsingSpecificKey(validTreeID, refName, "Revert invalid commit\n", gpgKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		// Create a new entry moving branch back to valid commit
+		entry = rsl.NewReferenceEntry(refName, newCommitID)
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		// No error anymore
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		// Skip the recovery entry as well
+		annotation = rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID = common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+	})
+
+	t.Run("with annotation but no fix entry", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicyUsingPersons)
+		refName := "refs/heads/main"
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		firstEntry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		firstEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo, firstEntry, gpgKeyBytes)
+		firstEntry.ID = firstEntryID
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.Nil(t, err)
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 5, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[len(commitIDs)-1])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		// It's in an invalid state right now, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+
+		// Create a skip annotation for the invalid entry
+		annotation := rsl.NewAnnotationEntry([]gitinterface.Hash{entryID}, true, "invalid entry")
+		annotationID := common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+		annotation.ID = annotationID
+
+		// No fix entry, error out
+		err = VerifyRelativeForRef(testCtx, repo, firstEntry, entry, refName)
+		assert.ErrorIs(t, err, ErrUnauthorizedSignature)
+	})
 }
 
 func TestVerifyRelativeForRef(t *testing.T) {
@@ -691,6 +1301,21 @@ func TestVerifyEntry(t *testing.T) {
 
 	t.Run("successful verification", func(t *testing.T) {
 		repo, state := createTestRepository(t, createTestStateWithPolicy)
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err := verifyEntry(testCtx, repo, state, nil, entry)
+		assert.Nil(t, err)
+	})
+
+	t.Run("successful verification using persons", func(t *testing.T) {
+		t.Setenv(tufv02.AllowV02MetadataKey, "1")
+		t.Setenv(dev.DevModeKey, "1")
+
+		repo, state := createTestRepository(t, createTestStateWithPolicyUsingPersons)
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
 		entry := rsl.NewReferenceEntry(refName, commitIDs[0])

--- a/internal/tuf/migrations/migrations.go
+++ b/internal/tuf/migrations/migrations.go
@@ -1,0 +1,81 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations
+
+import (
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+)
+
+/*
+	adityasaky: We should probably have an automatic migration to the _next_
+	version every time so that it's easy to migrate from v01 to v0k easily using
+	consecutive migration functions. However, I think building that out now may
+	be overkill; I don't know if we expect a bunch of schema changes.
+*/
+
+// MigrateRootMetadataV01ToV02 converts tufv01.RootMetadata into
+// tufv02.RootMetadata.
+func MigrateRootMetadataV01ToV02(rootMetadata *tufv01.RootMetadata) *tufv02.RootMetadata {
+	newRootMetadata := tufv02.NewRootMetadata()
+
+	// Set same expires
+	newRootMetadata.Expires = rootMetadata.Expires
+
+	// Set keys
+	newRootMetadata.Principals = map[string]tuf.Principal{}
+	for keyID, key := range rootMetadata.Keys {
+		newRootMetadata.Principals[keyID] = key
+	}
+
+	// Set roles
+	newRootMetadata.Roles = map[string]tufv02.Role{}
+	for roleName, role := range rootMetadata.Roles {
+		newRole := tufv02.Role{
+			PrincipalIDs: role.KeyIDs,
+			Threshold:    role.Threshold,
+		}
+		newRootMetadata.Roles[roleName] = newRole
+	}
+
+	// Set app attestations support
+	newRootMetadata.GitHubApprovalsTrusted = rootMetadata.GitHubApprovalsTrusted
+
+	return newRootMetadata
+}
+
+// MigrateTargetsMetadataV01ToV02 converts tufv01.TargetsMetadata into
+// tufv02.TargetsMetadata.
+func MigrateTargetsMetadataV01ToV02(targetsMetadata *tufv01.TargetsMetadata) *tufv02.TargetsMetadata {
+	newTargetsMetadata := tufv02.NewTargetsMetadata()
+
+	// Set same expires
+	newTargetsMetadata.Expires = targetsMetadata.Expires
+
+	// Set delegations
+	newTargetsMetadata.Delegations = &tufv02.Delegations{
+		Principals: map[string]tuf.Principal{},
+		Roles:      []*tufv02.Delegation{},
+	}
+	for keyID, key := range targetsMetadata.Delegations.Keys {
+		newTargetsMetadata.Delegations.Principals[keyID] = key
+	}
+	for _, role := range targetsMetadata.Delegations.Roles {
+		newRole := &tufv02.Delegation{
+			Name:        role.Name,
+			Paths:       role.Paths,
+			Terminating: role.Terminating,
+			Custom:      role.Custom,
+			Role: tufv02.Role{
+				PrincipalIDs: role.KeyIDs,
+				Threshold:    role.Threshold,
+			},
+		}
+
+		newTargetsMetadata.Delegations.Roles = append(newTargetsMetadata.Delegations.Roles, newRole)
+	}
+
+	return newTargetsMetadata
+}

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -25,6 +25,8 @@ const (
 
 var (
 	ErrInvalidRootMetadata                      = errors.New("invalid root metadata")
+	ErrUnknownRootMetadataVersion               = errors.New("unknown schema version for root metadata")
+	ErrUnknownTargetsMetadataVersion            = errors.New("unknown schema version for rule file metadata")
 	ErrPrimaryRuleFileInformationNotFoundInRoot = errors.New("root metadata does not contain primary rule file information")
 	ErrGitHubAppInformationNotFoundInRoot       = errors.New("the special GitHub app role is not defined, but GitHub app approvals is set to trusted")
 	ErrDuplicatedRuleName                       = errors.New("two rules with same name found in policy")

--- a/internal/tuf/v02/helpers_test.go
+++ b/internal/tuf/v02/helpers_test.go
@@ -1,0 +1,47 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+var (
+	rootPubKeyBytes     = artifacts.SSHRSAPublicSSH
+	targets1PubKeyBytes = artifacts.SSHECDSAPublicSSH
+	targets2PubKeyBytes = artifacts.SSHED25519PublicSSH
+)
+
+func initialTestRootMetadata(t *testing.T) *RootMetadata {
+	t.Helper()
+
+	rootKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	rootMetadata := NewRootMetadata()
+	rootMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	if err := rootMetadata.addPrincipal(rootKey); err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata.addRole(tuf.RootRoleName, Role{
+		PrincipalIDs: set.NewSetFromItems(rootKey.KeyID),
+		Threshold:    1,
+	})
+
+	return rootMetadata
+}
+
+func initialTestTargetsMetadata(t *testing.T) *TargetsMetadata {
+	t.Helper()
+
+	targetsMetadata := NewTargetsMetadata()
+	targetsMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	targetsMetadata.Delegations = &Delegations{Roles: []*Delegation{AllowRule()}}
+	return targetsMetadata
+}

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -1,0 +1,382 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+const (
+	RootVersion = "https://gittuf.dev/policy/root/v0.2"
+)
+
+// RootMetadata defines the schema of TUF's Root role.
+type RootMetadata struct {
+	Type                   string                   `json:"type"`
+	Version                string                   `json:"schemaVersion"`
+	Expires                string                   `json:"expires"`
+	Principals             map[string]tuf.Principal `json:"principals"`
+	Roles                  map[string]Role          `json:"roles"`
+	GitHubApprovalsTrusted bool                     `json:"githubApprovalsTrusted"`
+}
+
+// NewRootMetadata returns a new instance of RootMetadata.
+func NewRootMetadata() *RootMetadata {
+	return &RootMetadata{
+		Type:    "root",
+		Version: RootVersion,
+	}
+}
+
+// SetExpires sets the expiry date of the RootMetadata to the value passed in.
+func (r *RootMetadata) SetExpires(expires string) {
+	r.Expires = expires
+}
+
+// SchemaVersion returns the metadata schema version.
+func (r *RootMetadata) SchemaVersion() string {
+	return r.Version
+}
+
+// AddRootPrincipal adds the specified principal to the root metadata and
+// authorizes the principal for the root role.
+func (r *RootMetadata) AddRootPrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// Add principal to metadata
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+
+	rootRole, ok := r.Roles[tuf.RootRoleName]
+	if !ok {
+		// Create a new root role entry with this principal
+		r.addRole(tuf.RootRoleName, Role{
+			PrincipalIDs: set.NewSetFromItems(principal.ID()),
+			Threshold:    1,
+		})
+
+		return nil
+	}
+
+	// Add principal ID to the root role if it's not already in it
+	rootRole.PrincipalIDs.Add(principal.ID())
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// DeleteRootPrincipal removes principalID from the list of trusted Root
+// principals in rootMetadata. It does not remove the principal entry itself as
+// it does not check if other roles can be verified using the same principal.
+func (r *RootMetadata) DeleteRootPrincipal(principalID string) error {
+	rootRole, has := r.Roles[tuf.RootRoleName]
+	if !has {
+		return tuf.ErrInvalidRootMetadata
+	}
+
+	if rootRole.PrincipalIDs.Len() <= rootRole.Threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	rootRole.PrincipalIDs.Remove(principalID)
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// AddPrimaryRuleFilePrincipal adds the 'principal' as a trusted signer in
+// 'rootMetadata' for the top level Targets role.
+func (r *RootMetadata) AddPrimaryRuleFilePrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// Add principal to the metadata file
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		// Create a new targets role entry with this principal
+		r.addRole(tuf.TargetsRoleName, Role{
+			PrincipalIDs: set.NewSetFromItems(principal.ID()),
+			Threshold:    1,
+		})
+
+		return nil
+	}
+
+	targetsRole.PrincipalIDs.Add(principal.ID())
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+
+	return nil
+}
+
+// DeletePrimaryRuleFilePrincipal removes the principal matching 'principalID'
+// from trusted principals for top level Targets role in 'rootMetadata'. Note:
+// It doesn't remove the principal entry itself as it doesn't check if other
+// roles can use the same principal.
+func (r *RootMetadata) DeletePrimaryRuleFilePrincipal(principalID string) error {
+	if principalID == "" {
+		return tuf.ErrInvalidPrincipalID
+	}
+
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		return tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	if targetsRole.PrincipalIDs.Len() <= targetsRole.Threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	targetsRole.PrincipalIDs.Remove(principalID)
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+	return nil
+}
+
+// AddGitHubAppPrincipal adds the 'principal' as a trusted principal in
+// 'rootMetadata' for the special GitHub app role. This key is used to verify
+// GitHub pull request approval attestation signatures.
+func (r *RootMetadata) AddGitHubAppPrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// TODO: support multiple principals / threshold for app
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+	role := Role{
+		PrincipalIDs: set.NewSetFromItems(principal.ID()),
+		Threshold:    1,
+	}
+	r.addRole(tuf.GitHubAppRoleName, role) // AddRole replaces the specified role if it already exists
+	return nil
+}
+
+// DeleteGitHubAppPrincipal removes the special GitHub app role from the root
+// metadata.
+func (r *RootMetadata) DeleteGitHubAppPrincipal() {
+	// TODO: support multiple principals / threshold for app
+	delete(r.Roles, tuf.GitHubAppRoleName)
+}
+
+// EnableGitHubAppApprovals sets GitHubApprovalsTrusted to true in the
+// root metadata.
+func (r *RootMetadata) EnableGitHubAppApprovals() {
+	r.GitHubApprovalsTrusted = true
+}
+
+// DisableGitHubAppApprovals sets GitHubApprovalsTrusted to false in the root
+// metadata.
+func (r *RootMetadata) DisableGitHubAppApprovals() {
+	r.GitHubApprovalsTrusted = false
+}
+
+// UpdateRootThreshold sets the threshold for the Root role.
+func (r *RootMetadata) UpdateRootThreshold(threshold int) error {
+	rootRole, ok := r.Roles[tuf.RootRoleName]
+	if !ok {
+		return tuf.ErrInvalidRootMetadata
+	}
+
+	if rootRole.PrincipalIDs.Len() < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+	rootRole.Threshold = threshold
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// UpdatePrimaryRuleFileThreshold sets the threshold for the top level Targets
+// role.
+func (r *RootMetadata) UpdatePrimaryRuleFileThreshold(threshold int) error {
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		return tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	if targetsRole.PrincipalIDs.Len() < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+	targetsRole.Threshold = threshold
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+	return nil
+}
+
+// GetPrincipals returns all the principals in the root metadata.
+func (r *RootMetadata) GetPrincipals() map[string]tuf.Principal {
+	return r.Principals
+}
+
+// GetRootThreshold returns the threshold of principals that must sign the root
+// of trust metadata.
+func (r *RootMetadata) GetRootThreshold() (int, error) {
+	role, hasRole := r.Roles[tuf.RootRoleName]
+	if !hasRole {
+		return -1, tuf.ErrInvalidRootMetadata
+	}
+
+	return role.Threshold, nil
+}
+
+// GetRootPrincipals returns the principals trusted for the root of trust
+// metadata.
+func (r *RootMetadata) GetRootPrincipals() ([]tuf.Principal, error) {
+	role, hasRole := r.Roles[tuf.RootRoleName]
+	if !hasRole {
+		return nil, tuf.ErrInvalidRootMetadata
+	}
+
+	principals := make([]tuf.Principal, 0, role.PrincipalIDs.Len())
+	for _, id := range role.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+// GetPrimaryRuleFileThreshold returns the threshold of principals that must
+// sign the primary rule file.
+func (r *RootMetadata) GetPrimaryRuleFileThreshold() (int, error) {
+	role, hasRole := r.Roles[tuf.TargetsRoleName]
+	if !hasRole {
+		return -1, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	return role.Threshold, nil
+}
+
+// GetPrimaryRuleFilePrincipals returns the principals trusted for the primary
+// rule file.
+func (r *RootMetadata) GetPrimaryRuleFilePrincipals() ([]tuf.Principal, error) {
+	role, hasRole := r.Roles[tuf.TargetsRoleName]
+	if !hasRole {
+		return nil, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	principals := make([]tuf.Principal, 0, role.PrincipalIDs.Len())
+	for _, id := range role.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+// IsGitHubAppApprovalTrusted indicates if the GitHub app is trusted.
+//
+// TODO: this needs to be generalized across tools
+func (r *RootMetadata) IsGitHubAppApprovalTrusted() bool {
+	return r.GitHubApprovalsTrusted
+}
+
+// GetGitHubAppPrincipals returns the principals trusted for the GitHub app
+// attestations.
+//
+// TODO: this needs to be generalized across tools
+func (r *RootMetadata) GetGitHubAppPrincipals() ([]tuf.Principal, error) {
+	role, hasRole := r.Roles[tuf.GitHubAppRoleName]
+	if !hasRole {
+		return nil, tuf.ErrGitHubAppInformationNotFoundInRoot
+	}
+
+	principals := make([]tuf.Principal, 0, role.PrincipalIDs.Len())
+	for _, id := range role.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+func (r *RootMetadata) UnmarshalJSON(data []byte) error {
+	// this type _has_ to be a copy of RootMetadata, minus the use of
+	// json.RawMessage in place of tuf.Principal
+	type tempType struct {
+		Type                   string                     `json:"type"`
+		Version                string                     `json:"schemaVersion"`
+		Expires                string                     `json:"expires"`
+		Principals             map[string]json.RawMessage `json:"principals"`
+		Roles                  map[string]Role            `json:"roles"`
+		GitHubApprovalsTrusted bool                       `json:"githubApprovalsTrusted"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	r.Type = temp.Type
+	r.Version = temp.Version
+	r.Expires = temp.Expires
+
+	r.Principals = make(map[string]tuf.Principal)
+	for principalID, principalBytes := range temp.Principals {
+		tempPrincipal := map[string]any{}
+		if err := json.Unmarshal(principalBytes, &tempPrincipal); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		if _, has := tempPrincipal["keyid"]; has {
+			// this is *Key
+			key := &Key{}
+			if err := json.Unmarshal(principalBytes, key); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.Principals[principalID] = key
+			continue
+		}
+
+		if _, has := tempPrincipal["personID"]; has {
+			// this is *Person
+			person := &Person{}
+			if err := json.Unmarshal(principalBytes, person); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.Principals[principalID] = person
+			continue
+		}
+
+		return fmt.Errorf("unrecognized principal type '%s'", string(principalBytes))
+	}
+
+	r.Roles = temp.Roles
+	r.GitHubApprovalsTrusted = temp.GitHubApprovalsTrusted
+
+	return nil
+}
+
+// addPrincipal adds a principal to the RootMetadata instance.  v02 of the
+// metadata supports Key and Person as supported principal types.
+func (r *RootMetadata) addPrincipal(principal tuf.Principal) error {
+	if r.Principals == nil {
+		r.Principals = map[string]tuf.Principal{}
+	}
+	switch principal := principal.(type) {
+	case *Key, *Person:
+		r.Principals[principal.ID()] = principal
+	default:
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	return nil
+}
+
+// addRole adds a role object and associates it with roleName in the
+// RootMetadata instance.
+func (r *RootMetadata) addRole(roleName string, role Role) {
+	if r.Roles == nil {
+		r.Roles = map[string]Role{}
+	}
+
+	r.Roles[roleName] = role
+}

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -1,0 +1,511 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRootMetadata(t *testing.T) {
+	rootMetadata := NewRootMetadata()
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	err := rootMetadata.addPrincipal(key)
+	assert.Nil(t, err)
+	assert.Equal(t, key, rootMetadata.Principals[key.KeyID])
+
+	person := &Person{
+		PersonID:   "jane.doe@example.com",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+	err = rootMetadata.addPrincipal(person)
+	assert.Nil(t, err)
+	assert.Equal(t, person, rootMetadata.Principals[person.PersonID])
+
+	t.Run("test SetExpires", func(t *testing.T) {
+		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)
+		rootMetadata.SetExpires(d.Format(time.RFC3339))
+		assert.Equal(t, "1995-10-26T09:00:00Z", rootMetadata.Expires)
+	})
+
+	t.Run("test addRole", func(t *testing.T) {
+		rootMetadata.addRole("targets", Role{
+			PrincipalIDs: set.NewSetFromItems(key.KeyID),
+			Threshold:    1,
+		})
+		assert.True(t, rootMetadata.Roles["targets"].PrincipalIDs.Has(key.KeyID))
+	})
+
+	t.Run("test SchemaVersion", func(t *testing.T) {
+		schemaVersion := rootMetadata.SchemaVersion()
+		assert.Equal(t, RootVersion, schemaVersion)
+	})
+
+	t.Run("test GetPrincipals", func(t *testing.T) {
+		expectedPrincipals := map[string]tuf.Principal{
+			key.KeyID:       key,
+			person.PersonID: person,
+		}
+
+		principals := rootMetadata.GetPrincipals()
+		assert.Equal(t, expectedPrincipals, principals)
+	})
+}
+
+func TestRootMetadataWithSSHKey(t *testing.T) {
+	// Setup test key pair
+	keys := []struct {
+		name string
+		data []byte
+	}{
+		{"rsa", artifacts.SSHRSAPrivate},
+		{"rsa.pub", artifacts.SSHRSAPublicSSH},
+	}
+	tmpDir := t.TempDir()
+	for _, key := range keys {
+		keyPath := filepath.Join(tmpDir, key.name)
+		if err := os.WriteFile(keyPath, key.data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	keyPath := filepath.Join(tmpDir, "rsa")
+	sslibKeyO, err := ssh.NewKeyFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sslibKey := NewKeyFromSSLibKey(sslibKeyO)
+
+	// Create TUF root and add test key
+	rootMetadata := NewRootMetadata()
+	if err := rootMetadata.addPrincipal(sslibKey); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap and and sign
+	ctx := context.Background()
+	env, err := dsse.CreateEnvelope(rootMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifier, err := ssh.NewVerifierFromKey(sslibKeyO)
+	if err != nil {
+		t.Fatal()
+	}
+	signer := &ssh.Signer{
+		Verifier: verifier,
+		Path:     keyPath,
+	}
+
+	env, err = dsse.SignEnvelope(ctx, env, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Unwrap and verify
+	// NOTE: For the sake of testing the contained key, we unwrap before we
+	// verify. Typically, in DSSE it should be the other way around.
+	payload, err := env.DecodeB64Payload()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootMetadata2 := &RootMetadata{}
+	if err := json.Unmarshal(payload, rootMetadata2); err != nil {
+		t.Log(string(payload))
+		t.Fatal(err)
+	}
+
+	sslibKey2 := rootMetadata2.Principals[sslibKey.KeyID]
+
+	// NOTE: Typically, a caller would choose this method, if KeyType==ssh.SSHKeyType
+	verifier2, err := ssh.NewVerifierFromKey(sslibKey2.Keys()[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = dsse.VerifyEnvelope(ctx, env, []sslibdsse.Verifier{verifier2}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddRootPrincipal(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+
+	t.Run("with root role already in metadata", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+
+		newRootKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+		err := rootMetadata.AddRootPrincipal(newRootKey)
+		assert.Nil(t, err)
+		assert.Equal(t, newRootKey, rootMetadata.Principals[newRootKey.KeyID])
+		assert.Equal(t, set.NewSetFromItems(key.KeyID, newRootKey.KeyID), rootMetadata.Roles[tuf.RootRoleName].PrincipalIDs)
+	})
+
+	t.Run("without root role already in metadata", func(t *testing.T) {
+		rootMetadata := NewRootMetadata()
+
+		err := rootMetadata.AddRootPrincipal(key)
+		assert.Nil(t, err)
+		assert.Equal(t, key, rootMetadata.Principals[key.KeyID])
+		assert.Equal(t, set.NewSetFromItems(key.KeyID), rootMetadata.Roles[tuf.RootRoleName].PrincipalIDs)
+	})
+
+	t.Run("with person", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+
+		person := &Person{
+			PersonID: "jane.doe@example.com",
+			PublicKeys: map[string]*Key{
+				key.KeyID: key,
+			},
+		}
+
+		err := rootMetadata.AddRootPrincipal(person)
+		assert.Nil(t, err)
+		assert.Equal(t, person, rootMetadata.Principals[person.PersonID])
+		assert.Equal(t, set.NewSetFromItems(person.PersonID, key.KeyID), rootMetadata.Roles[tuf.RootRoleName].PrincipalIDs)
+	})
+}
+
+func TestDeleteRootPrincipal(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+
+	rootMetadata := initialTestRootMetadata(t)
+
+	newRootKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	person := &Person{
+		PersonID: "jane.doe@example.com",
+		PublicKeys: map[string]*Key{
+			key.KeyID: key,
+		},
+	}
+
+	err := rootMetadata.AddRootPrincipal(newRootKey)
+	assert.Nil(t, err)
+
+	err = rootMetadata.AddRootPrincipal(person)
+	assert.Nil(t, err)
+
+	err = rootMetadata.DeleteRootPrincipal(newRootKey.KeyID)
+	assert.Nil(t, err)
+	assert.Equal(t, newRootKey, rootMetadata.Principals[newRootKey.KeyID])
+	assert.Equal(t, set.NewSetFromItems(key.KeyID, person.PersonID), rootMetadata.Roles[tuf.RootRoleName].PrincipalIDs)
+
+	err = rootMetadata.DeleteRootPrincipal(person.PersonID)
+	assert.Nil(t, err)
+	assert.Equal(t, person, rootMetadata.Principals[person.PersonID])
+	assert.Equal(t, set.NewSetFromItems(key.KeyID), rootMetadata.Roles[tuf.RootRoleName].PrincipalIDs)
+
+	err = rootMetadata.DeleteRootPrincipal(key.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrCannotMeetThreshold)
+}
+
+func TestAddPrimaryRuleFilePrincipal(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	targetsKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	err := rootMetadata.AddPrimaryRuleFilePrincipal(nil)
+	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalType)
+
+	err = rootMetadata.AddPrimaryRuleFilePrincipal(targetsKey)
+	assert.Nil(t, err)
+	assert.Equal(t, targetsKey, rootMetadata.Principals[targetsKey.KeyID])
+	assert.Equal(t, set.NewSetFromItems(targetsKey.KeyID), rootMetadata.Roles[tuf.TargetsRoleName].PrincipalIDs)
+
+	person := &Person{
+		PersonID: "jane.doe@example.com",
+		PublicKeys: map[string]*Key{
+			targetsKey.KeyID: targetsKey,
+		},
+	}
+
+	err = rootMetadata.AddPrimaryRuleFilePrincipal(person)
+	assert.Nil(t, err)
+	assert.Equal(t, person, rootMetadata.Principals[person.PersonID])
+	assert.Equal(t, set.NewSetFromItems(targetsKey.KeyID, person.PersonID), rootMetadata.Roles[tuf.TargetsRoleName].PrincipalIDs)
+}
+
+func TestDeletePrimaryRuleFilePrincipal(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	targetsKey1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	targetsKey2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	err := rootMetadata.AddPrimaryRuleFilePrincipal(targetsKey1)
+	assert.Nil(t, err)
+	err = rootMetadata.AddPrimaryRuleFilePrincipal(targetsKey2)
+	assert.Nil(t, err)
+
+	err = rootMetadata.DeletePrimaryRuleFilePrincipal("")
+	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalID)
+
+	err = rootMetadata.DeletePrimaryRuleFilePrincipal(targetsKey1.KeyID)
+	assert.Nil(t, err)
+	assert.Equal(t, targetsKey1, rootMetadata.Principals[targetsKey1.KeyID])
+	assert.Equal(t, targetsKey2, rootMetadata.Principals[targetsKey2.KeyID])
+	targetsRole := rootMetadata.Roles[tuf.TargetsRoleName]
+	assert.True(t, targetsRole.PrincipalIDs.Has(targetsKey2.KeyID))
+
+	person := &Person{
+		PersonID: "jane.doe@example.com",
+		PublicKeys: map[string]*Key{
+			targetsKey1.KeyID: targetsKey1,
+		},
+	}
+	err = rootMetadata.AddPrimaryRuleFilePrincipal(person)
+	assert.Nil(t, err)
+	assert.True(t, rootMetadata.Roles[tuf.TargetsRoleName].PrincipalIDs.Has(person.PersonID))
+
+	err = rootMetadata.DeletePrimaryRuleFilePrincipal(person.PersonID)
+	assert.Nil(t, err)
+	assert.False(t, rootMetadata.Roles[tuf.TargetsRoleName].PrincipalIDs.Has(person.PersonID))
+
+	err = rootMetadata.DeletePrimaryRuleFilePrincipal(targetsKey2.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrCannotMeetThreshold)
+}
+
+func TestAddGitHubAppPrincipal(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	err := rootMetadata.AddGitHubAppPrincipal(nil)
+	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalType)
+
+	err = rootMetadata.AddGitHubAppPrincipal(appKey)
+	assert.Nil(t, err)
+	assert.Equal(t, appKey, rootMetadata.Principals[appKey.KeyID])
+	assert.Equal(t, set.NewSetFromItems(appKey.KeyID), rootMetadata.Roles[tuf.GitHubAppRoleName].PrincipalIDs)
+}
+
+func TestDeleteGitHubAppPrincipal(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	err := rootMetadata.AddGitHubAppPrincipal(appKey)
+	assert.Nil(t, err)
+
+	rootMetadata.DeleteGitHubAppPrincipal()
+	assert.Nil(t, rootMetadata.Roles[tuf.GitHubAppRoleName].PrincipalIDs)
+}
+
+func TestEnableGitHubAppApprovals(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+	assert.False(t, rootMetadata.GitHubApprovalsTrusted)
+
+	rootMetadata.EnableGitHubAppApprovals()
+	assert.True(t, rootMetadata.GitHubApprovalsTrusted)
+}
+
+func TestDisableGitHubAppApprovals(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+	assert.False(t, rootMetadata.GitHubApprovalsTrusted)
+
+	rootMetadata.EnableGitHubAppApprovals()
+	assert.True(t, rootMetadata.GitHubApprovalsTrusted)
+
+	rootMetadata.DisableGitHubAppApprovals()
+	assert.False(t, rootMetadata.GitHubApprovalsTrusted)
+}
+
+func TestUpdateAndGetRootThreshold(t *testing.T) {
+	rootMetadata := NewRootMetadata()
+
+	err := rootMetadata.UpdateRootThreshold(3)
+	assert.ErrorIs(t, err, tuf.ErrInvalidRootMetadata)
+
+	threshold, err := rootMetadata.GetRootThreshold()
+	assert.ErrorIs(t, err, tuf.ErrInvalidRootMetadata)
+	assert.Equal(t, -1, threshold)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	if err := rootMetadata.AddRootPrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+	if err := rootMetadata.AddRootPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+
+	err = rootMetadata.UpdateRootThreshold(2)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, rootMetadata.Roles[tuf.RootRoleName].Threshold)
+
+	threshold, err = rootMetadata.GetRootThreshold()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, threshold)
+
+	err = rootMetadata.UpdateRootThreshold(3)
+	assert.ErrorIs(t, err, tuf.ErrCannotMeetThreshold)
+}
+
+func TestUpdateAndGetPrimaryRuleFileThreshold(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	err := rootMetadata.UpdatePrimaryRuleFileThreshold(3)
+	assert.ErrorIs(t, err, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot)
+
+	threshold, err := rootMetadata.GetPrimaryRuleFileThreshold()
+	assert.ErrorIs(t, err, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot)
+	assert.Equal(t, -1, threshold)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	if err := rootMetadata.AddPrimaryRuleFilePrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+	if err := rootMetadata.AddPrimaryRuleFilePrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+
+	err = rootMetadata.UpdatePrimaryRuleFileThreshold(2)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, rootMetadata.Roles[tuf.TargetsRoleName].Threshold)
+
+	threshold, err = rootMetadata.GetPrimaryRuleFileThreshold()
+	assert.Nil(t, err)
+	assert.Equal(t, 2, threshold)
+
+	err = rootMetadata.UpdatePrimaryRuleFileThreshold(3)
+	assert.ErrorIs(t, err, tuf.ErrCannotMeetThreshold)
+}
+
+func TestGetRootPrincipals(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe@example.com",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+
+	t.Run("root role exists", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+
+		expectedPrincipals := []tuf.Principal{key}
+		rootPrincipals, err := rootMetadata.GetRootPrincipals()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPrincipals, rootPrincipals)
+	})
+
+	t.Run("root role does not exist", func(t *testing.T) {
+		rootMetadata := NewRootMetadata()
+
+		rootPrincipals, err := rootMetadata.GetRootPrincipals()
+		assert.ErrorIs(t, err, tuf.ErrInvalidRootMetadata)
+		assert.Nil(t, rootPrincipals)
+	})
+
+	t.Run("with person", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+
+		err := rootMetadata.AddRootPrincipal(person)
+		assert.Nil(t, err)
+
+		expectedPrincipals := []tuf.Principal{key, person}
+		sort.Slice(expectedPrincipals, func(i, j int) bool {
+			return expectedPrincipals[i].ID() < expectedPrincipals[j].ID()
+		})
+
+		rootPrincipals, err := rootMetadata.GetRootPrincipals()
+		assert.Nil(t, err)
+		sort.Slice(rootPrincipals, func(i, j int) bool {
+			return rootPrincipals[i].ID() < rootPrincipals[j].ID()
+		})
+		assert.Equal(t, expectedPrincipals, rootPrincipals)
+	})
+}
+
+func TestGetPrimaryRuleFilePrincipals(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe@example.com",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+
+	t.Run("targets role exists", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+		err := rootMetadata.AddPrimaryRuleFilePrincipal(key)
+		assert.Nil(t, err)
+
+		expectedPrincipals := []tuf.Principal{key}
+		principals, err := rootMetadata.GetPrimaryRuleFilePrincipals()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPrincipals, principals)
+	})
+
+	t.Run("targets role does not exist", func(t *testing.T) {
+		rootMetadata := NewRootMetadata()
+
+		rootPrincipals, err := rootMetadata.GetPrimaryRuleFilePrincipals()
+		assert.ErrorIs(t, err, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot)
+		assert.Nil(t, rootPrincipals)
+	})
+
+	t.Run("with person", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+
+		err := rootMetadata.AddPrimaryRuleFilePrincipal(person)
+		assert.Nil(t, err)
+
+		expectedPrincipals := []tuf.Principal{person}
+		principals, err := rootMetadata.GetPrimaryRuleFilePrincipals()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPrincipals, principals)
+	})
+}
+
+func TestGetGitHubAppPrincipals(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+
+	t.Run("role exists", func(t *testing.T) {
+		rootMetadata := initialTestRootMetadata(t)
+		err := rootMetadata.AddGitHubAppPrincipal(key)
+		assert.Nil(t, err)
+
+		expectedPrincipals := []tuf.Principal{key}
+		principals, err := rootMetadata.GetGitHubAppPrincipals()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPrincipals, principals)
+	})
+
+	t.Run("role does not exist", func(t *testing.T) {
+		rootMetadata := NewRootMetadata()
+
+		rootPrincipals, err := rootMetadata.GetGitHubAppPrincipals()
+		assert.ErrorIs(t, err, tuf.ErrGitHubAppInformationNotFoundInRoot)
+		assert.Nil(t, rootPrincipals)
+	})
+}
+
+func TestIsGitHubAppApprovalTrusted(t *testing.T) {
+	rootMetadata := initialTestRootMetadata(t)
+
+	trusted := rootMetadata.IsGitHubAppApprovalTrusted()
+	assert.False(t, trusted)
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	err := rootMetadata.AddGitHubAppPrincipal(key)
+	assert.Nil(t, err)
+
+	rootMetadata.EnableGitHubAppApprovals()
+	trusted = rootMetadata.IsGitHubAppApprovalTrusted()
+	assert.True(t, trusted)
+}

--- a/internal/tuf/v02/targets.go
+++ b/internal/tuf/v02/targets.go
@@ -1,0 +1,379 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/danwakefield/fnmatch"
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+const (
+	TargetsVersion = "http://gittuf.dev/policy/rule-file/v0.2"
+)
+
+var ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
+
+// TargetsMetadata defines the schema of TUF's Targets role.
+type TargetsMetadata struct {
+	Type        string         `json:"type"`
+	Version     string         `json:"schemaVersion"`
+	Expires     string         `json:"expires"`
+	Targets     map[string]any `json:"targets"`
+	Delegations *Delegations   `json:"delegations"`
+}
+
+// NewTargetsMetadata returns a new instance of TargetsMetadata.
+func NewTargetsMetadata() *TargetsMetadata {
+	return &TargetsMetadata{
+		Type:        "targets",
+		Version:     TargetsVersion,
+		Delegations: &Delegations{Roles: []*Delegation{AllowRule()}},
+	}
+}
+
+// SetExpires sets the expiry date of the TargetsMetadata to the value passed
+// in.
+func (t *TargetsMetadata) SetExpires(expires string) {
+	t.Expires = expires
+}
+
+// SchemaVersion returns the metadata schema version.
+func (t *TargetsMetadata) SchemaVersion() string {
+	return t.Version
+}
+
+// Validate ensures the instance of TargetsMetadata matches gittuf expectations.
+func (t *TargetsMetadata) Validate() error {
+	if len(t.Targets) != 0 {
+		return ErrTargetsNotEmpty
+	}
+	return nil
+}
+
+// AddRule adds a new delegation to TargetsMetadata.
+func (t *TargetsMetadata) AddRule(ruleName string, authorizedPrincipals []tuf.Principal, rulePatterns []string, threshold int) error {
+	if ruleName == tuf.AllowRuleName {
+		return tuf.ErrCannotManipulateAllowRule
+	}
+
+	authorizedPrincipalIDs := set.NewSet[string]()
+	for _, principal := range authorizedPrincipals {
+		if err := t.Delegations.addPrincipal(principal); err != nil {
+			return err
+		}
+
+		authorizedPrincipalIDs.Add(principal.ID())
+	}
+
+	allDelegations := t.Delegations.Roles
+	if allDelegations == nil {
+		allDelegations = []*Delegation{}
+	}
+
+	newDelegation := &Delegation{
+		Name:        ruleName,
+		Paths:       rulePatterns,
+		Terminating: false,
+		Role: Role{
+			PrincipalIDs: authorizedPrincipalIDs,
+			Threshold:    threshold,
+		},
+	}
+	allDelegations = append(allDelegations[:len(allDelegations)-1], newDelegation, AllowRule())
+	t.Delegations.Roles = allDelegations
+	return nil
+}
+
+// UpdateRule is used to amend a delegation in TargetsMetadata.
+func (t *TargetsMetadata) UpdateRule(ruleName string, authorizedPrincipals []tuf.Principal, rulePatterns []string, threshold int) error {
+	if ruleName == tuf.AllowRuleName {
+		return tuf.ErrCannotManipulateAllowRule
+	}
+
+	if len(authorizedPrincipals) < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	authorizedPrincipalIDs := set.NewSet[string]()
+	for _, principal := range authorizedPrincipals {
+		if err := t.Delegations.addPrincipal(principal); err != nil {
+			return err
+		}
+
+		authorizedPrincipalIDs.Add(principal.ID())
+	}
+
+	allDelegations := []*Delegation{}
+	for _, delegation := range t.Delegations.Roles {
+		if delegation.ID() == tuf.AllowRuleName {
+			break
+		}
+
+		if delegation.ID() != ruleName {
+			allDelegations = append(allDelegations, delegation)
+			continue
+		}
+
+		if delegation.Name == ruleName {
+			delegation.Paths = rulePatterns
+			delegation.Role = Role{
+				PrincipalIDs: authorizedPrincipalIDs,
+				Threshold:    threshold,
+			}
+		}
+
+		allDelegations = append(allDelegations, delegation)
+	}
+	allDelegations = append(allDelegations, AllowRule())
+	t.Delegations.Roles = allDelegations
+	return nil
+}
+
+// ReorderRules changes the order of delegations, and the new order is specified
+// in `ruleNames []string`.
+func (t *TargetsMetadata) ReorderRules(ruleNames []string) error {
+	// Create a map of all existing delegations for quick look up
+	rolesMap := make(map[string]*Delegation)
+
+	// Create a set of current rules in metadata, skipping the allow rule
+	currentRules := set.NewSet[string]()
+	for _, delegation := range t.Delegations.Roles {
+		if delegation.Name == tuf.AllowRuleName {
+			continue
+		}
+		rolesMap[delegation.Name] = delegation
+		currentRules.Add(delegation.Name)
+	}
+
+	specifiedRules := set.NewSet[string]()
+	for _, name := range ruleNames {
+		if specifiedRules.Has(name) {
+			return fmt.Errorf("%w: '%s'", tuf.ErrDuplicatedRuleName, name)
+		}
+		specifiedRules.Add(name)
+	}
+
+	if !currentRules.Equal(specifiedRules) {
+		onlyInSpecifiedRules := specifiedRules.Minus(currentRules)
+		if onlyInSpecifiedRules.Len() != 0 {
+			if onlyInSpecifiedRules.Has(tuf.AllowRuleName) {
+				return fmt.Errorf("%w: do not specify allow rule", tuf.ErrCannotManipulateAllowRule)
+			}
+
+			contents := onlyInSpecifiedRules.Contents()
+			return fmt.Errorf("%w: rules '%s' do not exist in current rule file", tuf.ErrRuleNotFound, strings.Join(contents, ", "))
+		}
+
+		onlyInCurrentRules := currentRules.Minus(specifiedRules)
+		if onlyInCurrentRules.Len() != 0 {
+			contents := onlyInCurrentRules.Contents()
+			return fmt.Errorf("%w: rules '%s' not specified", tuf.ErrMissingRules, strings.Join(contents, ", "))
+		}
+	}
+
+	// Create newDelegations and set it in the targetsMetadata after adding allow rule
+	newDelegations := make([]*Delegation, 0, len(rolesMap)+1)
+	for _, ruleName := range ruleNames {
+		newDelegations = append(newDelegations, rolesMap[ruleName])
+	}
+	newDelegations = append(newDelegations, AllowRule())
+	t.Delegations.Roles = newDelegations
+	return nil
+}
+
+// RemoveRule deletes a delegation entry from TargetsMetadata.
+func (t *TargetsMetadata) RemoveRule(ruleName string) error {
+	if ruleName == tuf.AllowRuleName {
+		return tuf.ErrCannotManipulateAllowRule
+	}
+
+	allDelegations := t.Delegations.Roles
+	updatedDelegations := []*Delegation{}
+
+	for _, delegation := range allDelegations {
+		if delegation.Name != ruleName {
+			updatedDelegations = append(updatedDelegations, delegation)
+		}
+	}
+	t.Delegations.Roles = updatedDelegations
+	return nil
+}
+
+// GetPrincipals returns all the principals in the rule file.
+func (t *TargetsMetadata) GetPrincipals() map[string]tuf.Principal {
+	principals := map[string]tuf.Principal{}
+	for id, principal := range t.Delegations.Principals {
+		principals[id] = principal
+	}
+
+	return principals
+}
+
+// GetRules returns all the rules in the metadata.
+func (t *TargetsMetadata) GetRules() []tuf.Rule {
+	if t.Delegations == nil {
+		return nil
+	}
+
+	rules := make([]tuf.Rule, 0, len(t.Delegations.Roles))
+	for _, delegation := range t.Delegations.Roles {
+		rules = append(rules, delegation)
+	}
+
+	return rules
+}
+
+// AddPrincipal adds a principal to the metadata.
+//
+// TODO: this isn't associated with a specific rule; with the removal of
+// verify-commit and verify-tag, it may not make sense anymore
+func (t *TargetsMetadata) AddPrincipal(principal tuf.Principal) error {
+	return t.Delegations.addPrincipal(principal)
+}
+
+// Delegations defines the schema for specifying delegations in TUF's Targets
+// metadata.
+type Delegations struct {
+	Principals map[string]tuf.Principal `json:"principals"`
+	Roles      []*Delegation            `json:"roles"`
+}
+
+func (d *Delegations) UnmarshalJSON(data []byte) error {
+	// this type _has_ to be a copy of Delegations, minus the use of
+	// json.RawMessage in place of tuf.Principal
+	type tempType struct {
+		Principals map[string]json.RawMessage `json:"principals"`
+		Roles      []*Delegation              `json:"roles"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	d.Principals = make(map[string]tuf.Principal)
+	for principalID, principalBytes := range temp.Principals {
+		tempPrincipal := map[string]any{}
+		if err := json.Unmarshal(principalBytes, &tempPrincipal); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		if _, has := tempPrincipal["keyid"]; has {
+			// this is *Key
+			key := &Key{}
+			if err := json.Unmarshal(principalBytes, key); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			d.Principals[principalID] = key
+			continue
+		}
+
+		if _, has := tempPrincipal["personID"]; has {
+			// this is *Person
+			person := &Person{}
+			if err := json.Unmarshal(principalBytes, person); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			d.Principals[principalID] = person
+			continue
+		}
+
+		return fmt.Errorf("unrecognized principal type '%s'", string(principalBytes))
+	}
+
+	d.Roles = temp.Roles
+
+	return nil
+}
+
+// addPrincipal adds a delegations key or person.  v02 supports Key and Person
+// as principal types.
+func (d *Delegations) addPrincipal(principal tuf.Principal) error {
+	if d.Principals == nil {
+		d.Principals = map[string]tuf.Principal{}
+	}
+
+	switch principal := principal.(type) {
+	case *Key, *Person:
+		d.Principals[principal.ID()] = principal
+	default:
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	return nil
+}
+
+// AllowRule returns the default, last rule for all policy files.
+func AllowRule() *Delegation {
+	return &Delegation{
+		Name:        tuf.AllowRuleName,
+		Paths:       []string{"*"},
+		Terminating: true,
+		Role: Role{
+			Threshold: 1,
+		},
+	}
+}
+
+// Delegation defines the schema for a single delegation entry. It differs from
+// the standard TUF schema by allowing a `custom` field to record details
+// pertaining to the delegation. It implements the tuf.Rule interface.
+type Delegation struct {
+	Name        string           `json:"name"`
+	Paths       []string         `json:"paths"`
+	Terminating bool             `json:"terminating"`
+	Custom      *json.RawMessage `json:"custom,omitempty"`
+	Role
+}
+
+// ID returns the identifier of the delegation, its name.
+func (d *Delegation) ID() string {
+	return d.Name
+}
+
+// Matches checks if any of the delegation's patterns match the target.
+func (d *Delegation) Matches(target string) bool {
+	for _, pattern := range d.Paths {
+		// We validate pattern when it's added to / updated in the metadata
+		if matches := fnmatch.Match(pattern, target, 0); matches {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPrincipalIDs returns the identifiers of the principals that are listed as
+// trusted by the rule.
+func (d *Delegation) GetPrincipalIDs() *set.Set[string] {
+	return d.Role.PrincipalIDs
+}
+
+// GetThreshold returns the threshold of principals that must approve to meet
+// the rule.
+func (d *Delegation) GetThreshold() int {
+	return d.Role.Threshold
+}
+
+// IsLastTrustedInRuleFile indicates that subsequent rules in the rule file are
+// not to be trusted if the current rule matches the namespace under
+// verification (similar to TUF's terminating behavior). However, the current
+// rule's delegated rules as well as other rules already in the queue are
+// trusted.
+func (d *Delegation) IsLastTrustedInRuleFile() bool {
+	return d.Terminating
+}
+
+// GetProtectedNamespaces returns the set of namespaces protected by the
+// delegation.
+func (d *Delegation) GetProtectedNamespaces() []string {
+	return d.Paths
+}

--- a/internal/tuf/v02/targets_test.go
+++ b/internal/tuf/v02/targets_test.go
@@ -1,0 +1,403 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetsMetadataAndDelegations(t *testing.T) {
+	targetsMetadata := NewTargetsMetadata()
+
+	t.Run("test SetExpires", func(t *testing.T) {
+		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)
+		targetsMetadata.SetExpires(d.Format(time.RFC3339))
+		assert.Equal(t, "1995-10-26T09:00:00Z", targetsMetadata.Expires)
+	})
+
+	t.Run("test Validate", func(t *testing.T) {
+		err := targetsMetadata.Validate()
+		assert.Nil(t, err)
+
+		targetsMetadata.Targets = map[string]any{"test": true}
+		err = targetsMetadata.Validate()
+		assert.ErrorIs(t, err, ErrTargetsNotEmpty)
+		targetsMetadata.Targets = nil
+	})
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+
+	delegations := &Delegations{}
+
+	t.Run("test addPrincipal", func(t *testing.T) {
+		assert.Nil(t, delegations.Principals)
+
+		err := delegations.addPrincipal(key)
+		assert.Nil(t, err)
+		assert.Equal(t, key, delegations.Principals[key.KeyID])
+
+		err = delegations.addPrincipal(person)
+		assert.Nil(t, err)
+		assert.Equal(t, person, delegations.Principals[person.PersonID])
+	})
+}
+
+func TestDelegation(t *testing.T) {
+	t.Run("matches", func(t *testing.T) {
+		tests := map[string]struct {
+			patterns []string
+			target   string
+			expected bool
+		}{
+			"full path, matches": {
+				patterns: []string{"foo"},
+				target:   "foo",
+				expected: true,
+			},
+			"artifact in directory, matches": {
+				patterns: []string{"foo/*"},
+				target:   "foo/bar",
+				expected: true,
+			},
+			"artifact in directory, does not match": {
+				patterns: []string{"foo/*.txt"},
+				target:   "foo/bar.tgz",
+				expected: false,
+			},
+			"artifact in directory, one pattern matches": {
+				patterns: []string{"foo/*.txt", "foo/*.tgz"},
+				target:   "foo/bar.tgz",
+				expected: true,
+			},
+			"artifact in subdirectory, matches": {
+				patterns: []string{"foo/*"},
+				target:   "foo/bar/foobar",
+				expected: true,
+			},
+			"artifact in subdirectory with specified extension, matches": {
+				patterns: []string{"foo/*.tgz"},
+				target:   "foo/bar/foobar.tgz",
+				expected: true,
+			},
+			"pattern with single character selector, matches": {
+				patterns: []string{"foo/?.tgz"},
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, matches": {
+				patterns: []string{"foo/[abc].tgz"},
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, does not match": {
+				patterns: []string{"foo/[abc].tgz"},
+				target:   "foo/x.tgz",
+				expected: false,
+			},
+			"pattern with negative character sequence, matches": {
+				patterns: []string{"foo/[!abc].tgz"},
+				target:   "foo/x.tgz",
+				expected: true,
+			},
+			"pattern with negative character sequence, does not match": {
+				patterns: []string{"foo/[!abc].tgz"},
+				target:   "foo/a.tgz",
+				expected: false,
+			},
+			"artifact in arbitrary directory, matches": {
+				patterns: []string{"*/*.txt"},
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with specific name in arbitrary directory, matches": {
+				patterns: []string{"*/foobar.txt"},
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with arbitrary subdirectories, matches": {
+				patterns: []string{"foo/*/foobar.txt"},
+				target:   "foo/bar/baz/foobar.txt",
+				expected: true,
+			},
+			"artifact in arbitrary directory, does not match": {
+				patterns: []string{"*.txt"},
+				target:   "foo/bar/foobar.txtfile",
+				expected: false,
+			},
+			"arbitrary directory, does not match": {
+				patterns: []string{"*_test"},
+				target:   "foo/bar_test/foobar",
+				expected: false,
+			},
+			"no patterns": {
+				patterns: nil,
+				target:   "foo",
+				expected: false,
+			},
+			"pattern with multiple consecutive wildcards, matches": {
+				patterns: []string{"foo/*/*/*.txt"},
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with multiple non-consecutive wildcards, matches": {
+				patterns: []string{"foo/*/baz/*.txt"},
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with gittuf git prefix, matches": {
+				patterns: []string{"git:refs/heads/*"},
+				target:   "git:refs/heads/main",
+				expected: true,
+			},
+			"pattern with gittuf file prefix for all recursive contents, matches": {
+				patterns: []string{"file:src/signatures/*"},
+				target:   "file:src/signatures/rsa/rsa.go",
+				expected: true,
+			},
+		}
+
+		for name, test := range tests {
+			delegation := Delegation{Paths: test.patterns}
+			got := delegation.Matches(test.target)
+			assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+		}
+	})
+
+	t.Run("threshold", func(t *testing.T) {
+		delegation := &Delegation{}
+
+		threshold := delegation.GetThreshold()
+		assert.Equal(t, 0, threshold)
+
+		delegation.Threshold = 1
+		threshold = delegation.GetThreshold()
+		assert.Equal(t, 1, threshold)
+	})
+
+	t.Run("terminating", func(t *testing.T) {
+		delegation := &Delegation{}
+
+		isTerminating := delegation.IsLastTrustedInRuleFile()
+		assert.False(t, isTerminating)
+
+		delegation.Terminating = true
+		isTerminating = delegation.IsLastTrustedInRuleFile()
+		assert.True(t, isTerminating)
+	})
+
+	t.Run("protected namespaces", func(t *testing.T) {
+		delegation := &Delegation{
+			Paths: []string{"1", "2"},
+		}
+
+		protected := delegation.GetProtectedNamespaces()
+		assert.Equal(t, []string{"1", "2"}, protected)
+	})
+
+	t.Run("principal IDs", func(t *testing.T) {
+		keyIDs := set.NewSetFromItems("1", "2")
+		delegation := &Delegation{
+			Role: Role{PrincipalIDs: keyIDs},
+		}
+
+		principalIDs := delegation.GetPrincipalIDs()
+		assert.Equal(t, keyIDs, principalIDs)
+	})
+}
+
+func TestAddRuleAndGetRules(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key1.KeyID: key1},
+	}
+
+	err := targetsMetadata.AddRule("test-rule", []tuf.Principal{key1, key2, person}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key2.KeyID)
+	assert.Equal(t, key2, targetsMetadata.Delegations.Principals[key2.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, person.PersonID)
+	assert.Equal(t, person, targetsMetadata.Delegations.Principals[person.PersonID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+
+	rule := &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID, person.PersonID), Threshold: 1},
+	}
+	assert.Equal(t, rule, targetsMetadata.Delegations.Roles[0])
+
+	rules := targetsMetadata.GetRules()
+	assert.Equal(t, 2, len(rules))
+	assert.Equal(t, []tuf.Rule{rule, AllowRule()}, rules)
+}
+
+func TestUpdateDelegation(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	err := targetsMetadata.AddRule("test-rule", []tuf.Principal{key1}, []string{"test/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Equal(t, &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID), Threshold: 1},
+	}, targetsMetadata.Delegations.Roles[0])
+
+	err = targetsMetadata.UpdateRule("test-rule", []tuf.Principal{key1, key2}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key2.KeyID)
+	assert.Equal(t, key2, targetsMetadata.Delegations.Principals[key2.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Equal(t, &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID), Threshold: 1},
+	}, targetsMetadata.Delegations.Roles[0])
+}
+
+func TestReorderRules(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	err := targetsMetadata.AddRule("rule-1", []tuf.Principal{key1}, []string{"path1/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = targetsMetadata.AddRule("rule-2", []tuf.Principal{key2}, []string{"path2/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = targetsMetadata.AddRule("rule-3", []tuf.Principal{key1, key2}, []string{"path3/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		ruleNames     []string
+		expected      []string
+		expectedError error
+	}{
+		"reverse order (valid input)": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1"},
+			expected:      []string{"rule-3", "rule-2", "rule-1", tuf.AllowRuleName},
+			expectedError: nil,
+		},
+		"rule not specified in new order": {
+			ruleNames:     []string{"rule-3", "rule-2"},
+			expectedError: tuf.ErrMissingRules,
+		},
+		"rule repeated in the new order": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1", "rule-3"},
+			expectedError: tuf.ErrDuplicatedRuleName,
+		},
+		"unknown rule in the new order": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1", "rule-4"},
+			expectedError: tuf.ErrRuleNotFound,
+		},
+		"unknown rule in the new order (with correct length)": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-4"},
+			expectedError: tuf.ErrRuleNotFound,
+		},
+		"allow rule appears in the new order": {
+			ruleNames:     []string{"rule-2", "rule-3", "rule-1", tuf.AllowRuleName},
+			expectedError: tuf.ErrCannotManipulateAllowRule,
+		},
+	}
+
+	for name, test := range tests {
+		err = targetsMetadata.ReorderRules(test.ruleNames)
+		if test.expectedError != nil {
+			assert.ErrorIs(t, err, test.expectedError, fmt.Sprintf("unexpected error in test '%s'", name))
+		} else {
+			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
+			assert.Equal(t, len(test.expected), len(targetsMetadata.Delegations.Roles),
+				fmt.Sprintf("expected %d rules in test '%s', but got %d rules",
+					len(test.expected), name, len(targetsMetadata.Delegations.Roles)))
+			for i, ruleName := range test.expected {
+				assert.Equal(t, ruleName, targetsMetadata.Delegations.Roles[i].Name,
+					fmt.Sprintf("expected rule '%s' at index %d in test '%s', but got '%s'",
+						ruleName, i, name, targetsMetadata.Delegations.Roles[i].Name))
+			}
+		}
+	}
+}
+
+func TestRemoveRule(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	err := targetsMetadata.AddRule("test-rule", []tuf.Principal{key}, []string{"test/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(targetsMetadata.Delegations.Roles))
+
+	err = targetsMetadata.RemoveRule("test-rule")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(targetsMetadata.Delegations.Roles))
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key.KeyID)
+}
+
+func TestGetPrincipals(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	if err := targetsMetadata.AddRule("test", []tuf.Principal{key1}, []string{"1"}, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	principals := targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1}, principals)
+
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+	if err := targetsMetadata.AddPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+
+	principals = targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1, key2.KeyID: key2}, principals)
+}
+
+func TestAllowRule(t *testing.T) {
+	allowRule := AllowRule()
+	assert.Equal(t, tuf.AllowRuleName, allowRule.Name)
+	assert.Equal(t, []string{"*"}, allowRule.Paths)
+	assert.True(t, allowRule.Terminating)
+	assert.Empty(t, allowRule.PrincipalIDs)
+	assert.Equal(t, 1, allowRule.Threshold)
+}

--- a/internal/tuf/v02/tuf.go
+++ b/internal/tuf/v02/tuf.go
@@ -1,0 +1,64 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+// This package defines gittuf's take on TUF metadata. There are some minor
+// changes, such as the addition of `custom` to delegation entries. Some of it,
+// however, is inspired by or cloned from the go-tuf implementation.
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/dev"
+	v01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+)
+
+const AllowV02MetadataKey = "GITTUF_ALLOW_V02_POLICY"
+
+// AllowV02Metadata returns true if gittuf is in developer mode and
+// GITTUF_ALLOW_V02_POLICY=1.
+func AllowV02Metadata() bool {
+	return dev.InDevMode() && os.Getenv(AllowV02MetadataKey) == "1"
+}
+
+// Key defines the structure for how public keys are stored in TUF metadata. It
+// implements the tuf.Principal and is used for backwards compatibility where a
+// Principal is always represented directly by a signing key or identity.
+type Key = v01.Key
+
+// NewKeyFromSSLibKey converts the signerverifier.SSLibKey into a Key object.
+func NewKeyFromSSLibKey(key *signerverifier.SSLibKey) *Key {
+	k := Key(*key)
+	return &k
+}
+
+type Person struct {
+	PersonID             string            `json:"personID"`
+	PublicKeys           map[string]*Key   `json:"keys"`
+	AssociatedIdentities map[string]string `json:"associatedIdentities"`
+	Custom               map[string]string `json:"custom"`
+}
+
+func (p *Person) ID() string {
+	return p.PersonID
+}
+
+func (p *Person) Keys() []*signerverifier.SSLibKey {
+	keys := make([]*signerverifier.SSLibKey, 0, len(p.PublicKeys))
+	for _, key := range p.PublicKeys {
+		key := signerverifier.SSLibKey(*key)
+		keys = append(keys, &key)
+	}
+
+	return keys
+}
+
+// Role records common characteristics recorded in a role entry in Root metadata
+// and in a delegation entry.
+type Role struct {
+	PrincipalIDs *set.Set[string] `json:"principalIDs"`
+	Threshold    int              `json:"threshold"`
+}


### PR DESCRIPTION
This commit introduces v02 of policy metadata schemas for root and targets files. The biggest change is the introduction of the Person principal type. Additionally, this commit also sets v02 as the default and sets up migrations for existing v01 metadata.