### PR TITLE
*: Initial support for naming for gittuf app

### DIFF
--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -21,7 +21,7 @@ Tools for gittuf's root of trust
 ### SEE ALSO
 
 * [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
-* [gittuf trust add-github-app-key](gittuf_trust_add-github-app-key.md)	 - Add GitHub app key to gittuf root of trust
+* [gittuf trust add-github-app](gittuf_trust_add-github-app.md)	 - Add GitHub app to gittuf root of trust
 * [gittuf trust add-global-rule](gittuf_trust_add-global-rule.md)	 - Add a new global rule to root of trust (developer mode only, set GITTUF_DEV=1)
 * [gittuf trust add-policy-key](gittuf_trust_add-policy-key.md)	 - Add Policy key to gittuf root of trust
 * [gittuf trust add-root-key](gittuf_trust_add-root-key.md)	 - Add Root key to gittuf root of trust
@@ -30,7 +30,7 @@ Tools for gittuf's root of trust
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth
 * [gittuf trust init](gittuf_trust_init.md)	 - Initialize gittuf root of trust for repository
 * [gittuf trust remote](gittuf_trust_remote.md)	 - Tools for managing remote policies
-* [gittuf trust remove-github-app-key](gittuf_trust_remove-github-app-key.md)	 - Remove GitHub app key from gittuf root of trust
+* [gittuf trust remove-github-app](gittuf_trust_remove-github-app.md)	 - Remove GitHub app from gittuf root of trust
 * [gittuf trust remove-global-rule](gittuf_trust_remove-global-rule.md)	 - Remove a global rule from root of trust (developer mode only, set GITTUF_DEV=1)
 * [gittuf trust remove-policy-key](gittuf_trust_remove-policy-key.md)	 - Remove Policy key from gittuf root of trust
 * [gittuf trust remove-root-key](gittuf_trust_remove-root-key.md)	 - Remove Root key from gittuf root of trust

--- a/docs/cli/gittuf_trust_add-github-app.md
+++ b/docs/cli/gittuf_trust_add-github-app.md
@@ -1,20 +1,20 @@
-## gittuf trust add-github-app-key
+## gittuf trust add-github-app
 
-Add GitHub app key to gittuf root of trust
+Add GitHub app to gittuf root of trust
 
 ### Synopsis
 
-This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+This command allows users to add a name and trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
 
 ```
-gittuf trust add-github-app-key [flags]
+gittuf trust add-github-app [flags]
 ```
 
 ### Options
 
 ```
       --app-key string   app key to add to root of trust
-  -h, --help             help for add-github-app-key
+  -h, --help             help for add-github-app
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust_add-github-app.md
+++ b/docs/cli/gittuf_trust_add-github-app.md
@@ -4,7 +4,7 @@ Add GitHub app to gittuf root of trust
 
 ### Synopsis
 
-This command allows users to add a name and trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
 
 ```
 gittuf trust add-github-app [flags]

--- a/docs/cli/gittuf_trust_remove-github-app.md
+++ b/docs/cli/gittuf_trust_remove-github-app.md
@@ -1,15 +1,15 @@
-## gittuf trust remove-github-app-key
+## gittuf trust remove-github-app
 
-Remove GitHub app key from gittuf root of trust
+Remove GitHub app from gittuf root of trust
 
 ```
-gittuf trust remove-github-app-key [flags]
+gittuf trust remove-github-app [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help   help for remove-github-app-key
+  -h, --help   help for remove-github-app
 ```
 
 ### Options inherited from parent commands

--- a/experimental/gittuf/attestations.go
+++ b/experimental/gittuf/attestations.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/go-git/go-git/v5/plumbing"
 	gogithub "github.com/google/go-github/v61/github"
 	ita "github.com/in-toto/attestation/go/v1"
@@ -404,6 +405,7 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 	if err != nil {
 		return err
 	}
+	appName := tuf.GitHubAppRoleName // TODO: make this configurable, check appName's key matches signer
 
 	baseRef, fromID, toID, err := getGitHubPullRequestReviewDetails(ctx, currentAttestations, options.GitHubBaseURL, options.GitHubToken, owner, repository, pullRequestNumber, reviewID)
 	if err != nil {
@@ -412,7 +414,7 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 
 	// TODO: if the helper above has an indexPath, we can directly load that blob, simplifying the logic here
 	hasApprovalAttestation := false
-	env, err := currentAttestations.GetGitHubPullRequestApprovalAttestationFor(r.r, keyID, baseRef, fromID, toID)
+	env, err := currentAttestations.GetGitHubPullRequestApprovalAttestationFor(r.r, appName, baseRef, fromID, toID)
 	if err == nil {
 		slog.Debug("Found existing GitHub pull request approval attestation...")
 		hasApprovalAttestation = true
@@ -453,7 +455,7 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 		return err
 	}
 
-	if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(r.r, env, options.GitHubBaseURL, reviewID, keyID, baseRef, fromID, toID); err != nil {
+	if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(r.r, env, options.GitHubBaseURL, reviewID, appName, baseRef, fromID, toID); err != nil {
 		return err
 	}
 
@@ -495,8 +497,9 @@ func (r *Repository) DismissGitHubPullRequestApprover(ctx context.Context, signe
 	if err != nil {
 		return err
 	}
+	appName := tuf.GitHubAppRoleName
 
-	env, err := currentAttestations.GetGitHubPullRequestApprovalAttestationForReviewID(r.r, options.GitHubBaseURL, reviewID, keyID)
+	env, err := currentAttestations.GetGitHubPullRequestApprovalAttestationForReviewID(r.r, options.GitHubBaseURL, reviewID, appName)
 	if err != nil {
 		return err
 	}
@@ -541,7 +544,7 @@ func (r *Repository) DismissGitHubPullRequestApprover(ctx context.Context, signe
 		return err
 	}
 
-	if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(r.r, env, options.GitHubBaseURL, reviewID, keyID, baseRef, fromID, toID); err != nil {
+	if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(r.r, env, options.GitHubBaseURL, reviewID, appName, baseRef, fromID, toID); err != nil {
 		return err
 	}
 

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -284,10 +284,10 @@ func (r *Repository) RemoveTopLevelTargetsKey(ctx context.Context, signer sslibd
 	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, signCommit)
 }
 
-// AddGitHubAppKey is the interface for the user to add the authorized key for
-// the special GitHub app role. This key is used to verify GitHub pull request
-// approval attestation signatures.
-func (r *Repository) AddGitHubAppKey(ctx context.Context, signer sslibdsse.SignerVerifier, appKey tuf.Principal, signCommit bool) error {
+// AddGitHubApp is the interface for the user to add the authorized key for the
+// trusted GitHub app. This key is used to verify GitHub pull request approval
+// attestation signatures recorded by the app.
+func (r *Repository) AddGitHubApp(ctx context.Context, signer sslibdsse.SignerVerifier, appKey tuf.Principal, signCommit bool) error {
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -313,7 +313,7 @@ func (r *Repository) AddGitHubAppKey(ctx context.Context, signer sslibdsse.Signe
 	}
 
 	slog.Debug("Adding GitHub app key...")
-	if err := rootMetadata.AddGitHubAppPrincipal(appKey); err != nil {
+	if err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey); err != nil {
 		return fmt.Errorf("failed to add GitHub app key: %w", err)
 	}
 
@@ -321,9 +321,9 @@ func (r *Repository) AddGitHubAppKey(ctx context.Context, signer sslibdsse.Signe
 	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, signCommit)
 }
 
-// RemoveGitHubAppKey is the interface for the user to de-authorize the key for
-// the special GitHub app role.
-func (r *Repository) RemoveGitHubAppKey(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
+// RemoveGitHubApp is the interface for the user to de-authorize the key for the
+// special GitHub app role.
+func (r *Repository) RemoveGitHubApp(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool) error {
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -349,7 +349,7 @@ func (r *Repository) RemoveGitHubAppKey(ctx context.Context, signer sslibdsse.Si
 	}
 
 	slog.Debug("Removing GitHub app key...")
-	rootMetadata.DeleteGitHubAppPrincipal()
+	rootMetadata.DeleteGitHubAppPrincipal(tuf.GitHubAppRoleName)
 
 	commitMessage := "Remove GitHub app key from root"
 	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, signCommit)

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -281,13 +281,13 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestAddGitHubAppKey(t *testing.T) {
+func TestAddGitHubApp(t *testing.T) {
 	r := createTestRepositoryWithRoot(t, "")
 
 	sv := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 	key := tufv01.NewKeyFromSSLibKey(sv.MetadataKey())
 
-	err := r.AddGitHubAppKey(testCtx, sv, key, false)
+	err := r.AddGitHubApp(testCtx, sv, key, false)
 	assert.Nil(t, err)
 
 	state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
@@ -308,13 +308,13 @@ func TestAddGitHubAppKey(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRemoveGitHubAppKey(t *testing.T) {
+func TestRemoveGitHubApp(t *testing.T) {
 	r := createTestRepositoryWithRoot(t, "")
 
 	sv := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 	key := tufv01.NewKeyFromSSLibKey(sv.MetadataKey())
 
-	err := r.AddGitHubAppKey(testCtx, sv, key, false)
+	err := r.AddGitHubApp(testCtx, sv, key, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -338,7 +338,7 @@ func TestRemoveGitHubAppKey(t *testing.T) {
 	_, err = dsse.VerifyEnvelope(testCtx, state.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
 	assert.Nil(t, err)
 
-	err = r.RemoveGitHubAppKey(testCtx, sv, false)
+	err = r.RemoveGitHubApp(testCtx, sv, false)
 	assert.Nil(t, err)
 
 	state, err = policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
@@ -389,7 +389,7 @@ func TestTrustGitHubApp(t *testing.T) {
 
 		assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted())
 
-		err = r.AddGitHubAppKey(testCtx, sv, key, false)
+		err = r.AddGitHubApp(testCtx, sv, key, false)
 		assert.Nil(t, err)
 
 		err = r.TrustGitHubApp(testCtx, sv, false)
@@ -429,7 +429,7 @@ func TestUntrustGitHubApp(t *testing.T) {
 
 	assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted())
 
-	err = r.AddGitHubAppKey(testCtx, sv, key, false)
+	err = r.AddGitHubApp(testCtx, sv, key, false)
 	assert.Nil(t, err)
 
 	err = r.TrustGitHubApp(testCtx, sv, false)

--- a/internal/cmd/trust/addgithubapp/addgithubapp.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp.go
@@ -1,7 +1,7 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package addgithubappkey
+package addgithubapp
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
@@ -41,15 +41,15 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return repo.AddGitHubAppKey(cmd.Context(), signer, appKey, true)
+	return repo.AddGitHubApp(cmd.Context(), signer, appKey, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "add-github-app-key",
-		Short:             "Add GitHub app key to gittuf root of trust",
-		Long:              `This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Use:               "add-github-app",
+		Short:             "Add GitHub app to gittuf root of trust",
+		Long:              `This command allows users to add a name and trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/addgithubapp/addgithubapp.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp.go
@@ -49,7 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-github-app",
 		Short:             "Add GitHub app to gittuf root of trust",
-		Long:              `This command allows users to add a name and trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Long:              `This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/removegithubapp/removegithubapp.go
+++ b/internal/cmd/trust/removegithubapp/removegithubapp.go
@@ -1,7 +1,7 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package removegithubappkey
+package removegithubapp
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
@@ -27,14 +27,14 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return repo.RemoveGitHubAppKey(cmd.Context(), signer, true)
+	return repo.RemoveGitHubApp(cmd.Context(), signer, true)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "remove-github-app-key",
-		Short:             "Remove GitHub app key from gittuf root of trust",
+		Use:               "remove-github-app",
+		Short:             "Remove GitHub app from gittuf root of trust",
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -4,7 +4,7 @@
 package trust
 
 import (
-	"github.com/gittuf/gittuf/internal/cmd/trust/addgithubappkey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/addgithubapp"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addglobalrule"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpolicykey"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addrootkey"
@@ -12,7 +12,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/cmd/trust/removegithubappkey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/removegithubapp"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removeglobalrule"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removepolicykey"
 	"github.com/gittuf/gittuf/internal/cmd/trust/removerootkey"
@@ -35,7 +35,7 @@ func New() *cobra.Command {
 	o.AddPersistentFlags(cmd)
 
 	cmd.AddCommand(i.New(o))
-	cmd.AddCommand(addgithubappkey.New(o))
+	cmd.AddCommand(addgithubapp.New(o))
 	cmd.AddCommand(addglobalrule.New(o))
 	cmd.AddCommand(addpolicykey.New(o))
 	cmd.AddCommand(addrootkey.New(o))
@@ -43,7 +43,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))
 	cmd.AddCommand(remote.New())
-	cmd.AddCommand(removegithubappkey.New(o))
+	cmd.AddCommand(removegithubapp.New(o))
 	cmd.AddCommand(removeglobalrule.New(o))
 	cmd.AddCommand(removepolicykey.New(o))
 	cmd.AddCommand(removerootkey.New(o))

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -517,18 +517,21 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
+	appName := tuf.GitHubAppRoleName // TODO: this should be generalized more
+
 	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	appKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
-	if err := rootMetadata.AddGitHubAppPrincipal(appKey); err != nil {
+	if err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey); err != nil {
 		t.Fatal(err)
 	}
 	rootMetadata.EnableGitHubAppApprovals()
 	state.githubAppApprovalsTrusted = true
 	state.githubAppKeys = []tuf.Principal{appKey}
+	state.githubAppRoleName = appName
 
 	rootEnv, err := dsse.CreateEnvelope(rootMetadata)
 	if err != nil {
@@ -553,7 +556,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 	person := &tufv02.Person{
 		PersonID:             "jane.doe",
 		PublicKeys:           map[string]*tufv02.Key{gpgKey.KeyID: gpgKey},
-		AssociatedIdentities: map[string]string{appKey.KeyID: "jane.doe"},
+		AssociatedIdentities: map[string]string{appName: "jane.doe"},
 	}
 
 	if err := targetsMetadata.AddPrincipal(person); err != nil {
@@ -564,7 +567,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 	approver := &tufv02.Person{
 		PersonID:             "john.doe",
 		PublicKeys:           map[string]*tufv02.Key{approverKey.KeyID: approverKey},
-		AssociatedIdentities: map[string]string{appKey.KeyID: "john.doe"},
+		AssociatedIdentities: map[string]string{appName: "john.doe"},
 	}
 	if err := targetsMetadata.AddPrincipal(approver); err != nil {
 		t.Fatal(err)
@@ -611,18 +614,21 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
+	appName := tuf.GitHubAppRoleName // TODO: this should be generalized more
+
 	rootMetadata, err := state.GetRootMetadata(false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	appKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
-	if err := rootMetadata.AddGitHubAppPrincipal(appKey); err != nil {
+	if err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey); err != nil {
 		t.Fatal(err)
 	}
 	rootMetadata.EnableGitHubAppApprovals()
 	state.githubAppApprovalsTrusted = true
 	state.githubAppKeys = []tuf.Principal{appKey}
+	state.githubAppRoleName = appName
 
 	rootEnv, err := dsse.CreateEnvelope(rootMetadata)
 	if err != nil {
@@ -647,7 +653,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 	person := &tufv02.Person{
 		PersonID:             "jane.doe",
 		PublicKeys:           map[string]*tufv02.Key{gpgKey.KeyID: gpgKey},
-		AssociatedIdentities: map[string]string{appKey.KeyID: "jane.doe"},
+		AssociatedIdentities: map[string]string{appName: "jane.doe"},
 	}
 	if err := targetsMetadata.AddPrincipal(person); err != nil {
 		t.Fatal(err)
@@ -660,7 +666,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 	approver1 := &tufv02.Person{
 		PersonID:             "john.doe",
 		PublicKeys:           map[string]*tufv02.Key{approver1Key.KeyID: approver1Key},
-		AssociatedIdentities: map[string]string{appKey.KeyID: "john.doe"},
+		AssociatedIdentities: map[string]string{appName: "john.doe"},
 	}
 	if err := targetsMetadata.AddPrincipal(approver1); err != nil {
 		t.Fatal(err)
@@ -674,7 +680,7 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *
 	approver2 := &tufv02.Person{
 		PersonID:             "jill.doe",
 		PublicKeys:           map[string]*tufv02.Key{approver2Key.KeyID: approver2Key},
-		AssociatedIdentities: map[string]string{appKey.KeyID: "jill.doe"},
+		AssociatedIdentities: map[string]string{appName: "jill.doe"},
 	}
 	if err := targetsMetadata.AddPrincipal(approver2); err != nil {
 		t.Fatal(err)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -64,6 +64,7 @@ type State struct {
 
 	githubAppApprovalsTrusted bool
 	githubAppKeys             []tuf.Principal
+	githubAppRoleName         string
 
 	repository     *gitinterface.Repository
 	verifiersCache map[string][]*SignatureVerifier
@@ -976,6 +977,7 @@ func loadStateForEntry(repo *gitinterface.Repository, entry *rsl.ReferenceEntry)
 	githubAppPrincipals, err := rootMetadata.GetGitHubAppPrincipals()
 	if err == nil {
 		state.githubAppKeys = githubAppPrincipals
+		state.githubAppRoleName = tuf.GitHubAppRoleName
 	} else if state.githubAppApprovalsTrusted {
 		return nil, tuf.ErrGitHubAppInformationNotFoundInRoot
 	}

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -729,7 +729,7 @@ func getApproverAttestationAndKeyIDsForIndex(ctx context.Context, repo *gitinter
 			}
 			_, err := approvalVerifier.Verify(ctx, nil, githubApprovalAttestation)
 			if err != nil {
-				return nil, nil, fmt.Errorf("failed to verify GitHub app approval attestation, signed by untrusted key")
+				return nil, nil, fmt.Errorf("%w: failed to verify GitHub app approval attestation, signed by untrusted key", ErrVerificationFailed)
 			}
 
 			payloadBytes, err := githubApprovalAttestation.DecodeB64Payload()

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -711,9 +711,7 @@ func getApproverAttestationAndKeyIDsForIndex(ctx context.Context, repo *gitinter
 	if !isTag && policy.githubAppApprovalsTrusted {
 		slog.Debug("GitHub pull request approvals are trusted, loading applicable attestations...")
 
-		appName := policy.githubAppKeys[0].ID()
-
-		githubApprovalAttestation, err := attestationsState.GetGitHubPullRequestApprovalAttestationFor(repo, appName, targetRef, fromID.String(), toID.String())
+		githubApprovalAttestation, err := attestationsState.GetGitHubPullRequestApprovalAttestationFor(repo, policy.githubAppRoleName, targetRef, fromID.String(), toID.String())
 		if err != nil {
 			if !errors.Is(err, github.ErrPullRequestApprovalAttestationNotFound) {
 				return nil, nil, err
@@ -852,11 +850,9 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 		}
 	}
 
-	// TODO: app name is likely not always going to be the signer ID
-	// We should probably make that an option?
 	appName := ""
 	if policy.githubAppApprovalsTrusted {
-		appName = policy.githubAppKeys[0].ID()
+		appName = policy.githubAppRoleName
 	}
 	verifiedUsing, acceptedPrincipalIDs, rslSignatureNeededForThreshold, err := verifyGitObjectAndAttestationsUsingVerifiers(ctx, verifiers, gitID, authorizationAttestation, appName, options.approverPrincipalIDs, options.verifyMergeable)
 	if err != nil {

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -791,7 +791,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -853,7 +853,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -938,7 +938,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -1001,7 +1001,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -1078,7 +1078,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -1155,7 +1155,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1255,7 +1255,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -1333,7 +1333,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, baseCommitIDs[1].String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -2196,7 +2196,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -2251,7 +2251,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -2329,7 +2329,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
@@ -2383,7 +2383,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppKeys[0].ID(), refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -2216,6 +2216,64 @@ func TestVerifyEntry(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+	t.Run("unsuccessful verification with higher threshold but using GitHub approval due to invalid app key", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		t.Setenv(tufv02.AllowV02MetadataKey, "1")
+
+		repo, state := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrust)
+
+		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This is using the jane.doe signer
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+
+		commitTreeID, err := repo.GetCommitTreeID(commitIDs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create authorization for this change using john.doe trusted as approver
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This signer for the GitHub app is NOT trusted in the root setup by
+		// the policy state creator helper
+		signer := setupSSHKeysForSigning(t, targets2KeyBytes, targets2PubKeyBytes)
+
+		env, err := dsse.CreateEnvelope(githubAppApproval)
+		if err != nil {
+			t.Fatal(err)
+		}
+		env, err = dsse.SignEnvelope(testCtx, env, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+			t.Fatal(err)
+		}
+		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
+			t.Fatal(err)
+		}
+
+		currentAttestations, err = attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+		assert.ErrorIs(t, err, ErrVerificationFailed)
+	})
+
 	t.Run("successful verification with higher threshold but using GitHub approval and reference authorization v0.2", func(t *testing.T) {
 		repo, state := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations)
 
@@ -2293,6 +2351,85 @@ func TestVerifyEntry(t *testing.T) {
 
 		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
 		assert.Nil(t, err)
+	})
+
+	t.Run("unsuccessful verification with higher threshold but using GitHub approval from untrusted key and reference authorization v0.2", func(t *testing.T) {
+		repo, state := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations)
+
+		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This is the jane.doe principal
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+
+		commitTreeID, err := repo.GetCommitTreeID(commitIDs[0])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Approved by jill.doe
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// This signer for the GitHub app is NOT trusted in the root setup by
+		// the policy state creator helper
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		env, err := dsse.CreateEnvelope(githubAppApproval)
+		if err != nil {
+			t.Fatal(err)
+		}
+		env, err = dsse.SignEnvelope(testCtx, env, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, state.githubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+			t.Fatal(err)
+		}
+		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add reference authorization for john.doe
+		signer = setupSSHKeysForSigning(t, targets2KeyBytes, targets2PubKeyBytes)
+
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		env, err = dsse.CreateEnvelope(authorization)
+		if err != nil {
+			t.Fatal(err)
+		}
+		env, err = dsse.SignEnvelope(testCtx, env, signer)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+			t.Fatal(err)
+		}
+		if err := currentAttestations.Commit(repo, "Add authorization", false); err != nil {
+			t.Fatal(err)
+		}
+
+		currentAttestations, err = attestations.LoadCurrentAttestations(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+		assert.ErrorIs(t, err, ErrVerificationFailed)
 	})
 
 	t.Run("unsuccessful verification with higher threshold but using GitHub approval", func(t *testing.T) {

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -121,12 +121,10 @@ type RootMetadata interface {
 
 	// AddGitHubAppPrincipal adds the corresponding principal to the root
 	// metadata and is trusted for GitHub app attestations.
-	// TODO: this needs to be generalized across tools
-	AddGitHubAppPrincipal(principal Principal) error
+	AddGitHubAppPrincipal(appName string, principal Principal) error
 	// DeleteGitHubAppPrincipal removes the GitHub app attestations role from
 	// the root of trust metadata.
-	// TODO: this needs to be generalized across tools
-	DeleteGitHubAppPrincipal()
+	DeleteGitHubAppPrincipal(appName string)
 	// EnableGitHubAppApprovals indicates attestations from the GitHub app role
 	// must be trusted.
 	// TODO: this needs to be generalized across tools

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -158,7 +158,7 @@ func (r *RootMetadata) DeletePrimaryRuleFilePrincipal(keyID string) error {
 // AddGitHubAppPrincipal adds the 'appKey' as a trusted public key in
 // 'rootMetadata' for the special GitHub app role. This key is used to verify
 // GitHub pull request approval attestation signatures.
-func (r *RootMetadata) AddGitHubAppPrincipal(key tuf.Principal) error {
+func (r *RootMetadata) AddGitHubAppPrincipal(name string, key tuf.Principal) error {
 	if key == nil {
 		return tuf.ErrInvalidPrincipalType
 	}
@@ -171,15 +171,15 @@ func (r *RootMetadata) AddGitHubAppPrincipal(key tuf.Principal) error {
 		KeyIDs:    set.NewSetFromItems(key.ID()),
 		Threshold: 1,
 	}
-	r.addRole(tuf.GitHubAppRoleName, role) // AddRole replaces the specified role if it already exists
+	r.addRole(name, role) // AddRole replaces the specified role if it already exists
 	return nil
 }
 
 // DeleteGitHubAppPrincipal removes the special GitHub app role from the root
 // metadata.
-func (r *RootMetadata) DeleteGitHubAppPrincipal() {
+func (r *RootMetadata) DeleteGitHubAppPrincipal(name string) {
 	// TODO: support multiple keys / threshold for app
-	delete(r.Roles, tuf.GitHubAppRoleName)
+	delete(r.Roles, name)
 }
 
 // EnableGitHubAppApprovals sets GitHubApprovalsTrusted to true in the

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -229,10 +229,10 @@ func TestAddGitHubAppPrincipal(t *testing.T) {
 
 	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	err := rootMetadata.AddGitHubAppPrincipal(nil)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, nil)
 	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalType)
 
-	err = rootMetadata.AddGitHubAppPrincipal(appKey)
+	err = rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey)
 	assert.Nil(t, err)
 	assert.Equal(t, appKey, rootMetadata.Keys[appKey.KeyID])
 	assert.Equal(t, set.NewSetFromItems(appKey.KeyID), rootMetadata.Roles[tuf.GitHubAppRoleName].KeyIDs)
@@ -243,10 +243,10 @@ func TestDeleteGitHubAppPrincipal(t *testing.T) {
 
 	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	err := rootMetadata.AddGitHubAppPrincipal(appKey)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey)
 	assert.Nil(t, err)
 
-	rootMetadata.DeleteGitHubAppPrincipal()
+	rootMetadata.DeleteGitHubAppPrincipal(tuf.GitHubAppRoleName)
 	assert.Nil(t, rootMetadata.Roles[tuf.GitHubAppRoleName].KeyIDs)
 }
 
@@ -382,7 +382,7 @@ func TestGetGitHubAppPrincipals(t *testing.T) {
 
 	t.Run("role exists", func(t *testing.T) {
 		rootMetadata := initialTestRootMetadata(t)
-		err := rootMetadata.AddGitHubAppPrincipal(key)
+		err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, key)
 		assert.Nil(t, err)
 
 		expectedPrincipals := []tuf.Principal{key}
@@ -407,7 +407,7 @@ func TestIsGitHubAppApprovalTrusted(t *testing.T) {
 	assert.False(t, trusted)
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
-	err := rootMetadata.AddGitHubAppPrincipal(key)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, key)
 	assert.Nil(t, err)
 
 	rootMetadata.EnableGitHubAppApprovals()

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -159,7 +159,7 @@ func (r *RootMetadata) DeletePrimaryRuleFilePrincipal(principalID string) error 
 // AddGitHubAppPrincipal adds the 'principal' as a trusted principal in
 // 'rootMetadata' for the special GitHub app role. This key is used to verify
 // GitHub pull request approval attestation signatures.
-func (r *RootMetadata) AddGitHubAppPrincipal(principal tuf.Principal) error {
+func (r *RootMetadata) AddGitHubAppPrincipal(name string, principal tuf.Principal) error {
 	if principal == nil {
 		return tuf.ErrInvalidPrincipalType
 	}
@@ -172,15 +172,15 @@ func (r *RootMetadata) AddGitHubAppPrincipal(principal tuf.Principal) error {
 		PrincipalIDs: set.NewSetFromItems(principal.ID()),
 		Threshold:    1,
 	}
-	r.addRole(tuf.GitHubAppRoleName, role) // AddRole replaces the specified role if it already exists
+	r.addRole(name, role) // AddRole replaces the specified role if it already exists
 	return nil
 }
 
 // DeleteGitHubAppPrincipal removes the special GitHub app role from the root
 // metadata.
-func (r *RootMetadata) DeleteGitHubAppPrincipal() {
+func (r *RootMetadata) DeleteGitHubAppPrincipal(name string) {
 	// TODO: support multiple principals / threshold for app
-	delete(r.Roles, tuf.GitHubAppRoleName)
+	delete(r.Roles, name)
 }
 
 // EnableGitHubAppApprovals sets GitHubApprovalsTrusted to true in the

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -296,10 +296,10 @@ func TestAddGitHubAppPrincipal(t *testing.T) {
 
 	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	err := rootMetadata.AddGitHubAppPrincipal(nil)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, nil)
 	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalType)
 
-	err = rootMetadata.AddGitHubAppPrincipal(appKey)
+	err = rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey)
 	assert.Nil(t, err)
 	assert.Equal(t, appKey, rootMetadata.Principals[appKey.KeyID])
 	assert.Equal(t, set.NewSetFromItems(appKey.KeyID), rootMetadata.Roles[tuf.GitHubAppRoleName].PrincipalIDs)
@@ -310,10 +310,10 @@ func TestDeleteGitHubAppPrincipal(t *testing.T) {
 
 	appKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	err := rootMetadata.AddGitHubAppPrincipal(appKey)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, appKey)
 	assert.Nil(t, err)
 
-	rootMetadata.DeleteGitHubAppPrincipal()
+	rootMetadata.DeleteGitHubAppPrincipal(tuf.GitHubAppRoleName)
 	assert.Nil(t, rootMetadata.Roles[tuf.GitHubAppRoleName].PrincipalIDs)
 }
 
@@ -488,7 +488,7 @@ func TestGetGitHubAppPrincipals(t *testing.T) {
 
 	t.Run("role exists", func(t *testing.T) {
 		rootMetadata := initialTestRootMetadata(t)
-		err := rootMetadata.AddGitHubAppPrincipal(key)
+		err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, key)
 		assert.Nil(t, err)
 
 		expectedPrincipals := []tuf.Principal{key}
@@ -513,7 +513,7 @@ func TestIsGitHubAppApprovalTrusted(t *testing.T) {
 	assert.False(t, trusted)
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
-	err := rootMetadata.AddGitHubAppPrincipal(key)
+	err := rootMetadata.AddGitHubAppPrincipal(tuf.GitHubAppRoleName, key)
 	assert.Nil(t, err)
 
 	rootMetadata.EnableGitHubAppApprovals()


### PR DESCRIPTION
gittuf has a companion app for GitHub that can record attestations for pull request reviews. Previously, the app was identified by its signing key. This commit adds initial support for naming the app, with an eye towards eventually supporting attestations from multiple apps.