### PR TITLE
docs: add Long description to policy commandDoc policy long desc

### DIFF
--- a/docs/cli/main.go
+++ b/docs/cli/main.go
@@ -18,8 +18,14 @@ var (
 	dir string
 	cmd = &cobra.Command{
 		Use:   "gendoc",
-		Short: "Generate help docs",
-		Args:  cobra.NoArgs,
+		Short: "Generate Markdown documentation for all commands in gittuf",
+		Long: `The 'gendoc' command generates Markdown documentation for all available
+commands in the gittuf CLI. This is useful for creating detailed, human-readable
+docs for the project that describe how each command works and its options.
+
+The generated documentation will be saved to the specified directory, which
+defaults to the current working directory if not provided.`,
+		Args: cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
 			return doc.GenMarkdownTree(root.New(), dir)
 		},

--- a/docs/sandbox/main.go
+++ b/docs/sandbox/main.go
@@ -22,6 +22,11 @@ var (
 	cmd = &cobra.Command{
 		Use:   "gendoc",
 		Short: "Generate sandbox docs",
+		Long: `The 'gendoc' command generates documentation for all available Lua sandbox APIs used within the gittuf CLI.
+
+This includes API signatures, descriptions, and examples, making it easier for developers to understand and utilize available sandbox functionality.
+
+The generated documentation is saved to the specified directory, defaulting to the current working directory if not provided.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			repository, err := gitinterface.LoadRepository(".")

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -47,8 +47,13 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "add-hooks",
-		Short:             "Add git hooks that automatically create and sync RSL",
+		Use:   "add-hooks",
+		Short: "Add git hooks that automatically create and sync RSL",
+		Long: `The 'add-hooks' command installs Git hooks that automatically create and sync the Repository Snapshot Log (RSL) when certain Git actions occur, such as a push.
+
+By default, it prevents overwriting existing hooks unless the '--force' flag is specified. This ensures users can integrate gittuf functionality without unintentionally disrupting existing workflows.
+
+The hooks enable automatic integration of trusted commit metadata, enhancing repository security.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/attest/apply/apply.go
+++ b/internal/cmd/attest/apply/apply.go
@@ -40,7 +40,16 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply and push local attestations changes to remote repository",
-		RunE:  o.Run,
+		Long: `The 'apply' command takes all locally recorded attestations (stored in the
+Reference State Log, or RSL) and applies them to the target repository.
+
+By default, the command pushes those attestations to the remote specified
+in your Git configuration.  Pass '--local-only' to record the attestation
+locally without pushing upstream.
+
+Optionally, you may supply the remote name as the first positional argument.
+If omitted, the default remote is used.`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/attest.go
+++ b/internal/cmd/attest/attest.go
@@ -14,8 +14,13 @@ import (
 func New() *cobra.Command {
 	o := &persistent.Options{}
 	cmd := &cobra.Command{
-		Use:               "attest",
-		Short:             "Tools for attesting to code contributions",
+		Use:   "attest",
+		Short: "Tools for attesting to code contributions",
+		Long: `The 'attest' command serves as a parent command that provides tools for attesting to code contributions made to a gittuf-secured repository.
+
+It includes subcommands to apply attestations, authorize contributors, and integrate GitHub-based attestations.
+
+These tools help strengthen the trust and authenticity of commits, making it easier to verify contributor identities and their roles.`,
 		DisableAutoGenTag: true,
 	}
 	o.AddPersistentFlags(cmd)

--- a/internal/cmd/attest/github/dismissapproval/dismissapproval.go
+++ b/internal/cmd/attest/github/dismissapproval/dismissapproval.go
@@ -66,7 +66,12 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dismiss-approval",
 		Short: "Record dismissal of GitHub pull request approval",
-		RunE:  o.Run,
+		Long: `The 'dismiss-approval' command creates an attestation that a previously recorded approval of a GitHub pull request has been dismissed.
+
+It requires the review ID of the pull request and the identity of the dismissed approver. These attestations provide an auditable record of review state changes on GitHub, improving transparency and trust in the contribution workflow.
+
+This command supports custom GitHub base URLs for enterprise environments and can optionally include the attestation in the Repository Snapshot Log (RSL).`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/github/github.go
+++ b/internal/cmd/attest/github/github.go
@@ -14,8 +14,16 @@ import (
 
 func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "github",
-		Short:   "Tools to attest about GitHub actions and entities",
+		Use:   "github",
+		Short: "Tools to attest about GitHub actions and entities",
+		Long: `The 'github' command is a parent command that provides tools to create attestations for actions and entities associated with GitHub, such as pull requests and approvals.
+
+It includes subcommands to:
+- Record approval of a GitHub pull request
+- Dismiss a previously recorded approval
+- Attest to metadata related to GitHub pull requests
+
+These attestations help establish trust around code contributions made through GitHub by enabling verifiable links between repository events and contributor actions.`,
 		PreRunE: common.CheckForSigningKeyFlag,
 	}
 

--- a/internal/cmd/attest/github/pullrequest/pullrequest.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest.go
@@ -99,7 +99,12 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pull-request",
 		Short: "Record GitHub pull request information as an attestation",
-		RunE:  o.Run,
+		Long: `The 'pull-request' command creates an attestation for a GitHub pull request in a gittuf-secured repository.
+
+It supports attesting either by pull request number or a specific commit and its associated base branch. These attestations help verify the origin and legitimacy of code contributions merged via GitHub.
+
+The command also supports custom GitHub base URLs and optionally includes the attestation in the Repository Snapshot Log (RSL), improving traceability of changes in both public and enterprise GitHub instances.`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/github/recordapproval/recordapproval.go
+++ b/internal/cmd/attest/github/recordapproval/recordapproval.go
@@ -92,7 +92,12 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "record-approval",
 		Short: "Record GitHub pull request approval",
-		RunE:  o.Run,
+		Long: `The 'record-approval' command creates an attestation for an approval action on a GitHub pull request in a gittuf-secured repository.
+
+This command requires the repository in the {owner}/{repo} format, the pull request number, the specific review ID, and the identity of the reviewer who approved the pull request. These attestations enhance transparency and trust in the pull request review process by recording verified reviewer approvals.
+
+It supports GitHub Enterprise and custom deployments via the --base-URL flag and can optionally include the attestation in the Repository Snapshot Log (RSL).`,
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -63,8 +63,13 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "clone",
-		Short:             "Clone repository and its gittuf references",
+		Use:   "clone",
+		Short: "Clone repository and its gittuf references",
+		Long: `The 'clone' command clones a gittuf-secured Git repository along with its associated TUF metadata and trusted references.
+
+This command behaves similarly to 'git clone' but also ensures the repository's trust root is established correctly by using specified root keys. These keys can be supplied using the --root-key flag, supporting multiple formats such as SSH key paths, GPG fingerprints, and Sigstore/Fulcio identities.
+
+You may specify a particular branch to check out with --branch and choose whether to create a bare repository using --bare. This is a foundational step in working with secure gittuf repositories, as it sets up the verification context for future secure operations.`,
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/dev/dev.go
+++ b/internal/cmd/dev/dev.go
@@ -17,9 +17,13 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "dev",
-		Short:   "Developer mode commands",
-		Long:    fmt.Sprintf("These commands are meant to be used to aid gittuf development, and are not expected to be used during standard workflows. If used, they can undermine repository security. To proceed, set %s=1.", dev.DevModeKey),
+		Use:   "dev",
+		Short: "Developer mode commands",
+		Long: fmt.Sprintf(`The 'dev' command group provides advanced utilities for use during gittuf development and debugging.
+
+These commands are intended strictly for internal or development use and are not designed to be run in production or standard repository workflows. Improper use may compromise repository security guarantees.
+
+To enable these commands, the environment variable %s must be set to 1. This acts as a safeguard to prevent accidental invocation in secure environments.`, dev.DevModeKey),
 		PreRunE: checkInDevMode,
 	}
 

--- a/internal/cmd/dev/populatecache/populatecache.go
+++ b/internal/cmd/dev/populatecache/populatecache.go
@@ -29,7 +29,12 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "populate-cache",
 		Short: fmt.Sprintf("Populate persistent cache (developer mode only, set %s=1)", dev.DevModeKey),
-		RunE:  o.Run,
+		Long: fmt.Sprintf(`The 'populate-cache' command generates and populates the local persistent cache for a gittuf repository.
+
+This command is intended for development and debugging purposes. It may be useful when inspecting or modifying the cache layer during the development of gittuf internals.
+
+Warning: This command bypasses certain security checks and is not safe for production use. It requires developer mode to be enabled by setting the environment variable %s=1.`, dev.DevModeKey),
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/dev/rslrecordat/rslrecordat.go
+++ b/internal/cmd/dev/rslrecordat/rslrecordat.go
@@ -65,8 +65,22 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rsl-record",
 		Short: fmt.Sprintf("Record explicit state of a Git reference in the RSL, signed with specified key (developer mode only, set %s=1)", dev.DevModeKey),
-		Args:  cobra.ExactArgs(1),
-		RunE:  o.Run,
+		Long: fmt.Sprintf(`The 'rsl-record' command explicitly records the state of a Git reference into the Record of State Log (RSL),
+signed using the provided key.
+
+This command is intended for developer and testing workflows where you need to manually insert entries into
+the RSL for a specific Git reference (e.g., branch or tag) at a given commit (target ID).
+
+You can optionally specify a destination reference name using --dst-ref to override the default.
+
+Requirements:
+- Developer mode must be enabled by setting %s=1
+- The signing key must be in PEM format (SSH or GPG)
+
+Usage:
+  gittuf dev rsl-record <reference> --target <commit-id> --signing-key <path-to-key> [--dst-ref <override-ref>]`, dev.DevModeKey),
+		Args: cobra.ExactArgs(1),
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -28,8 +28,28 @@ import (
 func New() *cobra.Command {
 	o := &persistent.Options{}
 	cmd := &cobra.Command{
-		Use:               "policy",
-		Short:             "Tools to manage gittuf policies",
+		Use:   "policy",
+		Short: "Tools to manage gittuf policies",
+		Long: `The 'policy' command provides a suite of tools for managing gittuf policy configurations,
+which define and enforce trust relationships and verification requirements for Git repositories.
+
+This command serves as a parent for several subcommands that allow users to:
+
+- Initialize policy directories
+- Add or remove principals (e.g., people or machines)
+- Assign keys and define rules for commit or reference validation
+- View or reorder existing rules and principals
+- Apply, stage, or discard trust policy changes
+- Interact with policies through a terminal UI
+- Cryptographically sign policy documents
+
+These commands support both interactive and automated workflows to ensure Git repository security and compliance
+with organizational policies.
+
+Usage:
+  gittuf policy <subcommand> [flags]
+
+Run 'gittuf policy <subcommand> --help' for more information on a specific subcommand.`,
 		DisableAutoGenTag: true,
 	}
 	o.AddPersistentFlags(cmd)


### PR DESCRIPTION
This PR adds a comprehensive Long description to the 'policy' command in the gittuf CLI.

It documents the purpose, capabilities, and structure of the policy management suite, including subcommand usage for principal and rule management, key assignment, signing, and UI interaction.

This update is part of the ongoing documentation initiative for all Cobra commands.

Contributor: Syed Mohammed Sylani
