### PR TITLE
tuf: Add propagation directive for policy-staging when adding controller

### DIFF
--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -465,9 +465,16 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	// Add the controller as a repository whose policy contents must be
 	// propagated into this repository
-	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
-	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
+	policyPropagationName := fmt.Sprintf("%s-%s-policy", tuf.GittufControllerPrefix, name)
+	policyPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+
+	policyStagingPropagationName := fmt.Sprintf("%s-%s-policy-staging", tuf.GittufControllerPrefix, name)
+	policyStagingPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+
+	if err := r.AddPropagationDirective(NewPropagationDirective(policyStagingPropagationName, location, "refs/gittuf/policy-staging", "refs/gittuf/policy-staging", policyStagingPropagationLocation)); err != nil {
+		return err
+	}
+	return r.AddPropagationDirective(NewPropagationDirective(policyPropagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", policyPropagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -110,14 +110,17 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: []*Key{key}}}, controllerRepositories)
 
 		propagations := rootMetadata.GetPropagationDirectives()
-		found := false
+		foundPolicy, foundStaging := false, false
 		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test" {
-				found = true
-				break
+			if propagation.GetName() == "gittuf-controller-test-policy" {
+				foundPolicy = true
+			}
+			if propagation.GetName() == "gittuf-controller-test-policy-staging" {
+				foundStaging = true
 			}
 		}
-		assert.True(t, found)
+		assert.True(t, foundPolicy)
+		assert.True(t, foundStaging)
 
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -558,9 +558,16 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	// Add the controller as a repository whose policy contents must be
 	// propagated into this repository
-	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
-	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
+	policyPropagationName := fmt.Sprintf("%s-%s-policy", tuf.GittufControllerPrefix, name)
+	policyPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+
+	policyStagingPropagationName := fmt.Sprintf("%s-%s-policy-staging", tuf.GittufControllerPrefix, name)
+	policyStagingPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+
+	if err := r.AddPropagationDirective(NewPropagationDirective(policyStagingPropagationName, location, "refs/gittuf/policy-staging", "refs/gittuf/policy-staging", policyStagingPropagationLocation)); err != nil {
+		return err
+	}
+	return r.AddPropagationDirective(NewPropagationDirective(policyPropagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", policyPropagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -121,14 +121,17 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: initialRootPrincipals}}, controllerRepositories)
 
 		propagations := rootMetadata.GetPropagationDirectives()
-		found := false
+		foundPolicy, foundStaging := false, false
 		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test" {
-				found = true
-				break
+			if propagation.GetName() == "gittuf-controller-test-policy" {
+				foundPolicy = true
+			}
+			if propagation.GetName() == "gittuf-controller-test-policy-staging" {
+				foundStaging = true
 			}
 		}
-		assert.True(t, found)
+		assert.True(t, foundPolicy)
+		assert.True(t, foundStaging)
 
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)


### PR DESCRIPTION
This PR adds a propagation directive to propagate the `policy-staging` ref from a controller repository, in addition to `policy`.

Related: See #825.