### PR TITLE
cmd: Fix base URL use for GitHub PR attestation

### DIFF
--- a/internal/cmd/attest/github/pullrequest/pullrequest.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest.go
@@ -82,7 +82,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	opts := []githubopts.Option{githubopts.WithGitHubBaseURL(o.baseBranch)}
+	opts := []githubopts.Option{githubopts.WithGitHubBaseURL(o.baseURL)}
 	if o.p.WithRSLEntry {
 		opts = append(opts, githubopts.WithRSLEntry())
 	}


### PR DESCRIPTION
This fixes a bug with the new gittuf attest github pull-request command.