### PR TITLE
gitinterface: Support types for tree entries

### DIFF
--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -47,7 +47,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 
 		// Create common base for main and feature branches
 		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-		emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -166,7 +166,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 
 		// Create common base for main and feature branches
 		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-		emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -26,7 +26,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	repo := &Repository{r: r}
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestRecordRSLEntryForReferenceAtTarget(t *testing.T) {
 			repo := &Repository{r: r}
 
 			treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-			emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+			emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -222,7 +222,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -337,7 +337,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -382,7 +382,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -447,7 +447,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -541,7 +541,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -619,7 +619,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -663,7 +663,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -699,7 +699,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -745,7 +745,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		remoteRepo := &Repository{r: remoteR}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/experimental/gittuf/sync_test.go
+++ b/experimental/gittuf/sync_test.go
@@ -27,7 +27,7 @@ func TestClone(t *testing.T) {
 	remoteR := gitinterface.CreateTestGitRepository(t, remoteTmpDir, true)
 	remoteRepo := &Repository{r: remoteR}
 	treeBuilder := gitinterface.NewTreeBuilder(remoteR)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/attestations/attestations.go
+++ b/internal/attestations/attestations.go
@@ -169,18 +169,18 @@ func (a *Attestations) Commit(repo *gitinterface.Repository, commitMessage strin
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
 
-	allAttestations := map[string]gitinterface.Hash{}
+	allAttestations := []gitinterface.TreeEntry{}
 	for name, blobID := range a.referenceAuthorizations {
-		allAttestations[path.Join(referenceAuthorizationsTreeEntryName, name)] = blobID
+		allAttestations = append(allAttestations, gitinterface.NewEntryBlob(path.Join(referenceAuthorizationsTreeEntryName, name), blobID))
 	}
 	for name, blobID := range a.githubPullRequestAttestations {
-		allAttestations[path.Join(githubPullRequestAttestationsTreeEntryName, name)] = blobID
+		allAttestations = append(allAttestations, gitinterface.NewEntryBlob(path.Join(githubPullRequestAttestationsTreeEntryName, name), blobID))
 	}
 	for name, blobID := range a.codeReviewApprovalAttestations {
-		allAttestations[path.Join(codeReviewApprovalAttestationsTreeEntryName, name)] = blobID
+		allAttestations = append(allAttestations, gitinterface.NewEntryBlob(path.Join(codeReviewApprovalAttestationsTreeEntryName, name), blobID))
 	}
 
-	attestationsTreeID, err := treeBuilder.WriteTreeFromEntryIDs(allAttestations)
+	attestationsTreeID, err := treeBuilder.WriteTreeFromEntries(allAttestations)
 	if err != nil {
 		return err
 	}

--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -153,7 +153,7 @@ func TestAttestationsCommit(t *testing.T) {
 	attestations := &Attestations{referenceAuthorizations: authorizations}
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	expectedTreeID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]gitinterface.Hash{path.Join(referenceAuthorizationsTreeEntryName, ReferenceAuthorizationPath(testRef, testID, testID)): blobID})
+	expectedTreeID, err := treeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{gitinterface.NewEntryBlob(path.Join(referenceAuthorizationsTreeEntryName, ReferenceAuthorizationPath(testRef, testID, testID)), blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -65,7 +65,7 @@ func (p *Persistent) Commit(repo *gitinterface.Repository) error {
 	}
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	treeID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]gitinterface.Hash{persistentTreeEntryName: blobID})
+	treeID, err := treeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{gitinterface.NewEntryBlob(persistentTreeEntryName, blobID)})
 	if err != nil {
 		return err
 	}

--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -95,12 +95,12 @@ func AddNTestCommitsToSpecifiedRef(t *testing.T, repo *gitinterface.Repository, 
 	// Create N trees with 1...N artifacts
 	treeHashes := make([]gitinterface.Hash, 0, n)
 	for i := 1; i <= n; i++ {
-		objects := map[string]gitinterface.Hash{}
+		objects := []gitinterface.TreeEntry{}
 		for j := 0; j < i; j++ {
-			objects[fmt.Sprintf("%d", j+1)] = emptyBlobHash
+			objects = append(objects, gitinterface.NewEntryBlob(fmt.Sprintf("%d", j+1), emptyBlobHash))
 		}
 
-		treeHash, err := treeBuilder.WriteTreeFromEntryIDs(objects)
+		treeHash, err := treeBuilder.WriteTreeFromEntries(objects)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/changes_test.go
+++ b/internal/gitinterface/changes_test.go
@@ -25,7 +25,7 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 		blobIDs = append(blobIDs, blobID)
 	}
 
-	emptyTree, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTree, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,12 +37,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	// in a previous test
 
 	t.Run("modify single file", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -63,12 +63,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("rename single file", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"b": blobIDs[0]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("b", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,12 +89,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("swap two files around", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0], "b": blobIDs[1]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0]), NewEntryBlob("b", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[1], "b": blobIDs[0]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[1]), NewEntryBlob("b", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -115,12 +115,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("create new file", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0], "b": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0]), NewEntryBlob("b", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -141,12 +141,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("delete file", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0], "b": blobIDs[1]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0]), NewEntryBlob("b", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,12 +167,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("modify file and create new file", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[2], "b": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[2]), NewEntryBlob("b", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -193,7 +193,7 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("no parent", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -209,12 +209,12 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("merge commit with commit matching parent", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,17 +250,17 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("merge commit with no matching parent", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"b": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("b", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeC, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"c": blobIDs[2]})
+		treeC, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("c", blobIDs[2])})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -296,17 +296,17 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 	})
 
 	t.Run("merge commit with overlapping parent trees", func(t *testing.T) {
-		treeA, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[0]})
+		treeA, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[0])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeB, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[1]})
+		treeB, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[1])})
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		treeC, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"a": blobIDs[2]})
+		treeC, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("a", blobIDs[2])})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/commit_test.go
+++ b/internal/gitinterface/commit_test.go
@@ -29,7 +29,7 @@ func TestRepositoryCommit(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestRepositoryCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	treeWithContentsID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"README.md": blobID})
+	treeWithContentsID, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("README.md", blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,7 @@ func TestRepositoryCommitUsingSpecificKey(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestRepositoryCommitUsingSpecificKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	treeWithContentsID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"README.md": blobID})
+	treeWithContentsID, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("README.md", blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,7 +137,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +147,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	treeWithContentsID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"README.md": blobID})
+	treeWithContentsID, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("README.md", blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ func TestRepositoryVerifyCommit(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func TestKnowsCommit(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -443,7 +443,7 @@ func TestRepositoryGetCommitMessage(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +467,7 @@ func TestGetCommitTreeID(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -477,7 +477,7 @@ func TestGetCommitTreeID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	treeWithContentsID, err := treeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"README.md": blobID})
+	treeWithContentsID, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("README.md", blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +513,7 @@ func TestGetCommitParentIDs(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -548,7 +548,7 @@ func TestGetCommonAncestor(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitinterface/log_test.go
+++ b/internal/gitinterface/log_test.go
@@ -20,7 +20,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,12 +331,12 @@ func createTestTrees(t *testing.T, repo *Repository, emptyBlobHash Hash, num int
 	treeBuilder := NewTreeBuilder(repo)
 	treeHashes := make([]Hash, 0, num)
 	for i := 1; i <= num; i++ {
-		objects := map[string]Hash{}
+		objects := []TreeEntry{}
 		for j := 0; j < i; j++ {
-			objects[fmt.Sprintf("%d", j+1)] = emptyBlobHash
+			objects = append(objects, NewEntryBlob(fmt.Sprintf("%d", j+1), emptyBlobHash))
 		}
 
-		treeHash, err := treeBuilder.WriteTreeFromEntryIDs(objects)
+		treeHash, err := treeBuilder.WriteTreeFromEntries(objects)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/object_test.go
+++ b/internal/gitinterface/object_test.go
@@ -32,7 +32,7 @@ func TestHasObject(t *testing.T) {
 	assert.True(t, repo.HasObject(blobID)) // now repo has it too
 
 	backupRepoTreeBuilder := NewTreeBuilder(backupRepo)
-	treeID, err := backupRepoTreeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"file": blobID})
+	treeID, err := backupRepoTreeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("file", blobID)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func TestHasObject(t *testing.T) {
 	assert.False(t, repo.HasObject(treeID))      // repo does not
 
 	repoTreeBuilder := NewTreeBuilder(repo)
-	if _, err := repoTreeBuilder.WriteTreeFromEntryIDs(map[string]Hash{"file": blobID}); err != nil {
+	if _, err := repoTreeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("file", blobID)}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/gitinterface/references_test.go
+++ b/internal/gitinterface/references_test.go
@@ -19,7 +19,7 @@ func TestGetReference(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func TestSetReference(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,7 +72,7 @@ func TestCheckAndSetReference(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func TestGetSymbolicReferenceTarget(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestRepositoryRefSpec(t *testing.T) {
 	qualifiedRemoteRefName := "refs/remotes/origin/master"
 
 	treeBuilder := NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gitinterface/sync_test.go
+++ b/internal/gitinterface/sync_test.go
@@ -34,9 +34,9 @@ func TestPushRefSpecRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -52,9 +52,10 @@ func TestPushRefSpecRepository(t *testing.T) {
 		err = localRepo.PushRefSpec(remoteName, []string{refSpecs})
 		assert.Nil(t, err)
 
+		expectedFiles := map[string]Hash{"foo": emptyBlobHash}
 		remoteEntries, err := remoteRepo.GetAllFilesInTree(tree)
 		assert.Nil(t, err)
-		assert.Equal(t, entries, remoteEntries)
+		assert.Equal(t, expectedFiles, remoteEntries)
 	})
 
 	t.Run("assert after push that src and dst refs match", func(t *testing.T) {
@@ -75,9 +76,9 @@ func TestPushRefSpecRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,9 +121,9 @@ func TestPushRefSpecRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -174,9 +175,9 @@ func TestPushRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -192,9 +193,10 @@ func TestPushRepository(t *testing.T) {
 		err = localRepo.Push(remoteName, []string{refName})
 		assert.Nil(t, err)
 
+		expectedFiles := map[string]Hash{"foo": emptyBlobHash}
 		remoteEntries, err := remoteRepo.GetAllFilesInTree(tree)
 		assert.Nil(t, err)
-		assert.Equal(t, entries, remoteEntries)
+		assert.Equal(t, expectedFiles, remoteEntries)
 	})
 
 	t.Run("assert after push that src and dst refs match", func(t *testing.T) {
@@ -215,9 +217,9 @@ func TestPushRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -260,9 +262,9 @@ func TestPushRepository(t *testing.T) {
 		// Create a tree in the local repository
 		emptyBlobHash, err := localRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := localTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := localTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -315,9 +317,9 @@ func TestFetchRefSpecRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -334,9 +336,10 @@ func TestFetchRefSpecRepository(t *testing.T) {
 		err = localRepo.FetchRefSpec(remoteName, []string{refSpecs})
 		assert.Nil(t, err)
 
+		expectedFiles := map[string]Hash{"foo": emptyBlobHash}
 		localEntries, err := localRepo.GetAllFilesInTree(tree)
 		assert.Nil(t, err)
-		assert.Equal(t, entries, localEntries)
+		assert.Equal(t, expectedFiles, localEntries)
 	})
 
 	t.Run("assert after fetch that both refs match", func(t *testing.T) {
@@ -357,9 +360,9 @@ func TestFetchRefSpecRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -403,9 +406,9 @@ func TestFetchRefSpecRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -462,9 +465,9 @@ func TestFetchRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -481,9 +484,10 @@ func TestFetchRepository(t *testing.T) {
 		err = localRepo.Fetch(remoteName, []string{refName}, true)
 		assert.Nil(t, err)
 
+		expectedFiles := map[string]Hash{"foo": emptyBlobHash}
 		localEntries, err := localRepo.GetAllFilesInTree(tree)
 		assert.Nil(t, err)
-		assert.Equal(t, entries, localEntries)
+		assert.Equal(t, expectedFiles, localEntries)
 	})
 
 	t.Run("assert after fetch that both refs match", func(t *testing.T) {
@@ -504,9 +508,9 @@ func TestFetchRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -550,9 +554,9 @@ func TestFetchRepository(t *testing.T) {
 		// Create a tree in the remote repository
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -601,9 +605,9 @@ func TestCloneAndFetchRepository(t *testing.T) {
 
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -645,9 +649,9 @@ func TestCloneAndFetchRepository(t *testing.T) {
 
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -689,9 +693,9 @@ func TestCloneAndFetchRepository(t *testing.T) {
 
 		emptyBlobHash, err := remoteRepo.WriteBlob(nil)
 		require.Nil(t, err)
-		entries := map[string]Hash{"foo": emptyBlobHash}
+		entries := []TreeEntry{NewEntryBlob("foo", emptyBlobHash)}
 
-		tree, err := remoteTreeBuilder.WriteTreeFromEntryIDs(entries)
+		tree, err := remoteTreeBuilder.WriteTreeFromEntries(entries)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/gitinterface/tag_test.go
+++ b/internal/gitinterface/tag_test.go
@@ -22,7 +22,7 @@ func TestGetTagTarget(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestRepositoryVerifyTag(t *testing.T) {
 	treeBuilder := NewTreeBuilder(repo)
 
 	// Write empty tree
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -517,7 +517,7 @@ func (s *State) Commit(repo *gitinterface.Repository, commitMessage string, sign
 		}
 	}
 
-	allTreeEntries := map[string]gitinterface.Hash{}
+	allTreeEntries := []gitinterface.TreeEntry{}
 
 	for name, env := range metadata {
 		envContents, err := json.Marshal(env)
@@ -530,12 +530,12 @@ func (s *State) Commit(repo *gitinterface.Repository, commitMessage string, sign
 			return err
 		}
 
-		allTreeEntries[path.Join(metadataTreeEntryName, name+".json")] = blobID
+		allTreeEntries = append(allTreeEntries, gitinterface.NewEntryBlob(path.Join(metadataTreeEntryName, name+".json"), blobID))
 	}
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
 
-	policyRootTreeID, err := treeBuilder.WriteTreeFromEntryIDs(allTreeEntries)
+	policyRootTreeID, err := treeBuilder.WriteTreeFromEntries(allTreeEntries)
 	if err != nil {
 		return err
 	}

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -404,7 +404,7 @@ func TestGetStateForCommit(t *testing.T) {
 	// Create some commits
 	refName := "refs/heads/main"
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -1034,7 +1034,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		require.Nil(t, err)
 
 		initialCommitHash, err := repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
@@ -1078,7 +1078,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		require.Nil(t, err)
 
 		skippedEntries := []gitinterface.Hash{}
@@ -1139,7 +1139,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		require.Nil(t, err)
 
 		initialCommitHash, err := repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
@@ -1172,7 +1172,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 		require.Nil(t, err)
 
 		initialCommitHash, err := repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
@@ -1213,7 +1213,7 @@ func TestGetFirstReferenceEntryForCommit(t *testing.T) {
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeHash, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1541,7 +1541,7 @@ func TestAnnotationEntryRefersTo(t *testing.T) {
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo)
-	emptyTreeID, err := treeBuilder.WriteTreeFromEntryIDs(nil)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This cleans up tree builder to accept entry types. It also refactors how blobs are managed to (in future) add support for custom permission bits for blob entries. This is necessary for #758 pieces.