### PR TITLE
gitinterface: Support bare clones

### DIFF
--- a/docs/cli/gittuf_clone.md
+++ b/docs/cli/gittuf_clone.md
@@ -9,6 +9,7 @@ gittuf clone [flags]
 ### Options
 
 ```
+      --bare                   make a bare Git repository
   -b, --branch string          specify branch to check out
   -h, --help                   help for clone
       --root-key public-keys   set of initial root of trust keys for the repository (supported values: paths to SSH keys, GPG key fingerprints, Sigstore/Fulcio identities)

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -297,7 +297,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -354,7 +354,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -399,7 +399,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -464,7 +464,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -558,7 +558,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -636,7 +636,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -680,7 +680,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -716,7 +716,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -762,7 +762,7 @@ func TestCheckRemoteRSLForUpdates(t *testing.T) {
 		// TODO: this should be handled by the Repository package
 		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
 		defer os.RemoveAll(localTmpDir) //nolint:errcheck
-		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/experimental/gittuf/sync.go
+++ b/experimental/gittuf/sync.go
@@ -28,7 +28,7 @@ var (
 // to the standard refs. It performs a verification of the RSL against the
 // specified HEAD after cloning the repository.
 // TODO: resolve how root keys are trusted / bootstrapped.
-func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRootKeys []tuf.Principal) (*Repository, error) {
+func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRootKeys []tuf.Principal, bare bool) (*Repository, error) {
 	slog.Debug(fmt.Sprintf("Cloning from '%s'...", remoteURL))
 
 	if dir == "" {
@@ -55,7 +55,7 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRo
 	refs := []string{"refs/gittuf/*"}
 
 	slog.Debug("Cloning repository...")
-	r, err := gitinterface.CloneAndFetchRepository(remoteURL, dir, initialBranch, refs)
+	r, err := gitinterface.CloneAndFetchRepository(remoteURL, dir, initialBranch, refs, bare)
 	if err != nil {
 		if e := os.RemoveAll(dir); e != nil {
 			return nil, errors.Join(ErrCloningRepository, err, e)

--- a/experimental/gittuf/sync_test.go
+++ b/experimental/gittuf/sync_test.go
@@ -72,7 +72,7 @@ func TestClone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Run("successful clone without specifying dir", func(t *testing.T) {
+	t.Run("successful clone without specifying dir, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -80,7 +80,7 @@ func TestClone(t *testing.T) {
 		}
 		defer os.Chdir(currentDir) //nolint:errcheck
 
-		repo, err := Clone(testCtx, remoteTmpDir, "", "", nil)
+		repo, err := Clone(testCtx, remoteTmpDir, "", "", nil, true)
 		assert.Nil(t, err)
 		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
 		if err != nil {
@@ -96,7 +96,7 @@ func TestClone(t *testing.T) {
 		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
 	})
 
-	t.Run("successful clone with dir", func(t *testing.T) {
+	t.Run("successful clone with dir, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -105,7 +105,7 @@ func TestClone(t *testing.T) {
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		dirName := "myRepo"
-		repo, err := Clone(testCtx, remoteTmpDir, dirName, "", nil)
+		repo, err := Clone(testCtx, remoteTmpDir, dirName, "", nil, true)
 		assert.Nil(t, err)
 		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
 		if err != nil {
@@ -125,7 +125,7 @@ func TestClone(t *testing.T) {
 		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
 	})
 
-	t.Run("successful clone without specifying dir, with non-HEAD initial branch", func(t *testing.T) {
+	t.Run("successful clone without specifying dir, with non-HEAD initial branch, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -133,7 +133,7 @@ func TestClone(t *testing.T) {
 		}
 		defer os.Chdir(currentDir) //nolint:errcheck
 
-		repo, err := Clone(testCtx, remoteTmpDir, "", anotherRefName, nil)
+		repo, err := Clone(testCtx, remoteTmpDir, "", anotherRefName, nil, true)
 		assert.Nil(t, err)
 		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
 		if err != nil {
@@ -150,7 +150,7 @@ func TestClone(t *testing.T) {
 		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
 	})
 
-	t.Run("unsuccessful clone when unspecified dir already exists", func(t *testing.T) {
+	t.Run("unsuccessful clone when unspecified dir already exists, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -158,14 +158,14 @@ func TestClone(t *testing.T) {
 		}
 		defer os.Chdir(currentDir) //nolint:errcheck
 
-		_, err = Clone(testCtx, remoteTmpDir, "", "", nil)
+		_, err = Clone(testCtx, remoteTmpDir, "", "", nil, true)
 		assert.Nil(t, err)
 
-		_, err = Clone(testCtx, remoteTmpDir, "", "", nil)
+		_, err = Clone(testCtx, remoteTmpDir, "", "", nil, true)
 		assert.ErrorIs(t, err, ErrDirExists)
 	})
 
-	t.Run("unsuccessful clone when specified dir already exists", func(t *testing.T) {
+	t.Run("unsuccessful clone when specified dir already exists, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -177,11 +177,11 @@ func TestClone(t *testing.T) {
 		if err := os.Mkdir(dirName, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		_, err = Clone(testCtx, remoteTmpDir, dirName, "", nil)
+		_, err = Clone(testCtx, remoteTmpDir, dirName, "", nil, true)
 		assert.ErrorIs(t, err, ErrDirExists)
 	})
 
-	t.Run("successful clone without specifying dir, with trailing slashes in repository path", func(t *testing.T) {
+	t.Run("successful clone without specifying dir, with trailing slashes in repository path, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -189,7 +189,7 @@ func TestClone(t *testing.T) {
 		}
 		defer os.Chdir(currentDir) //nolint:errcheck
 
-		repo, err := Clone(testCtx, remoteTmpDir+"//", "", "", nil)
+		repo, err := Clone(testCtx, remoteTmpDir+"//", "", "", nil, true)
 		assert.Nil(t, err)
 		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
 		if err != nil {
@@ -205,7 +205,7 @@ func TestClone(t *testing.T) {
 		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
 	})
 
-	t.Run("successful clone without specifying dir, with multiple expected root keys", func(t *testing.T) {
+	t.Run("successful clone without specifying dir, with multiple expected root keys, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -216,7 +216,7 @@ func TestClone(t *testing.T) {
 		rootPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
 		targetsPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
 
-		repo, err := Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{targetsPublicKey, rootPublicKey})
+		repo, err := Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{targetsPublicKey, rootPublicKey}, true)
 		assert.Nil(t, err)
 
 		head, err := repo.r.GetReference("HEAD")
@@ -229,7 +229,7 @@ func TestClone(t *testing.T) {
 		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
 	})
 
-	t.Run("unsuccessful clone without specifying dir, with expected root keys not equaling root keys", func(t *testing.T) {
+	t.Run("unsuccessful clone without specifying dir, with expected root keys not equaling root keys, bare", func(t *testing.T) {
 		localTmpDir := t.TempDir()
 
 		if err := os.Chdir(localTmpDir); err != nil {
@@ -245,7 +245,184 @@ func TestClone(t *testing.T) {
 
 		rootPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
 
-		_, err = Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{rootPublicKey, badPublicKey})
+		_, err = Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{rootPublicKey, badPublicKey}, true)
+		assert.ErrorIs(t, ErrExpectedRootKeysDoNotMatch, err)
+	})
+
+	t.Run("successful clone without specifying dir, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(testCtx, remoteTmpDir, "", "", nil, false)
+		assert.Nil(t, err)
+		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
+		if err != nil {
+			t.Fatal(err)
+		}
+		headID, err := repo.r.GetReference(head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, headID)
+
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, rsl.Ref)
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
+	})
+
+	t.Run("successful clone with dir, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		dirName := "myRepo"
+		repo, err := Clone(testCtx, remoteTmpDir, dirName, "", nil, false)
+		assert.Nil(t, err)
+		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
+		if err != nil {
+			t.Fatal(err)
+		}
+		headID, err := repo.r.GetReference(head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, headID)
+
+		dirInfo, err := os.Stat(dirName)
+		assert.Nil(t, err)
+		assert.True(t, dirInfo.IsDir())
+
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, rsl.Ref)
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
+	})
+
+	t.Run("successful clone without specifying dir, with non-HEAD initial branch, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(testCtx, remoteTmpDir, "", anotherRefName, nil, false)
+		assert.Nil(t, err)
+		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
+		if err != nil {
+			t.Fatal(err)
+		}
+		headID, err := repo.r.GetReference(head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, headID)
+		assert.Equal(t, anotherRefName, head)
+
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, rsl.Ref)
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
+	})
+
+	t.Run("unsuccessful clone when unspecified dir already exists, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		_, err = Clone(testCtx, remoteTmpDir, "", "", nil, false)
+		assert.Nil(t, err)
+
+		_, err = Clone(testCtx, remoteTmpDir, "", "", nil, false)
+		assert.ErrorIs(t, err, ErrDirExists)
+	})
+
+	t.Run("unsuccessful clone when specified dir already exists, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		dirName := "myRepo"
+		if err := os.Mkdir(dirName, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		_, err = Clone(testCtx, remoteTmpDir, dirName, "", nil, false)
+		assert.ErrorIs(t, err, ErrDirExists)
+	})
+
+	t.Run("successful clone without specifying dir, with trailing slashes in repository path, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		repo, err := Clone(testCtx, remoteTmpDir+"//", "", "", nil, false)
+		assert.Nil(t, err)
+		head, err := repo.r.GetSymbolicReferenceTarget("HEAD")
+		if err != nil {
+			t.Fatal(err)
+		}
+		headID, err := repo.r.GetReference(head)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, headID)
+
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, rsl.Ref)
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
+	})
+
+	t.Run("successful clone without specifying dir, with multiple expected root keys, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		rootPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+		targetsPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
+
+		repo, err := Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{targetsPublicKey, rootPublicKey}, false)
+		assert.Nil(t, err)
+
+		head, err := repo.r.GetReference("HEAD")
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, commitID, head)
+
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, rsl.Ref)
+		assertLocalAndRemoteRefsMatch(t, repo.r, remoteRepo.r, policy.PolicyRef)
+	})
+
+	t.Run("unsuccessful clone without specifying dir, with expected root keys not equaling root keys, not bare", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+
+		if err := os.Chdir(localTmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(currentDir) //nolint:errcheck
+
+		badPublicKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		badPublicKey := tufv01.NewKeyFromSSLibKey(badPublicKeyR)
+
+		rootPublicKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+
+		_, err = Clone(testCtx, remoteTmpDir, "", "", []tuf.Principal{rootPublicKey, badPublicKey}, false)
 		assert.ErrorIs(t, ErrExpectedRootKeysDoNotMatch, err)
 	})
 }

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -13,6 +13,7 @@ import (
 type options struct {
 	branch           string
 	expectedRootKeys common.PublicKeys
+	bare             bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -23,10 +24,18 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"",
 		"specify branch to check out",
 	)
+
 	cmd.Flags().Var(
 		&o.expectedRootKeys,
 		"root-key",
 		"set of initial root of trust keys for the repository (supported values: paths to SSH keys, GPG key fingerprints, Sigstore/Fulcio identities)",
+	)
+
+	cmd.Flags().BoolVar(
+		&o.bare,
+		"bare",
+		false,
+		"make a bare Git repository",
 	)
 }
 
@@ -47,7 +56,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		expectedRootKeys[index] = key
 	}
 
-	_, err := gittuf.Clone(cmd.Context(), args[0], dir, o.branch, expectedRootKeys)
+	_, err := gittuf.Clone(cmd.Context(), args[0], dir, o.branch, expectedRootKeys, o.bare)
 	return err
 }
 

--- a/internal/gitinterface/sync.go
+++ b/internal/gitinterface/sync.go
@@ -63,7 +63,7 @@ func (r *Repository) Fetch(remoteName string, refs []string, fastForwardOnly boo
 	return r.FetchRefSpec(remoteName, refSpecs)
 }
 
-func CloneAndFetchRepository(remoteURL, dir, initialBranch string, refs []string) (*Repository, error) {
+func CloneAndFetchRepository(remoteURL, dir, initialBranch string, refs []string, bare bool) (*Repository, error) {
 	if dir == "" {
 		return nil, fmt.Errorf("target directory must be specified")
 	}
@@ -77,12 +77,17 @@ func CloneAndFetchRepository(remoteURL, dir, initialBranch string, refs []string
 	}
 	args = append(args, dir)
 
+	if bare {
+		args = append(args, "--bare")
+		repo.gitDirPath = dir
+	} else {
+		repo.gitDirPath = path.Join(dir, ".git")
+	}
+
 	_, stdErr, err := repo.executor(args...).execute()
 	if err != nil {
 		return nil, fmt.Errorf("unable to clone repository: %s", stdErr)
 	}
-
-	repo.gitDirPath = path.Join(dir, ".git")
 
 	return repo, repo.Fetch(DefaultRemoteName, refs, true)
 }


### PR DESCRIPTION
This commit adds support for cloning a repo as a bare local repository. This is necessary for #758 pieces.