### PR TITLE
*: Propagate policy exhaustively without nesting

### DIFF
--- a/.github/workflows/ci-locale.yml
+++ b/.github/workflows/ci-locale.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24']
     runs-on: ubuntu-latest
     steps:
     - name: Set locale

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/.github/workflows/get-started-tests.yml
+++ b/.github/workflows/get-started-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24']
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code

--- a/.github/workflows/ubuntu-2204.yml
+++ b/.github/workflows/ubuntu-2204.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ['1.24']
     runs-on: ubuntu-22.04
     steps:
       - name: Downgrade Git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gittuf/gittuf
 
-go 1.23.4
+go 1.24
 
 require (
 	github.com/ProtonMail/go-crypto v1.3.0

--- a/internal/cmd/trust/listhooks/listhooks.go
+++ b/internal/cmd/trust/listhooks/listhooks.go
@@ -42,21 +42,21 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		for _, hook := range data {
 			fmt.Printf(indentString+"Hook '%s':\n", hook.ID())
 
-			fmt.Printf(strings.Repeat(indentString, 2) + "Principal IDs:\n")
+			fmt.Printf("%sPrincipal IDs:\n", strings.Repeat(indentString, 2))
 			for _, id := range hook.GetPrincipalIDs().Contents() {
-				fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", id)
+				fmt.Printf("%s%s\n", strings.Repeat(indentString, 3), id)
 			}
 
-			fmt.Printf(strings.Repeat(indentString, 2) + "Hashes:\n")
+			fmt.Printf("%sHashes:\n", strings.Repeat(indentString, 2))
 			for algo, hash := range hook.GetHashes() {
-				fmt.Printf(strings.Repeat(indentString, 3)+"%s: %s\n", algo, hash)
+				fmt.Printf("%s%s: %s\n", strings.Repeat(indentString, 3), algo, hash)
 			}
 
-			fmt.Printf(strings.Repeat(indentString, 2) + "Environment:\n")
-			fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", hook.GetEnvironment().String())
+			fmt.Printf("%sEnvironment:\n", strings.Repeat(indentString, 2))
+			fmt.Printf("%s%s\n", strings.Repeat(indentString, 3), hook.GetEnvironment().String())
 
-			fmt.Printf(strings.Repeat(indentString, 2) + "Timeout:\n")
-			fmt.Printf(strings.Repeat(indentString, 3)+"%s\n", hook.GetTimeout())
+			fmt.Printf("%sTimeout:\n", strings.Repeat(indentString, 2))
+			fmt.Printf("%s%d\n", strings.Repeat(indentString, 3), hook.GetTimeout())
 		}
 		fmt.Println()
 	}

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -6,7 +6,6 @@ package v01
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/danwakefield/fnmatch"
@@ -553,11 +552,7 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	r.MultiRepository.ControllerRepositories = append(r.MultiRepository.ControllerRepositories, otherRepository)
 
-	// Add the controller as a repository whose policy contents must be
-	// propagated into this repository
-	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
-	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "", "refs/gittuf/policy", propagationLocation))
+	return nil
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -110,16 +110,6 @@ func TestRootMetadata(t *testing.T) {
 		controllerRepositories := rootMetadata.GetControllerRepositories()
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: []*Key{key}}}, controllerRepositories)
 
-		propagations := rootMetadata.GetPropagationDirectives()
-		found := false
-		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test" {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found)
-
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)
 

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -6,7 +6,6 @@ package v02
 import (
 	"encoding/json"
 	"fmt"
-	"path"
 
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/tuf"
@@ -656,11 +655,7 @@ func (r *RootMetadata) AddControllerRepository(name, location string, initialRoo
 
 	r.MultiRepository.ControllerRepositories = append(r.MultiRepository.ControllerRepositories, otherRepository)
 
-	// Add the controller as a repository whose policy contents must be
-	// propagated into this repository
-	propagationName := fmt.Sprintf("%s-%s", tuf.GittufControllerPrefix, name)
-	propagationLocation := path.Join(tuf.GittufControllerPrefix, name)
-	return r.AddPropagationDirective(NewPropagationDirective(propagationName, location, "refs/gittuf/policy", "", "refs/gittuf/policy", propagationLocation))
+	return nil
 }
 
 // AddNetworkRepository adds the specified repository as part of the network for

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -142,16 +142,6 @@ func TestRootMetadata(t *testing.T) {
 		controllerRepositories := rootMetadata.GetControllerRepositories()
 		assert.Equal(t, []tuf.OtherRepository{&OtherRepository{Name: name, Location: location, InitialRootPrincipals: initialRootPrincipals}}, controllerRepositories)
 
-		propagations := rootMetadata.GetPropagationDirectives()
-		found := false
-		for _, propagation := range propagations {
-			if propagation.GetName() == "gittuf-controller-test" {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found)
-
 		err = rootMetadata.AddNetworkRepository(name, location, initialRootPrincipals)
 		assert.ErrorIs(t, err, tuf.ErrNotAControllerRepository)
 


### PR DESCRIPTION
This is a first pass at pre-computing the policy controller graph and propagating all changes _flatly_.