### PR TITLE
gittuf: Fix verbose cmd flag

### DIFF
--- a/experimental/gittuf/repository.go
+++ b/experimental/gittuf/repository.go
@@ -36,13 +36,11 @@ func (r *Repository) GetGitRepository() *gitinterface.Repository {
 }
 
 func LoadRepository(repositoryPath string) (*Repository, error) {
-	level := slog.LevelInfo
 	if InDebugMode() {
-		level = slog.LevelDebug
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-		Level: level,
-	})))
 
 	slog.Debug(fmt.Sprintf("Loading Git repository from '%s'...", repositoryPath))
 


### PR DESCRIPTION
The --verbose cmd flag was broken in a prior commit as we were setting the default level to info in the gittuf package.