### PR TITLE
ci: Fix Git 2.34 run

### DIFF
--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Downgrade Git
-        run: sudo apt-get update && sudo apt-get install -y --allow-downgrades git=1:2.34.1-1ubuntu1.11 git-man=1:2.34.1-1ubuntu1.11
+        run: sudo apt-get update && sudo apt-get install -y --allow-downgrades git=1:2.34.1-1ubuntu1.12 git-man=1:2.34.1-1ubuntu1.12
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Install Go


### PR DESCRIPTION
Looks like there was an update to Git 2.34: https://launchpad.net/ubuntu/+source/git/1:2.34.1-1ubuntu1.12

This PR fixes the broken workflow for the older Git version.