### PR TITLE
go: Fix dependency listing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect


### PR DESCRIPTION
A previous change made go-isatty a direct dependency but go.mod wasn't updated to reflect this.