### PR TITLE
Prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## v0.10.0
+
+Starting with this release, gittuf is now in beta!
+
+### Added
+
+- Added a sync workflow that updates gittuf metadata as needed before making
+  policy changes
+- Added functionality to list and update global rules
+- Added support to the API for loading repositories in a specified directory
+- Added features and workflows to support deploying gittuf over multiple
+  repositories
+- Added gittuf hooks, which enable support for user-defined checks in gittuf
+  metadata that are run in a sandboxed lua environment
+
+### Updated
+
+- Set v02 of gittuf's metadata as the default
+- Made Fulcio support no longer restricted to developer mode
+- Updated the policy staging and apply workflows to now use the sync workflow
+- Updated gitinterface to now support systems with different locales than en_US
+- Updated gittuf's roadmap
+- Updated various dependencies and CI workflows
+
 ## v0.9.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ as part of the [Supply Chain Integrity Working Group].
 
 ## Current Status
 
-gittuf is currently in alpha. gittuf's metadata may have breaking changes,
-meaning a repository's gittuf policy may have to be reinitialized from time to
-time. As such, gittuf is currently not intended to be the primary mechanism for
-enforcing a repository's security.
+gittuf is currently in beta. gittuf's metadata is versioned, and updates should
+not require reinitializing a repository's gittuf policy. gittuf may be used as a
+repository's primary security mechanism, but beta-type bugs may be present (and
+reports are welcome!)
 
-That said, we're actively seeking feedback from users. Take a look at the [get
+We're actively seeking feedback from users. Take a look at the [get
 started guide] to learn how to install and try gittuf out! Additionally,
 contributions are welcome, please refer to the [contributing guide], our
 [roadmap], and the issue tracker for ways to get involved.

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 ![Build and Tests (CI)](https://github.com/gittuf/gittuf/actions/workflows/ci.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/gittuf/gittuf/badge.svg)](https://coveralls.io/github/gittuf/gittuf)
 
-gittuf is a security layer for Git repositories. With gittuf, any developer who
-can pull from a Git repository can independently verify that the repository's
-security policies were followed. gittuf's policy, inspired by [The Update
-Framework (TUF)], handles key management for all trusted developers in a
-repository, allows for setting permissions for repository branches, tags, files,
-etc., protects against [other attacks] Git is vulnerable to, and more — all
-while being backwards compatible with forges such as GitHub and GitLab.
+gittuf is a platform-agnostic Git security system. The maintainers of a Git
+repository can use gittuf to protect the contents of a Git repository from
+unauthorized or malicious changes. Most significantly, gittuf’s policy controls
+and enforcement is not tied to your source control platform (SCP) or “forge”,
+meaning any developer can independently verify that a repository’s changes
+followed the expected security policies. In other words, gittuf removes the
+forge as a single point of trust in the software supply chain!
 
 gittuf is a sandbox project at the [Open Source Security Foundation (OpenSSF)]
 as part of the [Supply Chain Integrity Working Group].
@@ -18,21 +18,17 @@ as part of the [Supply Chain Integrity Working Group].
 ## Current Status
 
 gittuf is currently in beta. gittuf's metadata is versioned, and updates should
-not require reinitializing a repository's gittuf policy. gittuf may be used as a
-repository's primary security mechanism, but beta-type bugs may be present (and
-reports are welcome!)
+not require reinitializing a repository's gittuf policy. We recommend trying out
+gittuf in addition to existing repository security mechanisms you may already be
+using (e.g., forge security policies). We're actively seeking feedback from
+users, please open an issue with any suggestions or bugs you encounter!
 
-We're actively seeking feedback from users. Take a look at the [get
-started guide] to learn how to install and try gittuf out! Additionally,
-contributions are welcome, please refer to the [contributing guide], our
-[roadmap], and the issue tracker for ways to get involved.
+## Installation, Get Started, Get Involved
 
-## Installation & Get Started
+Take a look at the [get started guide] to learn how to install and try gittuf
+out! Additionally, contributions are welcome, please refer to the [contributing
+guide], our [roadmap], and the issue tracker for ways to get involved.
 
-See the [get started guide].
-
-[The Update Framework (TUF)]: https://theupdateframework.io/
-[other attacks]: https://ssl.engineering.nyu.edu/papers/torres_toto_usenixsec-2016.pdf
 [contributing guide]: /CONTRIBUTING.md
 [roadmap]: /docs/roadmap.md
 [Open Source Security Foundation (OpenSSF)]: https://openssf.org/


### PR DESCRIPTION
This PR prepares gittuf `v0.10.0`.

Blocked by:

- #860 
- #892 
- #638 
- #765 

EDIT: We can likely defer these features to the next release, since one can already add these to the metadata with the currently-merged PRs.