### PR TITLE
docs: add Long description to add-key commandDoc add key long desc

### DIFF
--- a/docs/cli/gittuf_policy_add-key.md
+++ b/docs/cli/gittuf_policy_add-key.md
@@ -4,7 +4,7 @@ Add a trusted key to a policy file
 
 ### Synopsis
 
-This command allows users to add trusted keys to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+The 'add-key' command adds one or more trusted public keys to a gittuf policy file. This command is used to define which keys are authorized to sign commits or policy changes according to the repository's trust model. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
 
 ```
 gittuf policy add-key [flags]

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -69,7 +69,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-key",
 		Short:             "Add a trusted key to a policy file",
-		Long:              `This command allows users to add trusted keys to the specified policy file. By default, the main policy file is selected. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Long:              `The 'add-key' command adds one or more trusted public keys to a gittuf policy file. This command is used to define which keys are authorized to sign commits or policy changes according to the repository's trust model. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
This PR enhances the 'add-key' command in the gittuf CLI by adding a detailed Long description.

The update clarifies the command’s purpose, supported key formats, required flags, and its integration with the trust policy framework and RSL system.

This update is part of the ongoing effort to fully document all Cobra commands.

Contributor: Syed Mohammed Sylani
