### PR TITLE
docs: Update getting started doc with beta status

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,7 +1,8 @@
 # Get Started
 
 This guide presents a quick primer to using gittuf. Note that gittuf is
-currently in alpha, and it is not intended for use in a production repository.
+currently in beta, so if you encounter any issues, we encourage you to
+[report them](https://github.com/gittuf/gittuf/issues).
 
 ## Install gittuf using pre-built binaries
 


### PR DESCRIPTION
Looks like a mention of gittuf in alpha in the getting started doc wasn't updated to reflect beta status.