### PR TITLE
*: Fix GetLatestReferenceEntry's before condition

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -141,7 +141,7 @@ func LoadPersistentCache(repo *gitinterface.Repository) (*Persistent, error) {
 	if err != nil {
 		if errors.Is(err, gitinterface.ErrReferenceNotFound) {
 			// Persistent cache doesn't exist
-			slog.Debug("Persistent cache does not exist, creating new instance...")
+			slog.Debug("Persistent cache does not exist")
 			return nil, ErrNoPersistentCache
 		}
 
@@ -162,7 +162,7 @@ func LoadPersistentCache(repo *gitinterface.Repository) (*Persistent, error) {
 	if !has {
 		// Persistent cache doesn't seem to exist? This maybe warrants
 		// an error but we may have more than one file here in future?
-		slog.Debug("Persistent cache does not exist, creating new instance...")
+		slog.Debug("Persistent cache does not exist")
 		return nil, ErrNoPersistentCache
 	}
 

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -570,6 +570,7 @@ func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *Sta
 
 	// Load the applicable reference authorization and approvals from trusted
 	// code review systems
+	slog.Debug("Searching for applicable reference authorizations and code reviews...")
 	authorizationAttestation, approverKeyIDs, err := getApproverAttestationAndKeyIDs(ctx, repo, policy, attestationsState, entry)
 	if err != nil {
 		return err
@@ -650,6 +651,7 @@ func getApproverAttestationAndKeyIDs(ctx context.Context, repo *gitinterface.Rep
 	}
 
 	firstEntry := false
+	slog.Debug(fmt.Sprintf("Searching for RSL entry for '%s' before entry '%s'...", entry.RefName, entry.ID.String()))
 	priorRefEntry, _, err := rsl.GetLatestReferenceEntry(repo, rsl.ForReference(entry.RefName), rsl.BeforeEntryID(entry.ID))
 	if err != nil {
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {


### PR DESCRIPTION
The before condition check was incorrect when handling repositories that were not numbered from the start. This commit updates the before entry number condition to only apply if the entry being examined is in fact numbered.

This commit also adds some debug statements.