### PR TITLE
docs: improve long description for list-rules command

### DIFF
--- a/internal/cmd/policy/listrules/listrules.go
+++ b/internal/cmd/policy/listrules/listrules.go
@@ -74,9 +74,27 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "list-rules",
-		Short:             "List rules for the current state",
-		Long:              `The 'list-rules' command displays all policy rules defined in the current gittuf policy. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Use:   "list-rules",
+		Short: "List rules for the current state",
+		Long: `List all policy rules defined in a gittuf-controlled Git repository at the specified reference.
+
+For each rule, this command shows:
+  • Rule ID and name
+  • The protected Git namespace(s) it applies to (branches, tags, paths)
+  • Principal IDs (signing keys or identities) authorized to modify those namespaces
+  • Required signature threshold for enforcement
+  • Delegation hierarchy, presented in a tree structure (root → delegated rules)
+
+By inspecting this output, users can understand which parts of the repository are protected, who is allowed to change them, and how trust is structured.
+
+Flags:
+  --target-ref string   Git reference containing the policy metadata (defaults to “policy”)
+
+Example:
+  gittuf list-rules --target-ref main
+`
+
+
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}


### PR DESCRIPTION
This pull request adds a detailed Long description to the list-rules sub-command
of policy in the gittuf CLI.

The new Long field explains what the command does, outlines the structure of each
policy rule (including rule ID, protected paths or refs, principal IDs, and signature
threshold), and describes how rules are visualized in a delegation tree.

This update continues the ongoing effort to enhance Cobra command
documentation across the gittuf project.

Contributor: Syed Mohammed Sylani