### PR TITLE
Various policy fixes

### DIFF
--- a/docs/cli/gittuf.md
+++ b/docs/cli/gittuf.md
@@ -20,6 +20,7 @@ A security layer for Git repositories, powered by TUF
 * [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
 * [gittuf rsl](gittuf_rsl.md)	 - Tools to manage the repository's reference state log
 * [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+* [gittuf verify-mergeable](gittuf_verify-mergeable.md)	 - Tools for verifying mergeability using gittuf policies
 * [gittuf verify-ref](gittuf_verify-ref.md)	 - Tools for verifying gittuf policies
 * [gittuf version](gittuf_version.md)	 - Version of gittuf
 

--- a/docs/cli/gittuf_verify-mergeable.md
+++ b/docs/cli/gittuf_verify-mergeable.md
@@ -1,0 +1,29 @@
+## gittuf verify-mergeable
+
+Tools for verifying mergeability using gittuf policies
+
+```
+gittuf verify-mergeable [flags]
+```
+
+### Options
+
+```
+      --base-branch string      base branch for proposed merge
+      --feature-branch string   feature branch for proposed merge
+  -h, --help                    help for verify-mergeable
+```
+
+### Options inherited from parent commands
+
+```
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
+

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/profile"
 	"github.com/gittuf/gittuf/internal/cmd/rsl"
 	"github.com/gittuf/gittuf/internal/cmd/trust"
+	"github.com/gittuf/gittuf/internal/cmd/verifymergeable"
 	"github.com/gittuf/gittuf/internal/cmd/verifyref"
 	"github.com/gittuf/gittuf/internal/cmd/version"
 	"github.com/spf13/cobra"
@@ -94,6 +95,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(trust.New())
 	cmd.AddCommand(policy.New())
 	cmd.AddCommand(rsl.New())
+	cmd.AddCommand(verifymergeable.New())
 	cmd.AddCommand(verifyref.New())
 	cmd.AddCommand(version.New())
 

--- a/internal/cmd/verifymergeable/verifymergeable.go
+++ b/internal/cmd/verifymergeable/verifymergeable.go
@@ -1,0 +1,56 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package verifymergeable
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	baseBranch    string
+	featureBranch string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.baseBranch,
+		"base-branch",
+		"",
+		"base branch for proposed merge",
+	)
+	cmd.MarkFlagRequired("base-branch") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.featureBranch,
+		"feature-branch",
+		"",
+		"feature branch for proposed merge",
+	)
+	cmd.MarkFlagRequired("feature-branch") //nolint:errcheck
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository()
+	if err != nil {
+		return err
+	}
+
+	_, err = repo.VerifyMergeable(cmd.Context(), o.baseBranch, o.featureBranch)
+	return err
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "verify-mergeable",
+		Short:             "Tools for verifying mergeability using gittuf policies",
+		Args:              cobra.ExactArgs(0),
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/policy/searcher.go
+++ b/internal/policy/searcher.go
@@ -50,7 +50,14 @@ func (r *regularSearcher) FindFirstPolicyEntry() (*rsl.ReferenceEntry, error) {
 
 func (r *regularSearcher) FindLatestPolicyEntry() (*rsl.ReferenceEntry, error) {
 	entry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(PolicyRef))
-	return entry, err
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			// we don't have a policy entry
+			return nil, ErrPolicyNotFound
+		}
+		return nil, err
+	}
+	return entry, nil
 }
 
 // FindPolicyEntryFor identifies the latest policy entry for the specified
@@ -117,5 +124,12 @@ func newRegularSearcher(repo *gitinterface.Repository) *regularSearcher {
 
 func (r *regularSearcher) FindLatestAttestationsEntry() (*rsl.ReferenceEntry, error) {
 	entry, _, err := rsl.GetLatestReferenceEntry(r.repo, rsl.ForReference(attestations.Ref))
-	return entry, err
+	if err != nil {
+		if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+			// we don't have an attestations entry
+			return nil, attestations.ErrAttestationsNotFound
+		}
+		return nil, err
+	}
+	return entry, nil
 }

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -193,6 +193,10 @@ func VerifyMergeable(ctx context.Context, repo *gitinterface.Repository, targetR
 	if err != nil {
 		return false, err
 	}
+	if len(verifiers) == 0 {
+		// No verifiers -> not protected
+		return false, nil
+	}
 
 	var appName string
 	if currentPolicy.githubAppApprovalsTrusted {


### PR DESCRIPTION
1. VerifyMergeable was incorrectly returning an error when no verifiers were found (for an unprotected base branch).

2. Policy's searcher interface was also returning the wrong error when the latest policy or attestation entry was not found.

3. A verify-mergeable command has been added to simplify debugging.