### PR TITLE
docs: add Long descriptions to attest apply and authorize subcommands

### DIFF
--- a/docs/cli/gittuf_attest_authorize.md
+++ b/docs/cli/gittuf_attest_authorize.md
@@ -2,6 +2,10 @@
 
 Add or revoke reference authorization
 
+### Synopsis
+
+Authorize or revoke permission to merge changes from one ref to another. Use '--from-ref' to specify the source reference.
+
 ```
 gittuf attest authorize [flags]
 ```

--- a/internal/cmd/attest/authorize/authorize.go
+++ b/internal/cmd/attest/authorize/authorize.go
@@ -70,6 +70,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "authorize",
 		Short:             "Add or revoke reference authorization",
+		Long:              `Authorize or revoke permission to merge changes from one ref to another. Use '--from-ref' to specify the source reference.`,
 		Args:              cobra.MinimumNArgs(1),
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,


### PR DESCRIPTION
This PR adds detailed Long descriptions to the 'apply' and 'authorize' subcommands under the 'attest' command.

- apply: explains applying local attestations and optionally pushing to remote
- authorize: explains adding or revoking reference authorizations

These additions improve the help output for users.
