### PR TITLE
gittuf-git: Add hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist/*
 *.prof
 vendor*
+.idea
+

--- a/experimental/gittuf/hooks/hooks.go
+++ b/experimental/gittuf/hooks/hooks.go
@@ -1,0 +1,371 @@
+package hooks
+
+import (
+	"context"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/rsl"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+
+	//"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	//"github.com/gittuf/gittuf/internal/policy"
+	//"github.com/gittuf/gittuf/internal/rsl"
+	//"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	//sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	//"io/ioutil"
+	"log/slog"
+	//"os"
+	"path"
+	//"path/filepath"
+	"strings"
+)
+
+const (
+	HooksRef              = "refs/gittuf/hooks"
+	DefaultCommitMessage  = "Create hooks ref"
+	RootRoleName          = "root"
+	TargetsRoleName       = "targets"
+	metadataTreeEntryName = "metadata"
+	hooksTreeEntryName    = "hooks"
+	HooksRoleName         = "hooks"
+	ApplyMessage          = "Apply hooks"
+)
+
+var (
+	ErrMetadataNotFound          = errors.New("unable to find requested metadata file; has it been initialized?")
+	ErrPolicyNotFound            = errors.New("cannot find policy")
+	ErrHooksMetadataHashMismatch = errors.New("Error verifying Hooks metadata - hashes do not match.")
+)
+
+// Hooks metadata should be encoded on existing policy metadata
+// We can have a default policy that protects the hooks ref, and use this
+// policy to encode the metadata
+
+// TODO: check how to initialize a default policy and reserve the name.
+// Use this policy to add hook path, key ids, etc.
+// policy.AddDelegation or policy.InitializeTargetsMetadata
+// check out policy/helpers_test.go, policy/policy_test.go and policy/targets_test.go
+// for information about how to init
+
+type StateWrapper struct {
+	RootEnvelope        *sslibdsse.Envelope
+	TargetsEnvelope     *sslibdsse.Envelope
+	HooksEnvelope       *sslibdsse.Envelope
+	DelegationEnvelopes map[string]*sslibdsse.Envelope
+	RootPublicKeys      []tuf.Principal
+	Repository          *gitinterface.Repository
+}
+
+type HooksMetadata struct {
+	HooksInfo map[string]*HooksInformation `json:"HooksInfo"`
+	Bindings  map[string]string            `json:"Bindings"`
+}
+
+type HooksInformation struct {
+	SHA256Hash string   `json:"SHA256Hash"`
+	BlobID     string   `json:"BlobID"`
+	Stage      string   `json:"Stage"`
+	Branches   []string `json:"Branches"`
+}
+
+type searcher interface {
+	FindHooksEntryFor(entry rsl.Entry) (*rsl.ReferenceEntry, error)
+	FindFirstHooksEntry() (*rsl.ReferenceEntry, error)
+}
+
+type regularSearcher struct {
+	repo *gitinterface.Repository
+}
+
+func newSearcher(repo *gitinterface.Repository) *regularSearcher {
+	return &regularSearcher{repo: repo}
+}
+func (r *regularSearcher) FindHooksEntryFor(entry rsl.Entry) (*rsl.ReferenceEntry, error) {
+	// If the requested entry itself is for the policy ref, return as is
+	if entry, isReferenceEntry := entry.(*rsl.ReferenceEntry); isReferenceEntry && entry.RefName == HooksRef {
+		slog.Debug(fmt.Sprintf("Initial entry '%s' is for gittuf policy, setting that as current policy...", entry.GetID().String()))
+		return entry, nil
+	}
+
+	policyEntry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(HooksRef), rsl.BeforeEntryID(entry.GetID()))
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			slog.Debug(fmt.Sprintf("No policy found before initial entry '%s'", entry.GetID().String()))
+			return nil, ErrPolicyNotFound
+		}
+
+		// Any other err must be returned
+		return nil, err
+	}
+
+	return policyEntry, nil
+}
+
+func (r *regularSearcher) FindFirstHooksEntry() (*rsl.ReferenceEntry, error) {
+	entry, _, err := rsl.GetFirstReferenceEntryForRef(r.repo, HooksRef)
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			// we don't have a policy entry yet
+			return nil, ErrPolicyNotFound
+		}
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+func (r *regularSearcher) FindHooksEntriesInRange(firstEntry, lastEntry rsl.Entry) ([]*rsl.ReferenceEntry, error) {
+	allPolicyEntries, _, err := rsl.GetReferenceEntriesInRangeForRef(r.repo, firstEntry.GetID(), lastEntry.GetID(), HooksRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return allPolicyEntries, nil
+}
+
+func loadStateForEntry(repo *gitinterface.Repository, entry *rsl.ReferenceEntry) (*StateWrapper, error) {
+	if entry.RefName != HooksRef {
+		return nil, rsl.ErrRSLEntryDoesNotMatchRef
+	}
+
+	commitTreeID, err := repo.GetCommitTreeID(entry.TargetID)
+	if err != nil {
+		return nil, err
+	}
+
+	allTreeEntries, err := repo.GetAllFilesInTree(commitTreeID)
+	if err != nil {
+		return nil, err
+	}
+
+	state := &StateWrapper{Repository: repo}
+
+	for name, blobID := range allTreeEntries {
+		contents, err := repo.ReadBlob(blobID)
+		if err != nil {
+			return nil, err
+		}
+
+		// We have this conditional because once upon a time we used to store
+		// the root keys on disk as well; now we just get them from the root
+		// metadata file. We ignore the keys on disk in the old policy states.
+		if strings.HasPrefix(name, metadataTreeEntryName+"/") {
+			env := &sslibdsse.Envelope{}
+			if err := json.Unmarshal(contents, env); err != nil {
+				return nil, err
+			}
+
+			metadataName := strings.TrimPrefix(name, metadataTreeEntryName+"/")
+			switch metadataName {
+			case fmt.Sprintf("%s.json", RootRoleName):
+				state.RootEnvelope = env
+
+			case fmt.Sprintf("%s.json", TargetsRoleName):
+				state.TargetsEnvelope = env
+
+			case fmt.Sprintf("%s.json", HooksRoleName):
+				state.HooksEnvelope = env
+			default:
+				if state.DelegationEnvelopes == nil {
+					state.DelegationEnvelopes = map[string]*sslibdsse.Envelope{}
+				}
+
+				state.DelegationEnvelopes[strings.TrimSuffix(metadataName, ".json")] = env
+			}
+		}
+	}
+
+	return state, nil
+}
+
+func LoadState(repo *gitinterface.Repository, requestedEntry *rsl.ReferenceEntry) (*StateWrapper, error) {
+	searcher := newSearcher(repo)
+	firstHooksEntry, err := searcher.FindFirstHooksEntry()
+	if err != nil {
+		if errors.Is(err, ErrPolicyNotFound) {
+			return loadStateForEntry(repo, requestedEntry)
+		}
+		return nil, err
+	}
+	knows, err := repo.KnowsCommit(requestedEntry.ID, firstHooksEntry.ID) // this is the problem
+	if err != nil {
+		return nil, err
+	}
+	if knows {
+		slog.Debug("knows")
+		return loadStateForEntry(repo, requestedEntry)
+	}
+
+	initialHooksState, err := loadStateForEntry(repo, firstHooksEntry)
+	if err != nil {
+		return nil, err
+	}
+
+	return initialHooksState, nil
+}
+
+func LoadCurrentState(ctx context.Context, repo *gitinterface.Repository) (*StateWrapper, error) {
+	entry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(HooksRef))
+	if err != nil {
+		return nil, err
+	}
+	fmt.Println(entry)
+	return LoadState(repo, entry)
+}
+
+// LoadFirstState returns the State corresponding to the first Hooks commit.
+// Verification of RoT is skipped since it is the initial commit.
+func LoadFirstState(ctx context.Context, repo *gitinterface.Repository) (*StateWrapper, error) {
+	policyState, err := policy.LoadCurrentState(ctx, repo, HooksRef)
+	if err != nil {
+		return nil, err
+	}
+	slog.Debug("policyState fetch did not return err")
+	returnState := StateWrapper{
+		Repository:          repo,
+		TargetsEnvelope:     policyState.TargetsEnvelope,
+		DelegationEnvelopes: policyState.DelegationEnvelopes,
+	}
+	return &returnState, nil
+}
+
+func InitializeHooksMetadata() HooksMetadata {
+	return HooksMetadata{HooksInfo: make(map[string]*HooksInformation), Bindings: make(map[string]string)}
+}
+
+func (s *StateWrapper) GetHooksMetadata() (*HooksMetadata, error) {
+	h := s.HooksEnvelope
+	if h == nil {
+		slog.Debug("Could not find requested metadata file; initializing hooks metadata")
+		return nil, ErrMetadataNotFound
+	}
+
+	payloadBytes, err := h.DecodeB64Payload()
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug(string(payloadBytes))
+	hooksMetadata := &HooksMetadata{}
+	if err := json.Unmarshal(payloadBytes, hooksMetadata); err != nil {
+		return nil, err
+	}
+
+	return hooksMetadata, nil
+}
+
+func (s *StateWrapper) Commit(repo *gitinterface.Repository, commitMessage, hookName string, addBlob gitinterface.Hash, sign bool) error {
+	if len(commitMessage) == 0 {
+		commitMessage = DefaultCommitMessage
+	}
+
+	metadata := map[string]*sslibdsse.Envelope{}
+	if s.TargetsEnvelope != nil {
+		metadata[TargetsRoleName] = s.TargetsEnvelope
+	}
+	if s.HooksEnvelope != nil {
+		metadata[HooksRoleName] = s.HooksEnvelope
+	}
+
+	allTreeEntries := map[string]gitinterface.Hash{}
+	for name, env := range metadata {
+		envContents, err := json.Marshal(env)
+		if err != nil {
+			return err
+		}
+
+		blobID, err := repo.WriteBlob(envContents)
+		if err != nil {
+			return err
+		}
+
+		allTreeEntries[path.Join(metadataTreeEntryName, name+".json")] = blobID
+	}
+
+	if len(addBlob) > 0 {
+		allTreeEntries[path.Join(hooksTreeEntryName, hookName)] = addBlob
+	}
+
+	slog.Debug("building and populating new tree...")
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+
+	hooksRootTreeID, err := treeBuilder.WriteRootTreeFromBlobIDs(allTreeEntries)
+	if err != nil {
+		return err
+	}
+
+	originalCommitID, err := repo.GetReference(HooksRef)
+	if err != nil {
+		if !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return err
+		}
+	}
+	commitID, err := repo.Commit(hooksRootTreeID, HooksRef, commitMessage, sign)
+	if err != nil {
+		return err
+	}
+	slog.Debug("committing hooks metadata successful!")
+	// record changes to RSL; reset to original policy commit if err != nil
+
+	newReferenceEntry := rsl.NewReferenceEntry(HooksRef, commitID)
+	if err := newReferenceEntry.Commit(repo, true); err != nil {
+		if !originalCommitID.IsZero() {
+			return repo.ResetDueToError(err, HooksRef, originalCommitID)
+		}
+
+		return err
+	}
+	slog.Debug("RSL entry recording successful!")
+	hooksTip, err := repo.GetReference(HooksRef)
+	if err := repo.SetReference(HooksRef, hooksTip); err != nil {
+		return fmt.Errorf("failed to set new hooks reference: %w", err)
+	}
+	return nil
+}
+
+func (h *HooksMetadata) GenerateMetadataFor(hookName, stage string, blobID, sha256HashSum gitinterface.Hash) error {
+	hookInfo := HooksInformation{
+		SHA256Hash: sha256HashSum.String(),
+		Stage:      stage,
+		BlobID:     blobID.String(),
+	}
+	h.HooksInfo[hookName] = &hookInfo
+	h.Bindings[stage] = hookName
+	return nil
+}
+
+func (s *StateWrapper) GetTargetsMetadata(roleName string) (tuf.TargetsMetadata, error) {
+	e := s.TargetsEnvelope
+	if roleName != TargetsRoleName {
+		env, ok := s.DelegationEnvelopes[roleName]
+		if !ok {
+			return nil, ErrMetadataNotFound
+		}
+		e = env
+	}
+
+	if e == nil {
+		return nil, ErrMetadataNotFound
+	}
+
+	payloadBytes, err := e.DecodeB64Payload()
+	if err != nil {
+		return nil, err
+	}
+
+	targetsMetadata := &tufv01.TargetsMetadata{}
+	if err := json.Unmarshal(payloadBytes, targetsMetadata); err != nil {
+		return nil, err
+	}
+
+	return targetsMetadata, nil
+}
+
+func (s *StateWrapper) HasBeenInitialized() bool {
+	return s.HooksEnvelope != nil
+}

--- a/experimental/gittuf/targets.go
+++ b/experimental/gittuf/targets.go
@@ -5,9 +5,16 @@ package gittuf
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"github.com/gittuf/gittuf/experimental/gittuf/hooks"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
@@ -411,4 +418,267 @@ func (r *Repository) SignTargets(ctx context.Context, signer sslibdsse.SignerVer
 
 	slog.Debug("Committing policy...")
 	return state.Commit(r.r, commitMessage, signCommit)
+}
+
+func (r *Repository) InitializeHooks(ctx context.Context) error {
+	repo := r.GetGitRepository()
+	stateChecker, err := hooks.LoadCurrentState(context.Background(), repo)
+	if stateChecker != nil {
+		return fmt.Errorf("Hooks ref already initialized, cannot initialize again.")
+	}
+
+	state := &hooks.StateWrapper{Repository: repo}
+
+	slog.Debug("Creating initial rule file...")
+	targetsMetadata := policy.InitializeTargetsMetadata()
+
+	env, err := dsse.CreateEnvelope(targetsMetadata)
+	if err != nil {
+		return err
+	}
+	state.TargetsEnvelope = env
+
+	slog.Debug("Creating initial empty hooks metadata file...")
+	hooksMetadata := hooks.InitializeHooksMetadata()
+
+	env, err = dsse.CreateEnvelope(hooksMetadata)
+	if err != nil {
+		return err
+	}
+	state.HooksEnvelope = env
+
+	return state.Commit(repo, hooks.DefaultCommitMessage, "", nil, true)
+}
+
+func (r *Repository) AddHooks(filePath, stage, hookName string) error {
+	repo := r.GetGitRepository()
+	hooksTip, err := repo.GetReference(hooks.HooksRef)
+	if err != nil {
+		if !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return fmt.Errorf("failed to get policy reference %s: %w", hooksTip, err)
+		}
+	}
+
+	state, err := hooks.LoadCurrentState(context.Background(), repo)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+	}
+	slog.Debug("Loaded current state")
+
+	if hookName == "" {
+		hookName = filepath.Base(filePath)
+	}
+
+	hookFile, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer hookFile.Close()
+
+	hookFileContents, err := io.ReadAll(hookFile)
+	if err != nil {
+		return err
+	}
+
+	sha256Hash := sha256.New()
+	sha256Hash.Write(hookFileContents)
+	sha256HashSum := sha256Hash.Sum(nil)
+
+	currentHooksMetadata, err := state.GetHooksMetadata()
+	if err != nil {
+		return err
+	}
+	blobID, err := repo.WriteBlob(hookFileContents)
+	if err != nil {
+		return err
+	}
+	fmt.Println(blobID)
+	if err := currentHooksMetadata.GenerateMetadataFor(hookName, stage, blobID, sha256HashSum); err != nil {
+		return err
+	}
+
+	env, err := dsse.CreateEnvelope(currentHooksMetadata)
+	state.HooksEnvelope = env
+
+	commitMessage := "Add " + hookName
+	return state.Commit(repo, commitMessage, hookName, blobID, true)
+}
+
+func (r *Repository) ApplyHooks() error {
+	repo := r.GetGitRepository()
+	hooksTip, err := repo.GetReference(hooks.HooksRef)
+	if err != nil {
+		if !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return fmt.Errorf("failed to get policy reference %s: %w", hooksTip, err)
+		}
+	}
+
+	state, err := hooks.LoadCurrentState(context.Background(), repo)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+	}
+	slog.Debug("Loaded current state")
+
+	targetsMetadata, err := state.GetTargetsMetadata(hooks.TargetsRoleName)
+	if err != nil {
+		return err
+	}
+
+	h := state.HooksEnvelope
+	payloadBytes, err := h.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	sha256Hash := sha256.New()
+	sha256Hash.Write(payloadBytes)
+	sha256HashSum := sha256Hash.Sum(nil)
+
+	targetsMetadata.SetHooksField(sha256HashSum)
+
+	env, err := dsse.CreateEnvelope(targetsMetadata)
+	if err != nil {
+		return err
+	}
+	state.TargetsEnvelope = env
+
+	return state.Commit(repo, hooks.ApplyMessage, "", nil, true)
+}
+
+// VerifyHooks verifies the signature of the metadata env
+// through dsse.VerifyEnvelope
+func (r *Repository) VerifyHooks(state *hooks.StateWrapper) error {
+	h := state.HooksEnvelope
+	payloadBytes, err := h.DecodeB64Payload()
+	if err != nil {
+		return err
+	}
+
+	sha256Hash := sha256.New()
+	sha256Hash.Write(payloadBytes)
+	sha256HashSum := sha256Hash.Sum(nil)
+
+	targetsMetadata, err := state.GetTargetsMetadata(hooks.TargetsRoleName)
+	if err != nil {
+		return err
+	}
+
+	// verify that both hashes are the same.
+	// to check hooksHash is going to be a string because the metadata is JSON encoded
+	// 	=> sha256HashSumGit needs to be converted to a string => needs to be of the type
+	// 	gitinterface.Hash
+	sha256HashSumGit := gitinterface.Hash(sha256HashSum)
+	hooksHash := targetsMetadata.GetHooksField()
+	if hooksHash != sha256HashSumGit.String() {
+		return hooks.ErrHooksMetadataHashMismatch
+	}
+
+	return nil
+}
+
+// LoadHooks should load the latest hooks metadata and load the hook files
+// todo: change workflow to work with Lua and gVisor - return the bytestream
+//
+//		instead of writing the file. The logic for deciding whether to write
+//	 the file or not should be in gittuf-git/cmd
+func (r *Repository) LoadHooks() error {
+	repo := r.GetGitRepository()
+	hooksTip, err := repo.GetReference(hooks.HooksRef)
+	if err != nil {
+		if !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return fmt.Errorf("failed to get policy reference %s: %w", hooksTip, err)
+		}
+	}
+
+	state, err := hooks.LoadCurrentState(context.Background(), repo)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+	}
+	slog.Debug("Loaded current state")
+
+	err = r.VerifyHooks(state)
+	if err != nil {
+		return err
+	}
+
+	hooksMetadata, err := state.GetHooksMetadata()
+	if err != nil {
+		return err
+	}
+
+	for filename, hookInfo := range hooksMetadata.HooksInfo {
+		hookContents, err := repo.ReadBlobFromString(hookInfo.BlobID)
+		if err != nil {
+			return err
+		}
+		filename = "hooks/" + filename
+		err = os.MkdirAll(filepath.Dir(filename), 0755)
+		if err != nil {
+			return err
+		}
+
+		err = os.WriteFile(filename, hookContents, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	slog.Debug("Loaded hooks files")
+	return nil
+}
+
+// LoadHookByStage takes in the stage as a string arg, and builds ONLY the file associated with that stage.
+// todo: might have to change workflow to return bytes instead of writing the file
+func (r *Repository) LoadHookByStage(stage string) error {
+	repo := r.GetGitRepository()
+	hooksTip, err := repo.GetReference(hooks.HooksRef)
+	if err != nil {
+		if !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return fmt.Errorf("failed to get policy reference %s: %w", hooksTip, err)
+		}
+	}
+
+	state, err := hooks.LoadCurrentState(context.Background(), repo)
+	if err != nil {
+		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			return fmt.Errorf("failed to load hooks: %w", err)
+		}
+	}
+	slog.Debug("Loaded current state")
+
+	err = r.VerifyHooks(state)
+	if err != nil {
+		return err
+	}
+
+	hooksMetadata, err := state.GetHooksMetadata()
+	if err != nil {
+		return err
+	}
+
+	hookName := hooksMetadata.Bindings[stage]
+	hookInfo := hooksMetadata.HooksInfo[hookName]
+	hookContents, err := repo.ReadBlobFromString(hookInfo.BlobID)
+	if err != nil {
+		return err
+	}
+	filename := "hooks/" + hookName
+	err = os.MkdirAll(filepath.Dir(filename), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(filename, hookContents, 0644)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Loaded hook file for ", stage)
+	return nil
 }

--- a/internal/cmd/hooks/add/add.go
+++ b/internal/cmd/hooks/add/add.go
@@ -1,0 +1,75 @@
+package add
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/spf13/cobra"
+)
+
+// todo: this function must take 2 arguments: path/to/hooks/file and stage
+// the file specified by the file must be copied properly and securely into directory
+// the stage specified by the data in the -s flag must be used for generating the metadata
+// the metadata can be as simple as
+// stage: path/to/hook
+// the metadata file will have to be updated everytime gittuf hooks add is called
+// the directory structure will be:
+// hooks/
+//		hooksMetadata.json
+//		hook1.hook
+//		hook2.hook
+
+// QUESTIONS: where will we be copying the scripts to?
+
+type options struct {
+	p        *persistent.Options
+	filepath string
+	stage    string
+	hookname string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.filepath,
+		"file",
+		"",
+		"filepath of the script to be run as a hook",
+	)
+	cmd.MarkFlagRequired("file")
+
+	cmd.Flags().StringVar(
+		&o.stage,
+		"stage",
+		"",
+		"stage at which the hook must be run",
+	)
+	cmd.MarkFlagRequired("stage")
+
+	cmd.Flags().StringVar(
+		&o.hookname,
+		"hookname",
+		"",
+		"Name of the hook",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.AddHooks(o.filepath, o.stage, o.hookname)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "add",
+		Short:             "add a script to be run as a hook and mention when to run it.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/hooks/apply/apply.go
+++ b/internal/cmd/hooks/apply/apply.go
@@ -1,0 +1,32 @@
+package apply
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p *persistent.Options
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) (err error) {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.ApplyHooks()
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "apply",
+		Short:             "secure hooks metadata file by embedding and committing with Targets",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}

--- a/internal/cmd/hooks/hooks.go
+++ b/internal/cmd/hooks/hooks.go
@@ -1,0 +1,27 @@
+package hooks
+
+import (
+	"github.com/gittuf/gittuf/internal/cmd/hooks/add"
+	"github.com/gittuf/gittuf/internal/cmd/hooks/apply"
+	i "github.com/gittuf/gittuf/internal/cmd/hooks/init"
+	"github.com/gittuf/gittuf/internal/cmd/hooks/load"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/spf13/cobra"
+)
+
+func New() *cobra.Command {
+	o := &persistent.Options{}
+	cmd := &cobra.Command{
+		Use:               "hooks",
+		Short:             "Tools to manage git hooks",
+		DisableAutoGenTag: true,
+	}
+	o.AddPersistentFlags(cmd)
+
+	cmd.AddCommand(i.New(o))
+	cmd.AddCommand(add.New())
+	cmd.AddCommand(apply.New())
+	cmd.AddCommand(load.New())
+
+	return cmd
+}

--- a/internal/cmd/hooks/init/init.go
+++ b/internal/cmd/hooks/init/init.go
@@ -1,0 +1,40 @@
+package init
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd/common"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p              *persistent.Options
+	policyName     string
+	authorizedKeys []string
+	threshold      int
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	// initialize policy
+	// add rule for protecting refs/gittuf/hooks
+
+	return repo.InitializeHooks(cmd.Context())
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "init",
+		Short:             "Initialize hooks ref",
+		PreRunE:           common.CheckIfSigningViableWithFlag,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}

--- a/internal/cmd/hooks/load/load.go
+++ b/internal/cmd/hooks/load/load.go
@@ -1,0 +1,32 @@
+package load
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p *persistent.Options
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) (err error) {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	return repo.LoadHooks()
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "load",
+		Short:             "load hooks files from metadata",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+
+	return cmd
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -4,6 +4,7 @@
 package root
 
 import (
+	"github.com/gittuf/gittuf/internal/cmd/hooks"
 	"log/slog"
 	"os"
 
@@ -93,6 +94,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(dev.New())
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())
+	cmd.AddCommand(hooks.New())
 	cmd.AddCommand(rsl.New())
 	cmd.AddCommand(verifyref.New())
 	cmd.AddCommand(version.New())

--- a/internal/gitinterface/blob.go
+++ b/internal/gitinterface/blob.go
@@ -26,6 +26,25 @@ func (r *Repository) ReadBlob(blobID Hash) ([]byte, error) {
 	return io.ReadAll(stdOut)
 }
 
+// ReadBlobFromString is a temporary function for when the argument being passed in is a string.
+// This is seen in the hooks loading use-case.
+// ReadBlob should probably be changed to accommodate both types
+func (r *Repository) ReadBlobFromString(blobID string) ([]byte, error) {
+	objType, err := r.executor("cat-file", "-t", blobID).executeString()
+	if err != nil {
+		return nil, fmt.Errorf("unable to inspect if object is blob: %w", err)
+	} else if objType != "blob" {
+		return nil, fmt.Errorf("requested Git ID '%s' is not a blob object", blobID)
+	}
+
+	stdOut, stdErr, err := r.executor("cat-file", "-p", blobID).execute()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read blob: %s", stdErr)
+	}
+
+	return io.ReadAll(stdOut)
+}
+
 // WriteBlob creates a blob object with the specified contents and returns the
 // ID of the resultant blob.
 func (r *Repository) WriteBlob(contents []byte) (Hash, error) {

--- a/internal/hooks/targets.go
+++ b/internal/hooks/targets.go
@@ -1,0 +1,1 @@
+package hooks

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -30,6 +30,11 @@ const (
 	// PolicyStagingRef defines the Git namespace used as a staging area when creating or updating gittuf policies.
 	PolicyStagingRef = "refs/gittuf/policy-staging"
 
+	// HooksRef defines the Git namespace used for storing and distributing hooks in gittuf
+	HooksRef = "refs/gittuf/hooks"
+
+	// HooksRoleName reserves the default policy name for protecting the hooks namespace
+	HooksRoleName = "protect-hooks"
 	// RootRoleName defines the expected name for the gittuf root of trust.
 	RootRoleName = "root"
 

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -5,6 +5,7 @@ package tuf
 
 import (
 	"errors"
+	"github.com/gittuf/gittuf/internal/gitinterface"
 
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
@@ -122,6 +123,9 @@ type TargetsMetadata interface {
 	// unenforced
 	SetExpires(expiry string)
 
+	SetHooksField(hooksID gitinterface.Hash)
+
+	GetHooksField() any
 	// SchemaVersion returns the metadata schema version.
 	SchemaVersion() string
 

--- a/internal/tuf/v01/targets.go
+++ b/internal/tuf/v01/targets.go
@@ -6,6 +6,7 @@ package v01
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/gittuf/gittuf/internal/gitinterface"
 	"strings"
 
 	"github.com/danwakefield/fnmatch"
@@ -31,6 +32,16 @@ func NewTargetsMetadata() *TargetsMetadata {
 		Type:        "targets",
 		Delegations: &Delegations{Roles: []*Delegation{AllowRule()}},
 	}
+}
+
+func (t *TargetsMetadata) SetHooksField(hooksID gitinterface.Hash) {
+	t.Targets = map[string]any{
+		"hooks": hooksID.String(),
+	}
+}
+
+func (t *TargetsMetadata) GetHooksField() any {
+	return t.Targets["hooks"]
 }
 
 // SetExpires sets the expiry date of the TargetsMetadata to the value passed


### PR DESCRIPTION
# gittuf-git Hooks distribution
This PR outlines a PoC for the git hooks distribution workflow. 
## Summary
* adds a new command family `gittuf hooks [command]`, where `[command]` could be one of: `init`, `add`, `apply` and `load`
* `init` initializes the `gittuf/hooks` ref 
* `add` allows adding and committing a hook, and populates the hooks metadata (hooks.json) with information about the hook file, including a SHA256 hash, the blob ID and the stage at which it should be run
* `apply` generates a SHA256 hash of the hooks metadata and puts it in the targets metadata and commits the new targets metadata
* `load` unpacks the targets and hooks metadata, verifies its hash with the hash in the targets metadata and writes the hook files as needed based on the stage when needed
* adds support for this in the `Commit` function for gittuf-git - loads the hook as needed by stage.

## TODOs:
* Integrate this with the Lua/gVisor sandbox effort
* Rethink the metadata structure