### PR TITLE
policy: Rename Verifier to SignatureVerifier

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -352,11 +352,11 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 
 		tests := map[string]struct {
 			path      string
-			verifiers []*Verifier
+			verifiers []*SignatureVerifier
 		}{
 			"verifiers for files 1": {
 				path: "file:1/*",
-				verifiers: []*Verifier{{
+				verifiers: []*SignatureVerifier{{
 					name:       "1",
 					principals: []tuf.Principal{key},
 					threshold:  1,
@@ -364,7 +364,7 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 			},
 			"verifiers for files": {
 				path: "file:2/*",
-				verifiers: []*Verifier{{
+				verifiers: []*SignatureVerifier{{
 					name:       "2",
 					principals: []tuf.Principal{key},
 					threshold:  1,
@@ -372,11 +372,11 @@ func TestStateFindVerifiersForPath(t *testing.T) {
 			},
 			"verifiers for unprotected branch": {
 				path:      "git:refs/heads/unprotected",
-				verifiers: []*Verifier{},
+				verifiers: []*SignatureVerifier{},
 			},
 			"verifiers for unprotected files": {
 				path:      "file:unprotected",
-				verifiers: []*Verifier{},
+				verifiers: []*SignatureVerifier{},
 			},
 		}
 

--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -1,0 +1,234 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/signerverifier/common"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
+	"github.com/gittuf/gittuf/internal/signerverifier/sigstore"
+	sigstoreverifieropts "github.com/gittuf/gittuf/internal/signerverifier/sigstore/options/verifier"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+)
+
+type SignatureVerifier struct {
+	repository *gitinterface.Repository
+	name       string
+	principals []tuf.Principal
+	threshold  int
+}
+
+func (v *SignatureVerifier) Name() string {
+	return v.name
+}
+
+func (v *SignatureVerifier) Threshold() int {
+	return v.threshold
+}
+
+func (v *SignatureVerifier) TrustedPrincipalIDs() *set.Set[string] {
+	principalIDs := set.NewSet[string]()
+	for _, principal := range v.principals {
+		principalIDs.Add(principal.ID())
+	}
+
+	return principalIDs
+}
+
+// Verify is used to check for a threshold of signatures using the verifier. The
+// threshold of signatures may be met using a combination of at most one Git
+// signature and signatures embedded in a DSSE envelope. Verify does not inspect
+// the envelope's payload, but instead only verifies the signatures. The caller
+// must ensure the validity of the envelope's contents.
+func (v *SignatureVerifier) Verify(ctx context.Context, gitObjectID gitinterface.Hash, env *sslibdsse.Envelope) (*set.Set[string], error) {
+	if v.threshold < 1 || len(v.principals) < 1 {
+		return nil, ErrInvalidVerifier
+	}
+
+	// usedPrincipalIDs is ultimately returned to track the set of principals
+	// who have been authenticated
+	usedPrincipalIDs := set.NewSet[string]()
+
+	// usedKeyIDs is tracked to ensure a key isn't duplicated between two
+	// principals, allowing two principals to meet a threshold using the same
+	// key
+	usedKeyIDs := set.NewSet[string]()
+
+	// gitObjectVerified is set to true if the gitObjectID's signature is
+	// verified
+	gitObjectVerified := false
+
+	// First, verify the gitObject's signature if one is presented
+	if gitObjectID != nil && !gitObjectID.IsZero() {
+		slog.Debug(fmt.Sprintf("Verifying signature of Git object with ID '%s'...", gitObjectID.String()))
+		for _, principal := range v.principals {
+			// there are multiple keys we must try
+			keys := principal.Keys()
+
+			for _, key := range keys {
+				err := v.repository.VerifySignature(ctx, gitObjectID, key)
+				if err == nil {
+					// Signature verification succeeded
+					slog.Debug(fmt.Sprintf("Public key '%s' belonging to principal '%s' successfully used to verify signature of Git object '%s', counting '%s' towards threshold...", key.KeyID, principal.ID(), gitObjectID.String(), principal.ID()))
+					usedPrincipalIDs.Add(principal.ID())
+					usedKeyIDs.Add(key.KeyID)
+					gitObjectVerified = true
+
+					// No need to try the other keys for this principal, break
+					break
+				}
+				if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
+					// TODO: this should be removed once we have unified signing
+					// methods across metadata and git signatures
+					continue
+				}
+				if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
+					return nil, err
+				}
+			}
+
+			if gitObjectVerified {
+				// No need to try other principals, break
+				break
+			}
+		}
+	}
+
+	// If threshold is 1 and the Git signature is verified, we can return
+	if v.threshold == 1 && gitObjectVerified {
+		return usedPrincipalIDs, nil
+	}
+
+	if env != nil {
+		// Second, verify signatures on the envelope
+
+		// We have to verify the envelope independently for each principal
+		// trusted in the verifier as a principal may have multiple keys
+		// associated with them.
+		for _, principal := range v.principals {
+			if usedPrincipalIDs.Has(principal.ID()) {
+				// Do not verify using this principal as they were verified for
+				// the Git signature
+				slog.Debug(fmt.Sprintf("Principal '%s' has already been counted towards the threshold, skipping...", principal.ID()))
+				continue
+			}
+
+			principalVerifiers := []sslibdsse.Verifier{}
+
+			keys := principal.Keys()
+			for _, key := range keys {
+				if usedKeyIDs.Has(key.KeyID) {
+					// this key has been encountered before, possibly because
+					// another Principal included this key
+					slog.Debug(fmt.Sprintf("Key with ID '%s' has already been used to verify a signature, skipping...", key.KeyID))
+					continue
+				}
+
+				var (
+					dsseVerifier sslibdsse.Verifier
+					err          error
+				)
+				switch key.KeyType {
+				case ssh.KeyType:
+					slog.Debug(fmt.Sprintf("Found SSH key '%s'...", key.KeyID))
+					dsseVerifier, err = ssh.NewVerifierFromKey(key)
+					if err != nil {
+						return nil, err
+					}
+				case gpg.KeyType:
+					slog.Debug(fmt.Sprintf("Found GPG key '%s', cannot use for DSSE signature verification yet...", key.KeyID))
+					continue
+				case sigstore.KeyType:
+					slog.Debug(fmt.Sprintf("Found Sigstore key '%s'...", key.KeyID))
+					opts := []sigstoreverifieropts.Option{}
+					config, err := v.repository.GetGitConfig()
+					if err != nil {
+						return nil, err
+					}
+					if rekorURL, has := config[sigstore.GitConfigRekor]; has {
+						slog.Debug(fmt.Sprintf("Using '%s' as Rekor server...", rekorURL))
+						opts = append(opts, sigstoreverifieropts.WithRekorURL(rekorURL))
+					}
+
+					dsseVerifier = sigstore.NewVerifierFromIdentityAndIssuer(key.KeyVal.Identity, key.KeyVal.Issuer, opts...)
+				case signerverifier.ED25519KeyType:
+					// These are only used to verify old policy metadata signed before the ssh-signer was added
+					slog.Debug(fmt.Sprintf("Found legacy ED25519 key '%s' in custom securesystemslib format...", key.KeyID))
+					dsseVerifier, err = signerverifier.NewED25519SignerVerifierFromSSLibKey(key)
+					if err != nil {
+						return nil, err
+					}
+				case signerverifier.RSAKeyType:
+					// These are only used to verify old policy metadata signed before the ssh-signer was added
+					slog.Debug(fmt.Sprintf("Found legacy RSA key '%s' in custom securesystemslib format...", key.KeyID))
+					dsseVerifier, err = signerverifier.NewRSAPSSSignerVerifierFromSSLibKey(key)
+					if err != nil {
+						return nil, err
+					}
+				case signerverifier.ECDSAKeyType:
+					// These are only used to verify old policy metadata signed before the ssh-signer was added
+					slog.Debug(fmt.Sprintf("Found legacy ECDSA key '%s' in custom securesystemslib format...", key.KeyID))
+					dsseVerifier, err = signerverifier.NewECDSASignerVerifierFromSSLibKey(key)
+					if err != nil {
+						return nil, err
+					}
+				default:
+					return nil, common.ErrUnknownKeyType
+				}
+
+				principalVerifiers = append(principalVerifiers, dsseVerifier)
+			}
+
+			// We have the principal's verifiers: use that to verify the envelope
+			if len(principalVerifiers) == 0 {
+				// TODO: remove this when we have signing method unification
+				// across git and dsse
+				continue
+			}
+
+			// We set threshold to 1 as we only need one of the keys for this
+			// principal to be matched. If more than one key is matched and
+			// returned in acceptedKeys, we count this only once towards the
+			// principal and therefore the verifier's threshold. However, for
+			// safety, we count both keys. If two principals share keys, this
+			// can lead to a problem meeting thresholds. Arguably, they
+			// shouldn't be sharing keys, so this seems reasonable.
+			acceptedKeys, err := dsse.VerifyEnvelope(ctx, env, principalVerifiers, 1)
+			if err != nil && !strings.Contains(err.Error(), "accepted signatures do not match threshold") {
+				return nil, err
+			}
+
+			for _, key := range acceptedKeys {
+				// Mark all accepted keys as used: this doesn't count towards
+				// the threshold directly, but if another principal has the same
+				// key, they may not be counted towards the threshold
+				usedKeyIDs.Add(key.KeyID)
+			}
+
+			if len(acceptedKeys) > 0 {
+				// We've verified this principal, one closer to the threshold
+				usedPrincipalIDs.Add(principal.ID())
+			}
+		}
+
+		if usedPrincipalIDs.Len() >= v.Threshold() {
+			return usedPrincipalIDs, nil
+		}
+	}
+
+	// Return usedPrincipalIDs so the consumer can decide what to do with the
+	// principals that were used
+	return usedPrincipalIDs, ErrVerifierConditionsUnmet
+}

--- a/internal/policy/signature_test.go
+++ b/internal/policy/signature_test.go
@@ -1,0 +1,171 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/common"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignatureVerifier(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+	gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
+
+	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+	rootPubKeyR := rootSigner.MetadataKey()
+	rootPubKey := tufv01.NewKeyFromSSLibKey(rootPubKeyR)
+
+	targetsSigner := setupSSHKeysForSigning(t, targets1KeyBytes, targets1PubKeyBytes)
+	targetsPubKeyR := targetsSigner.MetadataKey()
+	targetsPubKey := tufv01.NewKeyFromSSLibKey(targetsPubKeyR)
+
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+	commitID := commitIDs[0]
+	tagID := common.CreateTestSignedTag(t, repo, "test-tag", commitID, gpgKeyBytes)
+
+	attestation, err := dsse.CreateEnvelope(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestation, err = dsse.SignEnvelope(testCtx, attestation, rootSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	invalidAttestation, err := dsse.CreateEnvelope(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalidAttestation, err = dsse.SignEnvelope(testCtx, invalidAttestation, targetsSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attestationWithTwoSigs, err := dsse.CreateEnvelope(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestationWithTwoSigs, err = dsse.SignEnvelope(testCtx, attestationWithTwoSigs, rootSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestationWithTwoSigs, err = dsse.SignEnvelope(testCtx, attestationWithTwoSigs, targetsSigner)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		principals  []tuf.Principal
+		threshold   int
+		gitObjectID gitinterface.Hash
+		attestation *sslibdsse.Envelope
+
+		expectedError error
+	}{
+		"commit, no attestation, valid key, threshold 1": {
+			principals:  []tuf.Principal{gpgKey},
+			threshold:   1,
+			gitObjectID: commitID,
+		},
+		"commit, no attestation, valid key, threshold 2": {
+			principals:    []tuf.Principal{gpgKey},
+			threshold:     2,
+			gitObjectID:   commitID,
+			expectedError: ErrVerifierConditionsUnmet,
+		},
+		"commit, attestation, valid key, threshold 1": {
+			principals:  []tuf.Principal{gpgKey},
+			threshold:   1,
+			gitObjectID: commitID,
+			attestation: attestation,
+		},
+		"commit, attestation, valid keys, threshold 2": {
+			principals:  []tuf.Principal{gpgKey, rootPubKey},
+			threshold:   2,
+			gitObjectID: commitID,
+			attestation: attestation,
+		},
+		"commit, invalid signed attestation, threshold 2": {
+			principals:    []tuf.Principal{gpgKey, rootPubKey},
+			threshold:     2,
+			gitObjectID:   commitID,
+			attestation:   invalidAttestation,
+			expectedError: ErrVerifierConditionsUnmet,
+		},
+		"commit, attestation, valid keys, threshold 3": {
+			principals:  []tuf.Principal{gpgKey, rootPubKey, targetsPubKey},
+			threshold:   3,
+			gitObjectID: commitID,
+			attestation: attestationWithTwoSigs,
+		},
+		"tag, no attestation, valid key, threshold 1": {
+			principals:  []tuf.Principal{gpgKey},
+			threshold:   1,
+			gitObjectID: tagID,
+		},
+		"tag, no attestation, valid key, threshold 2": {
+			principals:    []tuf.Principal{gpgKey},
+			threshold:     2,
+			gitObjectID:   tagID,
+			expectedError: ErrVerifierConditionsUnmet,
+		},
+		"tag, attestation, valid key, threshold 1": {
+			principals:  []tuf.Principal{gpgKey},
+			threshold:   1,
+			gitObjectID: tagID,
+			attestation: attestation,
+		},
+		"tag, attestation, valid keys, threshold 2": {
+			principals:  []tuf.Principal{gpgKey, rootPubKey},
+			threshold:   2,
+			gitObjectID: tagID,
+			attestation: attestation,
+		},
+		"tag, invalid signed attestation, threshold 2": {
+			principals:    []tuf.Principal{gpgKey, rootPubKey},
+			threshold:     2,
+			gitObjectID:   tagID,
+			attestation:   invalidAttestation,
+			expectedError: ErrVerifierConditionsUnmet,
+		},
+		"tag, attestation, valid keys, threshold 3": {
+			principals:  []tuf.Principal{gpgKey, rootPubKey, targetsPubKey},
+			threshold:   3,
+			gitObjectID: tagID,
+			attestation: attestationWithTwoSigs,
+		},
+	}
+
+	for name, test := range tests {
+		verifier := &SignatureVerifier{
+			repository: repo,
+			name:       "test-verifier",
+			principals: test.principals,
+			threshold:  test.threshold,
+		}
+
+		_, err := verifier.Verify(testCtx, test.gitObjectID, test.attestation)
+		if test.expectedError == nil {
+			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
+		} else {
+			assert.ErrorIs(t, err, test.expectedError, fmt.Sprintf("incorrect error received in test '%s'", name))
+		}
+	}
+}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -18,17 +18,10 @@ import (
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
-	"github.com/gittuf/gittuf/internal/signerverifier/common"
-	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
-	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
-	"github.com/gittuf/gittuf/internal/signerverifier/sigstore"
-	sigstoreverifieropts "github.com/gittuf/gittuf/internal/signerverifier/sigstore/options/verifier"
-	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	ita "github.com/in-toto/attestation/go/v1"
-	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 )
 
 var (
@@ -760,7 +753,7 @@ func getApproverAttestationAndKeyIDsForIndex(ctx context.Context, repo *gitinter
 		// if it exists
 		if githubApprovalAttestation != nil {
 			slog.Debug("GitHub pull request approval found, verifying attestation signature...")
-			approvalVerifier := &Verifier{
+			approvalVerifier := &SignatureVerifier{
 				repository: policy.repository,
 				name:       tuf.GitHubAppRoleName,
 				principals: policy.githubAppKeys,
@@ -838,7 +831,7 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 	return verifyGitObjectAndAttestationsUsingVerifiers(ctx, verifiers, gitID, authorizationAttestation, appName, approverKeyIDs, false)
 }
 
-func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers []*Verifier, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, appName string, approverIDs *set.Set[string], verifyMergeable bool) (string, bool, error) {
+func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers []*SignatureVerifier, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, appName string, approverIDs *set.Set[string], verifyMergeable bool) (string, bool, error) {
 	if len(verifiers) == 0 {
 		return "", false, ErrNoVerifiers
 	}
@@ -919,214 +912,4 @@ func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers
 	}
 
 	return "", false, ErrVerifierConditionsUnmet
-}
-
-type Verifier struct {
-	repository *gitinterface.Repository
-	name       string
-	principals []tuf.Principal
-	threshold  int
-}
-
-func (v *Verifier) Name() string {
-	return v.name
-}
-
-func (v *Verifier) Threshold() int {
-	return v.threshold
-}
-
-func (v *Verifier) TrustedPrincipalIDs() *set.Set[string] {
-	principalIDs := set.NewSet[string]()
-	for _, principal := range v.principals {
-		principalIDs.Add(principal.ID())
-	}
-
-	return principalIDs
-}
-
-// Verify is used to check for a threshold of signatures using the verifier. The
-// threshold of signatures may be met using a combination of at most one Git
-// signature and signatures embedded in a DSSE envelope. Verify does not inspect
-// the envelope's payload, but instead only verifies the signatures. The caller
-// must ensure the validity of the envelope's contents.
-func (v *Verifier) Verify(ctx context.Context, gitObjectID gitinterface.Hash, env *sslibdsse.Envelope) (*set.Set[string], error) {
-	if v.threshold < 1 || len(v.principals) < 1 {
-		return nil, ErrInvalidVerifier
-	}
-
-	// usedPrincipalIDs is ultimately returned to track the set of principals
-	// who have been authenticated
-	usedPrincipalIDs := set.NewSet[string]()
-
-	// usedKeyIDs is tracked to ensure a key isn't duplicated between two
-	// principals, allowing two principals to meet a threshold using the same
-	// key
-	usedKeyIDs := set.NewSet[string]()
-
-	// gitObjectVerified is set to true if the gitObjectID's signature is
-	// verified
-	gitObjectVerified := false
-
-	// First, verify the gitObject's signature if one is presented
-	if gitObjectID != nil && !gitObjectID.IsZero() {
-		slog.Debug(fmt.Sprintf("Verifying signature of Git object with ID '%s'...", gitObjectID.String()))
-		for _, principal := range v.principals {
-			// there are multiple keys we must try
-			keys := principal.Keys()
-
-			for _, key := range keys {
-				err := v.repository.VerifySignature(ctx, gitObjectID, key)
-				if err == nil {
-					// Signature verification succeeded
-					slog.Debug(fmt.Sprintf("Public key '%s' belonging to principal '%s' successfully used to verify signature of Git object '%s', counting '%s' towards threshold...", key.KeyID, principal.ID(), gitObjectID.String(), principal.ID()))
-					usedPrincipalIDs.Add(principal.ID())
-					usedKeyIDs.Add(key.KeyID)
-					gitObjectVerified = true
-
-					// No need to try the other keys for this principal, break
-					break
-				}
-				if errors.Is(err, gitinterface.ErrUnknownSigningMethod) {
-					// TODO: this should be removed once we have unified signing
-					// methods across metadata and git signatures
-					continue
-				}
-				if !errors.Is(err, gitinterface.ErrIncorrectVerificationKey) {
-					return nil, err
-				}
-			}
-
-			if gitObjectVerified {
-				// No need to try other principals, break
-				break
-			}
-		}
-	}
-
-	// If threshold is 1 and the Git signature is verified, we can return
-	if v.threshold == 1 && gitObjectVerified {
-		return usedPrincipalIDs, nil
-	}
-
-	if env != nil {
-		// Second, verify signatures on the envelope
-
-		// We have to verify the envelope independently for each principal
-		// trusted in the verifier as a principal may have multiple keys
-		// associated with them.
-		for _, principal := range v.principals {
-			if usedPrincipalIDs.Has(principal.ID()) {
-				// Do not verify using this principal as they were verified for
-				// the Git signature
-				slog.Debug(fmt.Sprintf("Principal '%s' has already been counted towards the threshold, skipping...", principal.ID()))
-				continue
-			}
-
-			principalVerifiers := []sslibdsse.Verifier{}
-
-			keys := principal.Keys()
-			for _, key := range keys {
-				if usedKeyIDs.Has(key.KeyID) {
-					// this key has been encountered before, possibly because
-					// another Principal included this key
-					slog.Debug(fmt.Sprintf("Key with ID '%s' has already been used to verify a signature, skipping...", key.KeyID))
-					continue
-				}
-
-				var (
-					dsseVerifier sslibdsse.Verifier
-					err          error
-				)
-				switch key.KeyType {
-				case ssh.KeyType:
-					slog.Debug(fmt.Sprintf("Found SSH key '%s'...", key.KeyID))
-					dsseVerifier, err = ssh.NewVerifierFromKey(key)
-					if err != nil {
-						return nil, err
-					}
-				case gpg.KeyType:
-					slog.Debug(fmt.Sprintf("Found GPG key '%s', cannot use for DSSE signature verification yet...", key.KeyID))
-					continue
-				case sigstore.KeyType:
-					slog.Debug(fmt.Sprintf("Found Sigstore key '%s'...", key.KeyID))
-					opts := []sigstoreverifieropts.Option{}
-					config, err := v.repository.GetGitConfig()
-					if err != nil {
-						return nil, err
-					}
-					if rekorURL, has := config[sigstore.GitConfigRekor]; has {
-						slog.Debug(fmt.Sprintf("Using '%s' as Rekor server...", rekorURL))
-						opts = append(opts, sigstoreverifieropts.WithRekorURL(rekorURL))
-					}
-
-					dsseVerifier = sigstore.NewVerifierFromIdentityAndIssuer(key.KeyVal.Identity, key.KeyVal.Issuer, opts...)
-				case signerverifier.ED25519KeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy ED25519 key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewED25519SignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
-				case signerverifier.RSAKeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy RSA key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewRSAPSSSignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
-				case signerverifier.ECDSAKeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy ECDSA key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewECDSASignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
-				default:
-					return nil, common.ErrUnknownKeyType
-				}
-
-				principalVerifiers = append(principalVerifiers, dsseVerifier)
-			}
-
-			// We have the principal's verifiers: use that to verify the envelope
-			if len(principalVerifiers) == 0 {
-				// TODO: remove this when we have signing method unification
-				// across git and dsse
-				continue
-			}
-
-			// We set threshold to 1 as we only need one of the keys for this
-			// principal to be matched. If more than one key is matched and
-			// returned in acceptedKeys, we count this only once towards the
-			// principal and therefore the verifier's threshold. However, for
-			// safety, we count both keys. If two principals share keys, this
-			// can lead to a problem meeting thresholds. Arguably, they
-			// shouldn't be sharing keys, so this seems reasonable.
-			acceptedKeys, err := dsse.VerifyEnvelope(ctx, env, principalVerifiers, 1)
-			if err != nil && !strings.Contains(err.Error(), "accepted signatures do not match threshold") {
-				return nil, err
-			}
-
-			for _, key := range acceptedKeys {
-				// Mark all accepted keys as used: this doesn't count towards
-				// the threshold directly, but if another principal has the same
-				// key, they may not be counted towards the threshold
-				usedKeyIDs.Add(key.KeyID)
-			}
-
-			if len(acceptedKeys) > 0 {
-				// We've verified this principal, one closer to the threshold
-				usedPrincipalIDs.Add(principal.ID())
-			}
-		}
-
-		if usedPrincipalIDs.Len() >= v.Threshold() {
-			return usedPrincipalIDs, nil
-		}
-	}
-
-	// Return usedPrincipalIDs so the consumer can decide what to do with the
-	// principals that were used
-	return usedPrincipalIDs, ErrVerifierConditionsUnmet
 }

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -4,7 +4,6 @@
 package policy
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -17,7 +16,6 @@ import (
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
-	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
@@ -2596,157 +2594,4 @@ func TestStateVerifyNewState(t *testing.T) {
 		err = currentPolicy.VerifyNewState(testCtx, newPolicy)
 		assert.ErrorIs(t, err, ErrVerifierConditionsUnmet)
 	})
-}
-
-func TestVerifier(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-
-	gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
-
-	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
-	rootPubKeyR := rootSigner.MetadataKey()
-	rootPubKey := tufv01.NewKeyFromSSLibKey(rootPubKeyR)
-
-	targetsSigner := setupSSHKeysForSigning(t, targets1KeyBytes, targets1PubKeyBytes)
-	targetsPubKeyR := targetsSigner.MetadataKey()
-	targetsPubKey := tufv01.NewKeyFromSSLibKey(targetsPubKeyR)
-
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
-	commitID := commitIDs[0]
-	tagID := common.CreateTestSignedTag(t, repo, "test-tag", commitID, gpgKeyBytes)
-
-	attestation, err := dsse.CreateEnvelope(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	attestation, err = dsse.SignEnvelope(testCtx, attestation, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	invalidAttestation, err := dsse.CreateEnvelope(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	invalidAttestation, err = dsse.SignEnvelope(testCtx, invalidAttestation, targetsSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	attestationWithTwoSigs, err := dsse.CreateEnvelope(nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	attestationWithTwoSigs, err = dsse.SignEnvelope(testCtx, attestationWithTwoSigs, rootSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-	attestationWithTwoSigs, err = dsse.SignEnvelope(testCtx, attestationWithTwoSigs, targetsSigner)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := map[string]struct {
-		principals  []tuf.Principal
-		threshold   int
-		gitObjectID gitinterface.Hash
-		attestation *sslibdsse.Envelope
-
-		expectedError error
-	}{
-		"commit, no attestation, valid key, threshold 1": {
-			principals:  []tuf.Principal{gpgKey},
-			threshold:   1,
-			gitObjectID: commitID,
-		},
-		"commit, no attestation, valid key, threshold 2": {
-			principals:    []tuf.Principal{gpgKey},
-			threshold:     2,
-			gitObjectID:   commitID,
-			expectedError: ErrVerifierConditionsUnmet,
-		},
-		"commit, attestation, valid key, threshold 1": {
-			principals:  []tuf.Principal{gpgKey},
-			threshold:   1,
-			gitObjectID: commitID,
-			attestation: attestation,
-		},
-		"commit, attestation, valid keys, threshold 2": {
-			principals:  []tuf.Principal{gpgKey, rootPubKey},
-			threshold:   2,
-			gitObjectID: commitID,
-			attestation: attestation,
-		},
-		"commit, invalid signed attestation, threshold 2": {
-			principals:    []tuf.Principal{gpgKey, rootPubKey},
-			threshold:     2,
-			gitObjectID:   commitID,
-			attestation:   invalidAttestation,
-			expectedError: ErrVerifierConditionsUnmet,
-		},
-		"commit, attestation, valid keys, threshold 3": {
-			principals:  []tuf.Principal{gpgKey, rootPubKey, targetsPubKey},
-			threshold:   3,
-			gitObjectID: commitID,
-			attestation: attestationWithTwoSigs,
-		},
-		"tag, no attestation, valid key, threshold 1": {
-			principals:  []tuf.Principal{gpgKey},
-			threshold:   1,
-			gitObjectID: tagID,
-		},
-		"tag, no attestation, valid key, threshold 2": {
-			principals:    []tuf.Principal{gpgKey},
-			threshold:     2,
-			gitObjectID:   tagID,
-			expectedError: ErrVerifierConditionsUnmet,
-		},
-		"tag, attestation, valid key, threshold 1": {
-			principals:  []tuf.Principal{gpgKey},
-			threshold:   1,
-			gitObjectID: tagID,
-			attestation: attestation,
-		},
-		"tag, attestation, valid keys, threshold 2": {
-			principals:  []tuf.Principal{gpgKey, rootPubKey},
-			threshold:   2,
-			gitObjectID: tagID,
-			attestation: attestation,
-		},
-		"tag, invalid signed attestation, threshold 2": {
-			principals:    []tuf.Principal{gpgKey, rootPubKey},
-			threshold:     2,
-			gitObjectID:   tagID,
-			attestation:   invalidAttestation,
-			expectedError: ErrVerifierConditionsUnmet,
-		},
-		"tag, attestation, valid keys, threshold 3": {
-			principals:  []tuf.Principal{gpgKey, rootPubKey, targetsPubKey},
-			threshold:   3,
-			gitObjectID: tagID,
-			attestation: attestationWithTwoSigs,
-		},
-	}
-
-	for name, test := range tests {
-		verifier := Verifier{
-			repository: repo,
-			name:       "test-verifier",
-			principals: test.principals,
-			threshold:  test.threshold,
-		}
-
-		_, err := verifier.Verify(testCtx, test.gitObjectID, test.attestation)
-		if test.expectedError == nil {
-			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
-		} else {
-			assert.ErrorIs(t, err, test.expectedError, fmt.Sprintf("incorrect error received in test '%s'", name))
-		}
-	}
 }


### PR DESCRIPTION
I'm working on a policy verifier type that requires this name collision to be handled...