### PR TITLE
*: Propagate specific path in upstream repository

### DIFF
--- a/docs/cli/gittuf_trust_add-propagation-directive.md
+++ b/docs/cli/gittuf_trust_add-propagation-directive.md
@@ -9,6 +9,7 @@ gittuf trust add-propagation-directive [flags]
 ### Options
 
 ```
+      --from-path string         path in upstream reference to propagate contents from
       --from-reference string    reference to propagate from in upstream repository
       --from-repository string   location of upstream repository
   -h, --help                     help for add-propagation-directive

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -800,7 +800,7 @@ func (r *Repository) RemoveGlobalRule(ctx context.Context, signer sslibdsse.Sign
 	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, options.CreateRSLEntry, signCommit)
 }
 
-func (r *Repository) AddPropagationDirective(ctx context.Context, signer sslibdsse.SignerVerifier, directiveName, upstreamRepository, upstreamReference, downstreamReference, downstreamPath string, signCommit bool, opts ...trustpolicyopts.Option) error {
+func (r *Repository) AddPropagationDirective(ctx context.Context, signer sslibdsse.SignerVerifier, directiveName, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath string, signCommit bool, opts ...trustpolicyopts.Option) error {
 	if !dev.InDevMode() {
 		return dev.ErrNotInDevMode
 	}
@@ -838,9 +838,9 @@ func (r *Repository) AddPropagationDirective(ctx context.Context, signer sslibds
 	var directive tuf.PropagationDirective
 	switch rootMetadata.(type) {
 	case *tufv01.RootMetadata:
-		directive = tufv01.NewPropagationDirective(directiveName, upstreamRepository, upstreamReference, downstreamReference, downstreamPath)
+		directive = tufv01.NewPropagationDirective(directiveName, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath)
 	case *tufv02.RootMetadata:
-		directive = tufv02.NewPropagationDirective(directiveName, upstreamRepository, upstreamReference, downstreamReference, downstreamPath)
+		directive = tufv02.NewPropagationDirective(directiveName, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath)
 	}
 
 	if err := rootMetadata.AddPropagationDirective(directive); err != nil {

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -1216,7 +1216,7 @@ func TestAddPropagationDirective(t *testing.T) {
 
 		rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/", false)
+		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "", "refs/heads/main", "upstream/", false)
 		assert.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1234,7 +1234,7 @@ func TestAddPropagationDirective(t *testing.T) {
 
 		directives = rootMetadata.GetPropagationDirectives()
 		assert.Len(t, directives, 1)
-		assert.Equal(t, tufv01.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/"), directives[0])
+		assert.Equal(t, tufv01.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "", "refs/heads/main", "upstream/"), directives[0])
 	})
 
 	t.Run("with tuf v02 metadata", func(t *testing.T) {
@@ -1255,7 +1255,7 @@ func TestAddPropagationDirective(t *testing.T) {
 
 		rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/", false)
+		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "upstreamPath/", "refs/heads/main", "upstream/", false)
 		assert.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1273,7 +1273,7 @@ func TestAddPropagationDirective(t *testing.T) {
 
 		directives = rootMetadata.GetPropagationDirectives()
 		assert.Len(t, directives, 1)
-		assert.Equal(t, tufv02.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/"), directives[0])
+		assert.Equal(t, tufv02.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "upstreamPath/", "refs/heads/main", "upstream/"), directives[0])
 	})
 }
 
@@ -1298,7 +1298,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 
 		rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/", false)
+		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "upstreamPath/", "refs/heads/main", "upstream/", false)
 		require.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1316,7 +1316,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 
 		directives = rootMetadata.GetPropagationDirectives()
 		require.Len(t, directives, 1)
-		require.Equal(t, tufv01.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/"), directives[0])
+		require.Equal(t, tufv01.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "upstreamPath/", "refs/heads/main", "upstream/"), directives[0])
 
 		err = r.RemovePropagationDirective(testCtx, rootSigner, "test", false)
 		assert.Nil(t, err)
@@ -1359,7 +1359,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 
 		rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
-		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/", false)
+		err = r.AddPropagationDirective(testCtx, rootSigner, "test", "https://example.com/git/repository", "refs/heads/main", "", "refs/heads/main", "upstream/", false)
 		require.Nil(t, err)
 
 		err = r.StagePolicy(testCtx, "", true, false)
@@ -1377,7 +1377,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 
 		directives = rootMetadata.GetPropagationDirectives()
 		require.Len(t, directives, 1)
-		require.Equal(t, tufv02.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "refs/heads/main", "upstream/"), directives[0])
+		require.Equal(t, tufv02.NewPropagationDirective("test", "https://example.com/git/repository", "refs/heads/main", "", "refs/heads/main", "upstream/"), directives[0])
 
 		err = r.RemovePropagationDirective(testCtx, rootSigner, "test", false)
 		assert.Nil(t, err)

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -1083,7 +1083,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 		refName := "refs/heads/main"
 		localPath := "upstream"
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName, refName, localPath, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName, "", refName, localPath, false); err != nil {
 			t.Fatal(err)
 		}
 		if err := downstreamRepo.StagePolicy(testCtx, "", true, false); err != nil {
@@ -1218,10 +1218,10 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		refName2 := "refs/heads/feature"
 		localPath1 := "main"
 		localPath2 := "feature"
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName1, refName1, localPath1, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName1, "", refName1, localPath1, false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName2, refName1, localPath2, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName2, "", refName1, localPath2, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1383,10 +1383,10 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		refName1 := "refs/heads/main"
 		refName2 := "refs/heads/feature"
 		localPath := "upstream"
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName1, refName1, localPath, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName1, "", refName1, localPath, false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName2, refName2, localPath, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test", upstreamRepoLocation, refName2, "", refName2, localPath, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1568,10 +1568,10 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		refName := "refs/heads/main"
 		localPath1 := "upstream1"
 		localPath2 := "upstream2"
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-1", upstreamRepo1Location, refName, refName, localPath1, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-1", upstreamRepo1Location, refName, "", refName, localPath1, false); err != nil {
 			t.Fatal(err)
 		}
-		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-2", upstreamRepo2Location, refName, refName, localPath2, false); err != nil {
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-2", upstreamRepo2Location, refName, "", refName, localPath2, false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
@@ -19,6 +19,7 @@ type options struct {
 	name                string
 	upstreamRepository  string
 	upstreamReference   string
+	upstreamPath        string
 	downstreamReference string
 	downstreamPath      string
 }
@@ -47,6 +48,13 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"reference to propagate from in upstream repository",
 	)
 	cmd.MarkFlagRequired("from-reference") //nolint:errcheck
+
+	cmd.Flags().StringVar(
+		&o.upstreamPath,
+		"from-path",
+		"",
+		"path in upstream reference to propagate contents from",
+	)
 
 	cmd.Flags().StringVar(
 		&o.downstreamReference,
@@ -84,7 +92,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	if o.p.WithRSLEntry {
 		opts = append(opts, trustpolicyopts.WithRSLEntry())
 	}
-	return repo.AddPropagationDirective(cmd.Context(), signer, o.name, o.upstreamRepository, o.upstreamReference, o.downstreamReference, o.downstreamPath, true, opts...)
+	return repo.AddPropagationDirective(cmd.Context(), signer, o.name, o.upstreamRepository, o.upstreamReference, o.upstreamPath, o.downstreamReference, o.downstreamPath, true, opts...)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {

--- a/internal/gitinterface/tree.go
+++ b/internal/gitinterface/tree.go
@@ -244,7 +244,7 @@ func (r *Repository) GetMergeTree(commitAID, commitBID Hash) (Hash, error) {
 // created commit in localRef. localPath must be specified, if left blank (say
 // to imply copying into the root directory of the downstream repository),
 // creating a subtree will fail.
-func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, upstreamCommitID Hash, localRef, localPath string) (Hash, error) {
+func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, upstreamCommitID Hash, upstreamPath, localRef, localPath string) (Hash, error) {
 	if localPath == "" {
 		return nil, ErrCannotCreateSubtreeIntoRootTree
 	}
@@ -290,6 +290,15 @@ func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, u
 	treeID, err := upstream.GetCommitTreeID(upstreamCommitID)
 	if err != nil {
 		return nil, err
+	}
+
+	if upstreamPath != "" {
+		// If upstreamPath is empty, then the entire tree is copied over,
+		// otherwise, identify the subtree to copy over
+		treeID, err = upstream.GetPathIDInTree(upstreamPath, treeID)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if r.HasObject(treeID) {

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -1127,7 +1127,7 @@ func PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo *gitint
 			continue
 		}
 
-		commitID, err := downstreamRepo.CreateSubtreeFromUpstreamRepository(upstreamRepo, latestUpstreamEntry.GetTargetID(), detail.GetDownstreamReference(), detail.GetDownstreamPath())
+		commitID, err := downstreamRepo.CreateSubtreeFromUpstreamRepository(upstreamRepo, latestUpstreamEntry.GetTargetID(), detail.GetUpstreamPath(), detail.GetDownstreamReference(), detail.GetDownstreamPath())
 		if err != nil {
 			return err
 		}

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -329,12 +329,17 @@ type PropagationDirective interface {
 	// the upstream repository.
 	GetUpstreamReference() string
 
+	// GetUpstreamPath returns the path in the Git tree of the upstream
+	// reference whose contents must be propagated into the downstream
+	// repository.
+	GetUpstreamPath() string
+
 	// GetDownstreamReference returns the reference that the upstream components
 	// must be propagated into in the downstream repository (i.e., the
 	// repository where this directive is set.)
 	GetDownstreamReference() string
 
-	// GetDownstreamPath() returns the path in the Git tree of the downstream
+	// GetDownstreamPath returns the path in the Git tree of the downstream
 	// reference where the upstream repository's contents must be stored by the
 	// propagation workflow.
 	GetDownstreamPath() string

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -557,7 +557,7 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 	// propagated into this repository
 	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
 	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
+	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "", "refs/gittuf/policy", propagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for
@@ -818,6 +818,7 @@ type PropagationDirective struct {
 	Name                string `json:"name"`
 	UpstreamRepository  string `json:"upstreamRepository"`
 	UpstreamReference   string `json:"upstreamReference"`
+	UpstreamPath        string `json:"upstreamPath"`
 	DownstreamReference string `json:"downstreamReference"`
 	DownstreamPath      string `json:"downstreamPath"`
 }
@@ -834,6 +835,10 @@ func (p *PropagationDirective) GetUpstreamReference() string {
 	return p.UpstreamReference
 }
 
+func (p *PropagationDirective) GetUpstreamPath() string {
+	return p.UpstreamPath
+}
+
 func (p *PropagationDirective) GetDownstreamReference() string {
 	return p.DownstreamReference
 }
@@ -842,11 +847,12 @@ func (p *PropagationDirective) GetDownstreamPath() string {
 	return p.DownstreamPath
 }
 
-func NewPropagationDirective(name, upstreamRepository, upstreamReference, downstreamReference, downstreamPath string) tuf.PropagationDirective {
+func NewPropagationDirective(name, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath string) tuf.PropagationDirective {
 	return &PropagationDirective{
 		Name:                name,
 		UpstreamRepository:  upstreamRepository,
 		UpstreamReference:   upstreamReference,
+		UpstreamPath:        upstreamPath,
 		DownstreamReference: downstreamReference,
 		DownstreamPath:      downstreamPath,
 	}

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -677,10 +677,11 @@ func TestPropagationDirective(t *testing.T) {
 	refName := "refs/heads/main"
 	localPath := "upstream/"
 
-	directive := NewPropagationDirective(name, upstreamRepository, refName, refName, localPath)
+	directive := NewPropagationDirective(name, upstreamRepository, refName, "", refName, localPath)
 	assert.Equal(t, name, directive.GetName())
 	assert.Equal(t, upstreamRepository, directive.GetUpstreamRepository())
 	assert.Equal(t, refName, directive.GetUpstreamReference())
+	assert.Equal(t, "", directive.GetUpstreamPath())
 	assert.Equal(t, refName, directive.GetDownstreamReference())
 	assert.Equal(t, localPath, directive.GetDownstreamPath())
 }

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -660,7 +660,7 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 	// propagated into this repository
 	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
 	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "refs/gittuf/policy", propagationLocation))
+	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "", "refs/gittuf/policy", propagationLocation))
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for
@@ -791,11 +791,12 @@ var NewGlobalRuleBlockForcePushes = tufv01.NewGlobalRuleBlockForcePushes
 
 type PropagationDirective = tufv01.PropagationDirective
 
-func NewPropagationDirective(name, upstreamRepository, upstreamReference, downstreamReference, downstreamPath string) tuf.PropagationDirective {
+func NewPropagationDirective(name, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath string) tuf.PropagationDirective {
 	return &PropagationDirective{
 		Name:                name,
 		UpstreamRepository:  upstreamRepository,
 		UpstreamReference:   upstreamReference,
+		UpstreamPath:        upstreamPath,
 		DownstreamReference: downstreamReference,
 		DownstreamPath:      downstreamPath,
 	}


### PR DESCRIPTION
This PR adds support for propagating a specific path in the upstream reference in the upstream repository. Previously, propagation would copy the entire upstream reference root tree, but now a specific subtree path can be specified.