### PR TITLE
Add detailed Long descriptions to skiprewritten, sync, and trust commands

### DIFF
--- a/internal/cmd/rsl/skiprewritten/skiprewritten.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten.go
@@ -26,6 +26,15 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "skip-rewritten",
 		Short:             "Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref",
+		Long: "The skiprewritten command tells gittuf to ignore rewritten commits in the repository.
+
+This is useful in situations where commits are modified by automated tools (e.g., rebase,
+formatting tools, squashing, etc.) and you want gittuf to skip verification or enforcement
+for those rewritten commits. This command marks such commits explicitly so they are not
+subject to the same rules as regular, verified commits.
+
+It is typically used during complex history rewriting where preserving the verification
+status of original commits isn't possible or desired.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/sync/sync.go
+++ b/internal/cmd/sync/sync.go
@@ -55,6 +55,15 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync [remoteName]",
 		Short: "Synchronize local references with remote references based on RSL",
+		Long: "The sync command synchronizes the gittuf metadata between the local repository
+and the remote sources.
+
+It ensures that the local cache and state of trusted metadata is consistent with what's
+available on the remote. This is useful after changes are made to the trust policies,
+principals, or rules either locally or by other collaborators, and the updates have been
+pushed to a remote source of truth.
+
+Running this command helps maintain trust and consistency across multiple environments.",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  o.Run,
 	}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -42,6 +42,15 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "trust",
 		Short:             "Tools for gittuf's root of trust",
+		Long: 				"The trust command allows you to mark a specific Git identity (GPG or SSH key) as trusted.
+
+Trusted identities are allowed to sign commits, tags, or other Git objects, and their
+signatures will be considered valid when enforcing verification policies defined by gittuf.
+
+This command is a central part of the trust model in gittuf, allowing users to configure
+which contributors or automation tools are authorized to make verifiable contributions
+within a repository.",
+
 		DisableAutoGenTag: true,
 	}
 	o.AddPersistentFlags(cmd)


### PR DESCRIPTION
This pull request adds comprehensive Long descriptions to the following CLI commands in the gittuf project:

- `skiprewritten`: Explains the purpose of skipping rewritten commits in a repository, especially useful during rebases or history rewriting.
- `sync`: Describes how this command ensures local metadata stays consistent with remote sources.
- `trust`: Details how this command marks identities as trusted for signature verification.

These descriptions improve the clarity and usability of the CLI by helping users understand the purpose and context of each command directly from the help output (`--help`).

✅ DCO signed
✅ Follows existing documentation style
Contributor:- Syed Mohammed Sylani sylanmohammed@gmail.com