### PR TITLE
docs: add Long description to attest apply commandApply long doc

### DIFF
--- a/docs/cli/gittuf_attest_apply.md
+++ b/docs/cli/gittuf_attest_apply.md
@@ -2,6 +2,10 @@
 
 Apply and push local attestations changes to remote repository
 
+### Synopsis
+
+The 'apply' command records the latest state of gittuf attestations in the RSL and pushes them to the remote repository. Pass '--local-only' to record the attestation locally without pushing upstream. Otherwise, you must supply the remote name as the first positional argument.
+
 ```
 gittuf attest apply [flags]
 ```

--- a/internal/cmd/attest/apply/apply.go
+++ b/internal/cmd/attest/apply/apply.go
@@ -40,6 +40,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply and push local attestations changes to remote repository",
+		Long:  `The 'apply' command records the latest state of gittuf attestations in the RSL and pushes them to the remote repository. Pass '--local-only' to record the attestation locally without pushing upstream. Otherwise, you must supply the remote name as the first positional argument.`,
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
This pull request adds a detailed Long description to the 'apply' sub-command
of 'attest' in the gittuf CLI.

The new Long field explains what the command does, how the '--local-only'
flag changes behavior, and how an optional remote name can be supplied.

This update continues the ongoing effort to enhance Cobra command
documentation across the gittuf project.

Contributor: Syed Mohammed Sylani
