### PR TITLE
ci: Make PAT available to goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,5 @@ jobs:
           version: latest
           args: release --clean
         env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes the WinGet releasing workflow by making the PAT for the OpenSSF-Robot account available to the workflow.

Closes #964.