### PR TITLE
ci: Update various actions

### DIFF
--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Build gittuf
       run: make just-install
     - name: Test Getting Started

--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -3,15 +3,30 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "docs/*"
+      - "**.md"
   pull_request:
     branches:
       - main
+    path-ignore:
+      - "docs/*"
+      - "**.md"
 permissions: read-all
 jobs:
   demo:
     name: Run demo 
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: Build gittuf
+        run: make just-install
       - name: Checkout demo repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -20,7 +35,5 @@ jobs:
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:
           python-version: '3.12'
-      - name: Install gittuf-installer
-        uses: gittuf/gittuf-installer@f6589511b7fb806ce365de81caa949b5c468089a
       - name: Run demo script
         run: python run-demo.py --no-prompt


### PR DESCRIPTION
This PR addresses various nits in some of our GitHub actions.

Specifically:

- The `python-version` in `get-started-tests.yml` has been bumped to `3.12` from `3.10`.
- `run-demo.yml` no longer runs on changes to markdown or other document files
- `run-demo.yml` now builds gittuf from the PR instead of using the version provided by `gittuf-installer.yml`