### PR TITLE
Bugfix: Prevent reinitializing root of trust

### DIFF
--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -87,6 +87,29 @@ func TestInitializeRoot(t *testing.T) {
 	})
 }
 
+func TestPreventReinitializeRoot(t *testing.T) {
+	t.Run("fails when root already applied (policy ref exists)", func(t *testing.T) {
+		r := createTestRepositoryWithRoot(t, "")
+
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+		err := r.InitializeRoot(testCtx, signer, false)
+		assert.ErrorIs(t, err, ErrCannotReinitialize)
+	})
+
+	t.Run("fails when root staged but not applied (policy-staging has root)", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+		r := &Repository{r: repo}
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		err := r.InitializeRoot(testCtx, signer, false)
+		assert.Nil(t, err)
+
+		err = r.InitializeRoot(testCtx, signer, false)
+		assert.ErrorIs(t, err, ErrCannotReinitialize)
+	})
+}
+
 func TestSetRepositoryLocation(t *testing.T) {
 	r := createTestRepositoryWithRoot(t, "")
 


### PR DESCRIPTION
Check if references to a policy exist when gittuf trust init is invoked, and throw the appropriate ErrCannotReinitialize error to prevent overwriting the root of trust. See issue - https://github.com/gittuf/gittuf/issues/932

**Testing:**
Ran make to ensure unit test pass and gittuf builds successfully  ✅ 
Ran gittuf trust init on a separate repo to ensure it passes and policies can be enforced, verify re-running the same throws the appropriate error  ✅ 