### PR TITLE
docs: add Long description to add-hooks Cobra commandAdd hooks long doc

### DIFF
--- a/docs/cli/main.go
+++ b/docs/cli/main.go
@@ -18,8 +18,14 @@ var (
 	dir string
 	cmd = &cobra.Command{
 		Use:   "gendoc",
-		Short: "Generate help docs",
-		Args:  cobra.NoArgs,
+		Short: "Generate Markdown documentation for all commands in gittuf",
+		Long: `The 'gendoc' command generates Markdown documentation for all available
+commands in the gittuf CLI. This is useful for creating detailed, human-readable
+docs for the project that describe how each command works and its options.
+
+The generated documentation will be saved to the specified directory, which
+defaults to the current working directory if not provided.`,
+		Args: cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
 			return doc.GenMarkdownTree(root.New(), dir)
 		},

--- a/docs/sandbox/main.go
+++ b/docs/sandbox/main.go
@@ -22,6 +22,11 @@ var (
 	cmd = &cobra.Command{
 		Use:   "gendoc",
 		Short: "Generate sandbox docs",
+		Long: `The 'gendoc' command generates documentation for all available Lua sandbox APIs used within the gittuf CLI.
+
+This includes API signatures, descriptions, and examples, making it easier for developers to understand and utilize available sandbox functionality.
+
+The generated documentation is saved to the specified directory, defaulting to the current working directory if not provided.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			repository, err := gitinterface.LoadRepository(".")

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -47,8 +47,13 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "add-hooks",
-		Short:             "Add git hooks that automatically create and sync RSL",
+		Use:   "add-hooks",
+		Short: "Add git hooks that automatically create and sync RSL",
+		Long: `The 'add-hooks' command installs Git hooks that automatically create and sync the Repository Snapshot Log (RSL) when certain Git actions occur, such as a push.
+
+By default, it prevents overwriting existing hooks unless the '--force' flag is specified. This ensures users can integrate gittuf functionality without unintentionally disrupting existing workflows.
+
+The hooks enable automatic integration of trusted commit metadata, enhancing repository security.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}


### PR DESCRIPTION
This pull request adds a Long description to the 'add-hooks' command in the gittuf CLI.

The Long field offers a detailed explanation of the command's function, including the purpose of the Git hooks it installs and how the '--force' flag affects existing hooks.

This change is part of the ongoing effort to improve Cobra command documentation for the gittuf project.

Contributor: Syed Mohammed Sylani
