### PR TITLE
ci: Add sleep before verifying policy on merge

### DIFF
--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -13,5 +13,6 @@ jobs:
       - name: Checkout and verify repository
         run: |
           gittuf clone https://github.com/${{ github.repository }}
+          sleep 10s
           cd gittuf
           gittuf verify-ref main --verbose


### PR DESCRIPTION
This is very rudimentary but ideally this buys some time when verifying for the app to add the required entries.