### PR TITLE
Add Long description to gendoc Cobra command

### DIFF
--- a/docs/cli/main.go
+++ b/docs/cli/main.go
@@ -18,7 +18,8 @@ var (
 	dir string
 	cmd = &cobra.Command{
 		Use:   "gendoc",
-		Short: "Generate help docs",
+		Short: "Generate Markdown documentation for all commands in gittuf",
+		Long:  `The 'gendoc' command generates Markdown documentation for all available commands in the gittuf CLI. The generated documentation will be saved to the specified directory, which defaults to the current working directory if not provided.`,
 		Args:  cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
 			return doc.GenMarkdownTree(root.New(), dir)


### PR DESCRIPTION
This pull request addresses part of the issue related to enhancing CLI command documentation by adding a `Long` description to the `gendoc` Cobra command.

The `Long` field provides a more detailed explanation of what the command does, including its purpose (generating Markdown documentation for all gittuf CLI commands), its usage, and the default output behavior. This improves the CLI's usability and clarity for both new and experienced users.

This update is part of the broader effort to improve the documentation coverage for all Cobra commands in the gittuf project.

Contributor: Syed Mohammed Sylani
