### PR TITLE
gittuf paper citation.bib file

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,10 @@
+@inproceedings{yelgundhalli2025,
+    author = {Aditya Sirish A Yelgundhalli and Patrick Zielinski and Reza Curtmola and Justin Cappos},
+    title = {{Rethinking Trust in Forge-Based Git Security}},
+    booktitle = {{32nd Network and Distributed System Security Symposium (NDSS 2025)}},
+    year = {2025},
+    isbn = {979-8-9894372-8-3},
+    address = {San Diego, CA},
+    url = {https://www.ndss-symposium.org/ndss-paper/rethinking-trust-in-forge-based-git-security/},
+    publisher = {{Internet Society}},
+}


### PR DESCRIPTION
Opening this as a draft until the full details are available.

This PR adds the citation for the gittuf paper as presented in NDSS 2025.