### PR TITLE
signerverifier: Avoid race condition in test key cleanup

### DIFF
--- a/internal/signerverifier/ssh/ssh.go
+++ b/internal/signerverifier/ssh/ssh.go
@@ -120,7 +120,7 @@ func NewKeyFromBytes(t *testing.T, keyB []byte) *signerverifier.SSLibKey {
 	testName = strings.ReplaceAll(testName, "\\", "__")
 	hash := sha256.Sum256(keyB)
 	keyName := fmt.Sprintf("%s-%s", testName, hex.EncodeToString(hash[:]))
-	keyPath := filepath.Join(os.TempDir(), keyName)
+	keyPath := filepath.Join(t.TempDir(), keyName)
 
 	if err := os.WriteFile(keyPath, keyB, 0o600); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Possible fix for test race condition.