### PR TITLE
feat(trust): add inspect-root command to display root metadata

### DIFF
--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -13,9 +13,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	policyRef string
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyRef,
+		"policy-ref",
+		policy.PolicyStagingRef,
+		"policy reference to inspect",
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository(".")
@@ -23,7 +32,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), o.policyRef, policyopts.BypassRSL())
 	if err != nil {
 		return err
 	}
@@ -47,7 +56,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect-root",
 		Short:             "Inspect root metadata",
-		Long:              "This command displays the root metadata in a human-readable format.",
+		Long:              "This command displays the root metadata in a human-readable format. By default, it inspects the policy-staging ref, but you can specify a different policy ref using --policy-ref.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -1,0 +1,57 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectroot
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) AddFlags(_ *cobra.Command) {}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	prettyJSON, err := json.MarshalIndent(rootMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect-root",
+		Short:             "Inspect root metadata",
+		Long:              "This command displays the root metadata in a human-readable format.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/disablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
+	"github.com/gittuf/gittuf/internal/cmd/trust/inspectroot"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listglobalrules"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listhooks"
 	"github.com/gittuf/gittuf/internal/cmd/trust/makecontroller"
@@ -57,6 +58,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))
+	cmd.AddCommand(inspectroot.New())
 	cmd.AddCommand(listhooks.New())
 	cmd.AddCommand(makecontroller.New(o))
 	cmd.AddCommand(remote.New())


### PR DESCRIPTION
This PR adds a new command 'gittuf trust inspect-root' that displays the root metadata in a human-readable JSON format. This command is useful for debugging and inspecting the current state of the gittuf root of trust.


Example Output:
{

  "type": "root",

  "schemaVersion": "https://gittuf.dev/policy/root/v0.2",

  "expires": "2026-05-13T23:00:44+05:30",

  "principals": {

    "SHA256:mHq2yTWNE12txaCzmr1cFRsAakDMWIHYruoAszBmxmU": {

      "keyid_hash_algorithms": null,

      "keytype": "ssh",

      "keyval": {

        "public": "AAAAC3NzaC1lZDI1NTE5AAAAIMGNc6wybQYOkaZxSiFuDy651/wLMmG708HYroQst76w"

      },

      "scheme": "ssh-ed25519",

      "keyid": "SHA256:mHq2yTWNE12txaCzmr1cFRsAakDMWIHYruoAszBmxmU"

    }

  },

  "roles": {

    "root": {

      "principalIDs": [

        "SHA256:mHq2yTWNE12txaCzmr1cFRsAakDMWIHYruoAszBmxmU"

      ],

      "threshold": 1

    }

  }

}


Changes:
1.Added a new command 'inspect-root' under the 'trust' subcommand.

2.The command loads the repository, retrieves the current policy state, and pretty-prints the root metadata as JSON.

3.The command is registered in 'internal/cmd/trust/trust.go'.

Testing:
1.Built and tested the command in a gittuf-initialized repository.

2.Verified that the output is correctly formatted and matches the expected root metadata.

Closes: #953