### PR TITLE
docs: add Long description to dismiss-approval Cobra commandDismiss approval long doc

### DIFF
--- a/docs/cli/main.go
+++ b/docs/cli/main.go
@@ -18,8 +18,14 @@ var (
 	dir string
 	cmd = &cobra.Command{
 		Use:   "gendoc",
-		Short: "Generate help docs",
-		Args:  cobra.NoArgs,
+		Short: "Generate Markdown documentation for all commands in gittuf",
+		Long: `The 'gendoc' command generates Markdown documentation for all available
+commands in the gittuf CLI. This is useful for creating detailed, human-readable
+docs for the project that describe how each command works and its options.
+
+The generated documentation will be saved to the specified directory, which
+defaults to the current working directory if not provided.`,
+		Args: cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
 			return doc.GenMarkdownTree(root.New(), dir)
 		},

--- a/docs/sandbox/main.go
+++ b/docs/sandbox/main.go
@@ -22,6 +22,11 @@ var (
 	cmd = &cobra.Command{
 		Use:   "gendoc",
 		Short: "Generate sandbox docs",
+		Long: `The 'gendoc' command generates documentation for all available Lua sandbox APIs used within the gittuf CLI.
+
+This includes API signatures, descriptions, and examples, making it easier for developers to understand and utilize available sandbox functionality.
+
+The generated documentation is saved to the specified directory, defaulting to the current working directory if not provided.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			repository, err := gitinterface.LoadRepository(".")

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -47,8 +47,13 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "add-hooks",
-		Short:             "Add git hooks that automatically create and sync RSL",
+		Use:   "add-hooks",
+		Short: "Add git hooks that automatically create and sync RSL",
+		Long: `The 'add-hooks' command installs Git hooks that automatically create and sync the Repository Snapshot Log (RSL) when certain Git actions occur, such as a push.
+
+By default, it prevents overwriting existing hooks unless the '--force' flag is specified. This ensures users can integrate gittuf functionality without unintentionally disrupting existing workflows.
+
+The hooks enable automatic integration of trusted commit metadata, enhancing repository security.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/attest/apply/apply.go
+++ b/internal/cmd/attest/apply/apply.go
@@ -40,7 +40,16 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply and push local attestations changes to remote repository",
-		RunE:  o.Run,
+		Long: `The 'apply' command takes all locally recorded attestations (stored in the
+Reference State Log, or RSL) and applies them to the target repository.
+
+By default, the command pushes those attestations to the remote specified
+in your Git configuration.  Pass '--local-only' to record the attestation
+locally without pushing upstream.
+
+Optionally, you may supply the remote name as the first positional argument.
+If omitted, the default remote is used.`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/attest.go
+++ b/internal/cmd/attest/attest.go
@@ -14,8 +14,13 @@ import (
 func New() *cobra.Command {
 	o := &persistent.Options{}
 	cmd := &cobra.Command{
-		Use:               "attest",
-		Short:             "Tools for attesting to code contributions",
+		Use:   "attest",
+		Short: "Tools for attesting to code contributions",
+		Long: `The 'attest' command serves as a parent command that provides tools for attesting to code contributions made to a gittuf-secured repository.
+
+It includes subcommands to apply attestations, authorize contributors, and integrate GitHub-based attestations.
+
+These tools help strengthen the trust and authenticity of commits, making it easier to verify contributor identities and their roles.`,
 		DisableAutoGenTag: true,
 	}
 	o.AddPersistentFlags(cmd)

--- a/internal/cmd/attest/github/dismissapproval/dismissapproval.go
+++ b/internal/cmd/attest/github/dismissapproval/dismissapproval.go
@@ -66,7 +66,12 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dismiss-approval",
 		Short: "Record dismissal of GitHub pull request approval",
-		RunE:  o.Run,
+		Long: `The 'dismiss-approval' command creates an attestation that a previously recorded approval of a GitHub pull request has been dismissed.
+
+It requires the review ID of the pull request and the identity of the dismissed approver. These attestations provide an auditable record of review state changes on GitHub, improving transparency and trust in the contribution workflow.
+
+This command supports custom GitHub base URLs for enterprise environments and can optionally include the attestation in the Repository Snapshot Log (RSL).`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/github/github.go
+++ b/internal/cmd/attest/github/github.go
@@ -14,8 +14,16 @@ import (
 
 func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "github",
-		Short:   "Tools to attest about GitHub actions and entities",
+		Use:   "github",
+		Short: "Tools to attest about GitHub actions and entities",
+		Long: `The 'github' command is a parent command that provides tools to create attestations for actions and entities associated with GitHub, such as pull requests and approvals.
+
+It includes subcommands to:
+- Record approval of a GitHub pull request
+- Dismiss a previously recorded approval
+- Attest to metadata related to GitHub pull requests
+
+These attestations help establish trust around code contributions made through GitHub by enabling verifiable links between repository events and contributor actions.`,
 		PreRunE: common.CheckForSigningKeyFlag,
 	}
 


### PR DESCRIPTION
This pull request adds a Long description to the 'dismiss-approval' command in the gittuf CLI.

The Long field explains how this command creates attestations for dismissed GitHub pull request approvals, helping improve traceability of code review changes in GitHub-hosted repositories.

This update is part of the broader documentation improvement effort for Cobra commands in the gittuf project.

Contributor: Syed Mohammed Sylani
