### PR TITLE
docs: add long descriptions for add-root-key and GitHub App approval commands

### DIFF
--- a/internal/cmd/rsl/skiprewritten/skiprewritten.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten.go
@@ -24,8 +24,20 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "skip-rewritten",
-		Short:             "Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref",
+		Use:   "skip-rewritten",
+		Short: "Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref",
+		Long: `The 'skip-rewritten' command adds an RSL annotation to skip reference entries
+that point to commits no longer present in the given Git reference.
+
+This is useful when the history of a branch has been rewritten and some RSL entries
+refer to commits that no longer exist.
+
+It takes exactly one argument: the Git reference to check against.
+
+Example:
+
+  gittuf trust skip-rewritten main`,
+
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/sync/sync.go
+++ b/internal/cmd/sync/sync.go
@@ -55,8 +55,21 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sync [remoteName]",
 		Short: "Synchronize local references with remote references based on RSL",
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  o.Run,
+		Long: `The 'sync' command synchronizes local references with the remote references
+based on the RSL (Repository Signing Log).
+
+By default, it uses the 'origin' remote unless a different remote name is provided.
+If references have diverged, it prints the list of affected refs and suggests
+rerunning the command with --overwrite to apply remote changes.
+
+Use with caution: --overwrite may discard local changes.
+
+Example:
+
+  gittuf trust sync origin`,
+
+		Args: cobra.MaximumNArgs(1),
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -52,8 +52,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "add-root-key",
-		Short:             "Add Root key to gittuf root of trust",
+		Use:   "add-root-key",
+		Short: "Add Root key to gittuf root of trust",
+		Long: `The 'add-root-key' command allows users to add a new root key to the root of trust in a gittuf-secured Git repository.
+
+In gittuf, the root of trust is initialized with one or more root keys that are used to validate and authorize changes to the repository’s trust metadata. This command facilitates the addition of an extra root key to the existing trusted root keys, enabling a multi-root setup or key rotation.
+
+To perform this operation, the user must specify the new root key file using the '--root-key' flag, which should point to a PEM-encoded public key file. The current user must also provide a signing key via the persistent '--signing-key' flag, as adding a root key is a signed action that updates the trust policy.
+
+Optionally, the '--rsl-entry' flag can be set to indicate that the addition of the new root key should be recorded in the Repository Signing Log (RSL), providing an auditable trail of trust-related changes.
+
+This command is essential for administrative operations such as delegating trust to additional parties, performing key rotations, or implementing key recovery strategies within a secure and verifiable Git ecosystem.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -54,15 +54,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-root-key",
 		Short: "Add Root key to gittuf root of trust",
-		Long: `The 'add-root-key' command allows users to add a new root key to the root of trust in a gittuf-secured Git repository.
-
-In gittuf, the root of trust is initialized with one or more root keys that are used to validate and authorize changes to the repository’s trust metadata. This command facilitates the addition of an extra root key to the existing trusted root keys, enabling a multi-root setup or key rotation.
-
-To perform this operation, the user must specify the new root key file using the '--root-key' flag, which should point to a PEM-encoded public key file. The current user must also provide a signing key via the persistent '--signing-key' flag, as adding a root key is a signed action that updates the trust policy.
-
-Optionally, the '--rsl-entry' flag can be set to indicate that the addition of the new root key should be recorded in the Repository Signing Log (RSL), providing an auditable trail of trust-related changes.
-
-This command is essential for administrative operations such as delegating trust to additional parties, performing key rotations, or implementing key recovery strategies within a secure and verifiable Git ecosystem.`,
+		Long:  `The 'add-root-key' command adds a new root key to the root of trust in a gittuf-secured repository. It requires a public key file via --root-key and a signing key via --signing-key. Optionally, the change can be recorded in the RSL.`,
 
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -47,8 +47,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "disable-github-app-approvals",
-		Short:             "Mark GitHub app approvals as untrusted henceforth",
+		Use:   "disable-github-app-approvals",
+		Short: "Mark GitHub app approvals as untrusted henceforth",
+		Long: `The 'disable-github-app-approvals' command allows users to mark a GitHub App as untrusted in a gittuf-secured Git repository, thereby disabling its ability to approve changes in the future.
+
+GitHub Apps can be integrated into a repository’s trust policy to automatically approve commits, merges, or other protected operations based on their identity. However, there may be situations where a previously trusted GitHub App must be revoked due to a change in ownership, compromised credentials, or a shift in repository governance.
+
+This command enables repository maintainers to explicitly untrust a GitHub App by specifying its name using the '--app-name' flag. By default, the app name is set to the conventional role used by gittuf, but it can be overridden as needed. Once untrusted, the GitHub App will no longer have the authority to approve actions under the repository’s trust policy.
+
+The action requires a signing key, passed using the persistent '--signing-key' flag, to authorize the change. Optionally, if the '--rsl-entry' flag is set, the change will be recorded in the Repository Signing Log (RSL), ensuring that the modification to the trust configuration is auditable and tamper-evident.
+
+This command is useful for managing trust lifecycle events, reducing the risk of unauthorized access, and maintaining the integrity of the approval process within secure Git workflows.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -49,15 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "disable-github-app-approvals",
 		Short: "Mark GitHub app approvals as untrusted henceforth",
-		Long: `The 'disable-github-app-approvals' command allows users to mark a GitHub App as untrusted in a gittuf-secured Git repository, thereby disabling its ability to approve changes in the future.
-
-GitHub Apps can be integrated into a repository’s trust policy to automatically approve commits, merges, or other protected operations based on their identity. However, there may be situations where a previously trusted GitHub App must be revoked due to a change in ownership, compromised credentials, or a shift in repository governance.
-
-This command enables repository maintainers to explicitly untrust a GitHub App by specifying its name using the '--app-name' flag. By default, the app name is set to the conventional role used by gittuf, but it can be overridden as needed. Once untrusted, the GitHub App will no longer have the authority to approve actions under the repository’s trust policy.
-
-The action requires a signing key, passed using the persistent '--signing-key' flag, to authorize the change. Optionally, if the '--rsl-entry' flag is set, the change will be recorded in the Repository Signing Log (RSL), ensuring that the modification to the trust configuration is auditable and tamper-evident.
-
-This command is useful for managing trust lifecycle events, reducing the risk of unauthorized access, and maintaining the integrity of the approval process within secure Git workflows.`,
+		Long:  `The 'disable-github-app-approvals' command revokes a GitHub App's ability to approve changes by marking it untrusted in the trust policy.`,
 
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -47,8 +47,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "enable-github-app-approvals",
-		Short:             "Mark GitHub app approvals as trusted henceforth",
+		Use:   "enable-github-app-approvals",
+		Short: "Mark GitHub app approvals as trusted henceforth",
+		Long: `The 'enable-github-app-approvals' command allows users to mark a GitHub App as trusted in a gittuf-secured Git repository, enabling it to approve protected operations according to the repository’s trust policy.
+
+In gittuf, trust policies govern which actors—such as developers, maintainers, or automated systems—are authorized to perform critical actions. GitHub Apps can be included in these policies to automate and securely manage approvals, such as for pull requests, merges, or releases.
+
+This command registers the specified GitHub App as a trusted approver by adding it to the root of trust. The app’s name must be provided using the '--app-name' flag; by default, this is set to the conventional role used by gittuf, but it can be customized as needed.
+
+To authorize this trust modification, the user must provide a valid signing key via the persistent '--signing-key' flag. Optionally, the '--rsl-entry' flag may be included to log the trust change in the Repository Signing Log (RSL), providing a verifiable audit trail of trust policy updates.
+
+This command is essential for securely integrating GitHub Apps into the approval workflow of secure software supply chains, especially in CI/CD environments, automated governance setups, or multi-party review systems.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -49,15 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "enable-github-app-approvals",
 		Short: "Mark GitHub app approvals as trusted henceforth",
-		Long: `The 'enable-github-app-approvals' command allows users to mark a GitHub App as trusted in a gittuf-secured Git repository, enabling it to approve protected operations according to the repository’s trust policy.
-
-In gittuf, trust policies govern which actors—such as developers, maintainers, or automated systems—are authorized to perform critical actions. GitHub Apps can be included in these policies to automate and securely manage approvals, such as for pull requests, merges, or releases.
-
-This command registers the specified GitHub App as a trusted approver by adding it to the root of trust. The app’s name must be provided using the '--app-name' flag; by default, this is set to the conventional role used by gittuf, but it can be customized as needed.
-
-To authorize this trust modification, the user must provide a valid signing key via the persistent '--signing-key' flag. Optionally, the '--rsl-entry' flag may be included to log the trust change in the Repository Signing Log (RSL), providing a verifiable audit trail of trust policy updates.
-
-This command is essential for securely integrating GitHub Apps into the approval workflow of secure software supply chains, especially in CI/CD environments, automated governance setups, or multi-party review systems.`,
+		Long:  `The 'enable-github-app-approvals' command marks a GitHub App as trusted, allowing it to approve protected operations under the repository's trust policy.`,
 
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -40,8 +40,16 @@ import (
 func New() *cobra.Command {
 	o := &persistent.Options{}
 	cmd := &cobra.Command{
-		Use:               "trust",
-		Short:             "Tools for gittuf's root of trust",
+		Use:   "trust",
+		Short: "Tools for gittuf's root of trust",
+		Long: `The 'trust' command provides tools to manage gittuf's root of trust.
+
+It includes subcommands for initializing trust, adding or removing keys and rules,
+configuring GitHub App approvals, signing commits, and managing policy and repository settings.
+
+These commands enable fine-grained control over repository security and trust policies
+enforced through gittuf's RSL framework.`,
+
 		DisableAutoGenTag: true,
 	}
 	o.AddPersistentFlags(cmd)


### PR DESCRIPTION
This PR adds concise long descriptions for the following Cobra commands:

- `add-root-key`: Adds a new root key to the repository's root of trust.
- `enable-github-app-approvals`: Marks a GitHub App as trusted for approving changes.
- `disable-github-app-approvals`: Revokes trust from a GitHub App, disabling its approval authority.

These changes improve the CLI documentation and follow the recommended docstring style.

Signed-off-by: Syed Mohammed Sylan sylanmohammed@gmail.com