### PR TITLE
ci: Add gittuf verification on main branch

### DIFF
--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -1,0 +1,16 @@
+name: gittuf Verification
+on:
+  push:
+    branches: ['main']
+jobs:
+  gittuf-verify:
+    if: github.repository == 'gittuf/gittuf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install gittuf
+        uses: gittuf/gittuf-installer@fe9ac76ca1aa34dfebacfdb3e5a7b31bfbff1f1c
+      - name: Checkout and verify repository
+        run: |
+          gittuf clone https://github.com/${{ github.repository }}
+          cd gittuf
+          gittuf verify-ref main --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <img src="https://raw.githubusercontent.com/gittuf/community/bd8b367fa91fab0fddaa1943e0131e90e04e6b10/artwork/PNG/gittuf_horizontal-color.png" alt="gittuf logo" width="25%"/>
 
+[![gittuf Verification](https://github.com/gittuf/gittuf/actions/workflows/gittuf-verify.yml/badge.svg)](https://github.com/gittuf/gittuf/actions/workflows/gittuf-verify.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7789/badge)](https://www.bestpractices.dev/projects/7789)
 ![Build and Tests (CI)](https://github.com/gittuf/gittuf/actions/workflows/ci.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/gittuf/gittuf/badge.svg)](https://coveralls.io/github/gittuf/gittuf)


### PR DESCRIPTION
This PR adds a gittuf verification workflow to merges to the main branch.

Note that there may be a race condition here. The action may fail before the app has a chance to record the attestation + RSL entry for the merge. I suggest we add this and monitor it.