### PR TITLE
gitinterface: Add support for fetching object size

### DIFF
--- a/internal/gitinterface/object.go
+++ b/internal/gitinterface/object.go
@@ -6,6 +6,7 @@ package gitinterface
 import (
 	"errors"
 	"fmt"
+	"strconv"
 )
 
 type ObjectType uint
@@ -44,4 +45,18 @@ func (r *Repository) GetObjectType(objectID Hash) (ObjectType, error) {
 	default:
 		return 0, ErrInvalidObjectType
 	}
+}
+
+// GetObjectSize returns the size of the object with the specified Git ID.
+func (r *Repository) GetObjectSize(objectID Hash) (uint64, error) {
+	stdOut, err := r.executor("cat-file", "-s", objectID.String()).executeString()
+	if err != nil {
+		return 0, fmt.Errorf("unable to inspect object size: %w", err)
+	}
+
+	objSize, err := strconv.ParseUint(stdOut, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("unable to convert output to integer: %w", err)
+	}
+	return objSize, nil
 }

--- a/internal/gitinterface/object_test.go
+++ b/internal/gitinterface/object_test.go
@@ -99,3 +99,15 @@ func TestGetObjectType(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, TagObjectType, objType)
 }
+
+func TestGetObjectSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tmpDir, false)
+
+	blobID, err := repo.WriteBlob([]byte("gittuf"))
+	require.Nil(t, err)
+
+	objSize, err := repo.GetObjectSize(blobID)
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(6), objSize)
+}


### PR DESCRIPTION
This PR adds functionality to gitinterface to fetch the size of objects from the repository - primarily intended for the API exposed in the Lua sandbox.

~~WIP, possibly adding more functionality.~~