### PR TITLE
*: Remove hook modules field and add timeout

### DIFF
--- a/docs/cli/gittuf_trust_add-hook.md
+++ b/docs/cli/gittuf_trust_add-hook.md
@@ -19,8 +19,8 @@ gittuf trust add-hook [flags]
   -n, --hook-name string           Name of the hook
       --is-pre-commit              add the hook to the pre-commit stage
       --is-pre-push                add the hook to the pre-push stage
-      --modules stringArray        modules which the Lua hook must run
       --principal-ID stringArray   principal IDs which must run this hook
+      --timeout int                timeout for hook execution (default 100)
 ```
 
 ### Options inherited from parent commands

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -1435,7 +1435,7 @@ func TestAddHook(t *testing.T) {
 		hookStage := tuf.HookStagePreCommit
 		hookName := "test-hook"
 		environment := tuf.HookEnvironmentLua
-		modules := []string{}
+		timeout := 100
 		principals := []string{rootPubKey.KeyID}
 
 		hookHash, err := r.r.WriteBlob(hookBytes)
@@ -1457,7 +1457,7 @@ func TestAddHook(t *testing.T) {
 		_, err = rootMetadata.GetHooks(tuf.HookStagePreCommit)
 		assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-		err = r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, modules, principals, true, trustpolicyopts.WithRSLEntry())
+		err = r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, true, trustpolicyopts.WithRSLEntry())
 		assert.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1478,7 +1478,7 @@ func TestAddHook(t *testing.T) {
 			PrincipalIDs: set.NewSetFromItems(rootPubKey.KeyID),
 			Hashes:       map[string]string{gitinterface.GitBlobHashName: hookHash.String(), gitinterface.SHA256HashName: sha256HashSum},
 			Environment:  tuf.HookEnvironmentLua,
-			Modules:      []string{},
+			Timeout:      100,
 		}
 		preCommitHooks := []tuf.Hook{&preCommitHook}
 		assert.Equal(t, preCommitHooks, hooks)
@@ -1490,7 +1490,7 @@ func TestAddHook(t *testing.T) {
 		hookStage := tuf.HookStagePrePush
 		hookName := "test-hook"
 		environment := tuf.HookEnvironmentLua
-		modules := []string{}
+		timeout := 100
 		principals := []string{rootPubKey.KeyID}
 
 		hookHash, err := r.r.WriteBlob(hookBytes)
@@ -1512,7 +1512,7 @@ func TestAddHook(t *testing.T) {
 		_, err = rootMetadata.GetHooks(tuf.HookStagePrePush)
 		assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-		err = r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, modules, principals, true, trustpolicyopts.WithRSLEntry())
+		err = r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, true, trustpolicyopts.WithRSLEntry())
 		assert.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1532,7 +1532,7 @@ func TestAddHook(t *testing.T) {
 			PrincipalIDs: set.NewSetFromItems(rootPubKey.KeyID),
 			Hashes:       map[string]string{gitinterface.GitBlobHashName: hookHash.String(), gitinterface.SHA256HashName: sha256HashSum},
 			Environment:  tuf.HookEnvironmentLua,
-			Modules:      []string{},
+			Timeout:      100,
 		}
 		preCommitHooks := []tuf.Hook{&preCommitHook}
 		assert.Equal(t, preCommitHooks, hooks)
@@ -1551,7 +1551,7 @@ func TestRemoveHook(t *testing.T) {
 		hookStage := tuf.HookStagePreCommit
 		hookName := "test-hook"
 		environment := tuf.HookEnvironmentLua
-		modules := []string{}
+		timeout := 100
 		principals := []string{rootPubKey.KeyID}
 
 		state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
@@ -1570,7 +1570,7 @@ func TestRemoveHook(t *testing.T) {
 		assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
 		// Add hook
-		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, modules, principals, true, trustpolicyopts.WithRSLEntry()); err != nil {
+		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, true, trustpolicyopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1612,7 +1612,7 @@ func TestRemoveHook(t *testing.T) {
 		hookStage := tuf.HookStagePrePush
 		hookName := "test-hook"
 		environment := tuf.HookEnvironmentLua
-		modules := []string{}
+		timeout := 100
 		principals := []string{rootPubKey.KeyID}
 
 		state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
@@ -1631,7 +1631,7 @@ func TestRemoveHook(t *testing.T) {
 		assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
 		// Add hook
-		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, modules, principals, true, trustpolicyopts.WithRSLEntry()); err != nil {
+		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, true, trustpolicyopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
 		err = r.StagePolicy(testCtx, "", true, false)

--- a/internal/cmd/trust/listhooks/listhooks.go
+++ b/internal/cmd/trust/listhooks/listhooks.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
 
@@ -56,12 +55,8 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 			fmt.Printf(strings.Repeat(indentString, 2) + "Environment:\n")
 			fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", hook.GetEnvironment().String())
 
-			if hook.GetEnvironment() == tuf.HookEnvironmentLua {
-				fmt.Printf(strings.Repeat(indentString, 2) + "Lua modules:\n")
-				for _, module := range hook.GetModules() {
-					fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", module)
-				}
-			}
+			fmt.Printf(strings.Repeat(indentString, 2) + "Timeout:\n")
+			fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", hook.GetTimeout())
 		}
 		fmt.Println()
 	}

--- a/internal/luasandbox/options/luasandbox/luasandbox.go
+++ b/internal/luasandbox/options/luasandbox/luasandbox.go
@@ -1,0 +1,16 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package luasandbox
+
+type EnivronmentOptions struct {
+	LuaTimeout int
+}
+
+type EnvironmentOption func(*EnivronmentOptions)
+
+func WithLuaTimeout(timeout int) EnvironmentOption {
+	return func(o *EnivronmentOptions) {
+		o.LuaTimeout = timeout
+	}
+}

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -204,9 +204,9 @@ type RootMetadata interface {
 	// AddHook adds to the metadata for the specified Git stage a hook named
 	// hookName to be run by the specified principals. For support of more than
 	// one hashing algorithm, providing multiple hashes is supported. The hook's
-	// environment (e.g. lua) and modules to expose to the hook (if using Lua)
-	// are also required.
-	AddHook(stages []HookStage, hookName string, principalIDs []string, hashes map[string]string, environment HookEnvironment, modules []string) (Hook, error)
+	// environment (e.g. lua) and maximum allowable running time in seconds are
+	// also required.
+	AddHook(stages []HookStage, hookName string, principalIDs []string, hashes map[string]string, environment HookEnvironment, timeout int) (Hook, error)
 	// RemoveHook removes the hook identified by hookName in the specified Git
 	// stage.
 	RemoveHook(stages []HookStage, hookName string) error
@@ -519,6 +519,6 @@ type Hook interface {
 	// GetEnvironment returns the environment that the hook is to run in.
 	GetEnvironment() HookEnvironment
 
-	// GetModules returns the lua modules to load in, only for lua-based hooks.
-	GetModules() []string
+	// GetTimeout returns the maximum duration the hook can run for, in seconds.
+	GetTimeout() int
 }

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -878,7 +878,7 @@ func (o *OtherRepository) GetInitialRootPrincipals() []tuf.Principal {
 }
 
 // AddHook adds the specified hook to the metadata.
-func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, modules []string) (tuf.Hook, error) {
+func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, timeout int) (tuf.Hook, error) {
 	// TODO: Check if principal exists in RootMetadata/TargetsMetadata
 
 	newHook := &Hook{
@@ -886,7 +886,7 @@ func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principa
 		PrincipalIDs: set.NewSetFromItems(principalIDs...),
 		Hashes:       hashes,
 		Environment:  environment,
-		Modules:      modules,
+		Timeout:      timeout,
 	}
 
 	if r.Hooks == nil {
@@ -953,7 +953,7 @@ type Hook struct {
 	PrincipalIDs *set.Set[string]    `json:"principals"`
 	Hashes       map[string]string   `json:"hashes"`
 	Environment  tuf.HookEnvironment `json:"environment"`
-	Modules      []string            `json:"modules"`
+	Timeout      int                 `json:"timeout"`
 }
 
 // ID returns the identifier of the hook, its name.
@@ -981,7 +981,7 @@ func (h *Hook) GetEnvironment() tuf.HookEnvironment {
 	return h.Environment
 }
 
-// GetModules returns the Lua modules that the hook will have access to.
-func (h *Hook) GetModules() []string {
-	return h.Modules
+// GetTimeout returns the maximum duration the hook can run for, in seconds.
+func (h *Hook) GetTimeout() int {
+	return h.Timeout
 }

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -685,7 +685,7 @@ func TestHook(t *testing.T) {
 		PrincipalIDs: set.NewSetFromItems(key.KeyID),
 		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
 		Environment:  tuf.HookEnvironmentLua,
-		Modules:      []string{},
+		Timeout:      100,
 	}
 
 	t.Run("ID", func(t *testing.T) {
@@ -705,8 +705,8 @@ func TestHook(t *testing.T) {
 		assert.Equal(t, tuf.HookEnvironmentLua, hook.GetEnvironment())
 	})
 
-	t.Run("GetModules", func(t *testing.T) {
-		assert.Equal(t, []string{}, hook.GetModules())
+	t.Run("GetTimeout", func(t *testing.T) {
+		assert.Equal(t, 100, hook.GetTimeout())
 	})
 }
 
@@ -721,16 +721,16 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	_, err := rootMetadata.GetHooks(tuf.HookStagePreCommit)
 	assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrDuplicatedHookName)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrInvalidHookStage)
 
 	preCommitHook := []*Hook{{
@@ -738,7 +738,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
 		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
 		Environment:  tuf.HookEnvironmentLua,
-		Modules:      []string{},
+		Timeout:      100,
 	}}
 	assert.Equal(t, preCommitHook, rootMetadata.Hooks[tuf.HookStagePreCommit])
 
@@ -747,7 +747,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
 		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
 		Environment:  tuf.HookEnvironmentLua,
-		Modules:      []string{},
+		Timeout:      100,
 	}}
 	assert.Equal(t, prePushHook, rootMetadata.Hooks[tuf.HookStagePrePush])
 
@@ -765,11 +765,11 @@ func TestRemoveHook(t *testing.T) {
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	_, err := rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err := rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePrePush]))
 

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -876,7 +876,7 @@ func (o *OtherRepository) UnmarshalJSON(data []byte) error {
 type Hook = tufv01.Hook
 
 // AddHook adds the specified hook to the metadata.
-func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, modules []string) (tuf.Hook, error) {
+func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, timeout int) (tuf.Hook, error) {
 	// TODO: Check if principal exists in RootMetadata/TargetsMetadata
 
 	newHook := &Hook{
@@ -884,7 +884,7 @@ func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principa
 		PrincipalIDs: set.NewSetFromItems(principalIDs...),
 		Hashes:       hashes,
 		Environment:  environment,
-		Modules:      modules,
+		Timeout:      timeout,
 	}
 
 	if r.Hooks == nil {

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -727,16 +727,16 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	_, err := rootMetadata.GetHooks(tuf.HookStagePreCommit)
 	assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrDuplicatedHookName)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrInvalidHookStage)
 
 	preCommitHook := []*Hook{{
@@ -744,7 +744,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
 		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
 		Environment:  tuf.HookEnvironmentLua,
-		Modules:      []string{},
+		Timeout:      100,
 	}}
 	assert.Equal(t, preCommitHook, rootMetadata.Hooks[tuf.HookStagePreCommit])
 
@@ -753,7 +753,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
 		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
 		Environment:  tuf.HookEnvironmentLua,
-		Modules:      []string{},
+		Timeout:      100,
 	}}
 	assert.Equal(t, prePushHook, rootMetadata.Hooks[tuf.HookStagePrePush])
 
@@ -771,11 +771,11 @@ func TestRemoveHook(t *testing.T) {
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	_, err := rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err := rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, []string{})
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePrePush]))
 


### PR DESCRIPTION
This PR updates the hooks metadata to remove the `modules` field and add the `timeout` field. After the edits to the PR that added the Lua Sandbox (#859), it doesn't make too much sense to keep the `modules` field and allow arbitrary module loading. We should make the `timeout` configurable for users though, I think.

While this is a breaking change, we haven't released gittuf with these changes so I think we should be OK here.