### PR TITLE
ci: Reorder sleep and clone for gittuf verify

### DIFF
--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -12,7 +12,7 @@ jobs:
         uses: gittuf/gittuf-installer@fe9ac76ca1aa34dfebacfdb3e5a7b31bfbff1f1c
       - name: Checkout and verify repository
         run: |
-          gittuf clone https://github.com/${{ github.repository }}
           sleep 10s
+          gittuf clone https://github.com/${{ github.repository }}
           cd gittuf
           gittuf verify-ref main --verbose


### PR DESCRIPTION
We want to sleep before cloning the repo to give the app the chance to add its metadata!