### PR TITLE
ci: Update deprecated format specification in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,7 +47,7 @@ builds:
 
 archives:
 - id: binary
-  format: binary
+  formats: ['binary']
   allow_different_binary_count: true
 
 # This section defines how gittuf releases are automatically sent to WinGet as


### PR DESCRIPTION
This should fix this deprecation notice in the releasing workflow:

`DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info`

See  https://goreleaser.com/deprecations/#archivesformat.