### PR TITLE
docs: add Long description to dev Cobra commandDev long doc

### DIFF
--- a/docs/cli/gittuf_dev.md
+++ b/docs/cli/gittuf_dev.md
@@ -4,7 +4,7 @@ Developer mode commands
 
 ### Synopsis
 
-These commands are meant to be used to aid gittuf development, and are not expected to be used during standard workflows. If used, they can undermine repository security. To proceed, set GITTUF_DEV=1.
+The 'dev' command group provides advanced utilities for use during gittuf development and debugging. These commands are intended for internal or development use and are not designed to be run in production or standard repository workflows. Improper use may compromise repository security guarantees. To enable these commands, the environment variable GITTUF_DEV must be set to 1.
 
 ### Options
 

--- a/internal/cmd/dev/dev.go
+++ b/internal/cmd/dev/dev.go
@@ -19,7 +19,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dev",
 		Short:   "Developer mode commands",
-		Long:    fmt.Sprintf("These commands are meant to be used to aid gittuf development, and are not expected to be used during standard workflows. If used, they can undermine repository security. To proceed, set %s=1.", dev.DevModeKey),
+		Long:    fmt.Sprintf(`The 'dev' command group provides advanced utilities for use during gittuf development and debugging. These commands are intended for internal or development use and are not designed to be run in production or standard repository workflows. Improper use may compromise repository security guarantees. To enable these commands, the environment variable %s must be set to 1.`, dev.DevModeKey),
 		PreRunE: checkInDevMode,
 	}
 


### PR DESCRIPTION
This pull request adds a Long description to the 'dev' command group in the gittuf CLI.

The Long description explains the purpose and cautions associated with using development-only commands, including the requirement to set an environment variable to proceed.

This is part of an effort to fully document all Cobra commands in the repository.

Contributor: Syed Mohammed Sylani
