### PR TITLE
[WIP] attestations: Add hook attestations

### DIFF
--- a/experimental/gittuf/hook.go
+++ b/experimental/gittuf/hook.go
@@ -4,12 +4,20 @@
 package gittuf
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
+
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/gittuf/gittuf/internal/luasandbox"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	"github.com/gittuf/gittuf/internal/tuf"
 )
 
 type ErrHookExists struct {
@@ -22,7 +30,96 @@ func (e *ErrHookExists) Error() string {
 
 type HookType string
 
+var (
+	ErrNoHooksFoundForPrincipal = errors.New("no hooks found for the specified principal")
+)
+
 var HookPrePush = HookType("pre-push")
+
+// InvokeHook runs the hooks defined in the specified stage for the user defined
+// by the supplied signer. A check is performed that the user holds the private
+// key necessary for signing, to support the generation of attestations. Upon
+// successful completion of all hooks for the stage for the user, the map of
+// hook names to exit codes is returned.
+func (r *Repository) InvokeHook(ctx context.Context, stage tuf.HookStage, signer sslibdsse.Signer, targetsRoleName string, attest bool, parameters ...string) (map[string]int, error) {
+	keyID, err := signer.KeyID()
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyStagingRef)
+	if err != nil {
+		return nil, err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return nil, err
+	}
+	targetsMetadata, err := state.GetTargetsMetadata(targetsRoleName, false)
+	if err != nil {
+		return nil, err
+	}
+
+	allHooks, err := rootMetadata.GetHooks(stage)
+	if err != nil {
+		return nil, err
+	}
+
+	if attest {
+		// This is to check if we can sign an attestation
+		env, err := dsse.CreateEnvelope(rootMetadata) // nolint:ineffassign
+		if err != nil {
+			return nil, err
+		}
+		_, err = dsse.SignEnvelope(ctx, env, signer) // nolint:ineffassign,staticcheck
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var selectedHooks []tuf.Hook
+	var selectedPrincipal tuf.Principal
+	var found bool
+
+	// Read the principals from targetsMetadata and attempt to find a match for
+	// the specified principal to determine which hooks to run.
+	for _, principal := range targetsMetadata.GetPrincipals() {
+		// Attempt to match a key for the specified principal
+		for _, key := range principal.Keys() {
+			if key.KeyID == keyID {
+				selectedPrincipal = principal
+				break
+			}
+		}
+	}
+
+	// Couldn't match the key up to a principal, abort
+	if !found {
+		return nil, tuf.ErrPrincipalNotFound
+	}
+
+	// Now, read all hooks for the specified stage and find which ones we need
+	// to run
+	for _, hook := range allHooks {
+		principalIDs := hook.GetPrincipalIDs()
+		if principalIDs.Has(selectedPrincipal.ID()) {
+			selectedHooks = append(selectedHooks, hook)
+		}
+	}
+
+	exitCodes := make(map[string]int, len(selectedHooks))
+	for _, hook := range selectedHooks {
+		exitCode, err := r.executeHook(ctx, hook, parameters...)
+		if err != nil {
+			return nil, err
+		}
+		exitCodes[hook.ID()] = exitCode // nolint:staticcheck
+	}
+
+	return exitCodes, nil
+}
 
 // UpdateHook updates a git hook in the repository's .git/hooks folder.
 // Existing hook files are not overwritten, unless force flag is set.
@@ -69,4 +166,34 @@ func doesFileExist(path string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func (r *Repository) executeHook(ctx context.Context, hook tuf.Hook, parameters ...string) (int, error) {
+	var hookContents string
+	hookHashes := hook.GetHashes()
+
+	environment, err := luasandbox.NewLuaEnvironment(ctx, r.r)
+	if err != nil {
+		return -1, err
+	}
+	defer environment.Cleanup()
+
+	// Load the hook contents from the repository
+	hookHash, err := gitinterface.NewHash(hookHashes[gitinterface.GitBlobHashName])
+	if err != nil {
+		return -1, err
+	}
+	hookFileContents, err := r.r.ReadBlob(hookHash)
+	if err != nil {
+		return -1, err
+	}
+
+	hookContents = string(hookFileContents)
+
+	exitCode, err := environment.RunScript(hookContents, parameters...)
+	if err != nil {
+		return -1, err
+	}
+
+	return exitCode, nil
 }

--- a/internal/attestations/hooks.go
+++ b/internal/attestations/hooks.go
@@ -1,0 +1,38 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import (
+	"encoding/json"
+	"github.com/gittuf/gittuf/internal/tuf"
+
+	hooksv01 "github.com/gittuf/gittuf/internal/attestations/hooks/v01"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+	ita "github.com/in-toto/attestation/go/v1"
+)
+
+// NewHookExecutionAttestation creates a new
+func NewHookExecutionAttestation(targetRef, targetID, policyEntry string, stage tuf.HookStage, hookNames []string, executor string) (*ita.Statement, error) {
+	return hooksv01.NewHookExecutionAttestationForStage(targetRef, targetID, policyEntry, stage, hookNames, executor)
+}
+
+func (a *Attestations) SetHookExecutionAttestation(repo *gitinterface.Repository, env *sslibdsse.Envelope, stage string) error {
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+
+	blobID, err := repo.WriteBlob(envBytes)
+	if err != nil {
+		return err
+	}
+
+	if a.hookExecutionAttestations == nil {
+		a.hookExecutionAttestations = map[string]gitinterface.Hash{}
+	}
+	a.hookExecutionAttestations[stage] = blobID
+
+	return nil
+}

--- a/internal/attestations/hooks/hooks.go
+++ b/internal/attestations/hooks/hooks.go
@@ -1,0 +1,37 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package hooks
+
+import (
+	"errors"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+var (
+	ErrInvalidHookExecutionAttestation = errors.New("hook execution attestation does not match expected details")
+)
+
+// HookExecutionAttestation records the results of hook execution, and
+type HookExecutionAttestation interface {
+	// GetTargetRef returns the name of the reference on which the hooks were
+	// run.
+	GetTargetRef() string
+
+	// GetTargetID returns the Git ID of the reference on which the hooks were
+	// run.
+	GetTargetID() string
+
+	// GetPolicyEntry returns the GitID of the policy entry from which the
+	// hooks were loaded from.
+	GetPolicyEntry() string
+
+	// GetHookStage returns the name of the stage on which the hooks were run.
+	GetHookStage() tuf.HookStage
+
+	// GetHooks returns the names of the hooks which were run successfully.
+	GetHooks() []string
+
+	// GetHookRunner returns the ID of the principal who ran the hook.
+	GetHookRunner() string
+}

--- a/internal/attestations/hooks/v01/v01.go
+++ b/internal/attestations/hooks/v01/v01.go
@@ -1,0 +1,82 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"github.com/gittuf/gittuf/internal/attestations/common"
+	"github.com/gittuf/gittuf/internal/tuf"
+	ita "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const (
+	PredicateType = "https://gittuf.dev/hook-execution/v0.1"
+
+	digestGitTreeKey = "gitTree"
+)
+
+type HookExecutionAttestation struct {
+	TargetRef   string   `json:"targetRef"`
+	TargetID    string   `json:"targetID"`
+	PolicyEntry string   `json:"policyEntry"`
+	Stage       string   `json:"hookStage"`
+	HookNames   []string `json:"hooks"`
+	Runner      string   `json:"principalID"`
+}
+
+func (ha *HookExecutionAttestation) GetTargetRef() string {
+	return ha.TargetRef
+}
+
+func (ha *HookExecutionAttestation) GetPolicyEntry() string {
+	return ha.PolicyEntry
+}
+
+func (ha *HookExecutionAttestation) GetHookStage() string {
+	return ha.Stage
+}
+
+func (ha *HookExecutionAttestation) GetHooks() []string {
+	return ha.HookNames
+}
+
+func (ha *HookExecutionAttestation) GetHookRunner() string {
+	return ha.Runner
+}
+
+// NewHookExecutionAttestationForStage creates a new hook execution attestation
+// for the provided information. The attestation is embedded in an in in-toto
+// "statement" and returned with the appropriate "predicate type" set. The
+// `targetRef` specifies which branch was currently in use when running the
+// hooks, while the `policyEntry` specifies which policy entry the hooks were
+// loaded from.
+func NewHookExecutionAttestationForStage(targetRef, targetID, policyEntry string, stage tuf.HookStage, hookNames []string, executor string) (*ita.Statement, error) {
+	predicateStruct, err := newHookExecutionAttestationStruct(targetRef, targetID, policyEntry, stage, hookNames, executor)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ita.Statement{
+		Type: ita.StatementTypeUri,
+		Subject: []*ita.ResourceDescriptor{
+			{
+				Digest: map[string]string{digestGitTreeKey: targetRef},
+			},
+		},
+		PredicateType: PredicateType,
+		Predicate:     predicateStruct,
+	}, nil
+}
+
+func newHookExecutionAttestationStruct(targetRef, targetID, policyEntry string, stage tuf.HookStage, hookNames []string, executor string) (*structpb.Struct, error) {
+	predicate := &HookExecutionAttestation{
+		TargetRef:   targetRef,
+		TargetID:    targetID,
+		PolicyEntry: policyEntry,
+		Stage:       stage.String(),
+		HookNames:   hookNames,
+		Runner:      executor,
+	}
+	return common.PredicateToPBStruct(predicate)
+}

--- a/internal/attestations/hooks/v01/v01_test.go
+++ b/internal/attestations/hooks/v01/v01_test.go
@@ -1,0 +1,4 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01

--- a/internal/attestations/hooks_test.go
+++ b/internal/attestations/hooks_test.go
@@ -1,0 +1,10 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attestations
+
+import "testing"
+
+func TestSetHookExecutionAttestation(t *testing.T) {
+
+}

--- a/internal/luasandbox/luasandbox.go
+++ b/internal/luasandbox/luasandbox.go
@@ -81,6 +81,24 @@ func NewLuaEnvironment(ctx context.Context, repository *gitinterface.Repository)
 	return environment, nil
 }
 
+// RunScript runs the specified script in the given Lua environment, and returns
+// the result of running the script. Parameters are provided as strings.
+func (l *LuaEnvironment) RunScript(script string, parameters ...string) (int, error) {
+	for _, parameter := range parameters {
+		l.lState.Push(lua.LString(parameter))
+	}
+
+	err := l.lState.DoString(script)
+	if err != nil {
+		return -1, err
+	}
+
+	exitCode := l.lState.Get(-1)
+	l.lState.Pop(1)
+
+	return int(exitCode.(lua.LNumber)), err
+}
+
 func (l *LuaEnvironment) GetAPIs() []API {
 	return l.allAPIs
 }


### PR DESCRIPTION
This PR adds an attestation type for attesting to hook execution, as well as integrates it into the hook invocation workflow, such that a new attestation is created whenever a set of hooks is invoked.

This PR should be the final part of the hooks effort, minus any bug fixes or other changes.

WIP.