### PR TITLE
*: Move signing checks around

### DIFF
--- a/experimental/gittuf/attestations.go
+++ b/experimental/gittuf/attestations.go
@@ -47,6 +47,14 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 		return dev.ErrNotInDevMode
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	var err error
 
 	targetRef, err = r.r.AbsoluteReference(targetRef)
@@ -173,6 +181,14 @@ func (r *Repository) RemoveReferenceAuthorization(ctx context.Context, signer ss
 		return dev.ErrNotInDevMode
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	// Ensure only the key that created a reference authorization can remove it
 	slog.Debug("Evaluating if key can sign...")
 	_, err := signer.Sign(ctx, nil)
@@ -245,10 +261,19 @@ func (r *Repository) AddGitHubPullRequestAttestationForCommit(ctx context.Contex
 		return dev.ErrNotInDevMode
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	options := githubopts.DefaultOptions
 	for _, fn := range opts {
 		fn(options)
 	}
+
 	if options.GitHubToken == "" {
 		options.GitHubToken = os.Getenv(githubTokenEnvKey)
 
@@ -298,10 +323,19 @@ func (r *Repository) AddGitHubPullRequestAttestationForNumber(ctx context.Contex
 		return dev.ErrNotInDevMode
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	options := githubopts.DefaultOptions
 	for _, fn := range opts {
 		fn(options)
 	}
+
 	if options.GitHubToken == "" {
 		options.GitHubToken = os.Getenv(githubTokenEnvKey)
 
@@ -312,6 +346,7 @@ func (r *Repository) AddGitHubPullRequestAttestationForNumber(ctx context.Contex
 	}
 
 	client, err := getGitHubClient(options.GitHubBaseURL, options.GitHubToken)
+
 	if err != nil {
 		return err
 	}
@@ -338,10 +373,19 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 		return dev.ErrNotInDevMode
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	options := githubopts.DefaultOptions
 	for _, fn := range opts {
 		fn(options)
 	}
+
 	if options.GitHubToken == "" {
 		options.GitHubToken = os.Getenv(githubTokenEnvKey)
 
@@ -425,6 +469,14 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 func (r *Repository) DismissGitHubPullRequestApprover(ctx context.Context, signer sslibdsse.SignerVerifier, reviewID int64, dismissedApprover string, signCommit bool, opts ...githubopts.Option) error {
 	if !dev.InDevMode() {
 		return dev.ErrNotInDevMode
+	}
+
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
 	}
 
 	options := githubopts.DefaultOptions

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -24,10 +24,19 @@ import (
 // InitializeRoot is the interface for the user to create the repository's root
 // of trust.
 func (r *Repository) InitializeRoot(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	var (
 		publicKeyRaw *signerverifier.SSLibKey
 		err          error
 	)
+
 	switch signer := signer.(type) {
 	case *ssh.Signer:
 		publicKeyRaw = signer.MetadataKey()
@@ -72,6 +81,14 @@ func (r *Repository) InitializeRoot(ctx context.Context, signer sslibdsse.Signer
 // AddRootKey is the interface for the user to add an authorized key
 // for the Root role.
 func (r *Repository) AddRootKey(ctx context.Context, signer sslibdsse.SignerVerifier, newRootKey tuf.Principal, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -111,6 +128,14 @@ func (r *Repository) AddRootKey(ctx context.Context, signer sslibdsse.SignerVeri
 // RemoveRootKey is the interface for the user to de-authorize a key
 // trusted to sign the Root role.
 func (r *Repository) RemoveRootKey(ctx context.Context, signer sslibdsse.SignerVerifier, keyID string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -147,6 +172,14 @@ func (r *Repository) RemoveRootKey(ctx context.Context, signer sslibdsse.SignerV
 // AddTopLevelTargetsKey is the interface for the user to add an authorized key
 // for the top level Targets role / policy file.
 func (r *Repository) AddTopLevelTargetsKey(ctx context.Context, signer sslibdsse.SignerVerifier, targetsKey tuf.Principal, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -175,6 +208,14 @@ func (r *Repository) AddTopLevelTargetsKey(ctx context.Context, signer sslibdsse
 // RemoveTopLevelTargetsKey is the interface for the user to de-authorize a key
 // trusted to sign the top level Targets role / policy file.
 func (r *Repository) RemoveTopLevelTargetsKey(ctx context.Context, signer sslibdsse.SignerVerifier, targetsKeyID string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -204,6 +245,14 @@ func (r *Repository) RemoveTopLevelTargetsKey(ctx context.Context, signer sslibd
 // the special GitHub app role. This key is used to verify GitHub pull request
 // approval attestation signatures.
 func (r *Repository) AddGitHubAppKey(ctx context.Context, signer sslibdsse.SignerVerifier, appKey tuf.Principal, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -232,6 +281,14 @@ func (r *Repository) AddGitHubAppKey(ctx context.Context, signer sslibdsse.Signe
 // RemoveGitHubAppKey is the interface for the user to de-authorize the key for
 // the special GitHub app role.
 func (r *Repository) RemoveGitHubAppKey(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -258,6 +315,14 @@ func (r *Repository) RemoveGitHubAppKey(ctx context.Context, signer sslibdsse.Si
 // TrustGitHubApp updates the root metadata to mark GitHub app pull request
 // approvals as trusted.
 func (r *Repository) TrustGitHubApp(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -289,6 +354,14 @@ func (r *Repository) TrustGitHubApp(ctx context.Context, signer sslibdsse.Signer
 // UntrustGitHubApp updates the root metadata to mark GitHub app pull request
 // approvals as untrusted.
 func (r *Repository) UntrustGitHubApp(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -320,6 +393,14 @@ func (r *Repository) UntrustGitHubApp(ctx context.Context, signer sslibdsse.Sign
 // UpdateRootThreshold sets the threshold of valid signatures required for the
 // Root role.
 func (r *Repository) UpdateRootThreshold(ctx context.Context, signer sslibdsse.SignerVerifier, threshold int, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -348,6 +429,14 @@ func (r *Repository) UpdateRootThreshold(ctx context.Context, signer sslibdsse.S
 // UpdateTopLevelTargetsThreshold sets the threshold of valid signatures
 // required for the top level Targets role.
 func (r *Repository) UpdateTopLevelTargetsThreshold(ctx context.Context, signer sslibdsse.SignerVerifier, threshold int, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rootKeyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -376,6 +465,14 @@ func (r *Repository) UpdateTopLevelTargetsThreshold(ctx context.Context, signer 
 // SignRoot adds a signature to the Root envelope. Note that the metadata itself
 // is not modified, so its version remains the same.
 func (r *Repository) SignRoot(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -30,6 +30,14 @@ var (
 // RecordRSLEntryForReference is the interface for the user to add an RSL entry
 // for the specified Git reference.
 func (r *Repository) RecordRSLEntryForReference(refName string, signCommit bool, opts ...rslopts.Option) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	options := &rslopts.Options{}
 	for _, fn := range opts {
 		fn(options)
@@ -128,6 +136,14 @@ func (r *Repository) SkipAllInvalidReferenceEntriesForRef(targetRef string, sign
 // RecordRSLAnnotation is the interface for the user to add an RSL annotation
 // for one or more prior RSL entries.
 func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, message string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	rslEntryHashes := []gitinterface.Hash{}
 	for _, id := range rslEntryIDs {
 		hash, err := gitinterface.NewHash(id)
@@ -152,6 +168,14 @@ func (r *Repository) RecordRSLAnnotation(rslEntryIDs []string, skip bool, messag
 // entries are reapplied over the latest entries in the remote if the local only
 // RSL entries and remote only entries are for different Git references.
 func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName string, sign bool) error {
+	if sign {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	remoteURL, err := r.r.GetRemoteURL(remoteName)
 	if err != nil {
 		return err

--- a/experimental/gittuf/targets.go
+++ b/experimental/gittuf/targets.go
@@ -25,6 +25,14 @@ func (r *Repository) InitializeTargets(ctx context.Context, signer sslibdsse.Sig
 		return ErrInvalidPolicyName
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -78,6 +86,14 @@ func (r *Repository) InitializeTargets(ctx context.Context, signer sslibdsse.Sig
 func (r *Repository) AddDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, authorizedPrincipalIDs, rulePatterns []string, threshold int, signCommit bool) error {
 	if ruleName == policy.RootRoleName {
 		return ErrInvalidPolicyName
+	}
+
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
 	}
 
 	keyID, err := signer.KeyID()
@@ -146,6 +162,14 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 		return ErrInvalidPolicyName
 	}
 
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -203,6 +227,14 @@ func (r *Repository) UpdateDelegation(ctx context.Context, signer sslibdsse.Sign
 // ReorderDelegations is the interface for the user to reorder rules in gittuf
 // policy.
 func (r *Repository) ReorderDelegations(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleNames []string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return nil
@@ -255,6 +287,14 @@ func (r *Repository) ReorderDelegations(ctx context.Context, signer sslibdsse.Si
 // RemoveDelegation is the interface for a user to remove a rule from gittuf
 // policy.
 func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, ruleName string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -312,6 +352,14 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.Sign
 // AddPrincipalToTargets is the interface for a user to add a trusted principal
 // to gittuf rule file metadata.
 func (r *Repository) AddPrincipalToTargets(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, authorizedPrincipals []tuf.Principal, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err
@@ -375,6 +423,14 @@ func (r *Repository) AddPrincipalToTargets(ctx context.Context, signer sslibdsse
 // SignTargets adds a signature to specified Targets role's envelope. Note that
 // the metadata itself is not modified, so its version remains the same.
 func (r *Repository) SignTargets(ctx context.Context, signer sslibdsse.SignerVerifier, targetsRoleName string, signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
 	keyID, err := signer.KeyID()
 	if err != nil {
 		return err

--- a/internal/cmd/common/common.go
+++ b/internal/cmd/common/common.go
@@ -4,12 +4,13 @@
 package common
 
 import (
-	"fmt"
+	"errors"
 	"strings"
 
-	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/spf13/cobra"
 )
+
+var ErrSigningKeyNotSet = errors.New("required flag \"signing-key\" not set")
 
 // PublicKeys is a custom type to represent a list of paths
 type PublicKeys []string
@@ -30,26 +31,15 @@ func (p *PublicKeys) Type() string {
 	return "public-keys"
 }
 
-// CheckIfSigningViableWithFlag checks if a signing key was specified via the
-// "signing-key" flag, and then calls CheckIfSigningViable
-func CheckIfSigningViableWithFlag(cmd *cobra.Command, _ []string) error {
+// CheckForSigningKeyFlag checks if a signing key was specified via the
+// "signing-key" flag
+func CheckForSigningKeyFlag(cmd *cobra.Command, _ []string) error {
 	signingKeyFlag := cmd.Flags().Lookup("signing-key")
 
 	// Check if a signing key was specified via the "signing-key" flag
 	if signingKeyFlag.Value.String() == "" {
-		return fmt.Errorf("required flag \"signing-key\" not set")
+		return ErrSigningKeyNotSet
 	}
 
-	return CheckIfSigningViable(cmd, nil)
-}
-
-// CheckIfSigningViable checks if we are able to sign RSL entries given the
-// current environment
-func CheckIfSigningViable(_ *cobra.Command, _ []string) error {
-	repo, err := gitinterface.LoadRepository()
-	if err != nil {
-		return err
-	}
-
-	return repo.CanSign()
+	return nil
 }

--- a/internal/cmd/dev/authorize/authorize.go
+++ b/internal/cmd/dev/authorize/authorize.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
@@ -78,7 +77,6 @@ func New() *cobra.Command {
 		Use:               "authorize",
 		Short:             fmt.Sprintf("Add or revoke reference authorization (developer mode only, set %s=1)", dev.DevModeKey),
 		Args:              cobra.MinimumNArgs(1),
-		PreRunE:           common.CheckIfSigningViable,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -65,7 +65,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-key",
 		Short:             "Add a trusted key to a policy file",
 		Long:              `This command allows users to add trusted keys to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addperson/addperson.go
+++ b/internal/cmd/policy/addperson/addperson.go
@@ -124,7 +124,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-person",
 		Short:             fmt.Sprintf("Add a trusted person to a policy file (requires developer mode and v0.2 policy metadata to be enabled, set %s=1 and %s=1)", dev.DevModeKey, tufv02.AllowV02MetadataKey),
 		Long:              `This command allows users to add a trusted person to the specified policy file. By default, the main policy file is selected. Note that the person's keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -100,7 +100,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-rule",
 		Short:             "Add a new rule to a policy file",
 		Long:              `This command allows users to add a new rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -44,7 +44,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize policy file",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -53,7 +53,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-rule",
 		Short:             "Remove rule from a policy file",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/reorderrules/reorderrules.go
+++ b/internal/cmd/policy/reorderrules/reorderrules.go
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "reorder-rules",
 		Short:             "Reorder rules in the specified policy file",
 		Long:              "This command allows users to reorder rules in the specified policy file. By default, the main policy file is selected. The rule names need to be passed as arguments, in the new order they must appear in, starting from the first to the last rule. Rule names may contain spaces, so they should be enclosed in quotes if necessary.",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/sign/sign.go
+++ b/internal/cmd/policy/sign/sign.go
@@ -45,7 +45,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "sign",
 		Short:             "Sign policy file",
 		Long:              "This command allows users to add their signature to the specified policy file.",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -100,7 +100,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "update-rule",
 		Short:             "Update an existing rule in a policy file",
 		Long:              `This command allows users to update an existing rule to the specified policy file. By default, the main policy file is selected. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -5,7 +5,6 @@ package annotate
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,6 @@ func New() *cobra.Command {
 		Use:               "annotate",
 		Short:             "Annotate prior RSL entries",
 		Args:              cobra.MinimumNArgs(1),
-		PreRunE:           common.CheckIfSigningViable,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -6,7 +6,6 @@ package record
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
-	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,6 @@ func New() *cobra.Command {
 		Use:               "record",
 		Short:             "Record latest state of a Git reference in the RSL",
 		Args:              cobra.ExactArgs(1),
-		PreRunE:           common.CheckIfSigningViable,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/skiprewritten/skiprewritten.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten.go
@@ -5,7 +5,6 @@ package skiprewritten
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/spf13/cobra"
 )
 
@@ -28,7 +27,6 @@ func New() *cobra.Command {
 		Use:               "skip-rewritten",
 		Short:             "Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref",
 		Args:              cobra.ExactArgs(1),
-		PreRunE:           common.CheckIfSigningViable,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addgithubappkey/addgithubappkey.go
+++ b/internal/cmd/trust/addgithubappkey/addgithubappkey.go
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-github-app-key",
 		Short:             "Add GitHub app key to gittuf root of trust",
 		Long:              `This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "add-policy-key",
 		Short:             "Add Policy key to gittuf root of trust",
 		Long:              `This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -49,7 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-root-key",
 		Short:             "Add Root key to gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -35,7 +35,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "disable-github-app-approvals",
 		Short:             "Mark GitHub app approvals as untrusted henceforth",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -35,7 +35,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "enable-github-app-approvals",
 		Short:             "Mark GitHub app approvals as trusted henceforth",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -35,7 +35,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize gittuf root of trust for repository",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removegithubappkey/removegithubappkey.go
+++ b/internal/cmd/trust/removegithubappkey/removegithubappkey.go
@@ -35,7 +35,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-github-app-key",
 		Short:             "Remove GitHub app key from gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -46,7 +46,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-policy-key",
 		Short:             "Remove Policy key from gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removerootkey/removerootkey.go
+++ b/internal/cmd/trust/removerootkey/removerootkey.go
@@ -46,7 +46,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-root-key",
 		Short:             "Remove Root key from gittuf root of trust",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/sign/sign.go
+++ b/internal/cmd/trust/sign/sign.go
@@ -36,7 +36,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:               "sign",
 		Short:             "Sign root of trust",
 		Long:              "This command allows users to add their signature to the root of trust file.",
-		PreRunE:           common.CheckIfSigningViableWithFlag,
+		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -45,7 +45,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:     "update-policy-threshold",
 		Short:   "Update Policy threshold in the gittuf root of trust",
 		Long:    "This command allows users to update the threshold of valid signatures required for the policy.",
-		PreRunE: common.CheckIfSigningViableWithFlag,
+		PreRunE: common.CheckForSigningKeyFlag,
 		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
@@ -45,7 +45,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 		Use:     "update-root-threshold",
 		Short:   "Update Root threshold in the gittuf root of trust",
 		Long:    "This command allows users to update the threshold of valid signatures required for the root of trust.",
-		PreRunE: common.CheckIfSigningViableWithFlag,
+		PreRunE: common.CheckForSigningKeyFlag,
 		RunE:    o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
This PR moves the `CheckIfSigningViable` check to the gittuf API and updates the signing key argument check as well.

Closes #633 