### PR TITLE
docs: Add attestations extraction method to documentation

### DIFF
--- a/docs/development/gittuf-metadata.md
+++ b/docs/development/gittuf-metadata.md
@@ -19,11 +19,13 @@ Below is an explanation of how the process works.
 
 1. Obtain the commit hash for the policy state that you'd like to inspect
    metadata for:
+
 ```bash
 git log refs/gittuf/policy
 ```
 
 The output will look something like:
+
 ```
 commit 34360d799489d607ac5d29c8953c5fec9f0ac18f
 Author: Aditya Sirish <aditya@saky.in>
@@ -42,11 +44,13 @@ In this case, we'll inspect the latest policy state, which is commit
 `34360d799489d607ac5d29c8953c5fec9f0ac18f`.
 
 2. View the tree information for the specified commit:
+
 ```bash
 git ls-tree -r 34360d799489d607ac5d29c8953c5fec9f0ac18f
 ```
 
 The output will look something like:
+
 ```
 100644 blob 8fd789f032be4dd64990de85ae860a1a6b71bc01	metadata/root.json
 100644 blob 67f72e322aebbf4ee95b6694ecdc14ac355a58da	metadata/targets.json
@@ -64,6 +68,7 @@ git cat-file -p <hash> | jq -r .payload | base64 -d | jq -r .
 ```
 
 For example, if you'd like to inspect the root metadata from the example above, the command would be:
+
 ```bash
 git cat-file -p 8fd789f032be4dd64990de85ae860a1a6b71bc01 | jq -r .payload | base64 -d | jq -r .
 ```
@@ -76,6 +81,7 @@ The command above:
 4. Formats the JSON output nicely for the user.
 
 The output will look something like:
+
 ```
 {
   "type": "root",
@@ -136,6 +142,121 @@ The output will look something like:
       ],
       "threshold": 1
     }
+  }
+}
+```
+
+## Attestations
+
+Attestations created by and used by gittuf are stored in the
+`refs/gittuf/attestation` reference. As with the policy example above, see
+gittuf's GAPs for details on attestations' structure. The following example is
+also taken from the `gittuf/gittuf` repository.
+
+To view attestations in the repository, use the following process:
+
+1. Obtain the commit hash for the attestations state that you'd like to inspect
+   metadata for:
+
+```bash
+git log refs/gittuf/attestations
+```
+
+The output will look something like:
+
+```
+commit 75b1c36e2574b53557f84755e3944ec76a89d155
+Author: gittuf-github-app <179610826+gittuf-app-test[bot]@users.noreply.github.com>
+Date:   Mon Oct 6 18:49:27 2025 +0000
+
+    Add GitHub pull request attestation for 'gittuf-127987161/refs/heads/main' at '71a0daaec1e998931f2ed8c0f613850d224b681f'
+    
+    Source: https://github.com/gittuf/gittuf/pull/1109
+
+commit c11e46cbba7a18246e3f0fe08822e54dcea19bdb
+Author: gittuf-github-app <179610826+gittuf-app-test[bot]@users.noreply.github.com>
+Date:   Mon Oct 6 18:48:33 2025 +0000
+
+    Add GitHub pull request approval for 'refs/heads/main' from 'c3ef4dc745e37451446f8b6e4c90b4c17239b973' to '32af1b10212ee9d02b1d49b7b739a2a3ab44d620' (review ID 3306609844) for approval by 'adityasaky+8928778'
+```
+
+In this case, we'd like to inspect the attestation capturing the approval of
+the pull request, which is added by commit
+`c11e46cbba7a18246e3f0fe08822e54dcea19bdb`.
+
+2. View the tree information for the specified commit:
+
+```bash
+git ls-tree c11e46cbba7a18246e3f0fe08822e54dcea19bdb
+```
+
+The output will look something like:
+
+```
+040000 tree cb29826045d64737576029e3b18a703b68877077	code-review-approvals
+040000 tree 5db0e6c46a77ddb5589cab7506ff460b4deb6f64	github-pull-requests
+040000 tree e99bfd730ea54b765e79c23262a89b77a44f2c4c	reference-authorizations
+```
+
+3. Since we want to inspect an attestation that encodes an approval, we must
+   further inspect the `code-review-approvals` tree. This time, we can inspect
+   recursively as we've limited the attestations that will be shown:
+
+```bash
+git ls-tree -r cb29826045d64737576029e3b18a703b68877077
+```
+
+Doing so gives us the following output (truncated to show the part of interest):
+
+```
+100644 blob 3c40d5a249f4f1c3f5476a5a3e7fe05f6a8e3a67	refs/heads/main/bedce5122c630db87d7036f0b25650f3f8ae438c-4bdc2cfc0f67d9afea2e7271e1d70e0509069ed6/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+100644 blob 431ac2ba408d31d9afa6205c256b4397a58ce0ab	refs/heads/main/c3ef4dc745e37451446f8b6e4c90b4c17239b973-32af1b10212ee9d02b1d49b7b739a2a3ab44d620/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+100644 blob b4806c15328f38fc976138da5b4bf61edab8541e	refs/heads/main/c3ef4dc745e37451446f8b6e4c90b4c17239b973-848a8ce805f207d1e3f1e3ec2c60bb18042aa6a7/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+100644 blob 6f08f80ff34760963456ff5fdb23dcb341586da6	refs/heads/main/c4a5642991ca35a50c3c8d7994aadc8f520abdd1-245a9a636f82348fe31eb2f61e974c2f43d5c333/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+100644 blob 95248cec12070ee96fb099c36938f6d92429be10	refs/heads/main/c4c661618dc96351792ef542fe3cd29b15323d94-041ccb54ec82dc7ae0108632cecb073f11cea3a0/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+
+```
+
+4. Finding the attestation we'd like to inspect is a bit more complicated than
+   the policy, but we can find it by reading the message for the commit which added
+   the attestation. Of interest are the commit hashes in the line:
+```
+Add GitHub pull request approval for 'refs/heads/main' from 'c3ef4dc745e37451446f8b6e4c90b4c17239b973' to '32af1b10212ee9d02b1d49b7b739a2a3ab44d620' (review ID 3306609844) for approval by 'adityasaky+8928778'
+```
+
+Searching through the attestations listed before yields the correct blob:
+```
+100644 blob 431ac2ba408d31d9afa6205c256b4397a58ce0ab	refs/heads/main/c3ef4dc745e37451446f8b6e4c90b4c17239b973-32af1b10212ee9d02b1d49b7b739a2a3ab44d620/github/aHR0cHM6Ly9naXR0dWYuZGV2L2dpdGh1Yi1hcHA=
+```
+
+5. Finally, to extract and decode the attestation, we use the same method as
+   with the policy:
+
+```bash
+git cat-file -p 431ac2ba408d31d9afa6205c256b4397a58ce0ab | jq -r .payload | base64 -d | jq -r .
+```
+
+The output will look something like:
+
+```
+{
+  "type": "https://in-toto.io/Statement/v1",
+  "subject": [
+    {
+      "digest": {
+        "gitTree": "32af1b10212ee9d02b1d49b7b739a2a3ab44d620"
+      }
+    }
+  ],
+  "predicate_type": "https://gittuf.dev/github-pull-request-approval/v0.1",
+  "predicate": {
+    "approvers": [
+      "adityasaky+8928778"
+    ],
+    "dismissedApprovers": [],
+    "fromRevisionID": "c3ef4dc745e37451446f8b6e4c90b4c17239b973",
+    "targetRef": "refs/heads/main",
+    "targetTreeID": "32af1b10212ee9d02b1d49b7b739a2a3ab44d620"
   }
 }
 ```


### PR DESCRIPTION
When working on attestations-related code in gittuf, I found myself needing to read the raw attestations written to the repository. I figured that it might be useful to other folks to know how to extract said attestations.