### PR TITLE
transport: Some wants / haves negotiation fixes

### DIFF
--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -283,6 +283,8 @@ func handleSSH(repo *gittuf.Repository, remoteName, url string) (map[string]stri
 			var (
 				wroteGittufWantsAndHaves = false // track this in case there are multiple rounds of negotiation
 				wroteWants               = false
+				allWants                 = set.NewSet[string]()
+				allHaves                 = set.NewSet[string]()
 			)
 			for stdInScanner.Scan() {
 				input = stdInScanner.Bytes()
@@ -314,31 +316,51 @@ func handleSSH(repo *gittuf.Repository, remoteName, url string) (map[string]stri
 						}
 
 						for _, tip := range wants {
-							wantCmd := fmt.Sprintf("want %s\n", tip)
-							if _, err := helperStdIn.Write(packetEncode(wantCmd)); err != nil {
-								return nil, false, err
+							if !allWants.Has(tip) {
+								// indicate we
+								// want the
+								// gittuf obj
+								wantCmd := fmt.Sprintf("want %s\n", tip)
+								if _, err := helperStdIn.Write(packetEncode(wantCmd)); err != nil {
+									return nil, false, err
+								}
 							}
 						}
 
 						for _, tip := range haves {
-							haveCmd := fmt.Sprintf("have %s\n", tip)
-							if _, err := helperStdIn.Write(packetEncode(haveCmd)); err != nil {
-								return nil, false, err
+							if !allHaves.Has(tip) {
+								// indicate we
+								// have the
+								// gittuf obj
+								haveCmd := fmt.Sprintf("have %s\n", tip)
+								if _, err := helperStdIn.Write(packetEncode(haveCmd)); err != nil {
+									return nil, false, err
+								}
 							}
 						}
 						wroteGittufWantsAndHaves = true
 					}
 					wroteWants = true
 				} else {
-					for ref, tip := range gittufRefsTips {
-						wantCmd := fmt.Sprintf("want %s", tip)
-						if bytes.Contains(input, []byte(wantCmd)) {
-							// Take out this ref as
-							// something for us to
-							// update or add wants
-							// for
-							delete(gittufRefsTips, ref)
+					if bytes.Contains(input, []byte("want")) {
+						idx := bytes.Index(input, []byte("want "))
+						sha := string(bytes.TrimSpace(input[idx+len("want "):]))
+						allWants.Add(sha)
+
+						for ref, tip := range gittufRefsTips {
+							if tip == sha {
+								// Take out this ref as
+								// something for us to
+								// update or add wants
+								// for
+								log("taking out", ref, "as it matches", sha)
+								delete(gittufRefsTips, ref)
+							}
 						}
+					} else if bytes.Contains(input, []byte("have")) {
+						idx := bytes.Index(input, []byte("have "))
+						sha := string(bytes.TrimSpace(input[idx+len("have "):]))
+						allHaves.Add(sha)
 					}
 				}
 


### PR DESCRIPTION
Adding a duplicate have <sha> or want <sha> can cause the packfile negotiation to hang. Also, sometimes, not announcing a have for a gittuf ref but requesting a want for it can cause a hang. This fixes these scenarios by tracking all wants and haves, and adding gittuf wants only when it's not a duplicate, and always annoucing gittuf haves.