### PR TITLE
docs: add long descriptions for RSL subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ and enforcement is not tied to your source control platform (SCP) or “forge”
 meaning any developer can independently verify that a repository’s changes
 followed the expected security policies. In other words, gittuf removes the
 forge as a single point of trust in the software supply chain!
+📊 A detailed [comparison table](./docs/comparison.md) is available that contrasts gittuf’s design and goals with other trust-based systems like Guix and sequoia-git.
+
+
 
 gittuf is an incubating project at the [Open Source Security Foundation
 (OpenSSF)] as part of the [Supply Chain Integrity Working Group].

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and enforcement is not tied to your source control platform (SCP) or “forge”
 meaning any developer can independently verify that a repository’s changes
 followed the expected security policies. In other words, gittuf removes the
 forge as a single point of trust in the software supply chain!
-📊 A detailed [comparison table](./docs/comparison.md) is available that contrasts gittuf’s design and goals with other trust-based systems like Guix and sequoia-git.
+📊 A detailed [comparison](./docs/comparison.md) is available, showing how gittuf compares to other trust-based systems like Guix and sequoia-git across independent policy verification, guardrails, and system compatibility.
+
 
 
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,20 +1,38 @@
 # Comparison: gittuf vs Guix vs sequoia-git
 
+# Comparison: gittuf vs Guix vs sequoia-git
+
 This document compares gittuf with other systems that integrate trust, signing, and verification into Git-based workflows.  
 The criteria below are directly based on [gittuf’s stated goals](https://gittuf.dev/goals.html).
 
-| Goal                                           | gittuf | Guix | sequoia-git |
-|-----------------------------------------------|--------|------|--------------|
-| Enforce trust for all Git refs                | ✅     | ❌   | ✅           |
-| Store trust metadata in Git                   | ✅     | ✅   | ✅           |
-| Make trust decisions based on policy          | ✅     | ❌   | ❌           |
-| Support decentralized and delegated trust     | ✅     | ❌   | ❌           |
+---
+
+## 📊 Comparison: Independent Policy Verification
+
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Enables verification independent of SCP | ✅ Policies & signatures stored in repo, verifiable by anyone with read access | ✅ Package reproducibility can be independently verified | ⚠️ Focuses mainly on commit signing; policy verification is limited |
+| Uses cryptographic signatures for commits/policies | ✅ Uses public key cryptography | ✅ Uses cryptographic hashes for reproducibility | ✅ Commit signing via OpenPGP |
+| Designed to prevent bypass if SCP is compromised | ✅ Metadata & policies in repo, SCP compromise doesn't break verification | ⚠️ Less direct; relies on reproducibility | ⚠️ Relies on SCP for policies; focuses mainly on signatures |
 
 ---
 
-**Legend:**
+## 🛡️ Comparison: Guardrails & Logs
 
-- ✅ = Fully supported  
-- ❌ = Not supported  
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Guardrails on who can update policies | ✅ Policy can require multiple approvals & use delegations | ⚠️ Maintainers control package definitions; no enforced multi-approval | ⚠️ No built-in guardrails beyond commit signing |
+| Append-only repository activity log | ✅ Append-only log synchronized across clones | ⚠️ Logs are outside core model | ⚠️ Logs rely on SCP or external tools |
+| Mitigates single point of failure | ✅ Requires multiple maintainers for policy changes | ⚠️ Maintainers still have direct control | ⚠️ Single signer/maintainer can override |
 
-> **Note:** These are the core goals of gittuf. RSL (Reference State Log) and other internal features support these foundational principles.
+---
+
+## ⚙️ Comparison: System Compatibility & Metadata
+
+| Feature | gittuf | Guix | sequoia-git |
+|--------|:------:|:----:|:-----------:|
+| Works with existing Git repos | ✅ Compatible with native Git objects & refs | ⚠️ Separate from Git; manages packages & builds | ✅ Extends Git via OpenPGP |
+| Compatible with popular tools (GitHub, GitLab) | ✅ SCP-agnostic; works alongside popular Git hosts | ⚠️ Not built for standard Git workflows | ✅ Works alongside existing platforms |
+| Supports multiple signing mechanisms | ✅ GPG, SSH, Sigstore | ✅ GPG | ✅ OpenPGP |
+
+---

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,0 +1,20 @@
+# Comparison: gittuf vs Guix vs sequoia-git
+
+This document compares gittuf with other systems that integrate trust, signing, and verification into Git-based workflows.  
+The criteria below are directly based on [gittuf’s stated goals](https://gittuf.dev/goals.html).
+
+| Goal                                           | gittuf | Guix | sequoia-git |
+|-----------------------------------------------|--------|------|--------------|
+| Enforce trust for all Git refs                | ✅     | ❌   | ✅           |
+| Store trust metadata in Git                   | ✅     | ✅   | ✅           |
+| Make trust decisions based on policy          | ✅     | ❌   | ❌           |
+| Support decentralized and delegated trust     | ✅     | ❌   | ❌           |
+
+---
+
+**Legend:**
+
+- ✅ = Fully supported  
+- ❌ = Not supported  
+
+> **Note:** These are the core goals of gittuf. RSL (Reference State Log) and other internal features support these foundational principles.

--- a/internal/cmd/attest/apply/apply.go
+++ b/internal/cmd/attest/apply/apply.go
@@ -40,7 +40,11 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply and push local attestations changes to remote repository",
-		RunE:  o.Run,
+		Long: `Apply local attestation changes to the Repository Signing Log (RSL).
+Optionally push those changes to a remote repository.
+Use '--local-only' to apply without pushing.`,
+
+		RunE: o.Run,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/attest/authorize/authorize.go
+++ b/internal/cmd/attest/authorize/authorize.go
@@ -68,8 +68,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:               "authorize",
-		Short:             "Add or revoke reference authorization",
+		Use:   "authorize",
+		Short: "Add or revoke reference authorization",
+		Long: `Authorize or revoke permission to merge changes from one ref to another.
+Supports adding new authorizations or revoking existing ones.
+Use '--from-ref' to specify the source reference.`,
+
 		Args:              cobra.MinimumNArgs(1),
 		PreRunE:           common.CheckForSigningKeyFlag,
 		RunE:              o.Run,

--- a/internal/cmd/cache/cache.go
+++ b/internal/cmd/cache/cache.go
@@ -10,8 +10,11 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "cache",
-		Short:             "Manage gittuf's caching functionality",
+		Use:   "cache",
+		Short: "Manage gittuf's caching functionality",
+		Long: `The 'cache' command group contains subcommands to manage gittuf's local persistent cache.
+This cache helps improve performance by storing metadata locally. The cache is local-only and is not synchronized with remote repositories.`,
+
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -69,8 +69,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "annotate",
-		Short:             "Annotate prior RSL entries",
+		Use:   "annotate",
+		Short: "Annotate prior RSL entries",
+		Long: `The 'annotate' command adds annotations to prior entries in the Repository State Log (RSL).
+These annotations can mark entries to be skipped or add descriptive messages for auditing and review purposes.
+The command supports annotating entries locally or on a remote repository.`,
+
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/log/log.go
+++ b/internal/cmd/rsl/log/log.go
@@ -27,8 +27,12 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "log",
-		Short:             "Display the repository's Reference State Log",
+		Use:   "log",
+		Short: "Display the repository's Reference State Log",
+		Long: `The 'log' command shows the entries in the repository's Repository Signing Log (RSL).
+The RSL tracks significant security-related events and changes in the repository.
+This log helps with auditing and reviewing the repository's trusted state over time.`,
+
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/propagate/propagate.go
+++ b/internal/cmd/rsl/propagate/propagate.go
@@ -31,8 +31,12 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "propagate",
-		Short:             fmt.Sprintf("Propagate contents of remote repositories into local repository (developer mode only, set %s=1)", dev.DevModeKey),
+		Use:   "propagate",
+		Short: fmt.Sprintf("Propagate contents of remote repositories into local repository (developer mode only, set %s=1)", dev.DevModeKey),
+		Long: fmt.Sprintf(`The 'propagate' command copies RSL entries from upstream repositories into the local repository.
+This command is only available in developer mode (enable with %s=1).
+It helps simulate or test how upstream RSL changes affect the local repository.`, dev.DevModeKey),
+
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -72,8 +72,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "record",
-		Short:             "Record latest state of a Git reference in the RSL",
+		Use:   "record",
+		Short: "Record latest state of a Git reference in the RSL",
+		Long: `The 'record' command adds a new entry to the Repository Signing Log (RSL) reflecting the latest state of a Git reference.
+It can override the reference name, skip duplicate checks, and choose to record locally or push to a remote.
+This helps keep the RSL up-to-date with important repository state changes.`,
+
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/pull/pull.go
+++ b/internal/cmd/rsl/remote/pull/pull.go
@@ -23,8 +23,12 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "pull <remote>",
-		Short:             "Pull RSL from the specified remote",
+		Use:   "pull <remote>",
+		Short: "Pull RSL from the specified remote",
+		Long: `The 'pull' command downloads the Repository Signing Log (RSL) data from a specified remote.
+This ensures the local repository has up-to-date RSL entries reflecting trusted state from the remote.
+It requires exactly one argument: the name of the remote repository.`,
+
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/push/push.go
+++ b/internal/cmd/rsl/remote/push/push.go
@@ -23,8 +23,12 @@ func (o *options) Run(_ *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:               "push <remote>",
-		Short:             "Push RSL to the specified remote",
+		Use:   "push <remote>",
+		Short: "Push RSL to the specified remote",
+		Long: `The 'push' command uploads local Repository Signing Log (RSL) entries to the specified remote.
+This ensures the remote repository has up-to-date trusted RSL data reflecting local repository state.
+It requires exactly one argument: the name of the remote repository.`,
+
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -12,8 +12,11 @@ import (
 
 func New() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "remote",
-		Short:             "Tools for managing remote RSLs",
+		Use:   "remote",
+		Short: "Tools for managing remote RSLs",
+		Long: `The 'remote' command groups subcommands for interacting with remote Repository Signing Log (RSL). 
+It includes tools to pull, push, and reconcile the local RSL with remote repositories.`,
+
 		DisableAutoGenTag: true,
 	}
 


### PR DESCRIPTION
This PR adds missing Long descriptions for several subcommands under the main rsl command, including:

    annotate

    log

    propagate

    record

    remote pull

    remote push

These additions help improve the clarity and completeness of the CLI documentation.

If there are any suggestions or further improvements needed, please let me know!
Thank you 🙏
