### PR TITLE
*: Fix remoteRefName bug and spelling nits

### DIFF
--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -344,7 +344,7 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 				The helper has two commands, in reality: list, list
 				for-push. Both of these are used to list the states of refs
 				on the remote. The for-push variation just formats it in a
-				way that can be used for the push comamnd later.
+				way that can be used for the push command later.
 
 				We inspect this to learn we're in a push. We also use the
 				output of this command, implemented by git-remote-https, to

--- a/internal/gitinterface/references.go
+++ b/internal/gitinterface/references.go
@@ -149,7 +149,7 @@ func (r *Repository) AbsoluteReference(target string) (string, error) {
 	remoteRefName := RemoteReferenceName(target)
 	_, err = r.GetReference(remoteRefName)
 	if err == nil {
-		return branchName, nil
+		return remoteRefName, nil
 	}
 	if !errors.Is(err, ErrReferenceNotFound) {
 		return "", err
@@ -158,7 +158,7 @@ func (r *Repository) AbsoluteReference(target string) (string, error) {
 	remoteRefHEAD := path.Join(remoteRefName, "HEAD")
 	_, err = r.GetReference(remoteRefHEAD)
 	if err == nil {
-		return branchName, nil
+		return remoteRefHEAD, nil
 	}
 	if !errors.Is(err, ErrReferenceNotFound) {
 		return "", err

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -420,7 +420,7 @@ func (v *PolicyVerifier) VerifyNetwork(ctx context.Context) error {
 		}
 
 		// gittuf stores the controller metadata in a subdirectory in the policy
-		// ref that includes b64 encoded cntroller repo location
+		// ref that includes b64 encoded controller repo location
 		encodedLocation := base64.URLEncoding.EncodeToString([]byte(rootMetadata.GetRepositoryLocation()))
 
 		controllerPath := fmt.Sprintf("%s/%s-%s", tuf.GittufControllerPrefix, declaredControllerName, encodedLocation)


### PR DESCRIPTION
This fixes a bug with gittuf's reference package and some spelling nits.