### PR TITLE
ci: Add dependency review action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,16 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@56339e523c0409420f6c2c9a2f4292bbb3c07dd3
+        with:
+            allow-licenses: 'Apache-2.0, MIT'


### PR DESCRIPTION
This PR adds GitHub's dependency review action to scan for known vulnerable dependencies and check for licensing information, if available.