### PR TITLE
docs: add Long description to attest github commandGitHub long doc

### DIFF
--- a/docs/cli/gittuf_attest_github.md
+++ b/docs/cli/gittuf_attest_github.md
@@ -2,6 +2,10 @@
 
 Tools to attest about GitHub actions and entities
 
+### Synopsis
+
+The 'github' command provides tools to create attestations for actions and entities associated with GitHub, such as pull requests and approvals. It includes subcommands to record approval of a GitHub pull request. dismiss a previously recorded approval, and attest to metadata related to GitHub pull requests.
+
 ### Options
 
 ```

--- a/internal/cmd/attest/github/github.go
+++ b/internal/cmd/attest/github/github.go
@@ -16,6 +16,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "github",
 		Short:   "Tools to attest about GitHub actions and entities",
+		Long:    `The 'github' command provides tools to create attestations for actions and entities associated with GitHub, such as pull requests and approvals. It includes subcommands to record approval of a GitHub pull request. dismiss a previously recorded approval, and attest to metadata related to GitHub pull requests.`,
 		PreRunE: common.CheckForSigningKeyFlag,
 	}
 


### PR DESCRIPTION
This pull request adds a detailed Long description to the 'github' sub-command under 'attest' in the gittuf CLI.

The description outlines the purpose of this parent command and its subcommands for attesting to GitHub-specific actions such as pull request approvals and dismissals.

This enhancement is part of the ongoing effort to improve Cobra command documentation throughout the gittuf project.

Contributor: Syed Mohammed Sylani
