### PR TITLE
docs: add Long description to record-approval Cobra commandRecord approval long doc

### DIFF
--- a/docs/cli/gittuf_attest_github_record-approval.md
+++ b/docs/cli/gittuf_attest_github_record-approval.md
@@ -2,6 +2,10 @@
 
 Record GitHub pull request approval
 
+### Synopsis
+
+The 'record-approval' command creates an attestation for an approval action on a GitHub pull request. This command requires the repository in the {owner}/{repo} format, the pull request number, the specific review ID, and the identity of the reviewer who approved the pull request. The command also supports custom GitHub base URLs for enterprise GitHub instances, with the flag '--base-URL'.
+
 ```
 gittuf attest github record-approval [flags]
 ```

--- a/internal/cmd/attest/github/recordapproval/recordapproval.go
+++ b/internal/cmd/attest/github/recordapproval/recordapproval.go
@@ -92,6 +92,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "record-approval",
 		Short: "Record GitHub pull request approval",
+		Long:  `The 'record-approval' command creates an attestation for an approval action on a GitHub pull request. This command requires the repository in the {owner}/{repo} format, the pull request number, the specific review ID, and the identity of the reviewer who approved the pull request. The command also supports custom GitHub base URLs for enterprise GitHub instances, with the flag '--base-URL'.`,
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
This pull request adds a Long description to the 'record-approval' command in the gittuf CLI.

The Long field documents how this command creates attestations for GitHub pull request approvals, enhancing the integrity of the code review process.

This update is part of an effort to improve Cobra command documentation across the gittuf project.

Contributor: Syed Mohammed Sylani
