### PR TITLE
policy, cmd: Add list-principals sub command

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -25,6 +25,7 @@ Tools to manage gittuf policies
 * [gittuf policy add-rule](gittuf_policy_add-rule.md)	 - Add a new rule to a policy file
 * [gittuf policy apply](gittuf_policy_apply.md)	 - Validate and apply changes from policy-staging to policy
 * [gittuf policy init](gittuf_policy_init.md)	 - Initialize policy file
+* [gittuf policy list-principals](gittuf_policy_list-principals.md)	 - List principals for the current policy in the specified rule file
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state
 * [gittuf policy remote](gittuf_policy_remote.md)	 - Tools for managing remote policies
 * [gittuf policy remove-rule](gittuf_policy_remove-rule.md)	 - Remove rule from a policy file

--- a/docs/cli/gittuf_policy_list-principals.md
+++ b/docs/cli/gittuf_policy_list-principals.md
@@ -1,0 +1,30 @@
+## gittuf policy list-principals
+
+List principals for the current policy in the specified rule file
+
+```
+gittuf policy list-principals [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for list-principals
+      --policy-name string   specify rule file to list principals for (default "targets")
+      --policy-ref string    specify which policy ref should be inspected (default "policy")
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign policy file
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/experimental/gittuf/policy.go
+++ b/experimental/gittuf/policy.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/internal/tuf"
 )
 
 var (
@@ -53,4 +54,11 @@ func (r *Repository) ListRules(ctx context.Context, targetRef string) ([]*policy
 		return policy.ListRules(ctx, r.r, targetRef)
 	}
 	return policy.ListRules(ctx, r.r, "refs/gittuf/"+targetRef)
+}
+
+func (r *Repository) ListPrincipals(ctx context.Context, targetRef, policyName string) (map[string]tuf.Principal, error) {
+	if strings.HasPrefix(targetRef, "refs/gittuf/") {
+		return policy.ListPrincipals(ctx, r.r, targetRef, policyName)
+	}
+	return policy.ListPrincipals(ctx, r.r, "refs/gittuf/"+targetRef, policyName)
 }

--- a/internal/cmd/policy/listprincipals/listprincipals.go
+++ b/internal/cmd/policy/listprincipals/listprincipals.go
@@ -1,0 +1,70 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package listprincipals
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/spf13/cobra"
+)
+
+const indentString = "    "
+
+type options struct {
+	policyRef  string
+	policyName string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyRef,
+		"policy-ref",
+		"policy",
+		"specify which policy ref should be inspected",
+	)
+
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		tuf.TargetsRoleName,
+		"specify rule file to list principals for",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	principals, err := repo.ListPrincipals(cmd.Context(), o.policyRef, o.policyName)
+	if err != nil {
+		return err
+	}
+
+	for _, principal := range principals {
+		fmt.Printf("Principal %s:\n", principal.ID())
+		fmt.Printf(indentString + "Keys:\n")
+		for _, key := range principal.Keys() {
+			fmt.Printf(strings.Repeat(indentString, 2)+"%s (%s)\n", key.KeyID, key.KeyType)
+		}
+	}
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "list-principals",
+		Short:             "List principals for the current policy in the specified rule file",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/policy/listprincipals/listprincipals.go
+++ b/internal/cmd/policy/listprincipals/listprincipals.go
@@ -48,9 +48,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	for _, principal := range principals {
 		fmt.Printf("Principal %s:\n", principal.ID())
+
 		fmt.Printf(indentString + "Keys:\n")
 		for _, key := range principal.Keys() {
 			fmt.Printf(strings.Repeat(indentString, 2)+"%s (%s)\n", key.KeyID, key.KeyType)
+		}
+
+		customMetadata := principal.CustomMetadata()
+		if len(customMetadata) > 0 {
+			fmt.Printf(indentString + "Custom Metadata:\n")
+			for key, value := range principal.CustomMetadata() {
+				fmt.Printf(strings.Repeat(indentString, 2)+"%s: %s\n", key, value)
+			}
 		}
 	}
 	return nil

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/addkey"
 	"github.com/gittuf/gittuf/internal/cmd/policy/addrule"
 	i "github.com/gittuf/gittuf/internal/cmd/policy/init"
+	"github.com/gittuf/gittuf/internal/cmd/policy/listprincipals"
 	"github.com/gittuf/gittuf/internal/cmd/policy/listrules"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/cmd/policy/removerule"
@@ -31,6 +32,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addkey.New(o))
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(addrule.New(o))
+	cmd.AddCommand(listprincipals.New())
 	cmd.AddCommand(listrules.New())
 	cmd.AddCommand(remote.New())
 	cmd.AddCommand(removerule.New(o))

--- a/internal/policy/list.go
+++ b/internal/policy/list.go
@@ -1,0 +1,104 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+type DelegationWithDepth struct {
+	Delegation tuf.Rule
+	Depth      int
+}
+
+// ListRules returns a list of all the rules as an array of the delegations in a
+// pre-order traversal of the delegation tree, with the depth of each
+// delegation.
+func ListRules(ctx context.Context, repo *gitinterface.Repository, targetRef string) ([]*DelegationWithDepth, error) {
+	state, err := LoadCurrentState(ctx, repo, targetRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if !state.HasTargetsRole(TargetsRoleName) {
+		return nil, nil
+	}
+
+	topLevelTargetsMetadata, err := state.GetTargetsMetadata(TargetsRoleName, true)
+	if err != nil {
+		return nil, err
+	}
+
+	delegationsToSearch := []*DelegationWithDepth{}
+	allDelegations := []*DelegationWithDepth{}
+
+	for _, topLevelDelegation := range topLevelTargetsMetadata.GetRules() {
+		if topLevelDelegation.ID() == tuf.AllowRuleName {
+			continue
+		}
+		delegationsToSearch = append(delegationsToSearch, &DelegationWithDepth{Delegation: topLevelDelegation, Depth: 0})
+	}
+
+	seenRoles := map[string]bool{TargetsRoleName: true}
+
+	for len(delegationsToSearch) > 0 {
+		currentDelegation := delegationsToSearch[0]
+		delegationsToSearch = delegationsToSearch[1:]
+
+		// allDelegations will be the returned list of all the delegations in pre-order traversal, no delegations will be popped off
+		allDelegations = append(allDelegations, currentDelegation)
+
+		if _, seen := seenRoles[currentDelegation.Delegation.ID()]; seen {
+			continue
+		}
+
+		if state.HasTargetsRole(currentDelegation.Delegation.ID()) {
+			currentMetadata, err := state.GetTargetsMetadata(currentDelegation.Delegation.ID(), true)
+			if err != nil {
+				return nil, err
+			}
+
+			seenRoles[currentDelegation.Delegation.ID()] = true
+
+			// We construct localDelegations first so that we preserve the order
+			// of delegations in currentMetadata in delegationsToSearch
+			localDelegations := []*DelegationWithDepth{}
+			for _, delegation := range currentMetadata.GetRules() {
+				if delegation.ID() == tuf.AllowRuleName {
+					continue
+				}
+				localDelegations = append(localDelegations, &DelegationWithDepth{Delegation: delegation, Depth: currentDelegation.Depth + 1})
+			}
+
+			if len(localDelegations) > 0 {
+				delegationsToSearch = append(localDelegations, delegationsToSearch...)
+			}
+		}
+	}
+
+	return allDelegations, nil
+}
+
+// ListPrincipals returns the principals present in the specified rule file.
+// `targetRef` can be used to control which policy reference is used.
+func ListPrincipals(ctx context.Context, repo *gitinterface.Repository, targetRef, policyName string) (map[string]tuf.Principal, error) {
+	state, err := LoadCurrentState(ctx, repo, targetRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if !state.HasTargetsRole(policyName) {
+		return nil, ErrPolicyNotFound
+	}
+
+	metadata, err := state.GetTargetsMetadata(policyName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata.GetPrincipals(), nil
+}

--- a/internal/policy/list_test.go
+++ b/internal/policy/list_test.go
@@ -1,0 +1,141 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListRules(t *testing.T) {
+	t.Run("no delegations", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+		rules, err := ListRules(context.Background(), repo, PolicyRef)
+		assert.Nil(t, err)
+
+		expectedRules := []*DelegationWithDepth{
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "protect-main",
+					Paths:       []string{"git:refs/heads/main"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
+					},
+				},
+				Depth: 0,
+			},
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "protect-files-1-and-2",
+					Paths:       []string{"file:1", "file:2"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
+					},
+				},
+				Depth: 0,
+			},
+		}
+		assert.Equal(t, expectedRules, rules)
+	})
+
+	t.Run("with delegations", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithDelegatedPolicies)
+
+		rules, err := ListRules(context.Background(), repo, PolicyRef)
+		assert.Nil(t, err)
+
+		expectedRules := []*DelegationWithDepth{
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "1",
+					Paths:       []string{"file:1/*"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
+						Threshold:    1,
+					},
+				},
+				Depth: 0,
+			},
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "3",
+					Paths:       []string{"file:1/subpath1/*"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
+					},
+				},
+				Depth: 1,
+			},
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "4",
+					Paths:       []string{"file:1/subpath2/*"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
+						Threshold:    1,
+					},
+				},
+				Depth: 1,
+			},
+
+			{
+				Delegation: &tufv02.Delegation{
+					Name:        "2",
+					Paths:       []string{"file:2/*"},
+					Terminating: false,
+					Custom:      nil,
+					Role: tufv02.Role{
+						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
+						Threshold:    1,
+					},
+				},
+				Depth: 0,
+			},
+		}
+		assert.Equal(t, expectedRules, rules)
+	})
+}
+
+func TestListPrincipals(t *testing.T) {
+	repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+	t.Run("policy exists", func(t *testing.T) {
+		pubKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pubKey := tufv02.NewKeyFromSSLibKey(pubKeyR)
+		expectedPrincipals := map[string]tuf.Principal{pubKey.KeyID: pubKey}
+
+		principals, err := ListPrincipals(context.Background(), repo, PolicyRef, tuf.TargetsRoleName)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPrincipals, principals)
+	})
+
+	t.Run("policy does not exist", func(t *testing.T) {
+		principals, err := ListPrincipals(testCtx, repo, PolicyRef, "does-not-exist")
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+		assert.Nil(t, principals)
+	})
+}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
@@ -16,7 +15,6 @@ import (
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
-	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -487,109 +485,6 @@ func TestGetStateForCommit(t *testing.T) {
 	state, err = GetStateForCommit(context.Background(), repo, newCommitID)
 	assert.Nil(t, err)
 	assertStatesEqual(t, firstState, state)
-}
-
-func TestListRules(t *testing.T) {
-	t.Run("no delegations", func(t *testing.T) {
-		repo, _ := createTestRepository(t, createTestStateWithPolicy)
-
-		rules, err := ListRules(context.Background(), repo, PolicyRef)
-		assert.Nil(t, err)
-
-		expectedRules := []*DelegationWithDepth{
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "protect-main",
-					Paths:       []string{"git:refs/heads/main"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold:    1,
-					},
-				},
-				Depth: 0,
-			},
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "protect-files-1-and-2",
-					Paths:       []string{"file:1", "file:2"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold:    1,
-					},
-				},
-				Depth: 0,
-			},
-		}
-		assert.Equal(t, expectedRules, rules)
-	})
-
-	t.Run("with delegations", func(t *testing.T) {
-		repo, _ := createTestRepository(t, createTestStateWithDelegatedPolicies)
-
-		rules, err := ListRules(context.Background(), repo, PolicyRef)
-		assert.Nil(t, err)
-
-		expectedRules := []*DelegationWithDepth{
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "1",
-					Paths:       []string{"file:1/*"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
-						Threshold:    1,
-					},
-				},
-				Depth: 0,
-			},
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "3",
-					Paths:       []string{"file:1/subpath1/*"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold:    1,
-					},
-				},
-				Depth: 1,
-			},
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "4",
-					Paths:       []string{"file:1/subpath2/*"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("157507bbe151e378ce8126c1dcfe043cdd2db96e"),
-						Threshold:    1,
-					},
-				},
-				Depth: 1,
-			},
-
-			{
-				Delegation: &tufv02.Delegation{
-					Name:        "2",
-					Paths:       []string{"file:2/*"},
-					Terminating: false,
-					Custom:      nil,
-					Role: tufv02.Role{
-						PrincipalIDs: set.NewSetFromItems("SHA256:ESJezAOo+BsiEpddzRXS6+wtF16FID4NCd+3gj96rFo"),
-						Threshold:    1,
-					},
-				},
-				Depth: 0,
-			},
-		}
-		assert.Equal(t, expectedRules, rules)
-	})
 }
 
 func TestStateHasFileRule(t *testing.T) {

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -45,6 +45,7 @@ var (
 type Principal interface {
 	ID() string
 	Keys() []*signerverifier.SSLibKey
+	CustomMetadata() map[string]string
 }
 
 // RootMetadata represents the root of trust metadata for gittuf.

--- a/internal/tuf/v01/tuf.go
+++ b/internal/tuf/v01/tuf.go
@@ -39,6 +39,11 @@ func (k *Key) Keys() []*signerverifier.SSLibKey {
 	return []*signerverifier.SSLibKey{&key}
 }
 
+func (k *Key) CustomMetadata() map[string]string {
+	// Key does not support custom metadata
+	return nil
+}
+
 // Role records common characteristics recorded in a role entry in Root metadata
 // and in a delegation entry.
 type Role struct {

--- a/internal/tuf/v02/tuf.go
+++ b/internal/tuf/v02/tuf.go
@@ -8,6 +8,7 @@ package v02
 // however, is inspired by or cloned from the go-tuf implementation.
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/gittuf/gittuf/internal/common/set"
@@ -16,7 +17,11 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 )
 
-const AllowV02MetadataKey = "GITTUF_ALLOW_V02_POLICY"
+const (
+	AllowV02MetadataKey = "GITTUF_ALLOW_V02_POLICY"
+
+	associatedIdentityKey = "(associated identity)"
+)
 
 // AllowV02Metadata returns true if gittuf is in developer mode and
 // GITTUF_ALLOW_V02_POLICY=1.
@@ -54,6 +59,26 @@ func (p *Person) Keys() []*signerverifier.SSLibKey {
 	}
 
 	return keys
+}
+
+func (p *Person) CustomMetadata() map[string]string {
+	var metadata map[string]string
+
+	for provider, identity := range p.AssociatedIdentities {
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		metadata[fmt.Sprintf("%s %s", associatedIdentityKey, provider)] = identity
+	}
+
+	for key, value := range p.Custom {
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		metadata[key] = value
+	}
+
+	return metadata
 }
 
 // Role records common characteristics recorded in a role entry in Root metadata

--- a/internal/tuf/v02/tuf_test.go
+++ b/internal/tuf/v02/tuf_test.go
@@ -1,0 +1,104 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPerson(t *testing.T) {
+	keyR := ssh.NewKeyFromBytes(t, rootPubKeyBytes)
+	key := NewKeyFromSSLibKey(keyR)
+
+	tests := map[string]struct {
+		person                 *Person
+		expectedID             string
+		expectedKeys           []*signerverifier.SSLibKey
+		expectedCustomMetadata map[string]string
+	}{
+		"no custom metadata": {
+			person: &Person{
+				PersonID: "jane.doe",
+				PublicKeys: map[string]*Key{
+					key.KeyID: key,
+				},
+			},
+			expectedID:             "jane.doe",
+			expectedKeys:           []*signerverifier.SSLibKey{keyR},
+			expectedCustomMetadata: nil,
+		},
+		"only associated identities": {
+			person: &Person{
+				PersonID: "jane.doe",
+				PublicKeys: map[string]*Key{
+					key.KeyID: key,
+				},
+				AssociatedIdentities: map[string]string{
+					"https://github.com": "jane.doe",
+					"https://gitlab.com": "jane.doe",
+				},
+			},
+			expectedID:   "jane.doe",
+			expectedKeys: []*signerverifier.SSLibKey{keyR},
+			expectedCustomMetadata: map[string]string{
+				fmt.Sprintf("%s https://github.com", associatedIdentityKey): "jane.doe",
+				fmt.Sprintf("%s https://gitlab.com", associatedIdentityKey): "jane.doe",
+			},
+		},
+		"only custom metadata": {
+			person: &Person{
+				PersonID: "jane.doe",
+				PublicKeys: map[string]*Key{
+					key.KeyID: key,
+				},
+				Custom: map[string]string{
+					"key": "value",
+				},
+			},
+			expectedID:   "jane.doe",
+			expectedKeys: []*signerverifier.SSLibKey{keyR},
+			expectedCustomMetadata: map[string]string{
+				"key": "value",
+			},
+		},
+		"both associated identities and custom metadata": {
+			person: &Person{
+				PersonID: "jane.doe",
+				PublicKeys: map[string]*Key{
+					key.KeyID: key,
+				},
+				AssociatedIdentities: map[string]string{
+					"https://github.com": "jane.doe",
+					"https://gitlab.com": "jane.doe",
+				},
+				Custom: map[string]string{
+					"key": "value",
+				},
+			},
+			expectedID:   "jane.doe",
+			expectedKeys: []*signerverifier.SSLibKey{keyR},
+			expectedCustomMetadata: map[string]string{
+				fmt.Sprintf("%s https://github.com", associatedIdentityKey): "jane.doe",
+				fmt.Sprintf("%s https://gitlab.com", associatedIdentityKey): "jane.doe",
+				"key": "value",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		id := test.person.ID()
+		assert.Equal(t, test.expectedID, id, fmt.Sprintf("unexpected person ID in test '%s'", name))
+
+		keys := test.person.Keys()
+		assert.Equal(t, test.expectedKeys, keys, fmt.Sprintf("unexpected keys in test '%s'", name))
+
+		customMetadata := test.person.CustomMetadata()
+		assert.Equal(t, test.expectedCustomMetadata, customMetadata, fmt.Sprintf("unexpected custom metadata in test '%s'", name))
+	}
+}


### PR DESCRIPTION
adds a list-principals sub command. This is needed for #639 to be usable.

Specifically, #639 makes it so you add keys / persons first and then add rules referencing those keys / persons. This command is required to pick up on key IDs or principal IDs in that metadata when adding a rule.