### PR TITLE
Revert "tuf: Add propagation directive for policy-staging when adding controller"

### DIFF
--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -528,16 +528,9 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	// Add the controller as a repository whose policy contents must be
 	// propagated into this repository
-	policyPropagationName := fmt.Sprintf("%s-%s-policy", tuf.GittufControllerPrefix, name)
-	policyPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-
-	policyStagingPropagationName := fmt.Sprintf("%s-%s-policy-staging", tuf.GittufControllerPrefix, name)
-	policyStagingPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-
-	if err := r.AddPropagationDirective(NewPropagationDirective(policyStagingPropagationName, location, "refs/gittuf/policy-staging", "refs/gittuf/policy-staging", policyStagingPropagationLocation)); err != nil {
-		return err
-	}
-	return r.AddPropagationDirective(NewPropagationDirective(policyPropagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", policyPropagationLocation))
+	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
+	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -111,17 +111,14 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: []*Key{key}}}, controllerRepositories)
 
 		propagations := rootMetadata.GetPropagationDirectives()
-		foundPolicy, foundStaging := false, false
+		found := false
 		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test-policy" {
-				foundPolicy = true
-			}
-			if propagation.GetName() == "gittuf-controller-test-policy-staging" {
-				foundStaging = true
+			if propagation.GetName() == "gittuf-controller-test" {
+				found = true
+				break
 			}
 		}
-		assert.True(t, foundPolicy)
-		assert.True(t, foundStaging)
+		assert.True(t, found)
 
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -632,16 +632,9 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	// Add the controller as a repository whose policy contents must be
 	// propagated into this repository
-	policyPropagationName := fmt.Sprintf("%s-%s-policy", tuf.GittufControllerPrefix, name)
-	policyPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-
-	policyStagingPropagationName := fmt.Sprintf("%s-%s-policy-staging", tuf.GittufControllerPrefix, name)
-	policyStagingPropagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-
-	if err := r.AddPropagationDirective(NewPropagationDirective(policyStagingPropagationName, location, "refs/gittuf/policy-staging", "refs/gittuf/policy-staging", policyStagingPropagationLocation)); err != nil {
-		return err
-	}
-	return r.AddPropagationDirective(NewPropagationDirective(policyPropagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", policyPropagationLocation))
+	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
+	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
+	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -143,17 +143,14 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: initialRootPrincipals}}, controllerRepositories)
 
 		propagations := rootMetadata.GetPropagationDirectives()
-		foundPolicy, foundStaging := false, false
+		found := false
 		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test-policy" {
-				foundPolicy = true
-			}
-			if propagation.GetName() == "gittuf-controller-test-policy-staging" {
-				foundStaging = true
+			if propagation.GetName() == "gittuf-controller-test" {
+				found = true
+				break
 			}
 		}
-		assert.True(t, foundPolicy)
-		assert.True(t, foundStaging)
+		assert.True(t, found)
 
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)


### PR DESCRIPTION
Reverts gittuf/gittuf#882, in favor of the policy reconciliation workflow: #825.