### PR TITLE
Move functionality out of devmode

### DIFF
--- a/docs/cli/gittuf_rsl.md
+++ b/docs/cli/gittuf_rsl.md
@@ -23,7 +23,7 @@ Tools to manage the repository's reference state log
 * [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
 * [gittuf rsl annotate](gittuf_rsl_annotate.md)	 - Annotate prior RSL entries
 * [gittuf rsl log](gittuf_rsl_log.md)	 - Display the repository's Reference State Log
-* [gittuf rsl propagate](gittuf_rsl_propagate.md)	 - Propagate contents of remote repositories into local repository (developer mode only, set GITTUF_DEV=1)
+* [gittuf rsl propagate](gittuf_rsl_propagate.md)	 - Propagate contents of remote repositories into local repository
 * [gittuf rsl record](gittuf_rsl_record.md)	 - Record latest state of a Git reference in the RSL
 * [gittuf rsl remote](gittuf_rsl_remote.md)	 - Tools for managing remote RSLs
 * [gittuf rsl skip-rewritten](gittuf_rsl_skip-rewritten.md)	 - Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref

--- a/docs/cli/gittuf_rsl_propagate.md
+++ b/docs/cli/gittuf_rsl_propagate.md
@@ -1,6 +1,6 @@
 ## gittuf rsl propagate
 
-Propagate contents of remote repositories into local repository (developer mode only, set GITTUF_DEV=1)
+Propagate contents of remote repositories into local repository
 
 ```
 gittuf rsl propagate [flags]

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -23,13 +23,13 @@ Tools for gittuf's root of trust
 ### SEE ALSO
 
 * [gittuf](gittuf.md)	 - A security layer for Git repositories, powered by TUF
-* [gittuf trust add-controller-repository](gittuf_trust_add-controller-repository.md)	 - Add a controller repository (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust add-controller-repository](gittuf_trust_add-controller-repository.md)	 - Add a controller repository
 * [gittuf trust add-github-app](gittuf_trust_add-github-app.md)	 - Add GitHub app to gittuf root of trust
-* [gittuf trust add-global-rule](gittuf_trust_add-global-rule.md)	 - Add a new global rule to root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust add-global-rule](gittuf_trust_add-global-rule.md)	 - Add a new global rule to root of trust
 * [gittuf trust add-hook](gittuf_trust_add-hook.md)	 - Add a script to be run as a gittuf hook, specify when and where to run it (developer mode only, set GITTUF_DEV=1)
-* [gittuf trust add-network-repository](gittuf_trust_add-network-repository.md)	 - Add a network repository (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust add-network-repository](gittuf_trust_add-network-repository.md)	 - Add a network repository
 * [gittuf trust add-policy-key](gittuf_trust_add-policy-key.md)	 - Add Policy key to gittuf root of trust
-* [gittuf trust add-propagation-directive](gittuf_trust_add-propagation-directive.md)	 - Add propagation directive into gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust add-propagation-directive](gittuf_trust_add-propagation-directive.md)	 - Add propagation directive into gittuf root of trust
 * [gittuf trust add-root-key](gittuf_trust_add-root-key.md)	 - Add Root key to gittuf root of trust
 * [gittuf trust apply](gittuf_trust_apply.md)	 - Validate and apply changes from policy-staging to policy
 * [gittuf trust disable-github-app-approvals](gittuf_trust_disable-github-app-approvals.md)	 - Mark GitHub app approvals as untrusted henceforth
@@ -38,18 +38,18 @@ Tools for gittuf's root of trust
 * [gittuf trust inspect-root](gittuf_trust_inspect-root.md)	 - Inspect root metadata
 * [gittuf trust list-global-rules](gittuf_trust_list-global-rules.md)	 - List global rules for the current state
 * [gittuf trust list-hooks](gittuf_trust_list-hooks.md)	 - List gittuf hooks for the current policy state
-* [gittuf trust make-controller](gittuf_trust_make-controller.md)	 - Make current repository a controller (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust make-controller](gittuf_trust_make-controller.md)	 - Make current repository a controller
 * [gittuf trust remote](gittuf_trust_remote.md)	 - Tools for managing remote policies
 * [gittuf trust remove-github-app](gittuf_trust_remove-github-app.md)	 - Remove GitHub app from gittuf root of trust
-* [gittuf trust remove-global-rule](gittuf_trust_remove-global-rule.md)	 - Remove a global rule from root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust remove-global-rule](gittuf_trust_remove-global-rule.md)	 - Remove a global rule from root of trust
 * [gittuf trust remove-hook](gittuf_trust_remove-hook.md)	 - Remove a gittuf hook specified in the policy (developer mode only, set GITTUF_DEV=1)
 * [gittuf trust remove-policy-key](gittuf_trust_remove-policy-key.md)	 - Remove Policy key from gittuf root of trust
-* [gittuf trust remove-propagation-directive](gittuf_trust_remove-propagation-directive.md)	 - Remove propagation directive from gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust remove-propagation-directive](gittuf_trust_remove-propagation-directive.md)	 - Remove propagation directive from gittuf root of trust
 * [gittuf trust remove-root-key](gittuf_trust_remove-root-key.md)	 - Remove Root key from gittuf root of trust
 * [gittuf trust set-repository-location](gittuf_trust_set-repository-location.md)	 - Set repository location
 * [gittuf trust sign](gittuf_trust_sign.md)	 - Sign root of trust
 * [gittuf trust stage](gittuf_trust_stage.md)	 - Stage and push local policy-staging changes to remote repository
-* [gittuf trust update-global-rule](gittuf_trust_update-global-rule.md)	 - Update an existing global rule in the root of trust (developer mode only, set GITTUF_DEV=1)
+* [gittuf trust update-global-rule](gittuf_trust_update-global-rule.md)	 - Update an existing global rule in the root of trust
 * [gittuf trust update-policy-threshold](gittuf_trust_update-policy-threshold.md)	 - Update Policy threshold in the gittuf root of trust
 * [gittuf trust update-root-threshold](gittuf_trust_update-root-threshold.md)	 - Update Root threshold in the gittuf root of trust
 

--- a/docs/cli/gittuf_trust_add-controller-repository.md
+++ b/docs/cli/gittuf_trust_add-controller-repository.md
@@ -1,6 +1,6 @@
 ## gittuf trust add-controller-repository
 
-Add a controller repository (developer mode only, set GITTUF_DEV=1)
+Add a controller repository
 
 ```
 gittuf trust add-controller-repository [flags]

--- a/docs/cli/gittuf_trust_add-global-rule.md
+++ b/docs/cli/gittuf_trust_add-global-rule.md
@@ -1,6 +1,6 @@
 ## gittuf trust add-global-rule
 
-Add a new global rule to root of trust (developer mode only, set GITTUF_DEV=1)
+Add a new global rule to root of trust
 
 ### Synopsis
 

--- a/docs/cli/gittuf_trust_add-network-repository.md
+++ b/docs/cli/gittuf_trust_add-network-repository.md
@@ -1,6 +1,6 @@
 ## gittuf trust add-network-repository
 
-Add a network repository (developer mode only, set GITTUF_DEV=1)
+Add a network repository
 
 ```
 gittuf trust add-network-repository [flags]

--- a/docs/cli/gittuf_trust_add-propagation-directive.md
+++ b/docs/cli/gittuf_trust_add-propagation-directive.md
@@ -1,6 +1,6 @@
 ## gittuf trust add-propagation-directive
 
-Add propagation directive into gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+Add propagation directive into gittuf root of trust
 
 ```
 gittuf trust add-propagation-directive [flags]

--- a/docs/cli/gittuf_trust_make-controller.md
+++ b/docs/cli/gittuf_trust_make-controller.md
@@ -1,6 +1,6 @@
 ## gittuf trust make-controller
 
-Make current repository a controller (developer mode only, set GITTUF_DEV=1)
+Make current repository a controller
 
 ```
 gittuf trust make-controller [flags]

--- a/docs/cli/gittuf_trust_remove-global-rule.md
+++ b/docs/cli/gittuf_trust_remove-global-rule.md
@@ -1,6 +1,6 @@
 ## gittuf trust remove-global-rule
 
-Remove a global rule from root of trust (developer mode only, set GITTUF_DEV=1)
+Remove a global rule from root of trust
 
 ### Synopsis
 

--- a/docs/cli/gittuf_trust_remove-propagation-directive.md
+++ b/docs/cli/gittuf_trust_remove-propagation-directive.md
@@ -1,6 +1,6 @@
 ## gittuf trust remove-propagation-directive
 
-Remove propagation directive from gittuf root of trust (developer mode only, set GITTUF_DEV=1)
+Remove propagation directive from gittuf root of trust
 
 ```
 gittuf trust remove-propagation-directive [flags]

--- a/docs/cli/gittuf_trust_update-global-rule.md
+++ b/docs/cli/gittuf_trust_update-global-rule.md
@@ -1,6 +1,6 @@
 ## gittuf trust update-global-rule
 
-Update an existing global rule in the root of trust (developer mode only, set GITTUF_DEV=1)
+Update an existing global rule in the root of trust
 
 ### Synopsis
 

--- a/experimental/gittuf/cache_test.go
+++ b/experimental/gittuf/cache_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/cache"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/stretchr/testify/assert"
@@ -15,8 +14,6 @@ import (
 
 func TestPopulateCache(t *testing.T) {
 	t.Run("successful cache population", func(t *testing.T) {
-		t.Setenv(dev.DevModeKey, "1")
-
 		tmpDir := t.TempDir()
 		repo := createTestRepositoryWithPolicy(t, tmpDir)
 
@@ -52,8 +49,6 @@ func TestPopulateCache(t *testing.T) {
 	})
 
 	t.Run("successful repeated cache population", func(t *testing.T) {
-		t.Setenv(dev.DevModeKey, "1")
-
 		tmpDir := t.TempDir()
 		repo := createTestRepositoryWithPolicy(t, tmpDir)
 

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -572,10 +572,6 @@ func (r *Repository) UpdateTopLevelTargetsThreshold(ctx context.Context, signer 
 
 // AddGlobalRuleThreshold adds a threshold global rule to the root metadata.
 func (r *Repository) AddGlobalRuleThreshold(ctx context.Context, signer sslibdsse.SignerVerifier, name string, patterns []string, threshold int, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	options := &trustpolicyopts.Options{}
 	for _, fn := range opts {
 		fn(options)
@@ -616,10 +612,6 @@ func (r *Repository) AddGlobalRuleThreshold(ctx context.Context, signer sslibdss
 
 // AddGlobalRuleBlockForcePushes adds a global rule that blocks force pushes to the root metadata.
 func (r *Repository) AddGlobalRuleBlockForcePushes(ctx context.Context, signer sslibdsse.SignerVerifier, name string, patterns []string, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	options := &trustpolicyopts.Options{}
 	for _, fn := range opts {
 		fn(options)
@@ -665,10 +657,6 @@ func (r *Repository) AddGlobalRuleBlockForcePushes(ctx context.Context, signer s
 
 // UpdateGlobalRuleThreshold updates an existing threshold global rule in the root metadata.
 func (r *Repository) UpdateGlobalRuleThreshold(ctx context.Context, signer sslibdsse.SignerVerifier, name string, patterns []string, threshold int, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -709,10 +697,6 @@ func (r *Repository) UpdateGlobalRuleThreshold(ctx context.Context, signer sslib
 
 // UpdateGlobalRuleBlockForcePushes updates an existing block-force-pushes global rule in the root metadata.
 func (r *Repository) UpdateGlobalRuleBlockForcePushes(ctx context.Context, signer sslibdsse.SignerVerifier, name string, patterns []string, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -758,10 +742,6 @@ func (r *Repository) UpdateGlobalRuleBlockForcePushes(ctx context.Context, signe
 
 // RemoveGlobalRule removes a global rule from the root metadata.
 func (r *Repository) RemoveGlobalRule(ctx context.Context, signer sslibdsse.SignerVerifier, name string, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -801,10 +781,6 @@ func (r *Repository) RemoveGlobalRule(ctx context.Context, signer sslibdsse.Sign
 }
 
 func (r *Repository) AddPropagationDirective(ctx context.Context, signer sslibdsse.SignerVerifier, directiveName, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath string, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -852,10 +828,6 @@ func (r *Repository) AddPropagationDirective(ctx context.Context, signer sslibds
 }
 
 func (r *Repository) RemovePropagationDirective(ctx context.Context, signer sslibdsse.SignerVerifier, name string, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -1022,10 +994,6 @@ func (r *Repository) RemoveHook(ctx context.Context, signer sslibdsse.SignerVeri
 // EnableController makes the current repository a "controller" repository used
 // to specify gittuf policies for other repositories.
 func (r *Repository) EnableController(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -1068,10 +1036,6 @@ func (r *Repository) EnableController(ctx context.Context, signer sslibdsse.Sign
 // gittuf repositories. Any policies declared in this repository will not be
 // enforced for other repositories part of the network.
 func (r *Repository) DisableController(ctx context.Context, signer sslibdsse.SignerVerifier, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -1113,10 +1077,6 @@ func (r *Repository) DisableController(ctx context.Context, signer sslibdsse.Sig
 // AddControllerRepository adds a repository as a controller to the current
 // repository.
 func (r *Repository) AddControllerRepository(ctx context.Context, signer sslibdsse.SignerVerifier, repositoryName, repositoryLocation string, initialRootPrincipals []tuf.Principal, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
@@ -1158,10 +1118,6 @@ func (r *Repository) AddControllerRepository(ctx context.Context, signer sslibds
 // AddNetworkRepository adds a repository as part of the network overseen by the
 // current repository.
 func (r *Repository) AddNetworkRepository(ctx context.Context, signer sslibdsse.SignerVerifier, repositoryName, repositoryLocation string, initialRootPrincipals []tuf.Principal, signCommit bool, opts ...trustpolicyopts.Option) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	if signCommit {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -630,8 +630,6 @@ func TestSignRoot(t *testing.T) {
 }
 
 func TestAddGlobalRuleThreshold(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	r := createTestRepositoryWithRoot(t, "")
 
 	state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyRef)
@@ -676,8 +674,6 @@ func TestAddGlobalRuleThreshold(t *testing.T) {
 }
 
 func TestAddGlobalRuleBlockForcePushes(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	r := createTestRepositoryWithRoot(t, "")
 
 	state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyRef)
@@ -717,8 +713,6 @@ func TestAddGlobalRuleBlockForcePushes(t *testing.T) {
 	assert.Equal(t, []string{"git:refs/heads/main"}, globalRules[0].(tuf.GlobalRuleBlockForcePushes).GetProtectedNamespaces())
 }
 func TestRemoveGlobalRule(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("remove threshold global rule", func(t *testing.T) {
 		r := createTestRepositoryWithRoot(t, "")
 
@@ -831,8 +825,6 @@ func TestRemoveGlobalRule(t *testing.T) {
 }
 
 func TestUpdateGlobalRule(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("update threshold in threshold global rule", func(t *testing.T) {
 		r := createTestRepositoryWithRoot(t, "")
 
@@ -1172,8 +1164,6 @@ func TestUpdateGlobalRule(t *testing.T) {
 }
 
 func TestListGlobalRules(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("list global rules after add and remove", func(t *testing.T) {
 		r := createTestRepositoryWithRoot(t, "")
 
@@ -1196,8 +1186,6 @@ func TestListGlobalRules(t *testing.T) {
 }
 
 func TestAddPropagationDirective(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("with tuf v01 metadata", func(t *testing.T) {
 		r := createTestRepositoryWithRoot(t, "")
 
@@ -1278,8 +1266,6 @@ func TestAddPropagationDirective(t *testing.T) {
 }
 
 func TestRemovePropagationDirective(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("with tuf v01 metadata", func(t *testing.T) {
 		r := createTestRepositoryWithRoot(t, "")
 

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -773,11 +773,6 @@ func (r *Repository) isDuplicateEntry(refName string, targetID gitinterface.Hash
 // workflow. It inspects the latest policy metadata to find the applicable
 // propagation directives, and executes the workflow on each one.
 func (r *Repository) PropagateChangesFromUpstreamRepositories(ctx context.Context, sign bool) error {
-	if !dev.InDevMode() {
-		slog.Debug("Propagation is only supported in developer mode, skipping check...")
-		return nil
-	}
-
 	slog.Debug("Checking if upstream changes must be propagated...")
 	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyRef)
 	if err != nil {

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -1070,8 +1070,6 @@ func TestPullRSL(t *testing.T) {
 }
 
 func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("single upstream repo", func(t *testing.T) {
 		// Create upstreamRepo
 		upstreamRepoLocation := t.TempDir()

--- a/internal/cmd/rsl/propagate/propagate.go
+++ b/internal/cmd/rsl/propagate/propagate.go
@@ -4,10 +4,7 @@
 package propagate
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
 
@@ -16,10 +13,6 @@ type options struct{}
 func (o *options) AddFlags(_ *cobra.Command) {}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -32,7 +25,7 @@ func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
 		Use:               "propagate",
-		Short:             fmt.Sprintf("Propagate contents of remote repositories into local repository (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Propagate contents of remote repositories into local repository`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
@@ -4,13 +4,10 @@
 package addcontrollerrepository
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
@@ -49,10 +46,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -84,7 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "add-controller-repository",
-		Short:             fmt.Sprintf("Add a controller repository (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Add a controller repository`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/addglobalrule/addglobalrule.go
+++ b/internal/cmd/trust/addglobalrule/addglobalrule.go
@@ -10,7 +10,6 @@ import (
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
@@ -58,10 +57,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -101,7 +96,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "add-global-rule",
-		Short:             fmt.Sprintf("Add a new global rule to root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Add a new global rule to root of trust`,
 		Long:              "This command allows a user to add a new global rule to the root of trust. The user must specify the name, type, and rule pattern for the rule.",
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
@@ -4,13 +4,10 @@
 package addnetworkrepository
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
@@ -49,10 +46,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -84,7 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "add-network-repository",
-		Short:             fmt.Sprintf("Add a network repository (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Add a network repository`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
@@ -4,13 +4,10 @@
 package addpropagationdirective
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
 
@@ -74,10 +71,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -99,7 +92,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "add-propagation-directive",
-		Short:             fmt.Sprintf("Add propagation directive into gittuf root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Add propagation directive into gittuf root of trust`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/makecontroller/makecontroller.go
+++ b/internal/cmd/trust/makecontroller/makecontroller.go
@@ -4,13 +4,10 @@
 package makecontroller
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
 
@@ -21,10 +18,6 @@ type options struct {
 func (o *options) AddFlags(_ *cobra.Command) {}
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -47,7 +40,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "make-controller",
-		Short:             fmt.Sprintf("Make current repository a controller (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Make current repository a controller`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/removeglobalrule/removeglobalrule.go
+++ b/internal/cmd/trust/removeglobalrule/removeglobalrule.go
@@ -4,13 +4,10 @@
 package removeglobalrule
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +27,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -56,7 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "remove-global-rule",
-		Short:             fmt.Sprintf("Remove a global rule from root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Remove a global rule from root of trust`,
 		Long:              "This command allows users to remove an existing global rule from the root of trust. The name of the global rule must be specified.",
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/trust/removepropagationdirective/removepropagationdirective.go
+++ b/internal/cmd/trust/removepropagationdirective/removepropagationdirective.go
@@ -4,13 +4,10 @@
 package removepropagationdirective
 
 import (
-	"fmt"
-
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/spf13/cobra"
 )
 
@@ -30,10 +27,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -55,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "remove-propagation-directive",
-		Short:             fmt.Sprintf("Remove propagation directive from gittuf root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Remove propagation directive from gittuf root of trust`,
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/updateglobalrule/updateglobalrule.go
+++ b/internal/cmd/trust/updateglobalrule/updateglobalrule.go
@@ -10,7 +10,6 @@ import (
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/common"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/spf13/cobra"
 )
@@ -56,10 +55,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *options) Run(cmd *cobra.Command, _ []string) error {
-	if !dev.InDevMode() {
-		return dev.ErrNotInDevMode
-	}
-
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -99,7 +94,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "update-global-rule",
-		Short:             fmt.Sprintf("Update an existing global rule in the root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Short:             `Update an existing global rule in the root of trust`,
 		Long:              "This command allows users to update an existing global rule in the root of trust. The name of the global rule must be specified. Note that a global rule may only be updated with the same type of global rule, and changes to the type require removing and adding it again.",
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/gitinterface"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
@@ -701,8 +700,6 @@ func createTestStateWithThresholdPolicyAndGitHubAppTrust(t *testing.T) *State {
 //     ID set as the app name
 func createTestStateWithThresholdPolicyAndGitHubAppTrustForMixedAttestations(t *testing.T) *State {
 	t.Helper()
-
-	t.Setenv(dev.DevModeKey, "1")
 
 	state := createTestStateWithPolicyUsingPersons(t)
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -739,9 +739,6 @@ func TestVerifyRelativeForRefUsingPersons(t *testing.T) {
 func TestVerifyMergeable(t *testing.T) {
 	refName := "refs/heads/main"
 	featureRefName := "refs/heads/feature"
-
-	t.Setenv(dev.DevModeKey, "1")
-
 	t.Run("base commit zero, mergeable using GitHub approval, RSL entry signature required", func(t *testing.T) {
 		repo, _ := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrust)
 


### PR DESCRIPTION
This PR:

1. Removes unneeded devmode checks and env var settings that weren't removed when moving functionality out of devmode before.
2. Moves multi-repo functionality and global rules out of devmode.

I think that both items are candidates to move out of devmode, but I can split the PR into two parts if we want to hold off on promoting more functionality.