### PR TITLE
Reconcile sync and propagation workflows

### DIFF
--- a/docs/cli/gittuf_rsl_annotate.md
+++ b/docs/cli/gittuf_rsl_annotate.md
@@ -9,9 +9,11 @@ gittuf rsl annotate [flags]
 ### Options
 
 ```
-  -h, --help             help for annotate
-  -m, --message string   annotation message
-  -s, --skip             mark annotated entries as to be skipped
+  -h, --help                 help for annotate
+      --local-only           local only
+  -m, --message string       annotation message
+      --remote-name string   remote name
+  -s, --skip                 mark annotated entries as to be skipped
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -11,8 +11,9 @@ gittuf rsl record [flags]
 ```
       --dst-ref string         name of destination reference, if it differs from source reference
   -h, --help                   help for record
+      --local-only             local only
+      --remote-name string     remote name
       --skip-duplicate-check   skip check to see if latest entry for reference has same target
-      --skip-propagation       skip propagation workflow
 ```
 
 ### Options inherited from parent commands

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -172,7 +172,7 @@ hook and [#220] for planned gittuf and Git command compatibility).
 ```bash
 echo "Hello, world!" > README.md
 git add . && git commit -q -S -m "Initial commit"
-gittuf rsl record main
+gittuf rsl record main --local-only
 ```
 
 ## Verifying policy

--- a/docs/testing/tester-expected-unix.txt
+++ b/docs/testing/tester-expected-unix.txt
@@ -21,5 +21,5 @@ Flag --authorize-key has been deprecated, use --authorize instead
 + echo 'Hello, world!'
 + git add .
 + git commit -q -S -m 'Initial commit'
-+ gittuf rsl record main
++ gittuf rsl record main --local-only
 + gittuf verify-ref main

--- a/docs/testing/tester-expected-win.txt
+++ b/docs/testing/tester-expected-win.txt
@@ -57,5 +57,5 @@ DEBUG:   17+  >>>> gittuf policy apply
 DEBUG:   18+  >>>> echo "Hello, world!" > README.md
 DEBUG:   19+  >>>> git add . ; git commit -q -S -m "Initial commit"
 DEBUG:   19+ git add . ;  >>>> git commit -q -S -m "Initial commit"
-DEBUG:   20+  >>>> gittuf rsl record main
+DEBUG:   20+  >>>> gittuf rsl record main --local-only
 DEBUG:   21+  >>>> gittuf verify-ref main

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
 	"github.com/gittuf/gittuf/internal/attestations"
 	"github.com/gittuf/gittuf/internal/attestations/authorizations"
 	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
@@ -63,7 +64,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		// Add a single commit
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
 		fromCommitID := commitIDs[0]
-		if err := repo.RecordRSLEntryForReference(testCtx, targetRef, false); err != nil {
+		if err := repo.RecordRSLEntryForReference(testCtx, targetRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -71,7 +72,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		// Add two commits
 		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
 		featureCommitID := commitIDs[1]
-		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false); err != nil {
+		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -174,7 +175,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := repo.RecordRSLEntryForReference(testCtx, fromRef, false); err != nil {
+		if err := repo.RecordRSLEntryForReference(testCtx, fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -204,7 +205,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Add it to RSL
-		if err := repo.RecordRSLEntryForReference(testCtx, targetTagRef, false); err != nil {
+		if err := repo.RecordRSLEntryForReference(testCtx, targetTagRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 

--- a/experimental/gittuf/options/rsl/rsl.go
+++ b/experimental/gittuf/options/rsl/rsl.go
@@ -3,31 +3,56 @@
 
 package rsl
 
-type Options struct {
+type RecordOptions struct {
 	RefNameOverride       string
+	RemoteName            string
+	LocalOnly             bool
 	SkipCheckForDuplicate bool
-	SkipPropagation       bool
 }
 
-type Option func(o *Options)
+type RecordOption func(o *RecordOptions)
 
-func WithOverrideRefName(refNameOverride string) Option {
-	return func(o *Options) {
+func WithOverrideRefName(refNameOverride string) RecordOption {
+	return func(o *RecordOptions) {
 		o.RefNameOverride = refNameOverride
 	}
 }
 
 // WithSkipCheckForDuplicateEntry indicates that the RSL entry creation must not
 // check if the latest entry for the reference has the same target ID.
-func WithSkipCheckForDuplicateEntry() Option {
-	return func(o *Options) {
+func WithSkipCheckForDuplicateEntry() RecordOption {
+	return func(o *RecordOptions) {
 		o.SkipCheckForDuplicate = true
 	}
 }
 
-// WithSkipPropagation disables execution of the propagation workflow.
-func WithSkipPropagation() Option {
-	return func(o *Options) {
-		o.SkipPropagation = true
+func WithRecordRemote(remoteName string) RecordOption {
+	return func(o *RecordOptions) {
+		o.RemoteName = remoteName
+	}
+}
+
+func WithRecordLocalOnly() RecordOption {
+	return func(o *RecordOptions) {
+		o.LocalOnly = true
+	}
+}
+
+type AnnotateOptions struct {
+	RemoteName string
+	LocalOnly  bool
+}
+
+type AnnotateOption func(o *AnnotateOptions)
+
+func WithAnnotateRemote(remoteName string) AnnotateOption {
+	return func(o *AnnotateOptions) {
+		o.RemoteName = remoteName
+	}
+}
+
+func WithAnnotateLocalOnly() AnnotateOption {
+	return func(o *AnnotateOptions) {
+		o.LocalOnly = true
 	}
 }

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -35,7 +35,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false); err != nil {
+	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +56,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.RecordRSLEntryForReference(testCtx, "main", false); err != nil {
+	if err := repo.RecordRSLEntryForReference(testCtx, "main", false, rslopts.WithRecordLocalOnly()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	assert.Equal(t, "refs/heads/main", entry.RefName)
 	assert.Equal(t, newCommitID, entry.TargetID)
 
-	err = repo.RecordRSLEntryForReference(testCtx, "main", false)
+	err = repo.RecordRSLEntryForReference(testCtx, "main", false, rslopts.WithRecordLocalOnly())
 	assert.Nil(t, err)
 
 	entryT, err = rsl.GetLatestEntry(repo.r)
@@ -88,7 +88,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	assert.Equal(t, entry.GetID(), entryT.GetID())
 
 	// Record entry for a different dst ref
-	err = repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithOverrideRefName("refs/heads/not-main"))
+	err = repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithOverrideRefName("refs/heads/not-main"), rslopts.WithRecordLocalOnly())
 	assert.Nil(t, err)
 
 	entryT, err = rsl.GetLatestEntry(repo.r)
@@ -105,7 +105,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 
 	// Record entry for a different dst ref and skip check for duplicate
 	currentEntryID := entry.GetID()
-	err = repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithOverrideRefName("refs/heads/not-main"), rslopts.WithSkipCheckForDuplicateEntry())
+	err = repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithOverrideRefName("refs/heads/not-main"), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly())
 	assert.Nil(t, err)
 
 	entryT, err = rsl.GetLatestEntry(repo.r)
@@ -218,7 +218,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 
 	repo := &Repository{r: r}
 
-	err := repo.RecordRSLAnnotation(testCtx, []string{gitinterface.ZeroHash.String()}, false, "test annotation", false)
+	err := repo.RecordRSLAnnotation(testCtx, []string{gitinterface.ZeroHash.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
@@ -230,7 +230,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false); err != nil {
+	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,7 +240,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	}
 	entryID := latestEntry.GetID()
 
-	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false)
+	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.Nil(t, err)
 
 	latestEntry, err = rsl.GetLatestEntry(repo.r)
@@ -254,7 +254,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	assert.Equal(t, []gitinterface.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.False(t, annotation.Skip)
 
-	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, true, "skip annotation", false)
+	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, true, "skip annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.Nil(t, err)
 
 	latestEntry, err = rsl.GetLatestEntry(repo.r)
@@ -289,7 +289,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -309,7 +309,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -346,7 +346,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -391,7 +391,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -411,7 +411,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := localR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -456,7 +456,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -476,7 +476,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -484,7 +484,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := localRepo.r.Commit(emptyTreeHash, anotherRefName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -550,7 +550,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -570,7 +570,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -578,7 +578,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if _, err := localRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -628,7 +628,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -645,7 +645,7 @@ func TestSync(t *testing.T) {
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
-		divergedRefs, err := localRepo.Sync(remoteName, false)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.Nil(t, err)
 		assert.Empty(t, divergedRefs)
 	})
@@ -665,7 +665,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -686,7 +686,7 @@ func TestSync(t *testing.T) {
 		if _, err := localRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -695,7 +695,7 @@ func TestSync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, false)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.Nil(t, err)
 		assert.Empty(t, divergedRefs)
 
@@ -725,7 +725,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -746,7 +746,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -755,7 +755,7 @@ func TestSync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, false)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.Nil(t, err)
 		assert.Empty(t, divergedRefs)
 
@@ -785,7 +785,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -806,7 +806,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -814,11 +814,11 @@ func TestSync(t *testing.T) {
 		if _, err := localRepo.r.Commit(emptyTreeHash, refName, "Local test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, false)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.ErrorIs(t, err, ErrDivergedRefs)
 		assert.Contains(t, divergedRefs, rsl.Ref)
 	})
@@ -838,7 +838,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -859,7 +859,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -868,7 +868,7 @@ func TestSync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, false)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.ErrorIs(t, err, ErrDivergedRefs)
 		assert.Contains(t, divergedRefs, refName)
 	})
@@ -888,7 +888,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -909,7 +909,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -917,11 +917,11 @@ func TestSync(t *testing.T) {
 		if _, err := localRepo.r.Commit(emptyTreeHash, refName, "Local test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := localRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, true)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, true, false)
 		assert.Nil(t, err)
 		assert.Empty(t, divergedRefs)
 
@@ -945,7 +945,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -966,7 +966,7 @@ func TestSync(t *testing.T) {
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -975,7 +975,7 @@ func TestSync(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		divergedRefs, err := localRepo.Sync(remoteName, true)
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, true, false)
 		assert.Nil(t, err)
 		assert.Empty(t, divergedRefs)
 
@@ -1116,7 +1116,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		upstreamEntry, err := rsl.GetLatestEntry(upstreamRepo.r)
@@ -1150,7 +1150,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithSkipPropagation()); err != nil {
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1252,13 +1252,13 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName1, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false); err != nil {
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName2, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false); err != nil {
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		upstreamEntry2, err := rsl.GetLatestEntry(upstreamRepo.r)
@@ -1296,7 +1296,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName1, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithSkipPropagation()); err != nil {
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1414,13 +1414,13 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName1, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false); err != nil {
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName2, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false); err != nil {
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		upstreamEntry2, err := rsl.GetLatestEntry(upstreamRepo.r)
@@ -1458,13 +1458,13 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName1, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithSkipPropagation()); err != nil {
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName1, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName2, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false, rslopts.WithSkipPropagation()); err != nil {
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName2, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1596,7 +1596,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := upstreamRepo1.r.Commit(upstreamRootTree1ID, refName, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo1.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := upstreamRepo1.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 		upstreamEntry1, err := rsl.GetLatestEntry(upstreamRepo1.r)
@@ -1626,7 +1626,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := upstreamRepo2.r.Commit(upstreamRootTree2ID, refName, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := upstreamRepo2.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+		if err := upstreamRepo2.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1661,7 +1661,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName, "Initial commit\n", false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithSkipPropagation()); err != nil {
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
 

--- a/experimental/gittuf/sync_test.go
+++ b/experimental/gittuf/sync_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
@@ -57,13 +58,13 @@ func TestClone(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false); err != nil {
+	if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
 		t.Fatal(err)
 	}
 	if err := remoteRepo.r.SetReference(anotherRefName, commitID); err != nil {
 		t.Fatal(err)
 	}
-	if err := remoteRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false); err != nil {
+	if err := remoteRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false, rslopts.WithRecordLocalOnly()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -5,12 +5,15 @@ package annotate
 
 import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
 	"github.com/spf13/cobra"
 )
 
 type options struct {
-	skip    bool
-	message string
+	skip       bool
+	message    string
+	remoteName string
+	localOnly  bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -30,6 +33,23 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"annotation message",
 	)
 	cmd.MarkFlagRequired("message") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.remoteName,
+		"remote-name",
+		"",
+		"remote name",
+	)
+
+	cmd.Flags().BoolVar(
+		&o.localOnly,
+		"local-only",
+		false,
+		"local only",
+	)
+
+	cmd.MarkFlagsOneRequired("remote-name", "local-only")
+	cmd.MarkFlagsMutuallyExclusive("remote-name", "local-only")
 }
 
 func (o *options) Run(cmd *cobra.Command, args []string) error {
@@ -38,7 +58,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return repo.RecordRSLAnnotation(cmd.Context(), args, o.skip, o.message, true)
+	opts := []rslopts.AnnotateOption{rslopts.WithAnnotateRemote(o.remoteName)}
+	if o.localOnly {
+		opts = append(opts, rslopts.WithAnnotateLocalOnly())
+	}
+
+	return repo.RecordRSLAnnotation(cmd.Context(), args, o.skip, o.message, true, opts...)
 }
 
 func New() *cobra.Command {

--- a/internal/cmd/sync/sync.go
+++ b/internal/cmd/sync/sync.go
@@ -24,7 +24,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	)
 }
 
-func (o *options) Run(_ *cobra.Command, args []string) error {
+func (o *options) Run(cmd *cobra.Command, args []string) error {
 	repo, err := gittuf.LoadRepository()
 	if err != nil {
 		return err
@@ -35,7 +35,7 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 		remoteName = args[0]
 	}
 
-	divergedRefs, err := repo.Sync(remoteName, o.overwriteLocalRefs)
+	divergedRefs, err := repo.Sync(cmd.Context(), remoteName, o.overwriteLocalRefs, true)
 	switch {
 	case errors.Is(err, gittuf.ErrDivergedRefs):
 		fmt.Println("References have diverged:")

--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -446,7 +446,7 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 						// pushed by the user
 
 						// TODO: skipping propagation; invoke it once total instead of per ref
-						if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithSkipPropagation()); err != nil {
+						if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
 							return nil, false, err
 						}
 					}

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -549,7 +549,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 
 				if !strings.HasPrefix(dstRef, gittufRefPrefix) {
 					// TODO: skipping propagation; invoke it once total instead of per ref
-					if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithSkipPropagation()); err != nil {
+					if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
 						return nil, false, err
 					}
 				}


### PR DESCRIPTION
This tries to straighten out how RSL update syncing and propagation interact with each other.