### PR TITLE
docs: add Long description to sandbox gendoc commandSandbox docs long

### DIFF
--- a/docs/cli/main.go
+++ b/docs/cli/main.go
@@ -18,8 +18,14 @@ var (
 	dir string
 	cmd = &cobra.Command{
 		Use:   "gendoc",
-		Short: "Generate help docs",
-		Args:  cobra.NoArgs,
+		Short: "Generate Markdown documentation for all commands in gittuf",
+		Long: `The 'gendoc' command generates Markdown documentation for all available
+commands in the gittuf CLI. This is useful for creating detailed, human-readable
+docs for the project that describe how each command works and its options.
+
+The generated documentation will be saved to the specified directory, which
+defaults to the current working directory if not provided.`,
+		Args: cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
 			return doc.GenMarkdownTree(root.New(), dir)
 		},

--- a/docs/sandbox/main.go
+++ b/docs/sandbox/main.go
@@ -22,6 +22,11 @@ var (
 	cmd = &cobra.Command{
 		Use:   "gendoc",
 		Short: "Generate sandbox docs",
+		Long: `The 'gendoc' command generates documentation for all available Lua sandbox APIs used within the gittuf CLI.
+
+This includes API signatures, descriptions, and examples, making it easier for developers to understand and utilize available sandbox functionality.
+
+The generated documentation is saved to the specified directory, defaulting to the current working directory if not provided.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			repository, err := gitinterface.LoadRepository(".")


### PR DESCRIPTION
This pull request adds a Long description to the 'gendoc' command responsible for generating Lua sandbox API documentation.

The Long field provides a detailed explanation of the command's purpose, including what is generated and where the output is stored.

This update is part of the broader effort to improve documentation coverage for all Cobra commands in the gittuf project.

Contributor: Syed Mohammed Sylani
