### PR TITLE
Add duplicate check for PropagationDirectives

### DIFF
--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -67,6 +67,7 @@ var (
 	ErrGlobalRuleAlreadyExists                         = errors.New("global rule already exists")
 	ErrCannotUpdateGlobalRuleType                      = errors.New("cannot change type of global rule")
 	ErrPropagationDirectiveNotFound                    = errors.New("specified propagation directive not found")
+	ErrPropagationDirectiveAlreadyExists               = errors.New("specified propagation directive already exists")
 	ErrNotAControllerRepository                        = errors.New("current repository is not marked as a controller repository")
 	ErrDuplicatedHookName                              = errors.New("two hooks with same name found in policy")
 	ErrInvalidHookStage                                = errors.New("invalid stage for hook")

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -440,7 +440,16 @@ func (r *RootMetadata) UpdateGlobalRule(globalRule tuf.GlobalRule) error {
 
 // AddPropagationDirective adds a propagation directive to the root metadata.
 func (r *RootMetadata) AddPropagationDirective(directive tuf.PropagationDirective) error {
-	// TODO: handle duplicates
+	for _, existing := range r.Propagations {
+		if existing.GetUpstreamRepository() == directive.GetUpstreamRepository() &&
+			existing.GetUpstreamReference() == directive.GetUpstreamReference() &&
+			existing.GetUpstreamPath() == directive.GetUpstreamPath() &&
+			existing.GetDownstreamReference() == directive.GetDownstreamReference() &&
+			existing.GetDownstreamPath() == directive.GetDownstreamPath() {
+			return tuf.ErrPropagationDirectiveAlreadyExists
+		}
+	}
+
 	r.Propagations = append(r.Propagations, directive)
 	return nil
 }

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -86,6 +86,12 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, 1, len(directives))
 		assert.Equal(t, directive, directives[0])
 
+		err = rootMetadata.AddPropagationDirective(directive)
+		assert.ErrorIs(t, err, tuf.ErrPropagationDirectiveAlreadyExists)
+		directives = rootMetadata.GetPropagationDirectives()
+		assert.Equal(t, 1, len(directives))
+		assert.Equal(t, directive, directives[0])
+
 		updatedDirective := &PropagationDirective{
 			Name:                "test",
 			UpstreamRepository:  "https://example.org/git/repository",

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -529,7 +529,16 @@ func (r *RootMetadata) GetGlobalRules() []tuf.GlobalRule {
 
 // AddPropagationDirective adds a propagation directive to the root metadata.
 func (r *RootMetadata) AddPropagationDirective(directive tuf.PropagationDirective) error {
-	// TODO: handle duplicates
+	for _, existing := range r.Propagations {
+		if existing.GetUpstreamRepository() == directive.GetUpstreamRepository() &&
+			existing.GetUpstreamReference() == directive.GetUpstreamReference() &&
+			existing.GetUpstreamPath() == directive.GetUpstreamPath() &&
+			existing.GetDownstreamReference() == directive.GetDownstreamReference() &&
+			existing.GetDownstreamPath() == directive.GetDownstreamPath() {
+			return tuf.ErrPropagationDirectiveAlreadyExists
+		}
+	}
+
 	r.Propagations = append(r.Propagations, directive)
 	return nil
 }

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -97,6 +97,12 @@ func TestRootMetadata(t *testing.T) {
 		assert.Equal(t, 1, len(directives))
 		assert.Equal(t, directive, directives[0])
 
+		err = rootMetadata.AddPropagationDirective(directive)
+		assert.ErrorIs(t, err, tuf.ErrPropagationDirectiveAlreadyExists)
+		directives = rootMetadata.GetPropagationDirectives()
+		assert.Equal(t, 1, len(directives))
+		assert.Equal(t, directive, directives[0])
+
 		updatedDirective := &PropagationDirective{
 			Name:                "test",
 			UpstreamRepository:  "https://example.org/git/repository",


### PR DESCRIPTION
This PR implements a duplicate check for PropagationDirective objects added to repository metadata, addressing issue #788.