### PR TITLE
docs: add Long description to populate-cache commandDoc populate cache

### DIFF
--- a/docs/cli/gittuf_dev_populate-cache.md
+++ b/docs/cli/gittuf_dev_populate-cache.md
@@ -2,6 +2,10 @@
 
 Populate persistent cache (developer mode only, set GITTUF_DEV=1)
 
+### Synopsis
+
+The 'populate-cache' command generates and populates the local persistent cache for a gittuf repository, intended to improve performance of gittuf operations. This cache is local-only and is not synchronzied with the remote. It requires developer mode to be enabled by setting the environment variable GITTUF_DEV=1.
+
 ```
 gittuf dev populate-cache [flags]
 ```

--- a/internal/cmd/dev/populatecache/populatecache.go
+++ b/internal/cmd/dev/populatecache/populatecache.go
@@ -29,6 +29,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "populate-cache",
 		Short: fmt.Sprintf("Populate persistent cache (developer mode only, set %s=1)", dev.DevModeKey),
+		Long:  fmt.Sprintf(`The 'populate-cache' command generates and populates the local persistent cache for a gittuf repository, intended to improve performance of gittuf operations. This cache is local-only and is not synchronzied with the remote. It requires developer mode to be enabled by setting the environment variable %s=1.`, dev.DevModeKey),
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
This PR adds a Long description to the 'populate-cache' developer command in the gittuf CLI.

The description explains its purpose for development use and the requirement of enabling developer mode by setting the appropriate environment variable.

This change contributes to the complete documentation of all Cobra commands.

Contributor: Syed Mohammed Sylani
