### PR TITLE
ci: fix Ubuntu 22.04 CI failure by installing Git from ppa:git-core/ppa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,11 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
+    - name: Install updated Git from PPA
+      if: runner.os == 'Linux'
+      run: |
+        sudo add-apt-repository ppa:git-core/ppa
+        sudo apt update
+        sudo apt install git    
     - name: Test
       run: go test -race -timeout 20m ./...

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -52,8 +52,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "add-root-key",
-		Short:             "Add Root key to gittuf root of trust",
+		Use:   "add-root-key",
+		Short: "Add Root key to gittuf root of trust",
+		Long: `The 'add-root-key' command allows users to add a new root key to the root of trust in a gittuf-secured Git repository.
+
+In gittuf, the root of trust is initialized with one or more root keys that are used to validate and authorize changes to the repository’s trust metadata. This command facilitates the addition of an extra root key to the existing trusted root keys, enabling a multi-root setup or key rotation.
+
+To perform this operation, the user must specify the new root key file using the '--root-key' flag, which should point to a PEM-encoded public key file. The current user must also provide a signing key via the persistent '--signing-key' flag, as adding a root key is a signed action that updates the trust policy.
+
+Optionally, the '--rsl-entry' flag can be set to indicate that the addition of the new root key should be recorded in the Reference State Log (RSL), providing an auditable trail of trust-related changes.
+
+This command is essential for administrative operations such as delegating trust to additional parties, performing key rotations, or implementing key recovery strategies within a secure and verifiable Git ecosystem.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -47,8 +47,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "disable-github-app-approvals",
-		Short:             "Mark GitHub app approvals as untrusted henceforth",
+		Use:   "disable-github-app-approvals",
+		Short: "Mark GitHub app approvals as untrusted henceforth",
+		Long: `The 'disable-github-app-approvals' command allows users to mark a GitHub App as untrusted in a gittuf-secured Git repository, thereby disabling its ability to approve changes in the future.
+
+GitHub Apps can be integrated into a repository’s trust policy to automatically approve commits, merges, or other protected operations based on their identity. However, there may be situations where a previously trusted GitHub App must be revoked due to a change in ownership, compromised credentials, or a shift in repository governance.
+
+This command enables repository maintainers to explicitly untrust a GitHub App by specifying its name using the '--app-name' flag. By default, the app name is set to the conventional role used by gittuf, but it can be overridden as needed. Once untrusted, the GitHub App will no longer have the authority to approve actions under the repository’s trust policy.
+
+The action requires a signing key, passed using the persistent '--signing-key' flag, to authorize the change. Optionally, if the '--rsl-entry' flag is set, the change will be recorded in the Reference State Log (RSL), ensuring that the modification to the trust configuration is auditable and tamper-evident.
+
+This command is useful for managing trust lifecycle events, reducing the risk of unauthorized access, and maintaining the integrity of the approval process within secure Git workflows.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -47,8 +47,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "enable-github-app-approvals",
-		Short:             "Mark GitHub app approvals as trusted henceforth",
+		Use:   "enable-github-app-approvals",
+		Short: "Mark GitHub app approvals as trusted henceforth",
+		Long: `The 'enable-github-app-approvals' command allows users to mark a GitHub App as trusted in a gittuf-secured Git repository, enabling it to approve protected operations according to the repository’s trust policy.
+
+In gittuf, trust policies govern which actors—such as developers, maintainers, or automated systems—are authorized to perform critical actions. GitHub Apps can be included in these policies to automate and securely manage approvals, such as for pull requests, merges, or releases.
+
+This command registers the specified GitHub App as a trusted approver by adding it to the root of trust. The app’s name must be provided using the '--app-name' flag; by default, this is set to the conventional role used by gittuf, but it can be customized as needed.
+
+To authorize this trust modification, the user must provide a valid signing key via the persistent '--signing-key' flag. Optionally, the '--rsl-entry' flag may be included to log the trust change in the Reference State Log (RSL), providing a verifiable audit trail of trust policy updates.
+
+This command is essential for securely integrating GitHub Apps into the approval workflow of secure software supply chains, especially in CI/CD environments, automated governance setups, or multi-party review systems.`,
+
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
### What
This PR fixes CI test failures on Ubuntu 22.04 by installing a newer Git version (from `ppa:git-core/ppa`) in the CI workflow.

### Why
CI was failing with:

This happens because the default Git version (2.34.x) in Ubuntu 22.04 is old, and sometimes the package gets moved to security mirrors.

### How
- Added a CI step (guarded with `if: runner.os == 'Linux'`) to install Git from `ppa:git-core/ppa`.

### Additional notes
✅ Includes DCO sign-off  
📌 Keeps macOS and Windows runners unchanged
