### PR TITLE
tuf: Add globalRules to migrator

### DIFF
--- a/internal/tuf/migrations/migrations.go
+++ b/internal/tuf/migrations/migrations.go
@@ -46,6 +46,9 @@ func MigrateRootMetadataV01ToV02(rootMetadata *tufv01.RootMetadata) *tufv02.Root
 	// Set app attestations support
 	newRootMetadata.GitHubApprovalsTrusted = rootMetadata.GitHubApprovalsTrusted
 
+	// Set global rules
+	newRootMetadata.GlobalRules = rootMetadata.GlobalRules
+
 	return newRootMetadata
 }
 


### PR DESCRIPTION
The PR adding support for global rules in the metadata missed adding the migration between v01 and v02.