### PR TITLE
[GUPPIEs] *: Add hook invocation

### DIFF
--- a/experimental/gittuf/hook.go
+++ b/experimental/gittuf/hook.go
@@ -4,12 +4,23 @@
 package gittuf
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
+
+	hookopts "github.com/gittuf/gittuf/experimental/gittuf/options/hooks"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/luasandbox"
+	luasandboxopts "github.com/gittuf/gittuf/internal/luasandbox/options/luasandbox"
+	"github.com/gittuf/gittuf/internal/policy"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	lua "github.com/yuin/gopher-lua"
 )
 
 type ErrHookExists struct {
@@ -22,7 +33,147 @@ func (e *ErrHookExists) Error() string {
 
 type HookType string
 
+var (
+	ErrNoHooksFoundForPrincipal = errors.New("no hooks found for the specified principal")
+)
+
 var HookPrePush = HookType("pre-push")
+
+// InvokeHooksForStage runs the hooks defined in the specified stage for the
+// user defined by principalID. Upon successful completion of all hooks for the
+// stage for the user, the map of hook names to exit codes is returned.
+// TODO: Add attestations workflow
+func (r *Repository) InvokeHooksForStage(ctx context.Context, stage tuf.HookStage, signer sslibdsse.Signer, opts ...hookopts.Option) (map[string]int, error) {
+	options := &hookopts.Options{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	// TODO: Use signerverifier API to look at Git config if no signer specified
+	if signer == nil {
+		return nil, sslibdsse.ErrNoSigners
+	}
+
+	keyID, err := signer.KeyID()
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyRef)
+	if err != nil {
+		return nil, err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return nil, err
+	}
+
+	allHooks, err := rootMetadata.GetHooks(stage)
+	if err != nil {
+		return nil, err
+	}
+
+	var selectedHooks []tuf.Hook
+	var selectedPrincipal tuf.Principal
+
+	// Read the principals from targetsMetadata and attempt to find a match for
+	// the specified principal to determine which hooks to run.
+	for _, principal := range state.GetAllPrincipals() {
+		for _, key := range principal.Keys() {
+			if key.KeyID == keyID {
+				selectedPrincipal = principal
+				break
+			}
+		}
+	}
+
+	// Couldn't match the key up to a principal, abort
+	if selectedPrincipal == nil {
+		return nil, tuf.ErrPrincipalNotFound
+	}
+
+	// Now, read all hooks for the specified stage and find which ones we need
+	// to run
+	for _, hook := range allHooks {
+		principalIDs := hook.GetPrincipalIDs()
+		if principalIDs.Has(selectedPrincipal.ID()) {
+			selectedHooks = append(selectedHooks, hook)
+		}
+	}
+
+	if len(selectedHooks) == 0 {
+		return nil, ErrNoHooksFoundForPrincipal
+	}
+
+	// Determine what parameters must be supplied based on the hook stage
+	var luaParameters lua.LTable
+
+	// At the moment, the only stage that we support that requires parameters is
+	// the pre-push stage.
+	if stage == tuf.HookStagePrePush {
+		// https://git-scm.com/docs/githooks#_pre_push
+		// For pre-push hooks, we supply two things:
+		// 1. The remote name and destination, e.g.
+		// origin git@github.com:gittuf/gittuf
+		// 2. The local and remote refs/object IDs in the form:
+		// <local ref> <local hash> <remote ref> <remote hash>
+
+		luaParameters.RawSet(lua.LString("remoteName"), lua.LString(options.RemoteName))
+		luaParameters.RawSet(lua.LString("remoteURL"), lua.LString(options.RemoteURL))
+
+		remoteObjects := make(map[string][]gitinterface.Hash, len(options.RefSpecs))
+
+		for _, refSpec := range options.RefSpecs {
+			splitRefSpec := strings.Split(refSpec, ":")
+			localRef, remoteRef := splitRefSpec[0], splitRefSpec[1]
+
+			var remoteHash gitinterface.Hash
+
+			err = r.r.Fetch(options.RemoteName, []string{remoteRef}, true)
+			if err != nil {
+				// This likely means the remote doesn't have the specified ref.
+				// In this case, provide a zero hash as per original Git
+				// behavior.
+				remoteHash = gitinterface.ZeroHash
+			} else {
+				remoteHash, err = r.r.GetReference("FETCH_HEAD")
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			localHash, err := r.r.GetReference(localRef)
+			if err != nil {
+				return nil, err
+			}
+
+			remoteObjects[refSpec] = []gitinterface.Hash{localHash, remoteHash}
+		}
+
+		i := 0
+		for refSpec, hashes := range remoteObjects {
+			splitRefSpec := strings.Split(refSpec, ":")
+			localRef, remoteRef := splitRefSpec[0], splitRefSpec[1]
+
+			combinedString := fmt.Sprintf("%s %s %s %s", localRef, hashes[0], remoteRef, hashes[1])
+			luaParameters.Insert(i, lua.LString(combinedString))
+			i++
+		}
+	}
+
+	exitCodes := make(map[string]int, len(selectedHooks))
+	for _, hook := range selectedHooks {
+		exitCode, err := r.executeHook(ctx, hook, luaParameters)
+		if err != nil {
+			return nil, err
+		}
+		exitCodes[hook.ID()] = exitCode
+	}
+
+	return exitCodes, nil
+}
 
 // UpdateHook updates a git hook in the repository's .git/hooks folder.
 // Existing hook files are not overwritten, unless force flag is set.
@@ -69,4 +220,30 @@ func doesFileExist(path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (r *Repository) executeHook(ctx context.Context, hook tuf.Hook, parameters lua.LTable) (int, error) {
+	var hookContents string
+	hookBlobID := hook.GetBlobID()
+
+	environment, err := luasandbox.NewLuaEnvironment(ctx, r.r, luasandboxopts.WithLuaTimeout(hook.GetTimeout()))
+	if err != nil {
+		return -1, err
+	}
+	defer environment.Cleanup()
+
+	// Load the hook contents from the repository
+	hookFileContents, err := r.r.ReadBlob(hookBlobID)
+	if err != nil {
+		return -1, err
+	}
+
+	hookContents = string(hookFileContents)
+
+	exitCode, err := environment.RunScript(hookContents, parameters)
+	if err != nil {
+		return -1, err
+	}
+
+	return exitCode, nil
 }

--- a/experimental/gittuf/hook_test.go
+++ b/experimental/gittuf/hook_test.go
@@ -8,7 +8,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	hookopts "github.com/gittuf/gittuf/experimental/gittuf/options/hooks"
+	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,5 +67,133 @@ func TestUpdatePrePushHook(t *testing.T) {
 		content, err := os.ReadFile(hookFile)
 		assert.NoError(t, err)
 		assert.Equal(t, []byte("new hook script"), content)
+	})
+}
+
+func TestInvokeHooksForStage(t *testing.T) {
+	t.Setenv(dev.DevModeKey, "1")
+
+	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+	rootKey := tufv01.NewKeyFromSSLibKey(rootSigner.MetadataKey())
+	targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
+	targetsKey := tufv01.NewKeyFromSSLibKey(targetsSigner.MetadataKey())
+
+	t.Run("no signer configured", func(t *testing.T) {
+		// Until https://github.com/gittuf/gittuf/pull/905 is merged
+		// (adding automatic signer loading from the Git configuration), this
+		// test checks that there is an error if no signer is presented.
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		r := &Repository{r: repo}
+
+		_, err := r.InvokeHooksForStage(testCtx, tuf.HookStagePreCommit, nil)
+		assert.ErrorIs(t, err, sslibdsse.ErrNoSigners)
+	})
+
+	t.Run("pre-commit hook, but for different principal", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		r := &Repository{r: repo}
+
+		hookStage := tuf.HookStagePreCommit
+		hookName := "test-hook"
+		environment := tuf.HookEnvironmentLua
+		timeout := 100
+		principals := []string{targetsKey.KeyID}
+
+		if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.AddRootKey(testCtx, rootSigner, targetsKey, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, false); err != nil {
+			t.Fatal(err)
+		}
+
+		err := r.StagePolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+		err = r.ApplyPolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+
+		_, err = r.InvokeHooksForStage(testCtx, hookStage, rootSigner)
+		assert.ErrorIs(t, err, ErrNoHooksFoundForPrincipal)
+	})
+
+	t.Run("pre-commit hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		r := &Repository{r: repo}
+
+		hookStage := tuf.HookStagePreCommit
+		hookName := "test-hook"
+		environment := tuf.HookEnvironmentLua
+		timeout := 100
+		principals := []string{rootKey.KeyID}
+
+		if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, false); err != nil {
+			t.Fatal(err)
+		}
+
+		err := r.StagePolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+		err = r.ApplyPolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+
+		codes, err := r.InvokeHooksForStage(testCtx, hookStage, rootSigner)
+		assert.Nil(t, err)
+		assert.Len(t, codes, 1)
+	})
+
+	t.Run("pre-push hook", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		treeBuilder := gitinterface.NewTreeBuilder(repo)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		remoteTmpDir := t.TempDir()
+		_ = gitinterface.CreateTestGitRepository(t, remoteTmpDir, false)
+
+		if err := repo.CreateRemote("origin", remoteTmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		r := &Repository{r: repo}
+
+		hookStage := tuf.HookStagePrePush
+		hookName := "test-hook"
+		environment := tuf.HookEnvironmentLua
+		timeout := 100
+		principals := []string{rootKey.KeyID}
+
+		if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, false); err != nil {
+			t.Fatal(err)
+		}
+
+		err = r.StagePolicy(testCtx, "", true, false)
+		assert.Nil(t, err)
+		err = r.ApplyPolicy(testCtx, "", true, false)
+		assert.Nil(t, err)
+
+		codes, err := r.InvokeHooksForStage(testCtx, hookStage, rootSigner, hookopts.WithPrePush("origin", remoteTmpDir, []string{"refs/heads/main:refs/heads/main"}))
+		assert.Nil(t, err)
+		assert.Len(t, codes, 1)
 	})
 }

--- a/experimental/gittuf/hook_test.go
+++ b/experimental/gittuf/hook_test.go
@@ -87,7 +87,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 
 		r := &Repository{r: repo}
 
-		_, err := r.InvokeHooksForStage(testCtx, tuf.HookStagePreCommit, nil)
+		_, err := r.InvokeHooksForStage(testCtx, nil, tuf.HookStagePreCommit)
 		assert.ErrorIs(t, err, sslibdsse.ErrNoSigners)
 	})
 
@@ -118,7 +118,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		err = r.ApplyPolicy(testCtx, "", true, false)
 		require.Nil(t, err)
 
-		_, err = r.InvokeHooksForStage(testCtx, hookStage, rootSigner)
+		_, err = r.InvokeHooksForStage(testCtx, rootSigner, hookStage)
 		assert.ErrorIs(t, err, ErrNoHooksFoundForPrincipal)
 	})
 
@@ -146,7 +146,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		err = r.ApplyPolicy(testCtx, "", true, false)
 		require.Nil(t, err)
 
-		codes, err := r.InvokeHooksForStage(testCtx, hookStage, rootSigner)
+		codes, err := r.InvokeHooksForStage(testCtx, rootSigner, hookStage)
 		assert.Nil(t, err)
 		assert.Len(t, codes, 1)
 	})
@@ -192,7 +192,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		err = r.ApplyPolicy(testCtx, "", true, false)
 		assert.Nil(t, err)
 
-		codes, err := r.InvokeHooksForStage(testCtx, hookStage, rootSigner, hookopts.WithPrePush("origin", remoteTmpDir, []string{"refs/heads/main:refs/heads/main"}))
+		codes, err := r.InvokeHooksForStage(testCtx, rootSigner, hookStage, hookopts.WithPrePush("origin", remoteTmpDir, []string{"refs/heads/main:refs/heads/main"}))
 		assert.Nil(t, err)
 		assert.Len(t, codes, 1)
 	})

--- a/experimental/gittuf/options/hooks/hooks.go
+++ b/experimental/gittuf/options/hooks/hooks.go
@@ -1,0 +1,22 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hooks
+
+type Options struct {
+	RemoteName string
+	RemoteURL  string
+	RefSpecs   []string
+}
+
+type Option func(o *Options)
+
+// WithPrePush can be used to specify arguments normally passed to Git pre-push
+// hooks.
+func WithPrePush(remoteName, remoteURL string, refSpecs []string) Option {
+	return func(o *Options) {
+		o.RemoteName = remoteName
+		o.RemoteURL = remoteURL
+		o.RefSpecs = refSpecs
+	}
+}

--- a/experimental/gittuf/options/hooks/hooks.go
+++ b/experimental/gittuf/options/hooks/hooks.go
@@ -3,10 +3,15 @@
 
 package hooks
 
+import (
+	"errors"
+	"fmt"
+)
+
+var ErrRequiredOptionNotSet = errors.New("required option not set")
+
 type Options struct {
-	RemoteName string
-	RemoteURL  string
-	RefSpecs   []string
+	PrePush *PrePushOptions
 }
 
 type Option func(o *Options)
@@ -15,8 +20,32 @@ type Option func(o *Options)
 // hooks.
 func WithPrePush(remoteName, remoteURL string, refSpecs []string) Option {
 	return func(o *Options) {
-		o.RemoteName = remoteName
-		o.RemoteURL = remoteURL
-		o.RefSpecs = refSpecs
+		o.PrePush = &PrePushOptions{
+			RemoteName: remoteName,
+			RemoteURL:  remoteURL,
+			RefSpecs:   refSpecs,
+		}
 	}
+}
+
+type PrePushOptions struct {
+	RemoteName string
+	RemoteURL  string
+	RefSpecs   []string
+}
+
+func (o *PrePushOptions) Validate() error {
+	if o.RemoteName == "" {
+		return fmt.Errorf("%w: 'remoteName'", ErrRequiredOptionNotSet)
+	}
+
+	if o.RemoteURL == "" {
+		return fmt.Errorf("%w: 'remoteURL'", ErrRequiredOptionNotSet)
+	}
+
+	if len(o.RefSpecs) == 0 {
+		return fmt.Errorf("%w: 'refSpecs'", ErrRequiredOptionNotSet)
+	}
+
+	return nil
 }

--- a/internal/luasandbox/options/luasandbox/luasandbox.go
+++ b/internal/luasandbox/options/luasandbox/luasandbox.go
@@ -3,14 +3,14 @@
 
 package luasandbox
 
-type EnivronmentOptions struct {
+type EnvironmentOptions struct {
 	LuaTimeout int
 }
 
-type EnvironmentOption func(*EnivronmentOptions)
+type EnvironmentOption func(*EnvironmentOptions)
 
 func WithLuaTimeout(timeout int) EnvironmentOption {
-	return func(o *EnivronmentOptions) {
+	return func(o *EnvironmentOptions) {
 		o.LuaTimeout = timeout
 	}
 }

--- a/internal/testartifacts/testdata/scripts/hello.lua
+++ b/internal/testartifacts/testdata/scripts/hello.lua
@@ -1,1 +1,2 @@
 print("Hello World!")
+return 0


### PR DESCRIPTION
This PR adds functionality to the gittuf API that enables the invocation of gittuf hooks encoded in the metadata. This is used in gittuf-git to invoke hooks at the proper stage.

~~Blocked by #813.~~
~~Blocked by #839.~~