### PR TITLE
Fix/inspect root command

### DIFF
--- a/docs/cli/gittuf.md
+++ b/docs/cli/gittuf.md
@@ -19,6 +19,7 @@ A security layer for Git repositories, powered by TUF
 * [gittuf attest](gittuf_attest.md)	 - Tools for attesting to code contributions
 * [gittuf clone](gittuf_clone.md)	 - Clone repository and its gittuf references
 * [gittuf dev](gittuf_dev.md)	 - Developer mode commands
+* [gittuf inspect-root](gittuf_inspect-root.md)	 - Inspect and print all gittuf root metadata
 * [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
 * [gittuf rsl](gittuf_rsl.md)	 - Tools to manage the repository's reference state log
 * [gittuf sync](gittuf_sync.md)	 - Synchronize local references with remote references based on RSL

--- a/docs/cli/gittuf_inspect-root.md
+++ b/docs/cli/gittuf_inspect-root.md
@@ -1,0 +1,28 @@
+## gittuf inspect-root
+
+Inspect and print all gittuf root metadata
+
+```
+gittuf inspect-root [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for inspect-root
+```
+
+### Options inherited from parent commands
+
+```
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
+

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -35,6 +35,7 @@ Tools for gittuf's root of trust
 * [gittuf trust disable-github-app-approvals](gittuf_trust_disable-github-app-approvals.md)	 - Mark GitHub app approvals as untrusted henceforth
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth
 * [gittuf trust init](gittuf_trust_init.md)	 - Initialize gittuf root of trust for repository
+* [gittuf trust inspect-root](gittuf_trust_inspect-root.md)	 - Inspect root metadata
 * [gittuf trust list-global-rules](gittuf_trust_list-global-rules.md)	 - List global rules for the current state
 * [gittuf trust list-hooks](gittuf_trust_list-hooks.md)	 - List gittuf hooks for the current policy state
 * [gittuf trust make-controller](gittuf_trust_make-controller.md)	 - Make current repository a controller (developer mode only, set GITTUF_DEV=1)

--- a/docs/cli/gittuf_trust_inspect-root.md
+++ b/docs/cli/gittuf_trust_inspect-root.md
@@ -1,0 +1,35 @@
+## gittuf trust inspect-root
+
+Inspect root metadata
+
+### Synopsis
+
+This command displays the root metadata in a human-readable format. By default, it inspects the policy-staging ref, but you can specify a different policy ref using --policy-ref.
+
+```
+gittuf trust inspect-root [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for inspect-root
+      --policy-ref string   policy reference to inspect (default "refs/gittuf/policy-staging")
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -118,6 +118,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(verifymergeable.New())
 	cmd.AddCommand(verifyref.New())
 	cmd.AddCommand(version.New())
+	cmd.AddCommand(trust.NewInspectRootCommand())
 
 	return cmd
 }

--- a/internal/cmd/trust/inspectpolicykey/inspectpolicykey.go
+++ b/internal/cmd/trust/inspectpolicykey/inspectpolicykey.go
@@ -1,0 +1,84 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectpolicykey
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	policyRef string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyRef,
+		"policy-ref",
+		policy.PolicyStagingRef,
+		"policy reference to inspect",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), o.policyRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	// Get policy keys from the targets role
+	policyKeys := make(map[string]interface{})
+	principals, _ := rootMetadata.GetPrimaryRuleFilePrincipals()
+	threshold, _ := rootMetadata.GetPrimaryRuleFileThreshold()
+
+	policyKeys["principalIDs"] = principals
+	policyKeys["threshold"] = threshold
+
+	// Get the actual key details from principals
+	principalDetails := make(map[string]interface{})
+	for _, principal := range principals {
+		keyID := principal.ID()
+		if details, ok := rootMetadata.GetPrincipals()[keyID]; ok {
+			principalDetails[keyID] = details
+		}
+	}
+	policyKeys["principals"] = principalDetails
+
+	prettyJSON, err := json.MarshalIndent(policyKeys, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect-policy-key",
+		Short:             "Inspect policy keys from root metadata",
+		Long:              "This command displays the policy keys and their details from the root metadata. By default, it inspects the policy-staging ref, but you can specify a different policy ref using --policy-ref.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/inspectroot.go
+++ b/internal/cmd/trust/inspectroot.go
@@ -1,0 +1,56 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package trust
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/spf13/cobra"
+)
+
+type inspectRootOptions struct{}
+
+func (o *inspectRootOptions) AddFlags(cmd *cobra.Command) {}
+
+func (o *inspectRootOptions) Run(cmd *cobra.Command, args []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	state, err := policy.LoadCurrentState(context.Background(), repo.GetGitRepository(), policy.PolicyRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	// Marshal the root metadata to pretty-printed JSON
+	prettyJSON, err := json.MarshalIndent(rootMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func NewInspectRootCommand() *cobra.Command {
+	o := &inspectRootOptions{}
+	cmd := &cobra.Command{
+		Use:   "inspect-root",
+		Short: "Inspect and print all gittuf root metadata",
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -13,9 +13,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	policyRef string
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyRef,
+		"policy-ref",
+		policy.PolicyStagingRef,
+		"policy reference to inspect",
+	)
+}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository(".")
@@ -23,7 +32,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), o.policyRef, policyopts.BypassRSL())
 	if err != nil {
 		return err
 	}
@@ -47,7 +56,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect-root",
 		Short:             "Inspect root metadata",
-		Long:              "This command displays the root metadata in a human-readable format.",
+		Long:              "This command displays the root metadata in a human-readable format. By default, it inspects the policy-staging ref, but you can specify a different policy ref using --policy-ref.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -1,0 +1,57 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectroot
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) AddFlags(_ *cobra.Command) {}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	prettyJSON, err := json.MarshalIndent(rootMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect-root",
+		Short:             "Inspect root metadata",
+		Long:              "This command displays the root metadata in a human-readable format.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/disablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
+	"github.com/gittuf/gittuf/internal/cmd/trust/inspectroot"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listglobalrules"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listhooks"
 	"github.com/gittuf/gittuf/internal/cmd/trust/makecontroller"
@@ -57,6 +58,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))
+	cmd.AddCommand(inspectroot.New())
 	cmd.AddCommand(listhooks.New())
 	cmd.AddCommand(makecontroller.New(o))
 	cmd.AddCommand(remote.New())


### PR DESCRIPTION
 ## Description
 This PR adds a new command `gittuf trust inspect-root` that allows users to view the root metadata in a human-readable format. The command supports viewing metadata from different policy references using the `--policy-ref` flag.

     ## Changes
     - Added new command `inspect-root` under the trust subcommand
     - Added documentation for the new command
     - Implemented functionality to load and display root metadata
     - Added support for viewing metadata from different policy references

     ## Testing
     - Tested the command with default policy reference
     - Tested the command with custom policy reference
     - Verified JSON output format
     - Tested error handling for invalid repositories

     ## Related Issues
     Closes #953

     ## Checklist
     - I have signed the DCO
     -  I have added tests that prove my fix is effective or that my feature works
     -  I have added necessary documentation (if appropriate)
     -  Any dependent changes have been merged and published in downstream modules