### PR TITLE
Add skeleton for `approve-temp` CLI command

### DIFF
--- a/internal/attestations/approve.go
+++ b/internal/attestations/approve.go
@@ -1,0 +1,40 @@
+package attestations
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	dsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+)
+
+// TemporaryApprovalAttestation defines the structure for time-limited approvals.
+type TemporaryApprovalAttestation struct {
+	ActionID       string    `json:"action_id"`
+	ApproverKeyID  string    `json:"approver_key_id"`
+	ApprovalTime   time.Time `json:"approval_time"`
+	ExpirationTime time.Time `json:"expiration_time"`
+}
+
+// Media type identifier for the payload
+const TemporaryApprovalMediaType = "application/vnd.gittuf.temp-approval+json"
+
+// SignTemporaryApproval creates a DSSE envelope over the JSON-serialized attestation
+func SignTemporaryApproval(ctx context.Context, att *TemporaryApprovalAttestation, signer dsse.Signer) (*dsse.Envelope, error) {
+	payload, err := json.Marshal(att)
+	if err != nil {
+		return nil, err
+	}
+
+	envSigner, err := dsse.NewEnvelopeSigner(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	envelope, err := envSigner.SignPayload(ctx, TemporaryApprovalMediaType, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return envelope, nil
+}

--- a/internal/cmd/approve_temp/approve_temp.go
+++ b/internal/cmd/approve_temp/approve_temp.go
@@ -1,0 +1,32 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package approve_temp
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// New returns the cobra.Command for the `approve-temp` subcommand.
+func New() *cobra.Command {
+	var action string
+	var duration string
+
+	cmd := &cobra.Command{
+		Use:   "approve-temp",
+		Short: "Generate a temporary approval attestation",
+		Long: `Creates a signed, time-limited approval attestation for a PR or commit.
+Currently this is just a stub; full implementation will be added in later phases.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("Stub: would approve action '%s' for duration '%s'\n", action, duration)
+		},
+	}
+
+	cmd.Flags().StringVarP(&action, "action", "a", "", "Target action to approve (e.g. PR-123, commit SHA)")
+	cmd.Flags().StringVarP(&duration, "duration", "d", "24h", "Approval validity duration (e.g. 2h, 1d)")
+	cmd.MarkFlagRequired("action")
+
+	return cmd
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/verifynetwork"
 	"github.com/gittuf/gittuf/internal/cmd/verifyref"
 	"github.com/gittuf/gittuf/internal/cmd/version"
+	"github.com/gittuf/gittuf/internal/cmd/approve_temp"
 	"github.com/gittuf/gittuf/internal/display"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
@@ -123,6 +124,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(verifynetwork.New())
 	cmd.AddCommand(verifyref.New())
 	cmd.AddCommand(version.New())
+	cmd.AddCommand(approve_temp.New())
 
 	return cmd
 }


### PR DESCRIPTION
Adds a new `gittuf approve-temp` subcommand for generating temporary approval attestations. 

This pr implements only the CLI scaffolding with flags and stub output, without any signing or policy logic.
