### PR TITLE
policy: Consolidate some preprocessing passes

### DIFF
--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -137,7 +137,7 @@ func createTestStateWithPolicy(t *testing.T) *State {
 		RootPublicKeys:  []tuf.Principal{key},
 	}
 
-	if err := state.loadRuleNames(); err != nil {
+	if err := state.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -207,7 +207,7 @@ func createTestStateWithPolicyUsingPersons(t *testing.T) *State {
 		RootPublicKeys:  []tuf.Principal{key},
 	}
 
-	if err := state.loadRuleNames(); err != nil {
+	if err := state.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -310,7 +310,7 @@ func createTestStateWithDelegatedPolicies(t *testing.T) *State {
 	//   /\
 	//  3  4
 
-	if err := curState.loadRuleNames(); err != nil {
+	if err := curState.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -598,7 +598,7 @@ func createTestStateWithTagPolicy(t *testing.T) *State {
 	}
 	state.TargetsEnvelope = targetsEnv
 
-	if err := state.loadRuleNames(); err != nil {
+	if err := state.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -643,7 +643,7 @@ func createTestStateWithThresholdTagPolicy(t *testing.T) *State {
 	}
 	state.TargetsEnvelope = targetsEnv
 
-	if err := state.loadRuleNames(); err != nil {
+	if err := state.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -679,7 +679,7 @@ func createTestStateWithTagPolicyForUnauthorizedTest(t *testing.T) *State {
 	}
 	state.TargetsEnvelope = targetsEnv
 
-	if err := state.loadRuleNames(); err != nil {
+	if err := state.preprocess(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -503,8 +503,7 @@ func TestStateHasFileRule(t *testing.T) {
 	t.Run("with file rules", func(t *testing.T) {
 		state := createTestStateWithDelegatedPolicies(t)
 
-		hasFileRule, err := state.hasFileRule()
-		assert.Nil(t, err)
+		hasFileRule := state.hasFileRule
 		assert.True(t, hasFileRule)
 	})
 
@@ -512,8 +511,7 @@ func TestStateHasFileRule(t *testing.T) {
 		t.Parallel()
 		state := createTestStateWithOnlyRoot(t)
 
-		hasFileRule, err := state.hasFileRule()
-		assert.Nil(t, err)
+		hasFileRule := state.hasFileRule
 		assert.False(t, hasFileRule)
 	})
 }

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -204,11 +204,7 @@ func VerifyMergeable(ctx context.Context, repo *gitinterface.Repository, targetR
 		return false, fmt.Errorf("not enough approvals to meet Git namespace policies, %w", ErrUnauthorizedSignature)
 	}
 
-	hasFileRule, err := currentPolicy.hasFileRule()
-	if err != nil {
-		return false, err
-	}
-	if !hasFileRule {
+	if !currentPolicy.hasFileRule {
 		return rslEntrySignatureNeededForThreshold, nil
 	}
 
@@ -553,12 +549,7 @@ func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *Sta
 	}
 
 	// Check if policy has file rules at all for efficiency
-	hasFileRule, err := policy.hasFileRule()
-	if err != nil {
-		return err
-	}
-
-	if !hasFileRule {
+	if !policy.hasFileRule {
 		// No file rules to verify
 		return nil
 	}


### PR DESCRIPTION
We have some policy state specific tasks that need to happen only once and can be consolidated as part of a generic preprocessing flow.