### PR TITLE
Fix git-http-backend not found error in get-started-tests workflow

### DIFF
--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -33,6 +33,19 @@ jobs:
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: '3.10'
+    - name: Install Git (Ubuntu)
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y git
+    - name: Install Git (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install git
+    - name: Install Git (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install git -y
     - name: Build gittuf
       run: make just-install
     - name: Test Getting Started

--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -50,3 +50,4 @@ jobs:
       run: make just-install
     - name: Test Getting Started
       run: python3 docs/testing/test-get-started-md.py
+      


### PR DESCRIPTION
resolves
#945 

Description: 

This PR addresses an issue where the get-started-tests workflow was failing with the error message:
[!] git-http-backend not found. Is Git installed?
Error: Process completed with exit code 1.

The workflow was missing explicit Git installation steps for the different operating systems in the test matrix. This PR adds operating system-specific Git installation steps for Ubuntu, macOS, and Windows environments.
Changes

Add Git installation step for Ubuntu using apt-get
Add Git installation step for macOS using Homebrew
Add Git installation step for Windows using Chocolatey
Use conditional execution based on the matrix.os value

