### PR TITLE
gittuf: Expose GitHub token as an opt

### DIFF
--- a/experimental/gittuf/options/github/github.go
+++ b/experimental/gittuf/options/github/github.go
@@ -1,0 +1,33 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+const DefaultGitHubBaseURL = "https://github.com"
+
+type Options struct {
+	GitHubToken   string
+	GitHubBaseURL string
+}
+
+var DefaultOptions = &Options{
+	GitHubBaseURL: DefaultGitHubBaseURL,
+}
+
+type Option func(o *Options)
+
+// WithGitHubToken can be used to specify an authentication token to use the
+// GitHub API.
+func WithGitHubToken(token string) Option {
+	return func(o *Options) {
+		o.GitHubToken = token
+	}
+}
+
+// WithGitHubBaseURL can be used to specify a custom GitHub instance, such as an
+// on-premises GitHub Enterprise Server.
+func WithGitHubBaseURL(baseURL string) Option {
+	return func(o *Options) {
+		o.GitHubBaseURL = baseURL
+	}
+}

--- a/internal/cmd/dev/addgithubapproval/addgithubapproval.go
+++ b/internal/cmd/dev/addgithubapproval/addgithubapproval.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	githubopts "github.com/gittuf/gittuf/experimental/gittuf/options/github"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +35,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.baseURL,
 		"base-URL",
-		"https://github.com",
+		githubopts.DefaultGitHubBaseURL,
 		"location of GitHub instance",
 	)
 
@@ -87,7 +88,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return repo.AddGitHubPullRequestApprover(cmd.Context(), signer, o.baseURL, repositoryParts[0], repositoryParts[1], o.pullRequestNumber, o.reviewID, o.approver, true)
+	return repo.AddGitHubPullRequestApprover(cmd.Context(), signer, repositoryParts[0], repositoryParts[1], o.pullRequestNumber, o.reviewID, o.approver, true, githubopts.WithGitHubBaseURL(o.baseURL))
 }
 
 func New() *cobra.Command {

--- a/internal/cmd/dev/attestgithub/attestgithub.go
+++ b/internal/cmd/dev/attestgithub/attestgithub.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	githubopts "github.com/gittuf/gittuf/experimental/gittuf/options/github"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
@@ -34,7 +35,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.baseURL,
 		"base-URL",
-		"https://github.com",
+		githubopts.DefaultGitHubBaseURL,
 		"location of GitHub instance",
 	)
 
@@ -91,10 +92,10 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	if o.commitID != "" {
-		return repo.AddGitHubPullRequestAttestationForCommit(cmd.Context(), signer, o.baseURL, repositoryParts[0], repositoryParts[1], o.commitID, o.baseBranch, true)
+		return repo.AddGitHubPullRequestAttestationForCommit(cmd.Context(), signer, repositoryParts[0], repositoryParts[1], o.commitID, o.baseBranch, true, githubopts.WithGitHubBaseURL(o.baseURL))
 	}
 
-	return repo.AddGitHubPullRequestAttestationForNumber(cmd.Context(), signer, o.baseURL, repositoryParts[0], repositoryParts[1], o.pullRequestNumber, true)
+	return repo.AddGitHubPullRequestAttestationForNumber(cmd.Context(), signer, repositoryParts[0], repositoryParts[1], o.pullRequestNumber, true, githubopts.WithGitHubBaseURL(o.baseURL))
 }
 
 func New() *cobra.Command {

--- a/internal/cmd/dev/dismissgithubapproval/dismissgithubapproval.go
+++ b/internal/cmd/dev/dismissgithubapproval/dismissgithubapproval.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	githubopts "github.com/gittuf/gittuf/experimental/gittuf/options/github"
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.baseURL,
 		"base-URL",
-		"https://github.com",
+		githubopts.DefaultGitHubBaseURL,
 		"location of GitHub instance",
 	)
 
@@ -63,7 +64,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return repo.DismissGitHubPullRequestApprover(cmd.Context(), signer, o.baseURL, o.reviewID, o.dismissedApprover, true)
+	return repo.DismissGitHubPullRequestApprover(cmd.Context(), signer, o.reviewID, o.dismissedApprover, true, githubopts.WithGitHubBaseURL(o.baseURL))
 }
 
 func New() *cobra.Command {


### PR DESCRIPTION
This makes setting the token a bit cleaner with the gittuf API used in the github app.