### PR TITLE
Generate VSA during verification

### DIFF
--- a/experimental/gittuf/options/verify/verify.go
+++ b/experimental/gittuf/options/verify/verify.go
@@ -3,9 +3,15 @@
 
 package verify
 
+import sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+
 type Options struct {
 	RefNameOverride string
 	LatestOnly      bool
+
+	GranularVSAsPath string
+	MetaVSAPath      string
+	VSASigner        sslibdsse.SignerVerifier
 }
 
 type Option func(o *Options)
@@ -19,5 +25,23 @@ func WithOverrideRefName(refNameOverride string) Option {
 func WithLatestOnly() Option {
 	return func(o *Options) {
 		o.LatestOnly = true
+	}
+}
+
+func WithGranularVSAsPath(location string) Option {
+	return func(o *Options) {
+		o.GranularVSAsPath = location
+	}
+}
+
+func WithMetaVSAPath(location string) Option {
+	return func(o *Options) {
+		o.MetaVSAPath = location
+	}
+}
+
+func WithVSASigner(signer sslibdsse.SignerVerifier) Option {
+	return func(o *Options) {
+		o.VSASigner = signer
 	}
 }

--- a/internal/cmd/verifyref/verifyref.go
+++ b/internal/cmd/verifyref/verifyref.go
@@ -13,9 +13,12 @@ import (
 )
 
 type options struct {
-	latestOnly    bool
-	fromEntry     string
-	remoteRefName string
+	latestOnly       bool
+	fromEntry        string
+	remoteRefName    string
+	granularVSAsPath string
+	metaVSAPath      string
+	vsaSigner        string
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -41,6 +44,27 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"",
 		"name of remote reference, if it differs from the local name",
 	)
+
+	cmd.Flags().StringVar(
+		&o.granularVSAsPath,
+		"write-granular-verification-summaries",
+		"",
+		"path to write granular verification summary attestations (one per policy) as an in-toto attestation bundle",
+	)
+
+	cmd.Flags().StringVar(
+		&o.metaVSAPath,
+		"write-overall-verification-summary",
+		"",
+		"path to write a single verification summary attestation",
+	)
+
+	cmd.Flags().StringVar(
+		&o.vsaSigner,
+		"sign-verification-summary",
+		"",
+		"signing key or identity for one or more verification summaries",
+	)
 }
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
@@ -61,6 +85,23 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	if o.latestOnly {
 		opts = append(opts, verifyopts.WithLatestOnly())
 	}
+
+	if o.granularVSAsPath != "" {
+		opts = append(opts, verifyopts.WithGranularVSAsPath(o.granularVSAsPath))
+	}
+	if o.metaVSAPath != "" {
+		opts = append(opts, verifyopts.WithMetaVSAPath(o.metaVSAPath))
+	}
+
+	if o.vsaSigner != "" {
+		signer, err := gittuf.LoadSigner(repo, o.vsaSigner)
+		if err != nil {
+			return err
+		}
+
+		opts = append(opts, verifyopts.WithVSASigner(signer))
+	}
+
 	return repo.VerifyRef(cmd.Context(), args[0], opts...)
 }
 

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -51,6 +51,12 @@ func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State) (*
 		t.Fatal(err)
 	}
 
+	stateID, err := repo.GetReference(PolicyRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.policyID = stateID
+
 	latestEntry, err := rsl.GetLatestEntry(repo)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -66,6 +66,7 @@ type State struct {
 	GitHubApps map[string]tuf.GitHubApp
 
 	repository     *gitinterface.Repository
+	policyID       gitinterface.Hash
 	loadedEntry    rsl.ReferenceUpdaterEntry
 	verifiersCache map[string][]*SignatureVerifier
 	ruleNames      *set.Set[string]
@@ -294,6 +295,10 @@ func LoadFirstState(ctx context.Context, repo *gitinterface.Repository, opts ...
 	}
 
 	return LoadState(ctx, repo, firstEntry, opts...)
+}
+
+func (s *State) GetID() gitinterface.Hash {
+	return s.policyID
 }
 
 // FindVerifiersForPath identifies the trusted set of verifiers for the
@@ -1346,7 +1351,7 @@ func loadStateFromCommit(repo *gitinterface.Repository, commitID gitinterface.Ha
 		}
 	}
 
-	state := &State{repository: repo}
+	state := &State{repository: repo, policyID: commitID}
 
 	for len(metadataQueue) != 0 {
 		currentMetadataEntry := metadataQueue[0]

--- a/internal/policy/report.go
+++ b/internal/policy/report.go
@@ -1,0 +1,92 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+)
+
+type VerificationReport struct {
+	ExpectedTip gitinterface.Hash
+	RefName     string
+
+	FirstRSLEntryVerified gitinterface.Hash
+	LastRSLEntryVerified  gitinterface.Hash
+
+	EntryVerificationReports []*EntryVerificationReport
+}
+
+type EntryVerificationReport struct {
+	// First, record some meta information about the entry that was verified.
+
+	// EntryID indicates the ID of the RSL reference entry that was verified.
+	EntryID gitinterface.Hash
+	// PolicyID indicates the ID of the RSL reference entry for the policy used
+	// during verification.
+	PolicyID gitinterface.Hash
+	// RefName indicates the reference the verified entry is for.
+	RefName string
+	// TargetID indicates the target recorded in the verified entry.
+	TargetID gitinterface.Hash
+
+	// Second, record specific information about the entry verification result.
+
+	// AcceptedPrincipalIDs indicates the principal IDs that were identified as
+	// having approved the entry. This may be via the signature on the RSL entry
+	// itself, one or more signatures on reference authorization attestations,
+	// or via code review tool attestations (e.g., GitHub associated identity
+	// for a person).
+	AcceptedPrincipalIDs *set.Set[string]
+	// RuleName indicates the name of the rule used to verify the entry. This is
+	// only populated if an explicit rule is used during verification. In other
+	// words, global rules don't go here.
+	RuleName string
+	// ReferenceAuthorization records the DSSE envelope for the reference
+	// authorization identified as approving the entry.
+	// TODO: should we capture the full envelope or just its blobID?
+	ReferenceAuthorization *dsse.Envelope
+
+	// Third, record information about the commit(s) verification result.
+
+	CommitVerificationReports []*CommitVerificationReport
+
+	// Fourth, record information about the global rules enforced.
+
+	GlobalRuleVerificationReports []*GlobalRuleVerificationReport
+}
+
+type CommitVerificationReport struct {
+	// First, record some meta information about the commit that was verified.
+
+	// CommitID indicates the ID of the commit that is verified.
+	CommitID gitinterface.Hash
+
+	// Second, record specific information about the commit verification result.
+
+	FileVerificationReports []*FileVerificationReport
+}
+
+type FileVerificationReport struct {
+	FilePath string
+
+	// AcceptedPrincipalIDs indicates the principal IDs that were identified as
+	// having approved the entry. This may be via the signature on the RSL entry
+	// itself, one or more signatures on reference authorization attestations,
+	// or via code review tool attestations (e.g., GitHub associated identity
+	// for a person).
+	AcceptedPrincipalIDs *set.Set[string]
+	// RuleName indicates the name of the rule used to verify the entry. This is
+	// only populated if an explicit rule is used during verification. In other
+	// words, global rules don't go here.
+	RuleName string
+
+	GlobalRuleVerificationReports []*GlobalRuleVerificationReport
+}
+
+type GlobalRuleVerificationReport struct {
+	RuleName string
+	RuleType string
+}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -70,21 +70,28 @@ func NewPolicyVerifier(repo *gitinterface.Repository) *PolicyVerifier {
 // VerifyRef verifies the signature on the latest RSL entry for the target ref
 // using the latest policy. The expected Git ID for the ref in the latest RSL
 // entry is returned if the policy verification is successful.
-func (v *PolicyVerifier) VerifyRef(ctx context.Context, target string) (gitinterface.Hash, error) {
+func (v *PolicyVerifier) VerifyRef(ctx context.Context, target string) (*VerificationReport, error) {
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
-	return latestEntry.GetTargetID(), v.VerifyRelativeForRef(ctx, latestEntry, latestEntry, target)
+	verificationReport, err := v.VerifyRelativeForRef(ctx, latestEntry, latestEntry, target)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationReport.ExpectedTip = latestEntry.GetTargetID()
+
+	return verificationReport, nil
 }
 
 // VerifyRefFull verifies the entire RSL for the target ref from the first
 // entry. The expected Git ID for the ref in the latest RSL entry is returned if
 // the policy verification is successful.
-func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (gitinterface.Hash, error) {
+func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (*VerificationReport, error) {
 	// Trace RSL back to the start
 	slog.Debug(fmt.Sprintf("Identifying first RSL entry for '%s'...", target))
 	var (
@@ -98,7 +105,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 		if entryNumber != 0 {
 			firstEntry, err = loadRSLReferenceUpdaterEntry(v.repo, entryID)
 			if err != nil {
-				return gitinterface.ZeroHash, err
+				return nil, err
 			}
 
 			// break because we've loaded the entry and don't need to fallthrough
@@ -109,7 +116,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 	case false:
 		firstEntry, _, err = rsl.GetFirstReferenceUpdaterEntryForRef(v.repo, target)
 		if err != nil {
-			return gitinterface.ZeroHash, err
+			return nil, err
 		}
 	}
 
@@ -117,41 +124,53 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	slog.Debug("Verifying all entries...")
-	return latestEntry.GetTargetID(), v.VerifyRelativeForRef(ctx, firstEntry, latestEntry, target)
+	verificationReport, err := v.VerifyRelativeForRef(ctx, firstEntry, latestEntry, target)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationReport.ExpectedTip = latestEntry.GetTargetID()
+	return verificationReport, nil
 }
 
 // VerifyRefFromEntry performs verification for the reference from a specific
 // RSL entry. The expected Git ID for the ref in the latest RSL entry is
 // returned if the policy verification is successful.
-func (v *PolicyVerifier) VerifyRefFromEntry(ctx context.Context, target string, entryID gitinterface.Hash) (gitinterface.Hash, error) {
+func (v *PolicyVerifier) VerifyRefFromEntry(ctx context.Context, target string, entryID gitinterface.Hash) (*VerificationReport, error) {
 	// Load starting point entry
 	slog.Debug("Identifying starting RSL entry...")
 	fromEntryT, err := rsl.GetEntry(v.repo, entryID)
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	fromEntry, isRefEntry := fromEntryT.(*rsl.ReferenceEntry)
 	if !isRefEntry {
 		// TODO: we should instead find the latest reference entry
 		// before the entryID and use that
-		return gitinterface.ZeroHash, fmt.Errorf("starting entry is not an RSL reference entry")
+		return nil, fmt.Errorf("starting entry is not an RSL reference entry")
 	}
 
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	// Do a relative verify from start entry to the latest entry
 	slog.Debug("Verifying all entries...")
-	return latestEntry.GetTargetID(), v.VerifyRelativeForRef(ctx, fromEntry, latestEntry, target)
+	verificationReport, err := v.VerifyRelativeForRef(ctx, fromEntry, latestEntry, target)
+	if err != nil {
+		return nil, err
+	}
+
+	verificationReport.ExpectedTip = latestEntry.GetTargetID()
+	return verificationReport, nil
 }
 
 // VerifyMergeable checks if the targetRef can be updated to reflect the changes
@@ -270,9 +289,21 @@ func (v *PolicyVerifier) verifyMergeable(ctx context.Context, targetRef string, 
 		return false, err
 	}
 
-	_, rslEntrySignatureNeededForThreshold, err := verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, targetRef), gitinterface.ZeroHash, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withVerifyMergeable())
+	_, acceptedPrincipalIDs, rslEntrySignatureNeededForThreshold, err := verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, targetRef), gitinterface.ZeroHash, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withVerifyMergeable())
 	if err != nil {
 		return false, fmt.Errorf("not enough approvals to meet Git namespace policies, %w", ErrVerificationFailed)
+	}
+
+	// Create global rule opts
+	// No entry ID because this is verifying mergeability
+	// Force pushes rules, therefore, don't apply
+	globalRuleOpts := []verifyGlobalRulesOption{withAcceptedPrincipalIDs(acceptedPrincipalIDs)}
+	if rslEntrySignatureNeededForThreshold {
+		globalRuleOpts = append(globalRuleOpts, withReduceThresholdRequirementByOne())
+	}
+	if _, err := verifyGlobalRules(v.repo, currentPolicy.globalRules, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, targetRef), globalRuleOpts...); err != nil {
+		// We don't return a report so we only need to check for error here
+		return false, fmt.Errorf("verifying global rules for Git namespace failed, %w", ErrVerificationFailed)
 	}
 
 	if !currentPolicy.hasFileRule {
@@ -300,7 +331,7 @@ func (v *PolicyVerifier) verifyMergeable(ctx context.Context, targetRef string, 
 			// usual. Also, we don't use verifyMergeable=true here. File
 			// verification rules are not met using the signature on the RSL
 			// entry, so we don't count threshold-1 here.
-			verifiedUsing, _, err = verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", fileRuleScheme, path), commitID, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withTrustedVerifier(verifiedUsing))
+			verifiedUsing, _, _, err = verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", fileRuleScheme, path), commitID, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withTrustedVerifier(verifiedUsing))
 			if err != nil {
 				return false, fmt.Errorf("verifying file namespace policies failed, %w", ErrVerificationFailed)
 			}
@@ -446,7 +477,7 @@ func (v *PolicyVerifier) VerifyNetwork(ctx context.Context) error {
 
 // VerifyRelativeForRef verifies the RSL between specified start and end entries
 // using the provided policy entry for the first entry.
-func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, lastEntry rsl.ReferenceUpdaterEntry, target string) error {
+func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, lastEntry rsl.ReferenceUpdaterEntry, target string) (*VerificationReport, error) {
 	/*
 		require firstEntry != nil
 		require lastEntry != nil
@@ -463,19 +494,25 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 		err                 error
 	)
 
+	verificationReport := &VerificationReport{
+		RefName:               target,
+		FirstRSLEntryVerified: firstEntry.GetID(),
+		LastRSLEntryVerified:  lastEntry.GetID(), // this is fine to set here as long as the report is only returned on success
+	}
+
 	// Load policy applicable at firstEntry
 	slog.Debug(fmt.Sprintf("Loading policy applicable at first entry '%s'...", firstEntry.GetID().String()))
 	initialPolicyEntry, err := v.searcher.FindPolicyEntryFor(firstEntry)
 	if err == nil {
 		state, err := LoadState(ctx, v.repo, initialPolicyEntry)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		currentPolicy = state
 	} else if !errors.Is(err, ErrPolicyNotFound) {
 		// Searcher gives us nil when firstEntry is the very first entry
 		// or close to it (i.e., before a policy was applied)
-		return err
+		return nil, err
 	}
 	// require currentPolicy != nil || parent(firstEntry) == nil
 
@@ -484,13 +521,13 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 	if err == nil {
 		attestationsState, err := attestations.LoadAttestationsForEntry(v.repo, initialAttestationsEntry)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		currentAttestations = attestationsState
 	} else if !errors.Is(err, attestations.ErrAttestationsNotFound) {
 		// Attestations are not compulsory, so return err only
 		// if it's some other error
-		return err
+		return nil, err
 	}
 	// require currentAttestations != nil || (entry.Ref != attestations.Ref for entry in 0..firstEntry)
 
@@ -498,7 +535,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 	slog.Debug("Identifying all entries in range...")
 	entries, annotations, err := rsl.GetReferenceUpdaterEntriesInRangeForRef(v.repo, firstEntry.GetID(), lastEntry.GetID(), target)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// require len(entries) != 0
 
@@ -533,7 +570,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 
 					newPolicy, err := loadStateForEntry(v.repo, entry)
 					if err != nil {
-						return err
+						return nil, err
 					}
 					// require newPolicy != nil
 
@@ -544,7 +581,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 						// refs
 						slog.Debug("Verifying new policy using current policy...")
 						if err := currentPolicy.VerifyNewState(ctx, newPolicy); err != nil {
-							return err
+							return nil, err
 						}
 						slog.Debug("Updating current policy...")
 					} else {
@@ -564,7 +601,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 				if entry.GetRefName() == attestations.Ref {
 					newAttestationsState, err := attestations.LoadAttestationsForEntry(v.repo, entry)
 					if err != nil {
-						return err
+						return nil, err
 					}
 
 					currentAttestations = newAttestationsState
@@ -578,14 +615,14 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 
 				slog.Debug("Verifying changes...")
 				if currentPolicy == nil {
-					return ErrPolicyNotFound
+					return nil, ErrPolicyNotFound
 				}
-				if err := verifyEntry(ctx, v.repo, currentPolicy, currentAttestations, entry); err != nil {
+				if entryVerificationReport, err := verifyEntry(ctx, v.repo, currentPolicy, currentAttestations, entry); err != nil {
 					slog.Debug(fmt.Sprintf("Violation found: %s", err.Error()))
 					slog.Debug("Checking if entry has been revoked...")
 					// If the invalid entry is never marked as skipped, we return err
 					if !entry.SkippedBy(annotations[entry.GetID().String()]) {
-						return err
+						return nil, err
 					}
 
 					// The invalid entry's been marked as skipped but we still need
@@ -596,11 +633,22 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 
 					if len(entries) == 0 {
 						// Fix entry does not exist after revoking annotation
-						return verificationErr
+						return nil, verificationErr
 					}
 				} else if v.persistentCacheEnabled {
 					// Verification has passed, add to cache
 					v.persistentCache.SetLastVerifiedEntryForRef(entry.GetRefName(), entry.GetNumber(), entry.GetID())
+				} else {
+					if verificationReport.EntryVerificationReports == nil {
+						verificationReport.EntryVerificationReports = []*EntryVerificationReport{}
+					}
+
+					verificationReport.EntryVerificationReports = append(verificationReport.EntryVerificationReports, entryVerificationReport)
+
+					if v.persistentCacheEnabled {
+						// Verification has passed, add to cache
+						v.persistentCache.SetLastVerifiedEntryForRef(entry.RefName, entry.GetNumber(), entry.GetID())
+					}
 				}
 
 				continue
@@ -627,12 +675,12 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 		slog.Debug("Identifying last valid state...")
 		lastGoodEntry, lastGoodEntryAnnotations, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(invalidEntry.GetRefName()), rsl.BeforeEntryID(invalidEntry.GetID()), rsl.IsUnskipped(), rsl.IsReferenceEntry())
 		if err != nil {
-			return err
+			return nil, err
 		}
 		slog.Debug("Verifying identified last valid entry has not been revoked...")
 		if lastGoodEntry.(*rsl.ReferenceEntry).SkippedBy(lastGoodEntryAnnotations) {
 			// this type assertion is fine because we use the rsl.IsReferenceEntry opt
-			return ErrLastGoodEntryIsSkipped
+			return nil, ErrLastGoodEntryIsSkipped
 		}
 		// require lastGoodEntry != nil
 
@@ -642,7 +690,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 		// last good state
 		lastGoodTreeID, err := v.repo.GetCommitTreeID(lastGoodEntry.GetTargetID())
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		// 2. What entries do we have in the current verification set for the
@@ -677,7 +725,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 			case *rsl.ReferenceEntry:
 				newCommitTreeID, err := v.repo.GetCommitTreeID(newEntry.GetTargetID())
 				if err != nil {
-					return err
+					return nil, err
 				}
 
 				slog.Debug("Checking if entry is tree-same with last valid state...")
@@ -710,13 +758,13 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 
 		if !fixed {
 			// If we haven't found a fix, return the original error
-			return verificationErr
+			return nil, verificationErr
 		}
 
 		if len(invalidIntermediateEntries) != 0 {
 			// We may have found a fix but if an invalid intermediate entry
 			// wasn't skipped, return error
-			return ErrInvalidEntryNotSkipped
+			return nil, ErrInvalidEntryNotSkipped
 		}
 
 		// Reset these trackers to continue verification with rest of the queue
@@ -731,7 +779,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 		}
 	}
 
-	return nil
+	return verificationReport, nil
 }
 
 // VerifyNewState ensures that when a new policy is encountered, its root role
@@ -752,9 +800,9 @@ func (s *State) VerifyNewState(ctx context.Context, newPolicy *State) error {
 // via the RSL across all refs. Then, it uses the policy applicable at the
 // commit's first entry into the repository. If the commit is brand new to the
 // repository, the specified policy is used.
-func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) error {
+func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) (*EntryVerificationReport, error) {
 	if entry.RefName == PolicyRef || entry.RefName == attestations.Ref {
-		return nil
+		return nil, nil
 	}
 
 	if strings.HasPrefix(entry.RefName, gitinterface.TagRefPrefix) {
@@ -762,23 +810,50 @@ func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *Sta
 		return verifyTagEntry(ctx, repo, policy, attestationsState, entry)
 	}
 
+	entryVerificationReport := &EntryVerificationReport{
+		EntryID:  entry.GetID(),
+		PolicyID: policy.GetID(),
+		RefName:  entry.RefName,
+		TargetID: entry.TargetID,
+	}
+
 	// Load the applicable reference authorization and approvals from trusted
 	// code review systems
 	slog.Debug("Searching for applicable reference authorizations and code reviews...")
 	authorizationAttestation, approverKeyIDs, err := getApproverAttestationAndKeyIDs(ctx, repo, policy, attestationsState, entry)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	if authorizationAttestation != nil {
+		entryVerificationReport.ReferenceAuthorization = authorizationAttestation
 	}
 
 	// Verify Git namespace policies using the RSL entry and attestations
-	if _, _, err := verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName), entry.ID, authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs)); err != nil {
-		return fmt.Errorf("verifying Git namespace policies failed, %w", ErrVerificationFailed)
+	verifiedUsing, acceptedPrincipalIDs, _, err := verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName), entry.ID, authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs))
+	if err != nil {
+		return nil, fmt.Errorf("verifying Git namespace policies failed, %w", ErrVerificationFailed)
 	}
+
+	entryVerificationReport.AcceptedPrincipalIDs = acceptedPrincipalIDs
+	if !strings.HasPrefix(verifiedUsing, tuf.GittufPrefix) {
+		// We create special verifiers with a gittuf- prefix when no explicit
+		// rules protect a namespace but we still want to verify (e.g., due to a
+		// global rule). Regular user defined rules cannot start with gittuf-,
+		// and verifiedUsing will be set to the rule name when a particular user
+		// defined rule is met.
+		entryVerificationReport.RuleName = verifiedUsing
+	}
+
+	globalRulesReports, err := verifyGlobalRules(repo, policy.globalRules, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName), withAcceptedPrincipalIDs(acceptedPrincipalIDs), withEntryID(entry.ID))
+	if err != nil {
+		return nil, fmt.Errorf("verifying global rules for Git namespace failed, %w", ErrVerificationFailed)
+	}
+	entryVerificationReport.GlobalRuleVerificationReports = globalRulesReports
 
 	// Check if policy has file rules at all for efficiency
 	if !policy.hasFileRule {
 		// No file rules to verify
-		return nil
+		return entryVerificationReport, nil
 	}
 
 	// Verify modified files
@@ -786,57 +861,105 @@ func verifyEntry(ctx context.Context, repo *gitinterface.Repository, policy *Sta
 	// First, get all commits between the current and last entry for the ref.
 	commitIDs, err := getCommits(repo, entry) // note: this is ordered by commit ID
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for _, commitID := range commitIDs {
-		paths, err := repo.GetFilePathsChangedByCommit(commitID)
-		if err != nil {
-			return err
+		commitVerificationReport := &CommitVerificationReport{
+			CommitID: commitID,
 		}
 
+		paths, err := repo.GetFilePathsChangedByCommit(commitID)
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO: should verifiedUsing support multiple?
 		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
+		acceptedPrincipalIDs := set.NewSet[string]()
 		for _, path := range paths {
+			fileVerificationReport := &FileVerificationReport{
+				FilePath: path,
+			}
+
 			// If we've already verified and identified commit signature, we
 			// can just check if that verifier is trusted for the new path.
 			// If not found, we don't make any assumptions about it being a
 			// failure in case of name mismatches. So, the signature check
 			// proceeds as usual.
-			verifiedUsing, _, err = verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", fileRuleScheme, path), commitID, authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs), withTrustedVerifier(verifiedUsing))
+			newVerifiedUsing, newAcceptedPrincipalIDs, _, err := verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", fileRuleScheme, path), commitID, authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs), withTrustedVerifier(verifiedUsing))
 			if err != nil {
-				return fmt.Errorf("verifying file namespace policies failed, %w", ErrVerificationFailed)
+				return nil, fmt.Errorf("verifying file namespace policies failed, %w", ErrVerificationFailed)
 			}
+			if newVerifiedUsing != verifiedUsing {
+				// When the same verifier name is reused to avoid redundant
+				// verifications, acceptedPrincipalIDs is nil.
+				// TODO: maybe track all successful verifiedUsing options?
+				verifiedUsing = newVerifiedUsing
+				acceptedPrincipalIDs = newAcceptedPrincipalIDs
+			}
+
+			fileVerificationReport.AcceptedPrincipalIDs = acceptedPrincipalIDs
+			if !strings.HasPrefix(verifiedUsing, tuf.GittufPrefix) {
+				// We create special verifiers with a gittuf- prefix when no
+				// explicit rules protect a namespace but we still want to
+				// verify (e.g., due to a global rule). Regular user defined
+				// rules cannot start with gittuf-, and verifiedUsing will be
+				// set to the rule name when a particular user defined rule is
+				// met.
+				fileVerificationReport.RuleName = verifiedUsing
+			}
+
+			globalRulesReports, err := verifyGlobalRules(repo, policy.globalRules, fmt.Sprintf("%s:%s", fileRuleScheme, path), withAcceptedPrincipalIDs(acceptedPrincipalIDs))
+			if err != nil {
+				return nil, fmt.Errorf("verifying global rules for file namespace failed, %w", ErrVerificationFailed)
+			}
+			fileVerificationReport.GlobalRuleVerificationReports = globalRulesReports
+
+			if commitVerificationReport.FileVerificationReports == nil {
+				commitVerificationReport.FileVerificationReports = []*FileVerificationReport{}
+			}
+
+			commitVerificationReport.FileVerificationReports = append(commitVerificationReport.FileVerificationReports, fileVerificationReport)
 		}
+
+		if entryVerificationReport.CommitVerificationReports == nil {
+			entryVerificationReport.CommitVerificationReports = []*CommitVerificationReport{}
+		}
+
+		entryVerificationReport.CommitVerificationReports = append(entryVerificationReport.CommitVerificationReports, commitVerificationReport)
 	}
 
-	return nil
+	return entryVerificationReport, nil
 }
 
-func verifyTagEntry(ctx context.Context, repo *gitinterface.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) error {
+func verifyTagEntry(ctx context.Context, repo *gitinterface.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) (*EntryVerificationReport, error) {
 	entryTagRef, err := repo.GetReference(entry.RefName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	tagTargetID, err := repo.GetTagTarget(entry.TargetID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !entry.TargetID.Equal(entryTagRef) && !entry.TargetID.Equal(tagTargetID) {
-		return fmt.Errorf("verifying RSL entry failed, tag reference set to unexpected target")
+		return nil, fmt.Errorf("verifying RSL entry failed, tag reference set to unexpected target")
 	}
 
 	authorizationAttestation, approverKeyIDs, err := getApproverAttestationAndKeyIDs(ctx, repo, policy, attestationsState, entry)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	if _, _, err := verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName), entry.GetID(), authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs), withTagObjectID(entry.TargetID)); err != nil {
-		return fmt.Errorf("verifying tag entry failed, %w: %w", ErrVerificationFailed, err)
+	if _, _, _, err := verifyGitObjectAndAttestations(ctx, policy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, entry.RefName), entry.GetID(), authorizationAttestation, withApproverPrincipalIDs(approverKeyIDs), withTagObjectID(entry.TargetID)); err != nil {
+		return nil, fmt.Errorf("verifying tag entry failed, %w: %w", ErrVerificationFailed, err)
 	}
 
-	return nil
+	// TODO: handle global rules
+
+	return nil, nil // TODO: return report
 }
 
 func getApproverAttestationAndKeyIDs(ctx context.Context, repo *gitinterface.Repository, policy *State, attestationsState *attestations.Attestations, entry *rsl.ReferenceEntry) (*sslibdsse.Envelope, *set.Set[string], error) {
@@ -1031,7 +1154,7 @@ func withTagObjectID(objID gitinterface.Hash) verifyGitObjectAndAttestationsOpti
 	}
 }
 
-func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target string, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, opts ...verifyGitObjectAndAttestationsOption) (string, bool, error) {
+func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target string, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, opts ...verifyGitObjectAndAttestationsOption) (string, *set.Set[string], bool, error) {
 	options := &verifyGitObjectAndAttestationsOptions{tagObjectID: gitinterface.ZeroHash}
 	for _, fn := range opts {
 		fn(options)
@@ -1039,18 +1162,18 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 
 	verifiers, err := policy.FindVerifiersForPath(target)
 	if err != nil {
-		return "", false, err
+		return "", nil, false, err
 	}
 
 	if len(verifiers) == 0 {
 		// This target is not protected by gittuf policy
-		return "", false, nil
+		return "", nil, false, nil
 	}
 
 	if options.trustedVerifier != "" {
 		for _, verifier := range verifiers {
 			if verifier.Name() == options.trustedVerifier {
-				return options.trustedVerifier, false, nil
+				return options.trustedVerifier, nil, false, nil
 			}
 		}
 	}
@@ -1063,7 +1186,7 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 	}
 	verifiedUsing, acceptedPrincipalIDs, rslSignatureNeededForThreshold, err := verifyGitObjectAndAttestationsUsingVerifiers(ctx, verifiers, gitID, authorizationAttestation, appNames, options.approverPrincipalIDs, options.verifyMergeable)
 	if err != nil {
-		return "", false, err
+		return "", nil, false, err
 	}
 
 	if !options.tagObjectID.IsZero() {
@@ -1084,13 +1207,13 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 				break
 			} else if !errors.Is(err, ErrVerifierConditionsUnmet) {
 				// Unexpected error
-				return "", false, err
+				return "", nil, false, err
 			}
 			// Haven't found a valid verifier, continue with next verifier
 		}
 
 		if !tagObjVerified {
-			return "", false, fmt.Errorf("verifying tag object's signature failed")
+			return "", nil, false, fmt.Errorf("verifying tag object's signature failed")
 		}
 	}
 
@@ -1128,7 +1251,7 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 					// Check if the verifiedPrincipalIDs meets the required global
 					// threshold
 					slog.Debug(fmt.Sprintf("Global rule '%s' not met, required threshold '%d', only have '%d'", rule.GetName(), rule.GetThreshold(), verifiedPrincipalIDs))
-					return "", false, ErrVerifierConditionsUnmet
+					return "", nil, false, ErrVerifierConditionsUnmet
 				}
 
 				slog.Debug(fmt.Sprintf("Successfully verified global rule '%s'", rule.GetName()))
@@ -1159,13 +1282,13 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 				currentEntry, err := rsl.GetEntry(policy.repository, gitID)
 				if err != nil {
 					slog.Debug(fmt.Sprintf("unable to load RSL entry for '%s': %v", gitID.String(), err))
-					return "", false, err
+					return "", nil, false, err
 				}
 
 				currentEntryRef, isReferenceEntry := currentEntry.(*rsl.ReferenceEntry)
 				if !isReferenceEntry {
 					slog.Debug(fmt.Sprintf("Expected '%s' to be RSL reference entry, aborting verification of block force pushes global rule...", gitID.String()))
-					return "", false, rsl.ErrInvalidRSLEntry
+					return "", nil, false, rsl.ErrInvalidRSLEntry
 				}
 
 				previousEntryRef, _, err := rsl.GetLatestReferenceUpdaterEntry(policy.repository, rsl.BeforeEntryID(currentEntry.GetID()), rsl.ForReference(currentEntryRef.RefName), rsl.IsUnskipped())
@@ -1175,28 +1298,28 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 						break
 					}
 
-					return "", false, err
+					return "", nil, false, err
 				}
 
 				knows, err := policy.repository.KnowsCommit(currentEntryRef.TargetID, previousEntryRef.GetTargetID())
 				if err != nil {
-					return "", false, err
+					return "", nil, false, err
 				}
 				if !knows {
 					slog.Debug(fmt.Sprintf("Current entry's commit '%s' is not a descendant of prior entry's commit '%s'", currentEntryRef.TargetID.String(), previousEntryRef.GetTargetID().String()))
-					return "", false, ErrVerifierConditionsUnmet
+					return "", nil, false, ErrVerifierConditionsUnmet
 				}
 
 				slog.Debug(fmt.Sprintf("Successfully verified global rule '%s' as '%s' is a descendant of '%s'", rule.GetName(), currentEntryRef.TargetID.String(), previousEntryRef.GetTargetID().String()))
 
 			default:
 				slog.Debug("Unknown global rule type, aborting verification...")
-				return "", false, tuf.ErrUnknownGlobalRuleType
+				return "", nil, false, tuf.ErrUnknownGlobalRuleType
 			}
 		}
 	}
 
-	return verifiedUsing, rslSignatureNeededForThreshold, nil
+	return verifiedUsing, acceptedPrincipalIDs, rslSignatureNeededForThreshold, nil
 }
 
 func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers []*SignatureVerifier, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, appNames []string, approverIDs *set.Set[string], verifyMergeable bool) (string, *set.Set[string], bool, error) {
@@ -1291,4 +1414,159 @@ func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers
 	}
 
 	return "", nil, false, ErrVerifierConditionsUnmet
+}
+
+type verifyGlobalRulesOptions struct {
+	acceptedPrincipalIDs            *set.Set[string]
+	reduceThresholdRequirementByOne bool
+	entryID                         gitinterface.Hash
+}
+
+type verifyGlobalRulesOption func(*verifyGlobalRulesOptions)
+
+func withAcceptedPrincipalIDs(acceptedPrincipalIDs *set.Set[string]) verifyGlobalRulesOption {
+	return func(o *verifyGlobalRulesOptions) {
+		o.acceptedPrincipalIDs = acceptedPrincipalIDs
+	}
+}
+
+func withReduceThresholdRequirementByOne() verifyGlobalRulesOption {
+	return func(o *verifyGlobalRulesOptions) {
+		o.reduceThresholdRequirementByOne = true
+	}
+}
+
+func withEntryID(entryID gitinterface.Hash) verifyGlobalRulesOption {
+	return func(o *verifyGlobalRulesOptions) {
+		o.entryID = entryID
+	}
+}
+
+func verifyGlobalRules(repo *gitinterface.Repository, globalRules map[string][]tuf.GlobalRule, target string, opts ...verifyGlobalRulesOption) ([]*GlobalRuleVerificationReport, error) {
+	options := &verifyGlobalRulesOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	verifiedPrincipalIDs := 0
+	if options.acceptedPrincipalIDs != nil {
+		verifiedPrincipalIDs = options.acceptedPrincipalIDs.Len()
+	}
+
+	allVerificationReports := []*GlobalRuleVerificationReport{}
+
+	for controllerName, globalRules := range globalRules {
+		if controllerName == "" { // this is the special case
+			slog.Debug("Checking global rules declared in current repository...")
+		} else {
+			slog.Debug(fmt.Sprintf("Checking global rules declared in controller repository '%s'...", controllerName))
+		}
+		for _, rule := range globalRules {
+			// We check every global rule
+			slog.Debug(fmt.Sprintf("Checking if global rule '%s' applies...", rule.GetName()))
+
+			verificationReport := &GlobalRuleVerificationReport{
+				RuleName: rule.GetName(),
+			}
+
+			switch rule := rule.(type) {
+			case tuf.GlobalRuleThreshold:
+				if !rule.Matches(target) {
+					break
+				}
+
+				verificationReport.RuleType = tuf.GlobalRuleThresholdType
+
+				// The global rule applies to the namespace under verification
+				slog.Debug(fmt.Sprintf("Verifying threshold global rule '%s'...", rule.GetName()))
+				requiredThreshold := rule.GetThreshold()
+				if options.reduceThresholdRequirementByOne {
+					// Since we're verifying if it's mergeable and we already know
+					// that the RSL signature is needed to meet threshold, we can
+					// reduce the global constraint threshold as well
+					slog.Debug("Reducing required global threshold by 1 (verifying if change is mergeable and RSL signature is required)...")
+					requiredThreshold--
+				}
+				if verifiedPrincipalIDs < requiredThreshold {
+					// Check if the verifiedPrincipalIDs meets the required global
+					// threshold
+					slog.Debug(fmt.Sprintf("Global rule '%s' not met, required threshold '%d', only have '%d'", rule.GetName(), rule.GetThreshold(), verifiedPrincipalIDs))
+					return nil, ErrVerifierConditionsUnmet
+				}
+
+				slog.Debug(fmt.Sprintf("Successfully verified global rule '%s'", rule.GetName()))
+
+			case tuf.GlobalRuleBlockForcePushes:
+				// TODO: we use policy.repository, not ideal...
+				if !rule.Matches(target) {
+					break
+				}
+
+				verificationReport.RuleType = tuf.GlobalRuleBlockForcePushesType
+
+				// The global rule applies to the namespace under verification
+				slog.Debug(fmt.Sprintf("Verifying block force pushes global rule '%s'...", rule.GetName()))
+
+				if options.entryID == nil || options.entryID.IsZero() {
+					// When can this happen?
+					// When target is for a git ref (file targets are caught in the
+					// Matches() check) and when entryID is not set / is zero.
+					// entryID is like that when we are verifying mergeability
+					// This design places the onus on the caller to set the entryID
+					// everytime minus VerifyMergeable, and this is far from ideal.
+					slog.Debug("Cannot verify block force pushes global rule as entry ID is not specified")
+					break
+				}
+
+				// TODO: should we not look up the entry's afresh in the RSL here?
+				// the in-memory cache _should_ make this okay, but something to
+				// consider...
+
+				// gitID _must_ be for an RSL reference entry, and we must find
+				// its predecessor entry.
+				// Why? Because the rule type only accepts git:<> as patterns.
+				// If we have another object here, we've gone wrong somewhere.
+				currentEntry, err := rsl.GetEntry(repo, options.entryID)
+				if err != nil {
+					slog.Debug(fmt.Sprintf("unable to load RSL entry for '%s': %v", options.entryID.String(), err))
+					return nil, err
+				}
+
+				currentEntryRef, isReferenceEntry := currentEntry.(*rsl.ReferenceEntry)
+				if !isReferenceEntry {
+					slog.Debug(fmt.Sprintf("Expected '%s' to be RSL reference entry, aborting verification of block force pushes global rule...", options.entryID.String()))
+					return nil, rsl.ErrInvalidRSLEntry
+				}
+
+				previousEntryRef, _, err := rsl.GetLatestReferenceUpdaterEntry(repo, rsl.BeforeEntryID(currentEntry.GetID()), rsl.ForReference(currentEntryRef.RefName), rsl.IsUnskipped())
+				if err != nil {
+					if errors.Is(err, rsl.ErrRSLEntryNotFound) {
+						slog.Debug(fmt.Sprintf("Entry '%s' is the first one for reference '%s', cannot check if it's a force push", currentEntryRef.GetID().String(), currentEntryRef.RefName))
+						break
+					}
+
+					return nil, err
+				}
+
+				knows, err := repo.KnowsCommit(currentEntryRef.TargetID, previousEntryRef.GetTargetID())
+				if err != nil {
+					return nil, err
+				}
+				if !knows {
+					slog.Debug(fmt.Sprintf("Current entry's commit '%s' is not a descendant of prior entry's commit '%s'", currentEntryRef.TargetID.String(), previousEntryRef.GetTargetID().String()))
+					return nil, ErrVerifierConditionsUnmet
+				}
+
+				slog.Debug(fmt.Sprintf("Successfully verified global rule '%s' as '%s' is a descendant of '%s'", rule.GetName(), currentEntryRef.TargetID.String(), previousEntryRef.GetTargetID().String()))
+
+			default:
+				slog.Debug("Unknown global rule type, aborting verification...")
+				return nil, tuf.ErrUnknownGlobalRuleType
+			}
+
+			allVerificationReports = append(allVerificationReports, verificationReport)
+		}
+	}
+
+	return allVerificationReports, nil
 }

--- a/internal/slsa/slsa.go
+++ b/internal/slsa/slsa.go
@@ -1,0 +1,256 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package slsa
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/internal/version"
+	vsa "github.com/in-toto/attestation/go/predicates/vsa/v1"
+	ita "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	verifierIDFormatter              = "https://gittuf.dev/verifier/%s"
+	verificationSummaryPredicateType = "https://slsa.dev/verification_summary/v1"
+	gitCommitDigestType              = "gitCommit"
+	passedVSAStatus                  = "PASSED"
+	sourceBranchesAnnotationType     = "source_branches"
+)
+
+type slsaSourceLevel uint
+
+const (
+	sourceLevel1 slsaSourceLevel = iota + 1
+	sourceLevel2
+	sourceLevel3
+)
+
+const (
+	sourceLevel1String = "SLSA_SOURCE_LEVEL_1"
+	sourceLevel2String = "SLSA_SOURCE_LEVEL_2"
+	sourceLevel3String = "SLSA_SOURCE_LEVEL_3"
+)
+
+func (l slsaSourceLevel) String() string {
+	switch l {
+	case sourceLevel1:
+		return sourceLevel1String
+	case sourceLevel2:
+		return sourceLevel2String
+	case sourceLevel3:
+		return sourceLevel3String
+	default:
+		return ""
+	}
+}
+
+func slsaSourceLevelFromString(s string) slsaSourceLevel {
+	switch s {
+	case sourceLevel1String:
+		return sourceLevel1
+	case sourceLevel2String:
+		return sourceLevel2
+	case sourceLevel3String:
+		return sourceLevel3
+	default:
+		return 0
+	}
+}
+
+func GenerateGranularVSAs(verificationReport *policy.VerificationReport, repositoryLocation string) ([]*ita.Statement, error) {
+	generators := []*vsaGenerator{}
+
+	for index, entryVerificationReport := range verificationReport.EntryVerificationReports {
+		// As we process the entry verification reports, we determine when and
+		// how many VSAs to generate. We populate VSA generators with the
+		// appropriate information, and generate all VSAs later.
+		if len(generators) == 0 {
+			// This is the very start of verification
+			generators = append(generators, &vsaGenerator{
+				policyID:   entryVerificationReport.PolicyID,
+				revisionID: entryVerificationReport.TargetID,
+				startIndex: 0, // hardcoded because this is the first, we also don't need this because it's the default, but more readable!
+			})
+		} else {
+			// We have at least one generator
+			// We have to update the existing generator **unless the policy has
+			// now changed**
+
+			if entryVerificationReport.PolicyID.Equal(generators[len(generators)-1].policyID) {
+				// The policy has not changed, so we just update the revision ID
+				generators[len(generators)-1].revisionID = entryVerificationReport.TargetID
+			} else {
+				// The policy has changed!
+				// So, first we set the end conditions for the last generator,
+				// then we add a new generator for subsequent entries
+
+				// Note that only endIndex must be set
+				// startIndex is set when the generator is added, as is the policyID
+				// the revisionID is not set here because the last entry that
+				// used the policy already has that set when there was no policy
+				// change
+				generators[len(generators)-1].endIndex = index // we don't use index-1 because we use this for range constraints later
+
+				generators = append(generators, &vsaGenerator{
+					policyID:   entryVerificationReport.PolicyID,
+					revisionID: entryVerificationReport.TargetID,
+					startIndex: index,
+				})
+			}
+		}
+	}
+
+	// We must update the end conditions for the last generator
+	generators[len(generators)-1].endIndex = len(verificationReport.EntryVerificationReports)
+
+	// Now, for each generator, we produce the corresponding attestation
+	allAttestations := []*ita.Statement{}
+	for _, generator := range generators {
+		statement, err := generator.generate(repositoryLocation, verificationReport.RefName, verificationReport.EntryVerificationReports[generator.startIndex:generator.endIndex])
+		if err != nil {
+			return nil, err
+		}
+		allAttestations = append(allAttestations, statement)
+	}
+
+	return allAttestations, nil
+}
+
+func GenerateMetaVSAFromGranularVSAs(granularVSAs []*ita.Statement, repositoryLocation string) (*ita.Statement, error) {
+	// The meta VSA's policy is set to the applicable policy at the current revision
+	// However, SLSA source level is set to whatever is the lowest of all VSAs
+	// due to the current revision being built on top of the older changes that
+	// didn't conform with higher levels
+
+	sourceLevel := sourceLevel3
+	predicate := &vsa.VerificationSummary{}
+	for _, statement := range granularVSAs {
+		predicateBytes, err := protojson.Marshal(statement.Predicate)
+		if err != nil {
+			return nil, err
+		}
+
+		predicate = &vsa.VerificationSummary{}
+		if err := protojson.Unmarshal(predicateBytes, predicate); err != nil {
+			return nil, err
+		}
+
+		predicateSourceLevel := slsaSourceLevelFromString(predicate.VerifiedLevels[0])
+		sourceLevel = min(predicateSourceLevel, sourceLevel)
+	}
+
+	policyID, _ := gitinterface.NewHash(predicate.Policy.Digest[gitCommitDigestType]) // predicate is the last VSA, FIXME
+
+	lastVSAStatement := granularVSAs[len(granularVSAs)-1]
+	revisionID, _ := gitinterface.NewHash(lastVSAStatement.Subject[0].Digest[gitCommitDigestType])    // TODO
+	refName := lastVSAStatement.Subject[0].Annotations.AsMap()[sourceBranchesAnnotationType].(string) // TODO
+
+	generator := &vsaGenerator{policyID: policyID, revisionID: revisionID}
+	return generator.generateWithSourceLevel(repositoryLocation, refName, sourceLevel)
+}
+
+type vsaGenerator struct {
+	policyID   gitinterface.Hash
+	revisionID gitinterface.Hash
+
+	startIndex int
+	endIndex   int
+}
+
+func (v *vsaGenerator) generate(repositoryLocation, refName string, entryVerificationReports []*policy.EntryVerificationReport) (*ita.Statement, error) {
+	sourceLevel := v.identifySourceLevel(entryVerificationReports)
+	return v.generateWithSourceLevel(repositoryLocation, refName, sourceLevel)
+}
+
+func (v *vsaGenerator) generateWithSourceLevel(repositoryLocation, refName string, sourceLevel slsaSourceLevel) (*ita.Statement, error) {
+	predicate := &vsa.VerificationSummary{
+		Verifier: &vsa.VerificationSummary_Verifier{
+			Id: generateVerifierID(),
+		},
+		TimeVerified: timestamppb.Now(),
+		ResourceUri:  repositoryLocation,
+		Policy: &vsa.VerificationSummary_Policy{
+			Digest: map[string]string{
+				gitCommitDigestType: v.policyID.String(),
+			},
+		},
+		VerificationResult: passedVSAStatus, // hardcoded, not generating VSA on failure
+		VerifiedLevels:     []string{sourceLevel.String()},
+	}
+
+	predicateBytes, err := protojson.Marshal(predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	predicateStruct := &structpb.Struct{}
+	if err := protojson.Unmarshal(predicateBytes, predicateStruct); err != nil {
+		return nil, err
+	}
+
+	annotations, err := structpb.NewStruct(map[string]any{sourceBranchesAnnotationType: refName})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{
+					gitCommitDigestType: v.revisionID.String(),
+				},
+				Annotations: annotations,
+			},
+		},
+		PredicateType: verificationSummaryPredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+func (v *vsaGenerator) identifySourceLevel(entryVerificationReports []*policy.EntryVerificationReport) slsaSourceLevel {
+	// If all entry verification reports have block-force-pushes type global rule, then it's level 2
+	// Otherwise, it's level 1
+	sourceLevel := sourceLevel2
+	for _, report := range entryVerificationReports {
+		has := false
+		for _, globalRule := range report.GlobalRuleVerificationReports {
+			if globalRule.RuleType == tuf.GlobalRuleBlockForcePushesType {
+				has = true
+				break
+			}
+		}
+
+		if !has {
+			sourceLevel = sourceLevel1
+			break
+		}
+	}
+
+	return sourceLevel
+}
+
+func generateVerifierID() string {
+	return fmt.Sprintf(verifierIDFormatter, version.GetVersion())
+}
+
+func generateRepositoryLocation(location string) string {
+	if location == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(location, "git+") {
+		return location
+	}
+
+	return fmt.Sprintf("git+%s", location)
+}


### PR DESCRIPTION
This is a stab at #190. This is also closely related to the SLSA source track <-> gittuf work. Also see: https://github.com/slsa-framework/slsa-source-poc