### PR TITLE
*: Organize various list functions

### DIFF
--- a/docs/cli/gittuf_trust_list-global-rules.md
+++ b/docs/cli/gittuf_trust_list-global-rules.md
@@ -9,7 +9,8 @@ gittuf trust list-global-rules [flags]
 ### Options
 
 ```
-  -h, --help   help for list-global-rules
+  -h, --help                help for list-global-rules
+      --target-ref string   specify which policy ref should be inspected (default "policy")
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust_list-hooks.md
+++ b/docs/cli/gittuf_trust_list-hooks.md
@@ -9,7 +9,8 @@ gittuf trust list-hooks [flags]
 ### Options
 
 ```
-  -h, --help   help for list-hooks
+  -h, --help                help for list-hooks
+      --target-ref string   specify which policy ref should be inspected (default "policy")
 ```
 
 ### Options inherited from parent commands

--- a/experimental/gittuf/policy.go
+++ b/experimental/gittuf/policy.go
@@ -183,8 +183,33 @@ func (r *Repository) ListPrincipals(ctx context.Context, targetRef, policyName s
 	return metadata.GetPrincipals(), nil
 }
 
-func (r *Repository) ListHooks(ctx context.Context) (map[tuf.HookStage][]tuf.Hook, error) {
-	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyRef)
+// ListGlobalRules returns a list of all global rules as an array of tuf.GlobalRules.
+func (r *Repository) ListGlobalRules(ctx context.Context, targetRef string) ([]tuf.GlobalRule, error) {
+	if !strings.HasPrefix(targetRef, "refs/gittuf/") {
+		targetRef = "refs/gittuf/" + targetRef
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, targetRef)
+	if err != nil {
+		return nil, err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return rootMetadata.GetGlobalRules(), nil
+}
+
+func (r *Repository) ListHooks(ctx context.Context, targetRef string) (map[tuf.HookStage][]tuf.Hook, error) {
+	if !strings.HasPrefix(targetRef, "refs/gittuf/") {
+		targetRef = "refs/gittuf/" + targetRef
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, targetRef)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -1262,19 +1262,3 @@ func (r *Repository) updateRootMetadata(ctx context.Context, state *policy.State
 	slog.Debug("Committing policy...")
 	return state.Commit(r.r, commitMessage, createRSLEntry, signCommit)
 }
-
-// ListGlobalRules returns a list of all global rules as an array of tuf.GlobalRules.
-func (r *Repository) ListGlobalRules(ctx context.Context) ([]tuf.GlobalRule, error) {
-	slog.Debug("Loading current policy...")
-	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyStagingRef)
-	if err != nil {
-		return nil, err
-	}
-
-	rootMetadata, err := state.GetRootMetadata(false)
-	if err != nil {
-		return nil, err
-	}
-
-	return rootMetadata.GetGlobalRules(), nil
-}

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -1198,14 +1198,14 @@ func TestListGlobalRules(t *testing.T) {
 		err := r.AddGlobalRuleThreshold(testCtx, rootSigner, "require-approval-for-main", []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry())
 		assert.Nil(t, err)
 
-		globalRules, err := r.ListGlobalRules(testCtx)
+		globalRules, err := r.ListGlobalRules(testCtx, policy.PolicyStagingRef)
 		assert.Nil(t, err)
 		assert.Len(t, globalRules, 1)
 
 		err = r.RemoveGlobalRule(testCtx, rootSigner, "require-approval-for-main", false, trustpolicyopts.WithRSLEntry())
 		assert.Nil(t, err)
 
-		globalRules, err = r.ListGlobalRules(testCtx)
+		globalRules, err = r.ListGlobalRules(testCtx, policy.PolicyStagingRef)
 		assert.Nil(t, err)
 		assert.Empty(t, globalRules)
 	})

--- a/internal/cmd/trust/listglobalrules/listglobalrules.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules.go
@@ -14,9 +14,18 @@ import (
 
 const indentString = "    "
 
-type options struct{}
+type options struct {
+	targetRef string
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.targetRef,
+		"target-ref",
+		"policy",
+		"specify which policy ref should be inspected",
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository()
@@ -24,7 +33,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	rules, err := repo.ListGlobalRules(cmd.Context())
+	rules, err := repo.ListGlobalRules(cmd.Context(), o.targetRef)
 	if len(rules) == 0 {
 		fmt.Println("No global rules are currently defined.")
 	}

--- a/internal/cmd/trust/listhooks/listhooks.go
+++ b/internal/cmd/trust/listhooks/listhooks.go
@@ -14,7 +14,18 @@ import (
 
 const indentString = "    "
 
-type options struct{}
+type options struct {
+	targetRef string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.targetRef,
+		"target-ref",
+		"policy",
+		"specify which policy ref should be inspected",
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository()
@@ -22,7 +33,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	hookStages, err := repo.ListHooks(cmd.Context())
+	hookStages, err := repo.ListHooks(cmd.Context(), o.targetRef)
 	if err != nil {
 		return err
 	}
@@ -66,6 +77,7 @@ func New() *cobra.Command {
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}
+	o.AddFlags(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
This PR addresses various nits in the `ListGlobalRules` and `ListHooks` functions (e.g. move to `experimental/gittuf/policy.go` and support passing in the policy ref to inspect).