### PR TITLE
added support for resetting the local persistent cache #1023 

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -179,6 +179,19 @@ func LoadPersistentCache(repo *gitinterface.Repository) (*Persistent, error) {
 	return persistentCache, nil
 }
 
+// ResetPersistentCache deletes the local persistent cache ref.
+// This is useful when the cache is corrupted or the user wants a fresh start.
+func ResetPersistentCache(repo *gitinterface.Repository) error {
+	err := repo.DeleteReference(Ref)
+	if err != nil {
+		if errors.Is(err, gitinterface.ErrReferenceNotFound) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // RSLEntryIndex is essentially a tuple that maps RSL entry IDs to numbers. This
 // may be expanded in future to include more information as needed.
 type RSLEntryIndex struct {

--- a/internal/cmd/cache/cache.go
+++ b/internal/cmd/cache/cache.go
@@ -5,6 +5,7 @@ package cache
 
 import (
 	i "github.com/gittuf/gittuf/internal/cmd/cache/init"
+	r "github.com/gittuf/gittuf/internal/cmd/cache/reset"
 	"github.com/spf13/cobra"
 )
 
@@ -16,6 +17,7 @@ func New() *cobra.Command {
 	}
 
 	cmd.AddCommand(i.New())
+	cmd.AddCommand(r.New())
 
 	return cmd
 }

--- a/internal/cmd/cache/reset/reset.go
+++ b/internal/cmd/cache/reset/reset.go
@@ -1,0 +1,37 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reset
+
+import (
+	"github.com/gittuf/gittuf/internal/cache"
+	"github.com/gittuf/gittuf/internal/gitinterface"
+	"github.com/spf13/cobra"
+)
+
+type options struct{}
+
+func (o *options) AddFlags(_ *cobra.Command) {
+}
+
+func (o *options) Run(_ *cobra.Command, _ []string) error {
+	repo, err := gitinterface.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	return cache.ResetPersistentCache(repo)
+}
+
+func New() *cobra.Command {
+	o := &options{}
+
+	cmd := &cobra.Command{
+		Use:   "reset",
+		Short: "Reset (delete) the local persistent cache",
+		Long:  `The 'reset' command deletes the local persistent cache used by gittuf.`,
+		RunE:  o.Run,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}


### PR DESCRIPTION
( #1023 )

This PR introduces a new subcommand under the `gittuf cache` CLI group:

- **`gittuf cache reset`**  
  Deletes the `refs/local/gittuf/persistent-cache` reference from the local Git repository.

---
###  Updated Files:
- `internal/cmd/cache/reset/reset.go`  
  Implements the command logic using `gitinterface.OpenRepository()` and `cache.ResetPersistentCache()`.

- `internal/cmd/cache/cache.go`  
  Adds the `reset` subcommand to the `cache` command group.

- `internal/cache/cache.go`  
  Defines the new function `ResetPersistentCache()` to safely delete the persistent cache ref.

---

###  Behavior:
- **Safe no-op:** If the ref `refs/local/gittuf/persistent-cache` doesn't exist, the command exits gracefully without error.
- Works seamlessly with the existing `gittuf cache init` command.

---

### 🧪 Manual Verification:
- `gittuf cache init` correctly creates the persistent cache ref.
- `gittuf cache reset` deletes the ref.
- Re-running `gittuf cache init` re-creates the ref as expected.

`gittuf cache init`
![image](https://github.com/user-attachments/assets/bdc01250-87bc-4565-89b5-44af00f12d8d)

`gittuf cache reset`
![image](https://github.com/user-attachments/assets/26e15f40-74ee-4cdc-b451-66792f13806f)
