### PR TITLE
ci: Update gittuf demo to use version from PR

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -12,6 +12,12 @@ jobs:
     name: Run demo 
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Go
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
+      - name: Build gittuf
+        run:  make just-install
       - name: Checkout demo repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -20,7 +26,5 @@ jobs:
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           python-version: '3.12'
-      - name: Install gittuf-installer
-        uses: gittuf/gittuf-installer@f6589511b7fb806ce365de81caa949b5c468089a
       - name: Run demo script
         run: python run-demo.py --no-prompt


### PR DESCRIPTION
This PR has the gittuf demo run on the code introduced by a PR, instead of just the latest released version.