### PR TITLE
debug: Add Dockerfile for debugging gittuf on Git 2.34.1

### DIFF
--- a/debug/Dockerfile.Git_2_34_1
+++ b/debug/Dockerfile.Git_2_34_1
@@ -1,0 +1,18 @@
+# This Dockerfile can be used to build a container image with Git 2.34.1 but the
+# latest Go and delve release. This is useful when debugging gittuf errors with
+# Git 2.34.1, a version of Git we support due to it being the latest on Ubuntu
+# 22.04 LTS. After building the container image, run it with the local
+# repository as a mounted volume. That way, changes can be made outside the
+# container but iteratively debugged within the container.
+
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install git software-properties-common -y
+
+RUN add-apt-repository ppa:longsleep/golang-backports -y
+
+RUN apt-get update && apt-get install golang -y
+
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+ENV PATH=/root/go/bin:$PATH

--- a/debug/README.md
+++ b/debug/README.md
@@ -1,0 +1,16 @@
+# Debug Helpers
+
+This directory contains tools or artifacts used by the gittuf developers during
+debugging.
+
+## Debugging gittuf with Git 2.34.1
+
+Build and run the container from the root of the gittuf repository.
+
+```bash
+docker build -t debug-gittuf-2-34-1 -f debug/Dockerfile.Git_2_34_1 .
+docker run -it --rm -v $PWD:/gittuf -w /gittuf debug-gittuf-2-34-1
+```
+
+As the gittuf repository is mounted as a volume, you can make changes on the
+host and iteratively debug within the container.


### PR DESCRIPTION
This should make life easier when debugging on Git 2.34.1.