### PR TITLE
gittuf: Remove GetRSLLog from API

### DIFF
--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"slices"
 	"strings"
 
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
@@ -496,26 +495,4 @@ func (r *Repository) isDuplicateEntry(refName string, targetID gitinterface.Hash
 	}
 
 	return latestUnskippedEntry.TargetID.Equal(targetID), nil
-}
-
-// GetRSLEntryLog gives us a list of all the rsl entries, and a map with a key being
-// a reference entry, and the value being an array of all applicable annotations for that reference entry
-func GetRSLEntryLog(repo *Repository) ([]*rsl.ReferenceEntry, map[string][]*rsl.AnnotationEntry, error) {
-	firstEntry, _, err := rsl.GetFirstEntry(repo.r)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	lastEntry, err := rsl.GetLatestEntry(repo.r)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	entries, annotationMap, err := rsl.GetReferenceEntriesInRange(repo.r, firstEntry.GetID(), lastEntry.GetID())
-	if err != nil {
-		return nil, nil, err
-	}
-
-	slices.Reverse(entries)
-	return entries, annotationMap, nil
 }

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
@@ -877,30 +876,4 @@ func TestPullRSL(t *testing.T) {
 		err := localRepo.PullRSL(remoteName)
 		assert.ErrorIs(t, err, ErrPullingRSL)
 	})
-}
-
-func TestGetRSLEntryLog(t *testing.T) {
-	r := createTestRepositoryWithPolicy(t, "")
-
-	entries, annotationMap, err := GetRSLEntryLog(r)
-	assert.Nil(t, err)
-
-	firstEntry, _, err := rsl.GetFirstEntry(r.r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lastEntry, err := rsl.GetLatestEntry(r.r)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expected, _, err := rsl.GetReferenceEntriesInRange(r.r, firstEntry.GetID(), lastEntry.GetID())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	slices.Reverse(expected)
-	assert.Equal(t, expected, entries)
-	assert.Equal(t, map[string][]*rsl.AnnotationEntry{}, annotationMap)
 }


### PR DESCRIPTION
This isn't used anymore since we updated how gittuf rsl log works.