### PR TITLE
Add slack link and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ users, please open an issue with any suggestions or bugs you encounter!
 
 Take a look at the [get started guide] to learn how to install and try gittuf
 out! Additionally, contributions are welcome, please refer to the [contributing
-guide], our [roadmap], and the issue tracker for ways to get involved.
+guide], our [roadmap], and the issue tracker for ways to get involved. In
+addition, you can join the gittuf channel on the [OpenSSF Slack] and say hello! 
 
 [contributing guide]: /CONTRIBUTING.md
 [roadmap]: /docs/roadmap.md
 [Open Source Security Foundation (OpenSSF)]: https://openssf.org/
 [Supply Chain Integrity Working Group]: https://github.com/ossf/wg-supply-chain-integrity
 [get started guide]: /docs/get-started.md
+[OpenSSF Slack]: https://slack.openssf.org/

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr, "unexpected error: %s\n\n", fmt.Sprint(r))
 			debug.PrintStack()
-			fmt.Fprintln(os.Stderr, "\nPlease consider filing a bug on https:/github.com/gittuf/gittuf/issues with the stack trace and steps to reproduce this state. Thanks!")
+			fmt.Fprintln(os.Stderr, "\nPlease consider filing a bug on https://github.com/gittuf/gittuf/issues with the stack trace and steps to reproduce this state. Thanks!")
 
 			os.Exit(1) // this is the last possible deferred function to run
 		}


### PR DESCRIPTION
This PR adds a link to the OpenSSF Slack workspace to help people new to the project reach out, as well as fixes a small typo in `main.go`.