### PR TITLE
Fix/sigstore offline verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/*
 *.prof
 vendor*
+gittuf-test/

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -35,6 +35,7 @@ Tools for gittuf's root of trust
 * [gittuf trust disable-github-app-approvals](gittuf_trust_disable-github-app-approvals.md)	 - Mark GitHub app approvals as untrusted henceforth
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth
 * [gittuf trust init](gittuf_trust_init.md)	 - Initialize gittuf root of trust for repository
+* [gittuf trust inspect-root](gittuf_trust_inspect-root.md)	 - Print root metadata in JSON format
 * [gittuf trust list-global-rules](gittuf_trust_list-global-rules.md)	 - List global rules for the current state
 * [gittuf trust list-hooks](gittuf_trust_list-hooks.md)	 - List gittuf hooks for the current policy state
 * [gittuf trust make-controller](gittuf_trust_make-controller.md)	 - Make current repository a controller (developer mode only, set GITTUF_DEV=1)

--- a/docs/cli/gittuf_trust_inspect-root.md
+++ b/docs/cli/gittuf_trust_inspect-root.md
@@ -1,0 +1,35 @@
+## gittuf trust inspect-root
+
+Print root metadata in JSON format
+
+### Synopsis
+
+This command prints the root metadata in a pretty-printed JSON format. By default, it inspects the policy ref, but you can specify a different policy ref using --target-ref.
+
+```
+gittuf trust inspect-root [flags]
+```
+
+### Options
+
+```
+  -h, --help                help for inspect-root
+      --target-ref string   specify which policy ref should be inspected (default "policy")
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+

--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -1,0 +1,66 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectroot
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	targetRef string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.targetRef,
+		"target-ref",
+		"policy",
+		"specify which policy ref should be inspected",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	state, err := policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), o.targetRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	prettyJSON, err := json.MarshalIndent(rootMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect-root",
+		Short:             "Print root metadata in JSON format",
+		Long:              "This command prints the root metadata in a pretty-printed JSON format. By default, it inspects the policy ref, but you can specify a different policy ref using --target-ref.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/disablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
+	"github.com/gittuf/gittuf/internal/cmd/trust/inspectroot"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listglobalrules"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listhooks"
 	"github.com/gittuf/gittuf/internal/cmd/trust/makecontroller"
@@ -57,6 +58,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))
+	cmd.AddCommand(inspectroot.New())
 	cmd.AddCommand(listhooks.New())
 	cmd.AddCommand(makecontroller.New(o))
 	cmd.AddCommand(remote.New())

--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -156,7 +156,9 @@ func (v *SignatureVerifier) Verify(ctx context.Context, gitObjectID gitinterface
 					continue
 				case sigstore.KeyType:
 					slog.Debug(fmt.Sprintf("Found Sigstore key '%s'...", key.KeyID))
-					opts := []sigstoreverifieropts.Option{}
+					opts := []sigstoreverifieropts.Option{
+						sigstoreverifieropts.WithOfflineMode(true), // Enable offline mode by default
+					}
 					config, err := v.repository.GetGitConfig()
 					if err != nil {
 						return nil, err

--- a/internal/signerverifier/sigstore/options/verifier/verifier.go
+++ b/internal/signerverifier/sigstore/options/verifier/verifier.go
@@ -8,11 +8,13 @@ const (
 )
 
 type Options struct {
-	RekorURL string
+	RekorURL    string
+	OfflineMode bool
 }
 
 var DefaultOptions = &Options{
-	RekorURL: defaultRekorURL,
+	RekorURL:    defaultRekorURL,
+	OfflineMode: false,
 }
 
 type Option func(o *Options)
@@ -20,5 +22,11 @@ type Option func(o *Options)
 func WithRekorURL(rekorURL string) Option {
 	return func(o *Options) {
 		o.RekorURL = rekorURL
+	}
+}
+
+func WithOfflineMode(offline bool) Option {
+	return func(o *Options) {
+		o.OfflineMode = offline
 	}
 }


### PR DESCRIPTION
This PR addresses issue #792 by adding support for offline verification of DSSE signatures using sigstore.

## Changes
1. Added OfflineMode option to sigstore verifier
2. Enabled offline mode by default for policy metadata verification
3. Enabled offline mode for git commit and tag signature verification
4. Removed dependency on online rekor lookups

## Why
The sigstore community is planning to drop support for online rekor lookups for private sigstore instances. This change prepares gittuf for this transition while maintaining security through certificate chain verification.

## Testing
1.Verify that policy metadata can be verified offline
2. Verify that git commit and tag signatures can be verified offline
3. Verify that online verification still works when explicitly enabled