### PR TITLE
Fix git test when global config has format value

### DIFF
--- a/internal/gitinterface/config.go
+++ b/internal/gitinterface/config.go
@@ -20,11 +20,12 @@ func (r *Repository) GetGitConfig() (map[string]string, error) {
 
 	lines := strings.Split(strings.TrimSpace(stdOut), "\n")
 	for _, line := range lines {
-		split := strings.Split(line, " ")
-		if len(split) < 2 {
-			continue
+		split := strings.SplitN(line, " ", 2)
+		if len(split) == 2 {
+			config[strings.ToLower(split[0])] = split[1]
+		} else if len(split) == 1 && split[0] == "gpg.format" {
+			config[strings.ToLower(split[0])] = ""
 		}
-		config[strings.ToLower(split[0])] = strings.Join(split[1:], " ")
 	}
 
 	return config, nil

--- a/internal/gitinterface/config_test.go
+++ b/internal/gitinterface/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetGitConfig(t *testing.T) {
@@ -18,4 +19,56 @@ func TestGetGitConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, testName, config["user.name"])
 	assert.Equal(t, testEmail, config["user.email"])
+}
+
+func TestSetGitConfig(t *testing.T) {
+	t.Run("basic sets", func(t *testing.T) {
+		const name = "John Doe"
+		const email = "john.doe@example.com"
+
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		err := repo.SetGitConfig("user.name", name)
+		require.NoError(t, err)
+		err = repo.SetGitConfig("user.email", email)
+		require.NoError(t, err)
+
+		config, err := repo.GetGitConfig()
+		require.NoError(t, err)
+		assert.Equal(t, name, config["user.name"])
+		assert.Equal(t, email, config["user.email"])
+	})
+	t.Run("empty set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		err := repo.SetGitConfig("user.name", "")
+		require.NoError(t, err)
+		err = repo.SetGitConfig("user.email", "")
+		require.NoError(t, err)
+
+		config, err := repo.GetGitConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "", config["user.name"])
+		assert.Equal(t, "", config["user.email"])
+	})
+	t.Run("gpg.format special case", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		err := repo.SetGitConfig("gpg.format", "gpg")
+		require.NoError(t, err)
+
+		config, err := repo.GetGitConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "gpg", config["gpg.format"])
+
+		err = repo.SetGitConfig("gpg.format", "")
+		require.NoError(t, err)
+
+		config, err = repo.GetGitConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "", config["gpg.format"])
+	})
 }

--- a/internal/signerverifier/git/git_test.go
+++ b/internal/signerverifier/git/git_test.go
@@ -19,10 +19,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		// If the local machine has a format set, setting it with an
-		// empty string would not overwrite the existing configuration.
-		// Setting it to "gpg" is equivalent to leaving it unspecified.
-		if err := repo.SetGitConfig("gpg.format", "gpg"); err != nil {
+		if err := repo.SetGitConfig("gpg.format", ""); err != nil {
 			t.Fatal(err)
 		}
 		if err := repo.SetGitConfig("user.signingkey", ""); err != nil {


### PR DESCRIPTION
The git config value cannot be set to an empty string, as it would not
overwrite if a value is already set.
