### PR TITLE
docs: add Long description to cache main command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ and enforcement is not tied to your source control platform (SCP) or “forge”
 meaning any developer can independently verify that a repository’s changes
 followed the expected security policies. In other words, gittuf removes the
 forge as a single point of trust in the software supply chain!
+📊 A detailed [comparison table](./docs/comparison.md) is available that contrasts gittuf’s design and goals with other trust-based systems like Guix and sequoia-git.
+
+
 
 gittuf is an incubating project at the [Open Source Security Foundation
 (OpenSSF)] as part of the [Supply Chain Integrity Working Group].

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and enforcement is not tied to your source control platform (SCP) or “forge”
 meaning any developer can independently verify that a repository’s changes
 followed the expected security policies. In other words, gittuf removes the
 forge as a single point of trust in the software supply chain!
-📊 A detailed [comparison table](./docs/comparison.md) is available that contrasts gittuf’s design and goals with other trust-based systems like Guix and sequoia-git.
+📊 A detailed [comparison](./docs/comparison.md) is available, showing how gittuf compares to other trust-based systems like Guix and sequoia-git across independent policy verification, guardrails, and system compatibility.
+
 
 
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,20 +1,38 @@
 # Comparison: gittuf vs Guix vs sequoia-git
 
+# Comparison: gittuf vs Guix vs sequoia-git
+
 This document compares gittuf with other systems that integrate trust, signing, and verification into Git-based workflows.  
 The criteria below are directly based on [gittuf’s stated goals](https://gittuf.dev/goals.html).
 
-| Goal                                           | gittuf | Guix | sequoia-git |
-|-----------------------------------------------|--------|------|--------------|
-| Enforce trust for all Git refs                | ✅     | ❌   | ✅           |
-| Store trust metadata in Git                   | ✅     | ✅   | ✅           |
-| Make trust decisions based on policy          | ✅     | ❌   | ❌           |
-| Support decentralized and delegated trust     | ✅     | ❌   | ❌           |
+---
+
+## 📊 Comparison: Independent Policy Verification
+
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Enables verification independent of SCP | ✅ Policies & signatures stored in repo, verifiable by anyone with read access | ✅ Package reproducibility can be independently verified | ⚠️ Focuses mainly on commit signing; policy verification is limited |
+| Uses cryptographic signatures for commits/policies | ✅ Uses public key cryptography | ✅ Uses cryptographic hashes for reproducibility | ✅ Commit signing via OpenPGP |
+| Designed to prevent bypass if SCP is compromised | ✅ Metadata & policies in repo, SCP compromise doesn't break verification | ⚠️ Less direct; relies on reproducibility | ⚠️ Relies on SCP for policies; focuses mainly on signatures |
 
 ---
 
-**Legend:**
+## 🛡️ Comparison: Guardrails & Logs
 
-- ✅ = Fully supported  
-- ❌ = Not supported  
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Guardrails on who can update policies | ✅ Policy can require multiple approvals & use delegations | ⚠️ Maintainers control package definitions; no enforced multi-approval | ⚠️ No built-in guardrails beyond commit signing |
+| Append-only repository activity log | ✅ Append-only log synchronized across clones | ⚠️ Logs are outside core model | ⚠️ Logs rely on SCP or external tools |
+| Mitigates single point of failure | ✅ Requires multiple maintainers for policy changes | ⚠️ Maintainers still have direct control | ⚠️ Single signer/maintainer can override |
 
-> **Note:** These are the core goals of gittuf. RSL (Reference State Log) and other internal features support these foundational principles.
+---
+
+## ⚙️ Comparison: System Compatibility & Metadata
+
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Works with existing Git repos | ✅ Compatible with native Git objects & refs | ⚠️ Separate from Git; manages packages & builds | ✅ Extends Git via OpenPGP |
+| Compatible with popular tools (GitHub, GitLab) | ✅ SCP-agnostic; works alongside popular Git hosts | ⚠️ Not built for standard Git workflows | ✅ Works alongside existing platforms |
+| Supports multiple signing mechanisms | ✅ GPG, SSH, Sigstore | ✅ GPG | ✅ OpenPGP |
+
+---

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,20 @@
+# Comparison: gittuf vs Guix vs sequoia-git
+
+This document compares gittuf with other systems that integrate trust, signing, and verification into Git-based workflows.  
+The criteria below are directly based on [gittuf’s stated goals](https://gittuf.dev/goals.html).
+
+| Goal                                           | gittuf | Guix | sequoia-git |
+|-----------------------------------------------|--------|------|--------------|
+| Enforce trust for all Git refs                | ✅     | ❌   | ✅           |
+| Store trust metadata in Git                   | ✅     | ✅   | ✅           |
+| Make trust decisions based on policy          | ✅     | ❌   | ❌           |
+| Support decentralized and delegated trust     | ✅     | ❌   | ❌           |
+
+---
+
+**Legend:**
+
+- ✅ = Fully supported  
+- ❌ = Not supported  
+
+> **Note:** These are the core goals of gittuf. RSL (Reference State Log) and other internal features support these foundational principles.

--- a/internal/cmd/attest/apply/apply.go
+++ b/internal/cmd/attest/apply/apply.go
@@ -40,7 +40,11 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply and push local attestations changes to remote repository",
-		RunE:  o.Run,
+		Long: `Apply local attestation changes to the Repository Signing Log (RSL).
+Optionally push those changes to a remote repository.
+Use '--local-only' to apply without pushing.`,
+
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/authorize/authorize.go
+++ b/internal/cmd/attest/authorize/authorize.go
@@ -68,8 +68,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "authorize",
-		Short:             "Add or revoke reference authorization",
+		Use:   "authorize",
+		Short: "Add or revoke reference authorization",
+		Long: `Authorize or revoke permission to merge changes from one ref to another.
+Supports adding new authorizations or revoking existing ones.
+Use '--from-ref' to specify the source reference.`,
+
 		Args:              cobra.MinimumNArgs(1),
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/cache/cache.go
+++ b/internal/cmd/cache/cache.go
@@ -10,8 +10,11 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "cache",
-		Short:             "Manage gittuf's caching functionality",
+		Use:   "cache",
+		Short: "Manage gittuf's caching functionality",
+		Long: `The 'cache' command group contains subcommands to manage gittuf's local persistent cache.
+This cache helps improve performance by storing metadata locally. The cache is local-only and is not synchronized with remote repositories.`,
+
 		DisableAutoGenTag: true,
 	}
 


### PR DESCRIPTION
This PR adds a detailed Long description to the 'cache' main command.
Other subcommand Long descriptions were already merged earlier.

Please let me know if there’s any feedback!
Signed Off by:- Syed Mohammed Sylani <sylanmohammed@gmail.com>