### PR TITLE
policy: Fix break scope in VerifyRelativeForRef

### DIFF
--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -653,6 +653,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 		var fixEntry *rsl.ReferenceEntry
 		invalidIntermediateEntries := []*rsl.ReferenceEntry{}
 		newEntryQueue := []rsl.ReferenceUpdaterEntry{}
+	lookForFixes:
 		for len(entries) != 0 {
 			newEntry := entries[0]
 			entries = entries[1:]
@@ -695,7 +696,7 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 					}
 				}
 				if fixed {
-					break
+					break lookForFixes
 				}
 
 				// newEntry is not tree-same / commit-same, so it is automatically


### PR DESCRIPTION
We had a break statement to exit the loop looking for fix entries when a policy violation was found. When we introduced propagation entries, we added a switch-case block within the loop but did not update the break statement to apply to the loop. This put the client in an invalid state: a fix for the policy violation is found but it continues in recovery mode eternally.

---

This is not the first time we've been hit by this (in part because of the linter's insistence we use switch-case instead of if-else ladders) but certainly the longest it's gone unnoticed. I propose we add labels for all invocations of `break` henceforth and backfill existing ones as we go along.