### PR TITLE
policy: Add VerifyMergeableForCommit

### DIFF
--- a/docs/cli/gittuf_verify-mergeable.md
+++ b/docs/cli/gittuf_verify-mergeable.md
@@ -10,6 +10,7 @@ gittuf verify-mergeable [flags]
 
 ```
       --base-branch string      base branch for proposed merge
+      --bypass-RSL              bypass RSL when identifying current state of feature ref
       --feature-branch string   feature branch for proposed merge
   -h, --help                    help for verify-mergeable
 ```

--- a/experimental/gittuf/options/verifymergeable/verifymergeable.go
+++ b/experimental/gittuf/options/verifymergeable/verifymergeable.go
@@ -1,0 +1,16 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package verifymergeable
+
+type Options struct {
+	BypassRSLForFeatureRef bool
+}
+
+type Option func(o *Options)
+
+func WithBypassRSLForFeatureRef() Option {
+	return func(o *Options) {
+		o.BypassRSLForFeatureRef = true
+	}
+}

--- a/internal/cmd/verifymergeable/verifymergeable.go
+++ b/internal/cmd/verifymergeable/verifymergeable.go
@@ -5,12 +5,14 @@ package verifymergeable
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/experimental/gittuf/options/verifymergeable"
 	"github.com/spf13/cobra"
 )
 
 type options struct {
 	baseBranch    string
 	featureBranch string
+	bypassRSL     bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -29,6 +31,13 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"feature branch for proposed merge",
 	)
 	cmd.MarkFlagRequired("feature-branch") //nolint:errcheck
+
+	cmd.Flags().BoolVar(
+		&o.bypassRSL,
+		"bypass-RSL",
+		false,
+		"bypass RSL when identifying current state of feature ref",
+	)
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
@@ -37,7 +46,12 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	_, err = repo.VerifyMergeable(cmd.Context(), o.baseBranch, o.featureBranch)
+	opts := []verifymergeable.Option{}
+	if o.bypassRSL {
+		opts = append(opts, verifymergeable.WithBypassRSLForFeatureRef())
+	}
+
+	_, err = repo.VerifyMergeable(cmd.Context(), o.baseBranch, o.featureBranch, opts...)
 	return err
 }
 


### PR DESCRIPTION
This is a stab at not using the RSL for the feature ref when checking for mergeability. We need this for the github app case.