### PR TITLE
Add control for RSL duplicate check

### DIFF
--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -9,8 +9,9 @@ gittuf rsl record [flags]
 ### Options
 
 ```
-      --dst-ref string   name of destination reference, if it differs from source reference
-  -h, --help             help for record
+      --dst-ref string         name of destination reference, if it differs from source reference
+  -h, --help                   help for record
+      --skip-duplicate-check   skip check to see if latest entry for reference has same target
 ```
 
 ### Options inherited from parent commands

--- a/experimental/gittuf/options/rsl/rsl.go
+++ b/experimental/gittuf/options/rsl/rsl.go
@@ -4,7 +4,8 @@
 package rsl
 
 type Options struct {
-	RefNameOverride string
+	RefNameOverride       string
+	SkipCheckForDuplicate bool
 }
 
 type Option func(o *Options)
@@ -12,5 +13,13 @@ type Option func(o *Options)
 func WithOverrideRefName(refNameOverride string) Option {
 	return func(o *Options) {
 		o.RefNameOverride = refNameOverride
+	}
+}
+
+// WithSkipCheckForDuplicateEntry indicates that the RSL entry creation must not
+// check if the latest entry for the reference has the same target ID.
+func WithSkipCheckForDuplicateEntry() Option {
+	return func(o *Options) {
+		o.SkipCheckForDuplicate = true
 	}
 }

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -102,6 +102,24 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 
 	assert.Equal(t, newCommitID, entry.TargetID)
 	assert.Equal(t, "refs/heads/not-main", entry.RefName)
+
+	// Record entry for a different dst ref and skip check for duplicate
+	currentEntryID := entry.GetID()
+	err = repo.RecordRSLEntryForReference("refs/heads/main", false, rslopts.WithOverrideRefName("refs/heads/not-main"), rslopts.WithSkipCheckForDuplicateEntry())
+	assert.Nil(t, err)
+
+	entryT, err = rsl.GetLatestEntry(repo.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok = entryT.(*rsl.ReferenceEntry)
+	if !ok {
+		t.Fatal(fmt.Errorf("invalid entry type"))
+	}
+
+	assert.NotEqual(t, currentEntryID, entry.GetID())
+	assert.Equal(t, newCommitID, entry.TargetID)
+	assert.Equal(t, "refs/heads/not-main", entry.RefName)
 }
 
 func TestRecordRSLEntryForReferenceAtTarget(t *testing.T) {

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -10,7 +10,8 @@ import (
 )
 
 type options struct {
-	dstRef string
+	dstRef             string
+	skipDuplicateCheck bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -20,6 +21,13 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"",
 		"name of destination reference, if it differs from source reference",
 	)
+
+	cmd.Flags().BoolVar(
+		&o.skipDuplicateCheck,
+		"skip-duplicate-check",
+		false,
+		"skip check to see if latest entry for reference has same target",
+	)
 }
 
 func (o *options) Run(_ *cobra.Command, args []string) error {
@@ -28,7 +36,12 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RecordRSLEntryForReference(args[0], true, rslopts.WithOverrideRefName(o.dstRef))
+	opts := []rslopts.Option{rslopts.WithOverrideRefName(o.dstRef)}
+	if o.skipDuplicateCheck {
+		opts = append(opts, rslopts.WithSkipCheckForDuplicateEntry())
+	}
+
+	return repo.RecordRSLEntryForReference(args[0], true, opts...)
 }
 
 func New() *cobra.Command {

--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -445,7 +445,7 @@ func handleCurl(repo *gittuf.Repository, remoteName, url string) (map[string]str
 						// A gittuf ref can pop up here when it's explicitly
 						// pushed by the user
 
-						if err := repo.RecordRSLEntryForReference(srcRef, true, rslopts.WithOverrideRefName(dstRef)); err != nil {
+						if err := repo.RecordRSLEntryForReference(srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry()); err != nil {
 							return nil, false, err
 						}
 					}

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -548,7 +548,7 @@ func handleSSH(repo *gittuf.Repository, remoteName, url string) (map[string]stri
 				}
 
 				if !strings.HasPrefix(dstRef, gittufRefPrefix) {
-					if err := repo.RecordRSLEntryForReference(srcRef, true, rslopts.WithOverrideRefName(dstRef)); err != nil {
+					if err := repo.RecordRSLEntryForReference(srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry()); err != nil {
 						return nil, false, err
 					}
 				}


### PR DESCRIPTION
The RSL entry creation flow checks to see if the latest entry for the reference being pushed has the same target ID as the proposed new entry. This check should be optional, depending on how the entry is created. When created using the "gittuf rsl record" command, the check should be performed by default. But when created using the git-remote-gittuf transport, the check is superfluous: the push is happening and an extra entry recording the push happened is better. This also speeds up the RSL entry creation for a new branch via the transport, as looking for an existing RSL entry for the branch in question is expensive (the entire RSL history must be checked).