### PR TITLE
docs: add Long description to pull-request Cobra commandPull request long doc

### DIFF
--- a/docs/cli/gittuf_attest_github_pull-request.md
+++ b/docs/cli/gittuf_attest_github_pull-request.md
@@ -2,6 +2,10 @@
 
 Record GitHub pull request information as an attestation
 
+### Synopsis
+
+The 'pull-request' command creates an attestation for a GitHub pull request. It supports attesting either by pull request number or a specific commit and its associated base branch. These attestations help verify the origin and legitimacy of code contributions merged via GitHub. The command also supports custom GitHub base URLs for enterprise GitHub instances, with the flag '--base-URL'.
+
 ```
 gittuf attest github pull-request [flags]
 ```

--- a/internal/cmd/attest/github/pullrequest/pullrequest.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest.go
@@ -99,6 +99,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull-request",
 		Short: "Record GitHub pull request information as an attestation",
+		Long:  `The 'pull-request' command creates an attestation for a GitHub pull request. It supports attesting either by pull request number or a specific commit and its associated base branch. These attestations help verify the origin and legitimacy of code contributions merged via GitHub. The command also supports custom GitHub base URLs for enterprise GitHub instances, with the flag '--base-URL'.`,
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
This pull request adds a Long description to the 'pull-request' command in the gittuf CLI.

The Long field documents how the command creates attestations for GitHub pull requests, helping verify merge origins and improve traceability in gittuf-secured repositories.

This is part of the overall effort to enhance Cobra command documentation in the gittuf project.

Contributor: Syed Mohammed Sylani
