### PR TITLE
rsl: log now incrementally writes output

### DIFF
--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"slices"
 	"strings"
@@ -513,4 +514,18 @@ func GetRSLEntryLog(repo *Repository) ([]*rsl.ReferenceEntry, map[string][]*rsl.
 
 	slices.Reverse(entries)
 	return entries, annotationMap, nil
+}
+
+func DisplayRSLLogIncrementally(repo *Repository, bufferedWriter io.WriteCloser) error {
+	firstEntry, _, err := rsl.GetFirstEntry(repo.r)
+	if err != nil {
+		return err
+	}
+
+	lastEntry, err := rsl.GetLatestEntry(repo.r)
+	if err != nil {
+		return err
+	}
+
+	return rsl.PrintAllEntriesInRangeFor(repo.r, firstEntry.GetID(), lastEntry.GetID(), "", bufferedWriter)
 }

--- a/internal/cmd/rsl/log/log.go
+++ b/internal/cmd/rsl/log/log.go
@@ -38,11 +38,6 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	entries, annotationMap, err := gittuf.GetRSLEntryLog(repo)
-	if err != nil {
-		return err
-	}
-
 	output := os.Stdout
 	if o.filePath != "" {
 		output, err = os.Create(o.filePath)
@@ -52,11 +47,8 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 		o.page = false // override page since we're not writing to stdout
 	}
 
-	outputContents := display.PrepareRSLLogOutput(entries, annotationMap)
 	writer := display.NewDisplayWriter(output, o.page)
-
-	_, err = writer.Write([]byte(outputContents))
-	return err
+	return gittuf.DisplayRSLLogIncrementally(repo, writer)
 }
 
 func New() *cobra.Command {


### PR DESCRIPTION
Aimed to solve issue #630 

The writer, which is now modified to call a buffered `Write` by default, is now passed into the command to identify all entries to the log and write them to output. 

The main command `PrintAllEntriesInRangeFor` is mostly a copy and paste of `GetReferenceEntriesInRangeForRef`. So there is duplication of code in 
`internal/rsl/rsl.go`. 

My reasoning  for this approach is mainly to follow the idea that each function should have one job. If I were to use optional parameters in and conditionals to get `GetReferenceEntriesInRangeForRef` to print, then this function would both be a getter function as well as a printing function. I think this is worse for the health of the codebase than just repeating myself. Additionally there are four other instances of  `GetReferenceEntriesInRangeForRef` being used in various parts of the codebase so I reasoned it was best not to tamper with it. What do you ya'll think? 

I can add tests to this PR later to test the different pagers `less` and `more` because they may not implement a buffered `Write` by default. But I wanted to get feedback before proceeding. 

(P.S I think this project is pretty cool I'd be happy to hack on this with ya'll) 