### PR TITLE
docs: Add API type to Lua documentation

### DIFF
--- a/docs/sandbox/README.md
+++ b/docs/sandbox/README.md
@@ -3,6 +3,7 @@
 ## gitGetAbsoluteReference
 
 **Signature:** `gitGetAbsoluteReference(ref) -> absoluteRef`
+**Implemented In:** Go
 
 Retried the fully qualified reference path for the specified Git reference.
 
@@ -15,6 +16,7 @@ gitGetAbsoluteReference("main") -> "refs/heads/main"
 ## gitGetCommitMessage
 
 **Signature:** `gitGetCommitMessage(commitID) -> message`
+**Implemented In:** Go
 
 Retrieve the message for the specified Git commit.
 
@@ -27,6 +29,7 @@ gitGetCommitMessage("e7fca95377c9bad2418c5df7ab3bab5d652a5309") -> "Commit messa
 ## gitGetFilePathsChangedByCommit
 
 **Signature:** `gitGetFilePathsChangedByCommit(commitID) -> paths`
+**Implemented In:** Go
 
 Retrieve a Lua table of file paths changed by the specified Git commit.
 
@@ -39,6 +42,7 @@ gitGetFilePathsChangedByCommit("e7fca95377c9bad2418c5df7ab3bab5d652a5309") -> 2,
 ## gitGetObjectSize
 
 **Signature:** `gitGetObjectSize(objectID) -> size`
+**Implemented In:** Go
 
 Retrieve the size of the Git object specified using its ID from the repository.
 
@@ -51,6 +55,7 @@ gitGetObjectSize("e7fca95377c9bad2418c5df7ab3bab5d652a5309") -> 13
 ## gitGetReference
 
 **Signature:** `gitGetReference(ref) -> hash`
+**Implemented In:** Go
 
 Retrieve the tip of the specified Git reference.
 
@@ -75,6 +80,7 @@ gitGetReference("refs/gittuf/reference-state-log") -> "c70885ffc33866dbdfe95d0e1
 ## gitGetRemoteURL
 
 **Signature:** `gitGetRemoteURL(remote) -> remoteURL`
+**Implemented In:** Go
 
 Retrieve the remote URL for the specified Git remote.
 
@@ -87,6 +93,7 @@ gitGetRemoteURL("origin") -> "example.com/example/example"
 ## gitGetStagedFilePaths
 
 **Signature:** `gitGetStagedFilePaths() -> paths`
+**Implemented In:** Go
 
 Retrieve a Lua table of file paths that have staged changes (changes in the index).
 
@@ -99,6 +106,7 @@ gitGetStagedFilePaths() -> ["foo/bar.txt", "baz/qux.py"]
 ## gitGetSymbolicReferenceTarget
 
 **Signature:** `gitGetSymbolicReferenceTarget(ref) -> ref`
+**Implemented In:** Go
 
 Retrieve the name of the Git reference the specified symbolic Git reference is pointing to.
 
@@ -111,6 +119,7 @@ gitGetSymbolicReferenceTarget("HEAD") -> "refs/heads/main"
 ## gitGetTagTarget
 
 **Signature:** `gitGetTagTarget(tagID) -> targetID`
+**Implemented In:** Go
 
 Retrieve the ID of the Git object that the tag with the specified ID points to.
 
@@ -123,6 +132,7 @@ gitGetTagTarget("f38f261f5df1d393a97aec3a5463017da6c22934") ->  "e7fca95377c9bad
 ## gitReadBlob
 
 **Signature:** `gitReadBlob(blobID) -> blob`
+**Implemented In:** Go
 
 Retrieve the bytes of the Git blob specified using its ID from the repository.
 
@@ -135,12 +145,14 @@ gitReadBlob("e7fca95377c9bad2418c5df7ab3bab5d652a5309") -> "Hello, world!"
 ## matchRegex
 
 **Signature:** `matchRegex(pattern, text) -> matched`
+**Implemented In:** Go
 
 Check if the regular expression pattern matches the provided text.
 
 ## strSplit
 
 **Signature:** `strSplit(str, sep) -> components`
+**Implemented In:** Lua
 
 Split string using provided separator. If a separator is not provided, then "\n" is used by default.
 

--- a/docs/sandbox/main.go
+++ b/docs/sandbox/main.go
@@ -47,6 +47,13 @@ var (
 				allLines = append(allLines, fmt.Sprintf("## %s", api.GetName()))
 				allLines = append(allLines, "")
 				allLines = append(allLines, fmt.Sprintf("**Signature:** `%s`", api.GetSignature()))
+				if _, isGo := api.(*luasandbox.GoAPI); isGo {
+					allLines = append(allLines, fmt.Sprintf("**Implemented In:** Go"))
+				} else if _, isLua := api.(*luasandbox.LuaAPI); isLua {
+					allLines = append(allLines, fmt.Sprintf("**Implemented In:** Lua"))
+				} else {
+					return fmt.Errorf("unknown API type: %s", api.GetName())
+				}
 				allLines = append(allLines, "")
 				allLines = append(allLines, api.GetHelp())
 


### PR DESCRIPTION
This PR adds information to the Lua Sandbox API documentation on the type of each API, e.g. whether it is implemented in Go or Lua.