### PR TITLE
test: add unit tests for policy options to achieve from 0% to 100% coverage (#463)

### DIFF
--- a/internal/policy/options/policy/policy_test.go
+++ b/internal/policy/options/policy/policy_test.go
@@ -1,0 +1,51 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package policy
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadStateOptions(t *testing.T) {
+	t.Run("default options", func(t *testing.T) {
+		opts := &LoadStateOptions{}
+		assert.Empty(t, opts.InitialRootPrincipals)
+		assert.False(t, opts.BypassRSL)
+	})
+
+	t.Run("WithInitialRootPrincipals", func(t *testing.T) {
+		principals := []tuf.Principal{}
+		opt := WithInitialRootPrincipals(principals)
+
+		opts := &LoadStateOptions{}
+		opt(opts)
+
+		assert.Equal(t, principals, opts.InitialRootPrincipals)
+		assert.False(t, opts.BypassRSL)
+	})
+
+	t.Run("BypassRSL", func(t *testing.T) {
+		opt := BypassRSL()
+
+		opts := &LoadStateOptions{}
+		opt(opts)
+
+		assert.True(t, opts.BypassRSL)
+		assert.Empty(t, opts.InitialRootPrincipals)
+	})
+
+	t.Run("multiple options", func(t *testing.T) {
+		principals := []tuf.Principal{}
+		opts := &LoadStateOptions{}
+
+		WithInitialRootPrincipals(principals)(opts)
+		BypassRSL()(opts)
+
+		assert.Equal(t, principals, opts.InitialRootPrincipals)
+		assert.True(t, opts.BypassRSL)
+	})
+}


### PR DESCRIPTION
What type of PR is this?
/kind test  
/area policy

What this PR does / why we need it:  
Adds a complete unit test suite for the policy options defined under `internal/policy/options/policy/policy.go`.

This improves code confidence and coverage for:

- Functional option: `WithInitialRootPrincipals`
- Functional option: `BypassRSL`
- Combined usage of multiple options
- Default values handling
- Edge cases (e.g. nil input handling)

Which issue(s) this PR fixes:  
Fixes #463 

Does this PR introduce a user-facing change?  
`None`
![image](https://github.com/user-attachments/assets/8cfe6f58-e5f6-47f9-9dd8-dfc21074ee9d)


