### PR TITLE
policy: Verify controller metadata with upstream

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -436,6 +436,138 @@ func TestStateVerify(t *testing.T) {
 		err := state.Verify(testCtx)
 		assert.Nil(t, err)
 	})
+
+	t.Run("successful verification with multiple repositories", func(t *testing.T) {
+		controllerRepositoryLocation := t.TempDir()
+		networkRepositoryLocation := t.TempDir()
+
+		controllerRepository := gitinterface.CreateTestGitRepository(t, controllerRepositoryLocation, true)
+		controllerState := createTestStateWithGlobalConstraintThreshold(t)
+		controllerState.repository = controllerRepository
+
+		networkRepository := gitinterface.CreateTestGitRepository(t, networkRepositoryLocation, false)
+		networkState := createTestStateWithOnlyRoot(t)
+		networkState.repository = networkRepository
+
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		controllerRootMetadata, err := controllerState.GetRootMetadata(false)
+		require.Nil(t, err)
+		err = controllerRootMetadata.EnableController()
+		require.Nil(t, err)
+		err = controllerRootMetadata.AddNetworkRepository("test", networkRepositoryLocation, []tuf.Principal{tufv01.NewKeyFromSSLibKey(signer.MetadataKey())})
+		require.Nil(t, err)
+		controllerRootEnv, err := dsse.CreateEnvelope(controllerRootMetadata)
+		require.Nil(t, err)
+		controllerRootEnv, err = dsse.SignEnvelope(testCtx, controllerRootEnv, signer)
+		require.Nil(t, err)
+		controllerState.Metadata.RootEnvelope = controllerRootEnv
+		err = controllerState.preprocess()
+		require.Nil(t, err)
+		err = controllerState.Commit(controllerRepository, "Initial policy\n", true, false)
+		require.Nil(t, err)
+		err = Apply(testCtx, controllerRepository, false)
+		require.Nil(t, err)
+		latestControllerEntry, err := rsl.GetLatestEntry(controllerRepository)
+		require.Nil(t, err)
+		controllerState.loadedEntry = latestControllerEntry.(rsl.ReferenceUpdaterEntry)
+
+		networkRootMetadata, err := networkState.GetRootMetadata(false)
+		require.Nil(t, err)
+		err = networkRootMetadata.AddControllerRepository("controller", controllerRepositoryLocation, []tuf.Principal{tufv01.NewKeyFromSSLibKey(signer.MetadataKey())})
+		require.Nil(t, err)
+		networkRootEnv, err := dsse.CreateEnvelope(networkRootMetadata)
+		require.Nil(t, err)
+		networkRootEnv, err = dsse.SignEnvelope(testCtx, networkRootEnv, signer)
+		require.Nil(t, err)
+		networkState.Metadata.RootEnvelope = networkRootEnv
+		err = networkState.preprocess()
+		require.Nil(t, err)
+		err = networkState.Commit(networkRepository, "Initial policy\n", true, false)
+		require.Nil(t, err)
+		err = Apply(testCtx, networkRepository, false)
+		require.Nil(t, err)
+		latestNetworkEntry, err := rsl.GetLatestEntry(networkRepository)
+		require.Nil(t, err)
+		networkState.loadedEntry = latestNetworkEntry.(rsl.ReferenceUpdaterEntry)
+
+		err = rsl.PropagateChangesFromUpstreamRepository(networkRepository, controllerRepository, networkRootMetadata.GetPropagationDirectives(), false)
+		require.Nil(t, err)
+
+		latestEntry, err := rsl.GetLatestEntry(networkRepository)
+		require.Nil(t, err)
+		state, err := loadStateForEntry(networkRepository, latestEntry.(rsl.ReferenceUpdaterEntry))
+		require.Nil(t, err)
+
+		err = state.Verify(testCtx)
+		assert.Nil(t, err)
+	})
+
+	t.Run("unsuccessful verification with multiple repositories due to mismatched keys", func(t *testing.T) {
+		controllerRepositoryLocation := t.TempDir()
+		networkRepositoryLocation := t.TempDir()
+
+		controllerRepository := gitinterface.CreateTestGitRepository(t, controllerRepositoryLocation, true)
+		controllerState := createTestStateWithGlobalConstraintThreshold(t)
+		controllerState.repository = controllerRepository
+
+		networkRepository := gitinterface.CreateTestGitRepository(t, networkRepositoryLocation, false)
+		networkState := createTestStateWithOnlyRoot(t)
+		networkState.repository = networkRepository
+
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		controllerRootMetadata, err := controllerState.GetRootMetadata(false)
+		require.Nil(t, err)
+		err = controllerRootMetadata.EnableController()
+		require.Nil(t, err)
+		err = controllerRootMetadata.AddNetworkRepository("test", networkRepositoryLocation, []tuf.Principal{tufv01.NewKeyFromSSLibKey(signer.MetadataKey())})
+		require.Nil(t, err)
+		controllerRootEnv, err := dsse.CreateEnvelope(controllerRootMetadata)
+		require.Nil(t, err)
+		controllerRootEnv, err = dsse.SignEnvelope(testCtx, controllerRootEnv, signer)
+		require.Nil(t, err)
+		controllerState.Metadata.RootEnvelope = controllerRootEnv
+		err = controllerState.preprocess()
+		require.Nil(t, err)
+		err = controllerState.Commit(controllerRepository, "Initial policy\n", true, false)
+		require.Nil(t, err)
+		err = Apply(testCtx, controllerRepository, false)
+		require.Nil(t, err)
+		latestControllerEntry, err := rsl.GetLatestEntry(controllerRepository)
+		require.Nil(t, err)
+		controllerState.loadedEntry = latestControllerEntry.(rsl.ReferenceUpdaterEntry)
+
+		networkRootMetadata, err := networkState.GetRootMetadata(false)
+		require.Nil(t, err)
+		err = networkRootMetadata.AddControllerRepository("controller", controllerRepositoryLocation, []tuf.Principal{tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))})
+		require.Nil(t, err)
+		networkRootEnv, err := dsse.CreateEnvelope(networkRootMetadata)
+		require.Nil(t, err)
+		networkRootEnv, err = dsse.SignEnvelope(testCtx, networkRootEnv, signer)
+		require.Nil(t, err)
+		networkState.Metadata.RootEnvelope = networkRootEnv
+		err = networkState.preprocess()
+		require.Nil(t, err)
+		err = networkState.Commit(networkRepository, "Initial policy\n", true, false)
+		require.Nil(t, err)
+		err = Apply(testCtx, networkRepository, false)
+		require.Nil(t, err)
+		latestNetworkEntry, err := rsl.GetLatestEntry(networkRepository)
+		require.Nil(t, err)
+		networkState.loadedEntry = latestNetworkEntry.(rsl.ReferenceUpdaterEntry)
+
+		err = rsl.PropagateChangesFromUpstreamRepository(networkRepository, controllerRepository, networkRootMetadata.GetPropagationDirectives(), false)
+		require.Nil(t, err)
+
+		latestEntry, err := rsl.GetLatestEntry(networkRepository)
+		require.Nil(t, err)
+		state, err := loadStateForEntry(networkRepository, latestEntry.(rsl.ReferenceUpdaterEntry))
+		require.Nil(t, err)
+
+		err = state.Verify(testCtx)
+		assert.ErrorIs(t, err, ErrControllerMetadataNotVerified)
+	})
 }
 
 func TestStateCommit(t *testing.T) {


### PR DESCRIPTION
This adds controller metadata verification to state.Verify.