### PR TITLE
[GUPPIEs] gittuf-git: Add git command compatibility layer

### DIFF
--- a/.test_ignore.txt
+++ b/.test_ignore.txt
@@ -7,6 +7,7 @@ github.com/gittuf/gittuf/internal/dev
 github.com/gittuf/gittuf/internal/git-remote-gittuf
 github.com/gittuf/gittuf/internal/luasandbox/options
 github.com/gittuf/gittuf/internal/policy/options
+github.com/gittuf/gittuf/internal/gittuf-git
 github.com/gittuf/gittuf/internal/testartifacts
 github.com/gittuf/gittuf/internal/third_party
 github.com/gittuf/gittuf/internal/version

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ ifeq ($(OS),Windows_NT)
 else
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf-git ./internal/gittuf-git
 endif
 
 install : test just-install
@@ -30,6 +31,7 @@ ifeq ($(OS),Windows_NT)
 else
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
 	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
+	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/gittuf-git
 endif
 
 test :

--- a/internal/gittuf-git/README.md
+++ b/internal/gittuf-git/README.md
@@ -1,0 +1,67 @@
+# gittuf-git
+
+gittuf also comes with a drop-in replacement for the `git` binary that aims to
+be command-compatible with Git, while also performing some gittuf operations for
+you. We call this the **command compatibility layer**, named `gittuf-git`.
+
+`gittuf-git` supports performing the following common operations for you:
+
+- Creating RSL entries upon pushing your changes
+- Fetching gittuf metadata when pulling changes
+
+> [!NOTE] The command compatibility layer does not perform the steps needed to
+> *initialize* a gittuf repository (i.e. setting up root of trust, policy,
+> etc.). These steps must be done manually for new repositories (see the
+> [getting started guide](/docs/get-started.md)).
+
+## How to Install
+
+At the moment, the command compatibility layer must be built from source, from
+the `experimental` branch of the repository. Running `make` will compile the
+command compatibility layer and place it in your `GOBIN`.
+
+## How to Use
+
+Once it's installed, using the command compatibility layer is easy. Simply
+invoke `gittuf-git` instead of `git` for any git operation, e.g.
+
+```bash
+gittuf-git clone git@github.com:gittuf/gittuf
+gittuf-git pull
+gittuf-git push
+```
+
+## How it Works
+
+The command compatibility layer has two modes of operation, depending on whether
+the repository it is being used on is gittuf-enabled:
+
+### A repository without gittuf
+
+All operations will be passed through directly to the `git` binary on the
+system. The behavior in this case is identical to running `git`.
+
+### A repository with gittuf
+
+For repositories with gittuf enabled, `gittuf-git` will check to see if the Git
+operation being performed necessitates adding to or validating gittuf metadata.
+The following is the list of Git operations that are intercepted and the changes
+made:
+
+- `clone`
+    - In addition to cloning the repository as Git would do, gittuf-specific
+      metadata, such as the RSL and policy are also fetched.
+
+- `commit`
+    - Before invoking `git commit`, gittuf verification is run. The result is
+     printed out to `stdout`, but the process continues regardless of whether
+     verification was successful or not.
+
+- `push`
+    - Before pushing, the changes are recorded to the RSL. After the
+     user-specified changes are pushed to the remote, the RSL and policy are
+     also pushed to the remote.
+
+- `pull` and `fetch`
+    - After the user-specified refs are pulled or fetched, the RSL and policy
+     are also fetched from the remote.

--- a/internal/gittuf-git/args/args.go
+++ b/internal/gittuf-git/args/args.go
@@ -1,0 +1,297 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// This file contains modified code from the hub project, available at
+// https://github.com/mislav/hub/blob/master/commands/args.go, and licensed
+// under the MIT License
+
+package args
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+)
+
+const (
+	noopFlag       = "--noop"
+	versionFlag    = "--version"
+	listCmds       = "--list-cmds="
+	helpFlag       = "--help"
+	configFlag     = "-c"
+	chdirFlag      = "-C"
+	gitDirFlag     = "--git-dir"
+	flagPrefix     = "-"
+	defaultRemote  = "origin"
+	defaultGitDir  = ".git"
+	defaultRootDir = "."
+)
+
+var (
+	ErrNoRemoteFound = errors.New("no remote found in Git configuration")
+)
+
+// Args stores any global flags for the invocation of Git (i.e. those before the
+// operation), the command/operation, and the parameters to said
+// command/operation.
+type Args struct {
+	GlobalFlags []string
+	Command     string
+	Parameters  []string
+	ConfigIdx   int
+	ChdirIdx    int
+	GitDir      string
+	RootDir     string
+}
+
+type GitConfig map[string]string
+
+// ProcessArgs takes in the arguments from the commandline, and then nicely
+// organizes them into an Args struct. This should only be called with 1 or more
+// arguments, excluding the base one (i.e. the executable name)
+func ProcessArgs(args []string) Args {
+	if len(args) < 1 {
+		return Args{
+			GlobalFlags: nil,
+			Command:     "",
+			Parameters:  nil,
+			GitDir:      defaultGitDir,
+			RootDir:     defaultRootDir,
+		}
+	}
+
+	// Find the command's index
+	cmdIndex, configIndex, chdirIndex, girDirIndex := locateCommand(args)
+
+	gitDir := defaultGitDir
+	rootDir := defaultRootDir
+	if chdirIndex > 0 {
+		gitDir = args[chdirIndex] + "/" + defaultGitDir
+		rootDir = args[chdirIndex]
+	}
+
+	if girDirIndex > 0 {
+		gitDir = args[girDirIndex]
+	}
+
+	return Args{
+		GlobalFlags: args[0:cmdIndex],
+		Command:     args[cmdIndex],
+		Parameters:  args[cmdIndex+1:],
+		ConfigIdx:   configIndex,
+		ChdirIdx:    chdirIndex,
+		GitDir:      gitDir,
+		RootDir:     rootDir,
+	}
+}
+
+// DetermineRemote attempts to find out what the remote is that the user would
+// like to push to. If there is no information to this regard in the original
+// command invocation, "origin" and the accompanying URL are assumed.
+func DetermineRemote(args Args) (string, string, error) {
+	repo, err := gitinterface.LoadRepository(args.RootDir)
+	if err != nil {
+		return "", "", err
+	}
+
+	config, err := repo.GetGitConfig()
+	if err != nil {
+		return "", "", err
+	}
+
+	// If there are no args, get the default remote from the git config
+	if len(args.Parameters) == 0 {
+		remoteName, remoteURL, err := getDefaultRemoteFromConfig(config)
+		if err != nil {
+			return "", "", err
+		}
+		return remoteName, remoteURL, nil
+	}
+
+	// Iterate args to find the remote
+	for _, arg := range args.Parameters {
+		if strings.HasPrefix(arg, flagPrefix) {
+			continue
+		}
+
+		if isValidRemoteName(arg, config) {
+			remoteURL := config["remote."+arg+".url"]
+			return arg, remoteURL, nil
+		}
+
+		// The remote must be specified before refspecs so this should work
+		if strings.Contains(arg, "https://") || strings.Contains(arg, "http://") || (strings.Contains(arg, "@") && strings.Contains(arg, ":")) {
+			return arg, arg, nil
+		}
+	}
+
+	// If no remote was found, get the default remote from the git config
+	remoteName, remoteURL, err := getDefaultRemoteFromConfig(config)
+	if err != nil {
+		return "", "", err
+	}
+
+	return remoteName, remoteURL, nil
+}
+
+// DeterminePushedRefs parses the git references from the given command-line
+// arguments.
+func DeterminePushedRefs(repo *gitinterface.Repository, gitArgs Args) ([]string, error) {
+	// There are a few possible cases for how the invocation of push can look
+	// like. The following examples are taken from the Git manpage:
+	// git push
+	// git push origin
+	// git push origin :
+	// git push origin master
+	// git push origin HEAD
+	// git push mothership master:satellite/master dev:satellite/dev
+	// git push origin HEAD:master
+	// git push origin master:refs/heads/experimental
+	// git push origin :experimental
+	// git push origin +dev:master
+
+	// There are also cases where a custom remote may be used:
+	// git push git@example.com:owner/repo
+	// git push git@example.com:owner/repo HEAD
+	// git push git@example.com:owner/repo refs/heads/main:refs/heads/main
+
+	// The good news here is that the remote must come as the first parameter,
+	// if it is supplied at all.
+
+	// As we can see, there are a ton of combinations to parse through. This
+	// function must accommodate all of these cases, and so follows the
+	// following algorithm:
+
+	// 0. For all arguments, if a "--" is present as the first part of the arg
+	// string, then we skip over it as it's a flag.
+	// 1. If len(parameters) == 0, then we resolve HEAD and create a refspec
+	// with it on both the local and remote part.
+	// 2. Iterate through all the args supplied on the commandline. For each
+	// arg:
+	//    a) Check if the arg contains a ":". If it does and it is the first
+	//   	 arg, then check if "refs/" is present anywhere in the arg. If it
+	//       is, then it's likely a refspec. Add it to the list of refspecs.
+	//    b) If the arg does not contain a ":" and it is the first arg, see if
+	//       we can resolve a remote in the Git configuration for this arg. If
+	//       we can, then skip over this arg. If not, then determine the refspec
+	//       for this arg.
+	//    c) If the arg does not contain a ":" and it is not the first arg, then
+	//       attempt to determine the refspec for it.
+
+	if len(gitArgs.Parameters) == 0 {
+		headTarget, err := repo.GetSymbolicReferenceTarget("HEAD")
+		if err != nil {
+			return nil, err
+		}
+		refSpec := fmt.Sprintf("%s:%s", headTarget, headTarget)
+		return []string{refSpec}, nil
+	}
+
+	var refNames []string
+
+	for i, arg := range gitArgs.Parameters {
+		if i == 0 {
+			possibleRemote, _, _ := DetermineRemote(gitArgs)
+			if possibleRemote == arg {
+				// If this is the only argument, then we must assume HEAD
+				if len(gitArgs.Parameters) == 1 {
+					headTarget, err := repo.GetSymbolicReferenceTarget("HEAD")
+					if err != nil {
+						return nil, err
+					}
+					refSpec := fmt.Sprintf("%s:%s", headTarget, headTarget)
+					return []string{refSpec}, nil
+				}
+				continue
+			}
+		}
+
+		if strings.HasPrefix(arg, flagPrefix) {
+			continue
+		}
+
+		if strings.Contains(arg, ":") {
+			refNames = append(refNames, arg)
+		} else {
+			refSpec, err := repo.RefSpec(arg, "", true)
+			if err != nil {
+				return nil, err
+			}
+			refNames = append(refNames, refSpec)
+		}
+	}
+
+	return refNames, nil
+}
+
+// isValidRemoteName checks if the given name is a valid remote name in the
+// repository's Git configuration.
+func isValidRemoteName(name string, config GitConfig) bool {
+	return config["remote."+name+".url"] != ""
+}
+
+// getDefaultRemoteFromConfig returns the default remote from the given config
+// map. If no remote is found, "origin" is returned.
+func getDefaultRemoteFromConfig(config GitConfig) (string, string, error) {
+	for key := range config {
+		if strings.HasPrefix(key, "remote.") && strings.HasSuffix(key, ".url") {
+			return strings.TrimSuffix(strings.TrimPrefix(key, "remote."), ".url"), config[key], nil
+		}
+	}
+
+	// If there isn't a remote, return an error
+	return "", "", ErrNoRemoteFound
+}
+
+// locateCommand attempts to find where the main Git operation is in the
+// arguments. We need to do this as flags can be specified before the command.
+// In addition, it returns the location of any specified config directory and
+// change directory operation.
+// (The output format is (commandIndex, configIndex, chdirIndex))
+func locateCommand(args []string) (int, int, int, int) {
+	skip := false
+	idx, config, chdir, gitDirInd := 0, 0, 0, 0
+
+	for i, arg := range args {
+		switch {
+		case skip:
+			// If skip is set, then the current arg is a parameter to the
+			// previous arg. As we've processed it below, increment idx and
+			// proceed to the next arg.
+			idx = i + 1
+			skip = false
+		case arg == versionFlag || arg == helpFlag || arg == gitDirFlag ||
+			strings.HasPrefix(arg, listCmds) || !strings.HasPrefix(arg, flagPrefix):
+			// If the arg is the version flag, a help / list cmd flag, or does
+			// not have the "-" prefix, we've reached the location of the
+			// operation.
+			slog.Debug(fmt.Sprintf("Decoded command as '%s'", args[idx]))
+			return idx, config, chdir, gitDirInd
+		default:
+			// Otherwise, we need to keep processing args. Advance the index and
+			// check if the arg is one of interest.
+			idx = i + 1
+			switch arg {
+			case configFlag:
+				// The current arg indicates that the next value will be a
+				// config file. Set the config index appropriately.
+				config = idx
+				skip = true
+			case chdirFlag:
+				// The current arg indicates that the next value will be a
+				// directory. Set the config index appropriately.
+				chdir = idx
+				skip = true
+			case gitDirFlag:
+				// The current arg indicates that the next value will be a
+				// directory. Set the config index appropriately.
+				gitDirInd = idx
+				skip = true
+			}
+		}
+	}
+	return idx, config, chdir, gitDirInd
+}

--- a/internal/gittuf-git/args/args_test.go
+++ b/internal/gittuf-git/args/args_test.go
@@ -1,0 +1,393 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package args
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessArgs(t *testing.T) {
+	tests := map[string]struct {
+		args     []string
+		expected Args
+	}{
+		"no arguments": {
+			args: []string{},
+			expected: Args{
+				GlobalFlags: nil,
+				Command:     "",
+				Parameters:  nil,
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"pull": {
+			args: []string{"pull"},
+			expected: Args{
+				GlobalFlags: []string{},
+				Command:     "pull",
+				Parameters:  []string{},
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"push": {
+			args: []string{"push"},
+			expected: Args{
+				GlobalFlags: []string{},
+				Command:     "push",
+				Parameters:  []string{},
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"fetch origin": {
+			args: []string{"fetch", "origin"},
+			expected: Args{
+				GlobalFlags: []string{},
+				Command:     "fetch",
+				Parameters:  []string{"origin"},
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"-C ../somedir fetch origin": {
+			args: []string{"-C", "../somedir", "fetch", "origin"},
+			expected: Args{
+				GlobalFlags: []string{"-C", "../somedir"},
+				Command:     "fetch",
+				Parameters:  []string{"origin"},
+				ChdirIdx:    1,
+				GitDir:      "../somedir/.git",
+				RootDir:     "../somedir",
+			},
+		},
+		"-c core.editor=vim commit": {
+			args: []string{"-c", "core.editor=vim", "commit"},
+			expected: Args{
+				GlobalFlags: []string{"-c", "core.editor=vim"},
+				Command:     "commit",
+				Parameters:  []string{},
+				ChdirIdx:    0,
+				ConfigIdx:   1,
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"-c user.name=Test -C ../somedir --version": {
+			args: []string{"-c", "user.name=Test", "-C", "../somedir", "--version"},
+			expected: Args{
+				GlobalFlags: []string{"-c", "user.name=Test", "-C", "../somedir"},
+				Command:     "--version",
+				Parameters:  []string{},
+				ChdirIdx:    3,
+				ConfigIdx:   1,
+				GitDir:      "../somedir/.git",
+				RootDir:     "../somedir",
+			},
+		},
+		"-c user.name=Test -C /tmp/git-repo push origin main": {
+			args: []string{"-c", "user.name=Test", "-C", "/tmp/git-repo", "push", "origin", "main"},
+			expected: Args{
+				GlobalFlags: []string{"-c", "user.name=Test", "-C", "/tmp/git-repo"},
+				Command:     "push",
+				Parameters:  []string{"origin", "main"},
+				ChdirIdx:    3,
+				ConfigIdx:   1,
+				GitDir:      "/tmp/git-repo/.git",
+				RootDir:     "/tmp/git-repo",
+			},
+		},
+		"--help": {
+			args: []string{"--help"},
+			expected: Args{
+				GlobalFlags: []string{},
+				Command:     "--help",
+				Parameters:  []string{},
+				ChdirIdx:    0,
+				ConfigIdx:   0,
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"--noop status": {
+			args: []string{"--noop", "status"},
+			expected: Args{
+				GlobalFlags: []string{"--noop"},
+				Command:     "status",
+				Parameters:  []string{},
+				ChdirIdx:    0,
+				ConfigIdx:   0,
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+		"--list-cmds=main": {
+			args: []string{"--list-cmds=main"},
+			expected: Args{
+				GlobalFlags: []string{},
+				Command:     "--list-cmds=main",
+				Parameters:  []string{},
+				ChdirIdx:    0,
+				ConfigIdx:   0,
+				GitDir:      ".git",
+				RootDir:     ".",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		got := ProcessArgs(test.args)
+		assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
+func TestLocateCommand(t *testing.T) {
+	tests := map[string]struct {
+		args              []string
+		expectedCmdIdx    int
+		expectedCfgIdx    int
+		expectedChdirIdx  int
+		expectedgitDirIdx int
+	}{
+		"no arguments": {
+			args:              []string{},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"pull": {
+			args:              []string{"pull"},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"push": {
+			args:              []string{"push"},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"fetch origin": {
+			args:              []string{"fetch", "origin"},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"-C ../somedir fetch origin": {
+			args:              []string{"-C", "../somedir", "fetch", "origin"},
+			expectedCmdIdx:    2,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  1,
+			expectedgitDirIdx: 0,
+		},
+		"-c core.editor=vim commit": {
+			args:              []string{"-c", "core.editor=vim", "commit"},
+			expectedCmdIdx:    2,
+			expectedCfgIdx:    1,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"-c user.name=Test -C ../somedir --version": {
+			args:              []string{"-c", "user.name=Test", "-C", "../somedir", "--version"},
+			expectedCmdIdx:    4,
+			expectedCfgIdx:    1,
+			expectedChdirIdx:  3,
+			expectedgitDirIdx: 0,
+		},
+		"--help": {
+			args:              []string{"--help"},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"--noop status": {
+			args:              []string{"--noop", "status"},
+			expectedCmdIdx:    1,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"--list-cmds=main": {
+			args:              []string{"--list-cmds=main"},
+			expectedCmdIdx:    0,
+			expectedCfgIdx:    0,
+			expectedChdirIdx:  0,
+			expectedgitDirIdx: 0,
+		},
+		"-c user.name=Test -C /tmp/git-repo push origin main": {
+			args:              []string{"-c", "user.name=Test", "-C", "/tmp/git-repo", "push", "origin", "main"},
+			expectedCmdIdx:    4,
+			expectedCfgIdx:    1,
+			expectedChdirIdx:  3,
+			expectedgitDirIdx: 0,
+		},
+	}
+
+	for name, test := range tests {
+		cmdIdx, cfgIdx, chdirIdx, girDirIndex := locateCommand(test.args)
+
+		assert.Equal(t, test.expectedCmdIdx, cmdIdx, fmt.Sprintf("unexpected result in test '%s'", name))
+		assert.Equal(t, test.expectedCfgIdx, cfgIdx, fmt.Sprintf("unexpected result in test '%s'", name))
+		assert.Equal(t, test.expectedChdirIdx, chdirIdx, fmt.Sprintf("unexpected result in test '%s'", name))
+		assert.Equal(t, test.expectedgitDirIdx, girDirIndex, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
+func TestDetermineRemote(t *testing.T) {
+	gitDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, gitDir, true)
+	err := repo.SetGitConfig("remote.notorigin.url", "https://github.com/test/test.git")
+	if err != nil {
+		t.Fatalf("failed to set git config: %s", err)
+	}
+
+	tests := map[string]struct {
+		args         Args
+		expectedName string
+		expectedURL  string
+	}{
+		"no remote specified": {
+			args:         Args{Parameters: []string{""}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"just remote specified": {
+			args:         Args{Parameters: []string{"notorigin"}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"remote with colon": {
+			args:         Args{Parameters: []string{"notorigin:main"}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"remote with branch": {
+			args:         Args{Parameters: []string{"notorigin", "main"}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"remote with multiple args": {
+			args:         Args{Parameters: []string{"-f", "notorigin", "main"}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"no args": {
+			args:         Args{Parameters: []string{}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"args without remote": {
+			args:         Args{Parameters: []string{"main"}, RootDir: gitDir},
+			expectedName: "notorigin",
+			expectedURL:  "https://github.com/test/test.git",
+		},
+		"custom remote": {
+			args:         Args{Parameters: []string{"git@example.com:/owner/repo", "main"}, RootDir: gitDir},
+			expectedName: "git@example.com:/owner/repo",
+			expectedURL:  "git@example.com:/owner/repo",
+		},
+	}
+
+	for name, test := range tests {
+		remoteName, remoteURL, err := DetermineRemote(test.args)
+		if err != nil {
+			t.Fatalf("unexpected error in test '%s': %s", name, err)
+		}
+
+		assert.Equal(t, test.expectedName, remoteName, fmt.Sprintf("unexpected result in test '%s'", name))
+		assert.Equal(t, test.expectedURL, remoteURL, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
+func TestDeterminePushedRefs(t *testing.T) {
+	gitDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, gitDir, true)
+
+	err := repo.SetGitConfig("remote.origin.url", "https://github.com/test/test.git")
+	if err != nil {
+		t.Fatalf("failed to set git config: %s", err)
+	}
+
+	mainRefName := "refs/heads/main"
+	featureRefName := "refs/heads/feature"
+	aRefName := "refs/heads/a"
+	bRefName := "refs/heads/b"
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+
+	// Write empty tree
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = repo.Commit(emptyTreeID, mainRefName, "Initial commit\n", false)
+	require.Nil(t, err)
+	_, err = repo.Commit(emptyTreeID, featureRefName, "Initial commit\n", false)
+	require.Nil(t, err)
+	_, err = repo.Commit(emptyTreeID, aRefName, "Initial commit\n", false)
+	require.Nil(t, err)
+	_, err = repo.Commit(emptyTreeID, bRefName, "Initial commit\n", false)
+	require.Nil(t, err)
+	err = repo.SetSymbolicReference("HEAD", mainRefName)
+	require.Nil(t, err)
+
+	tests := map[string]struct {
+		args             Args
+		expectedRefSpecs []string
+	}{
+		"no refs specified": {
+			args:             Args{Parameters: []string{}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main"},
+		},
+		"no refs specified, remote specified": {
+			args:             Args{Parameters: []string{"origin"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main"},
+		},
+		"one ref specified": {
+			args:             Args{Parameters: []string{"main"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main"},
+		},
+		"two refs specified": {
+			args:             Args{Parameters: []string{"main", "feature"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main", "refs/heads/feature:refs/heads/feature"},
+		},
+		"one refspec specified": {
+			args:             Args{Parameters: []string{"refs/heads/main:refs/heads/main"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main"},
+		},
+		"two refspecs specified": {
+			args:             Args{Parameters: []string{"refs/heads/main:refs/heads/main", "refs/heads/feature:refs/heads/feature"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main", "refs/heads/feature:refs/heads/feature"},
+		},
+		"mix of both refs and refspecs specified": {
+			args:             Args{Parameters: []string{"a", "refs/heads/main:refs/heads/main", "refs/heads/feature:refs/heads/feature", "b"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/a:refs/heads/a", "refs/heads/main:refs/heads/main", "refs/heads/feature:refs/heads/feature", "refs/heads/b:refs/heads/b"},
+		},
+		"custom remote": {
+			args:             Args{Parameters: []string{"git@example.com:/owner/repo", "main"}, RootDir: gitDir},
+			expectedRefSpecs: []string{"refs/heads/main:refs/heads/main"},
+		},
+	}
+
+	for name, test := range tests {
+		refSpecs, err := DeterminePushedRefs(repo, test.args)
+		if err != nil {
+			t.Fatalf("unexpected error in test '%s': %s", name, err)
+		}
+
+		assert.Equal(t, test.expectedRefSpecs, refSpecs, fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}

--- a/internal/gittuf-git/cmd/cmd.go
+++ b/internal/gittuf-git/cmd/cmd.go
@@ -1,0 +1,233 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	hookopts "github.com/gittuf/gittuf/experimental/gittuf/options/hooks"
+	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/gittuf-git/args"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+// Clone handles the clone operation for gittuf + git
+func Clone(ctx context.Context, gitArgs args.Args) error {
+	slog.Debug("Handling clone operation...")
+	// Set working directory as needed
+	if gitArgs.ChdirIdx > 0 {
+		if err := os.Chdir(gitArgs.GlobalFlags[gitArgs.ChdirIdx]); err != nil {
+			return err
+		}
+	}
+
+	// Clone the repository using gittuf
+	var dir string
+	if len(gitArgs.Parameters) > 2 {
+		dir = gitArgs.Parameters[1]
+	} else {
+		dir = ""
+	}
+
+	_, err := gittuf.Clone(ctx, gitArgs.Parameters[0], dir, "", nil, false)
+	return err
+}
+
+// SyncWithRemote handles the pull, fetch and push operations for gittuf + git
+func SyncWithRemote(ctx context.Context, gitArgs args.Args) error {
+	slog.Debug(fmt.Sprintf("Handling sync operation: '%s'...", gitArgs.Command))
+	// Set working directory as needed
+	if gitArgs.ChdirIdx > 0 {
+		if err := os.Chdir(gitArgs.GlobalFlags[gitArgs.ChdirIdx]); err != nil {
+			return err
+		}
+	}
+
+	slog.Debug(fmt.Sprintf("Loading repository from directory '%s'...", gitArgs.RootDir))
+	gittufRepo, err := gittuf.LoadRepository(gitArgs.RootDir)
+	if err != nil {
+		return err
+	}
+
+	gitinterfaceRepo, err := gitinterface.LoadRepository(gitArgs.RootDir)
+	if err != nil {
+		return err
+	}
+
+	if gitArgs.Command == "push" {
+		slog.Debug("Handling push operation...")
+		// Record changes to RSL and invoke pre-push hooks
+		pushedRefs, err := args.DeterminePushedRefs(gitinterfaceRepo, gitArgs)
+		if err != nil {
+			return err
+		}
+
+		slog.Debug(fmt.Sprintf("Determined pushed refs as '%s'", pushedRefs))
+
+		for _, ref := range pushedRefs {
+			slog.Debug(fmt.Sprintf("Recording RSL entry for reference '%s'", ref))
+			if err := gittufRepo.RecordRSLEntryForReference(ctx, ref, true, rslopts.WithOverrideRefName(ref)); err != nil {
+				return err
+			}
+		}
+
+		remoteName, remoteURL, err := args.DetermineRemote(gitArgs)
+		if err != nil {
+			return err
+		}
+
+		slog.Debug(fmt.Sprintf("Determined remote as '%s' with URL '%s'", remoteName, remoteURL))
+
+		// This is left in for debugging purposes
+		var signer dsse.Signer
+		if os.Getenv("GITTUF_DEV") == "1" && os.Getenv("GITTUF_GIT_SSH_KEYPATH") != "" {
+			slog.Debug("Using debug-specified SSH key...")
+			signer, err = loadDebugSigner(os.Getenv("GITTUF_GIT_SSH_KEYPATH"))
+			if err != nil {
+				return err
+			}
+		} else {
+			// If the signer is nil, then gittuf will attempt to load a signer from
+			// the user's Git configuration
+			slog.Debug("Omitting key, to be determined later in gittuf from the user's Git configuration...")
+			signer = nil
+		}
+
+		pushOpts := hookopts.WithPrePush(remoteName, remoteURL, pushedRefs)
+
+		repo, err := gittuf.LoadRepository(gitArgs.RootDir)
+		if err != nil {
+			return err
+		}
+
+		_, err = repo.InvokeHooksForStage(ctx, signer, tuf.HookStagePrePush, pushOpts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Sync non-RSL changes (user specified command)
+	slog.Debug("Handling synchronization of non-gittuf references...")
+	cmdArgs := []string{gitArgs.Command}
+	cmdArgs = append(cmdArgs, gitArgs.Parameters...)
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Handling synchronization of gittuf references...")
+	gitSyncCmd := exec.Command(gitPath, cmdArgs...)
+	gitSyncCmd.Stdout = os.Stdout
+	gitSyncCmd.Stderr = os.Stderr
+
+	if err := gitSyncCmd.Run(); err != nil {
+		return err
+	}
+
+	if gitArgs.Command == "pull" || gitArgs.Command == "fetch" {
+		fetchCmdArgs := []string{"fetch", "--atomic"}
+
+		// Add remote if required by pull command with simple git pull
+		if gitArgs.Command == "pull" && len(gitArgs.Parameters) == 0 {
+			config, err := gitinterfaceRepo.GetGitConfig()
+			if err != nil {
+				fmt.Println("error while retrieving git config")
+				return err
+			}
+			remote := config["branch.main.remote"]
+			fetchCmdArgs = append(fetchCmdArgs, remote)
+
+			fetchCmdArgs = append(fetchCmdArgs,
+				"refs/gittuf/reference-state-log:refs/gittuf/reference-state-log",
+				"refs/gittuf/policy:refs/gittuf/policy",
+				"refs/gittuf/policy-staging:refs/gittuf/policy-staging",
+				"refs/gittuf/attestations:refs/gittuf/attestations")
+		}
+
+		gitFetchCmd := exec.Command(gitPath, fetchCmdArgs...)
+		gitFetchCmd.Stdout = os.Stdout
+		gitFetchCmd.Stderr = os.Stderr
+
+		return gitFetchCmd.Run()
+	}
+
+	return nil
+}
+
+// Commit handles the commit operation for gittuf + git
+func Commit(_ context.Context, gitArgs args.Args) error { //nolint:revive
+	slog.Debug("Handling commit operation...")
+	if gitArgs.ChdirIdx > 0 {
+		if err := os.Chdir(gitArgs.GlobalFlags[gitArgs.ChdirIdx]); err != nil {
+			return err
+		}
+	}
+
+	repo, err := gittuf.LoadRepository(gitArgs.RootDir)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Do we attempt to verify here every time?
+
+	// This is left in for debugging purposes
+	var signer dsse.Signer
+	if os.Getenv("GITTUF_DEV") == "1" && os.Getenv("GITTUF_GIT_SSH_KEYPATH") != "" {
+		signer, err = loadDebugSigner(os.Getenv("GITTUF_GIT_SSH_KEYPATH"))
+		if err != nil {
+			return err
+		}
+	} else {
+		// If the signer is nil, then gittuf will attempt to load a signer from
+		// the user's Git configuration
+		signer = nil
+	}
+
+	// Invoke pre-commit hook
+	exitCodes, err := repo.InvokeHooksForStage(context.Background(), signer, tuf.HookStagePreCommit)
+	if err != nil {
+		return err
+	}
+
+	// Check if any of the exit codes are non-zero
+	for hookName, exitCode := range exitCodes {
+		if exitCode != 0 {
+			return fmt.Errorf("pre-commit hook %s failed with exit code %d", hookName, exitCode)
+		}
+	}
+
+	// Commit irrespective of failed verification. However, verification is
+	// important for debugging purposes. The user should be able to keep
+	// track of whether and why verification is failing.
+	cmdArgs := []string{gitArgs.Command}
+	cmdArgs = append(cmdArgs, gitArgs.Parameters...)
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return err
+	}
+
+	gitPushCmd := exec.Command(gitPath, cmdArgs...)
+	gitPushCmd.Stdout = os.Stdout
+	gitPushCmd.Stderr = os.Stderr
+
+	if err := gitPushCmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadDebugSigner attempts to load a signer from the SSH key specified by
+// the environment variable GITTUF_GIT_SSH_KEYPATH
+func loadDebugSigner(keypath string) (signer dsse.Signer, err error) {
+	return ssh.NewSignerFromFile(keypath)
+}

--- a/internal/gittuf-git/main.go
+++ b/internal/gittuf-git/main.go
@@ -1,0 +1,98 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+
+	"github.com/gittuf/gittuf/internal/gittuf-git/args"
+	"github.com/gittuf/gittuf/internal/gittuf-git/cmd"
+)
+
+/*
+	In addition to the git-remote-gittuf (transport) and the gittuf binary,
+	there is another way to use gittuf in a day-to-day workflow: as a drop-in
+	replacement for the git binary.
+
+	The gittuf-git command compatibility binary intercepts "interesting"
+	operations, such as pushing and pulling, performs gittuf-specific steps, and
+	then hands execution over to the actual Git binary.
+
+	All other operations which do not necessitate the creation or manipulation
+	of gittuf metadata or invocation of gittuf hooks are directly passed onto
+	the Git binary on the system unmodified.
+*/
+
+func main() {
+	// The main flow is simple:
+	// 1.  Process the arguments to facilitate step 2.
+	// 2.  Identify the Git operation.
+	// 3a. If the operation is something that we'll want to invoke gittuf for,
+	// 	   then do what we need with gittuf and then invoke Git as appropriate.
+	// 3b. Otherwise, simply pass all arguments to Git.
+
+	if os.Getenv("GITTUF_GIT_VERBOSE") == "1" {
+		// Setup logging
+		level := slog.LevelDebug
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: level,
+		})))
+	}
+
+	slog.Debug("Logging initialized.")
+
+	// Process args
+	var rawArgs []string
+	var gitArgs args.Args
+
+	if len(os.Args) < 2 { // No arguments to git
+		gitArgs = args.Args{
+			Command: "",
+		}
+	} else {
+		// Trim off the first argument; we don't need it.
+		rawArgs = os.Args[1:]
+		gitArgs = args.ProcessArgs(rawArgs)
+	}
+
+	// Categorize the Git operation.
+	switch gitArgs.Command {
+	case "clone":
+		handleCommand(cmd.Clone, gitArgs)
+	case "commit":
+		handleCommand(cmd.Commit, gitArgs)
+	case "pull", "fetch", "push":
+		handleCommand(cmd.SyncWithRemote, gitArgs)
+	default:
+		// If the git operation isn't one of the above ones, just send the args
+		// over to git without any gittuf invocation
+		executeGit(rawArgs)
+	}
+}
+
+func handleCommand(cmdFunc func(context.Context, args.Args) error, gitArgs args.Args) {
+	ctx := context.Background()
+	if err := cmdFunc(ctx, gitArgs); err != nil {
+		os.Exit(1)
+	}
+}
+
+func executeGit(rawArgs []string) {
+	// Resolve symlink to the git binary
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to find git executable: %s\n", err)
+		os.Exit(1)
+	}
+
+	gitCmd := exec.Command(gitPath, rawArgs...)
+	gitCmd.Stdout = os.Stdout
+	gitCmd.Stderr = os.Stderr
+
+	gitCmd.Run() //nolint:errcheck
+}

--- a/internal/luasandbox/luasandbox.go
+++ b/internal/luasandbox/luasandbox.go
@@ -105,7 +105,7 @@ func (l *LuaEnvironment) RunScript(script string, parameters lua.LTable) (int, e
 
 	// If a table is returned, then this likely means that the hook didn't
 	// return an exit code. Return a 1 for safety.
-	_, ok := returnValue.(*lua.LNumber)
+	_, ok := returnValue.(lua.LNumber)
 	if !ok {
 		return 1, nil
 	}

--- a/internal/luasandbox/luasandbox_test.go
+++ b/internal/luasandbox/luasandbox_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -27,6 +28,21 @@ func TestNewLuaEnvironment(t *testing.T) {
 	defer environment.Cleanup()
 	assert.Nil(t, err)
 	assert.NotNil(t, environment)
+}
+
+func TestRunScript(t *testing.T) {
+	t.Run("basic script", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		environment, err := NewLuaEnvironment(testCtx, repo)
+		defer environment.Cleanup()
+		require.Nil(t, err)
+
+		exitCode, err := environment.RunScript(string(artifacts.SampleHookScript), lua.LTable{})
+		assert.Nil(t, err)
+		assert.Equal(t, 0, exitCode)
+	})
 }
 
 func TestAPIMatchRegex(t *testing.T) {

--- a/internal/testartifacts/testdata/scripts/testprepush.lua
+++ b/internal/testartifacts/testdata/scripts/testprepush.lua
@@ -1,0 +1,4 @@
+function(args)
+    print(args)
+    return 0
+end


### PR DESCRIPTION
This PR adds the gittuf-git command compatibility layer that enables gittuf hooks to be run as part of an otherwise regular Git workflow.

This adds the functionality suggested by https://github.com/gittuf/gittuf/issues/220, but now into the main branch.

~Blocked by #839 and #861.~