### PR TITLE
tuf: Add v03 policy metadata with team principal

### DIFF
--- a/internal/policy/root.go
+++ b/internal/policy/root.go
@@ -8,13 +8,20 @@ import (
 
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	tufv03 "github.com/gittuf/gittuf/internal/tuf/v03"
 )
 
 // InitializeRootMetadata initializes a new instance of tuf.RootMetadata with
 // default values and a given key. The default values are version set to 1,
 // expiry date set to one year from now, and the provided key is added.
 func InitializeRootMetadata(key tuf.Principal) (tuf.RootMetadata, error) {
-	rootMetadata := tufv02.NewRootMetadata()
+	var rootMetadata tuf.RootMetadata
+	if tufv03.AllowV03Metadata() {
+		rootMetadata = tufv03.NewRootMetadata()
+	} else {
+		rootMetadata = tufv02.NewRootMetadata()
+	}
+
 	rootMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 
 	if err := rootMetadata.AddRootPrincipal(key); err != nil {

--- a/internal/policy/targets.go
+++ b/internal/policy/targets.go
@@ -8,11 +8,17 @@ import (
 
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	tufv03 "github.com/gittuf/gittuf/internal/tuf/v03"
 )
 
 // InitializeTargetsMetadata creates a new instance of TargetsMetadata.
 func InitializeTargetsMetadata() tuf.TargetsMetadata {
-	targetsMetadata := tufv02.NewTargetsMetadata()
+	var targetsMetadata tuf.TargetsMetadata
+	if tufv03.AllowV03Metadata() {
+		targetsMetadata = tufv03.NewTargetsMetadata()
+	} else {
+		targetsMetadata = tufv02.NewTargetsMetadata()
+	}
 
 	targetsMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
 	return targetsMetadata

--- a/internal/tuf/v03/helpers_test.go
+++ b/internal/tuf/v03/helpers_test.go
@@ -1,0 +1,47 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+var (
+	rootPubKeyBytes     = artifacts.SSHRSAPublicSSH
+	targets1PubKeyBytes = artifacts.SSHECDSAPublicSSH
+	targets2PubKeyBytes = artifacts.SSHED25519PublicSSH
+)
+
+func initialTestRootMetadata(t *testing.T) *RootMetadata {
+	t.Helper()
+
+	rootKey := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	rootMetadata := NewRootMetadata()
+	rootMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	if err := rootMetadata.addPrincipal(rootKey); err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata.addRole(tuf.RootRoleName, Role{
+		PrincipalIDs: set.NewSetFromItems(rootKey.KeyID),
+		Threshold:    1,
+	})
+
+	return rootMetadata
+}
+
+func initialTestTargetsMetadata(t *testing.T) *TargetsMetadata {
+	t.Helper()
+
+	targetsMetadata := NewTargetsMetadata()
+	targetsMetadata.SetExpires(time.Now().AddDate(1, 0, 0).Format(time.RFC3339))
+	targetsMetadata.Delegations = &Delegations{Roles: []*Delegation{AllowRule()}}
+	return targetsMetadata
+}

--- a/internal/tuf/v03/root.go
+++ b/internal/tuf/v03/root.go
@@ -1,0 +1,1066 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+)
+
+const (
+	RootVersion = "https://gittuf.dev/policy/root/v0.3"
+)
+
+// RootMetadata defines the schema of TUF's Root role.
+type RootMetadata struct {
+	Type               string                     `json:"type"`
+	Version            string                     `json:"schemaVersion"`
+	Expires            string                     `json:"expires"`
+	RepositoryLocation string                     `json:"repositoryLocation,omitempty"`
+	Principals         map[string]tuf.Principal   `json:"principals"`
+	Roles              map[string]Role            `json:"roles"`
+	GitHubApps         map[string]*GitHubApp      `json:"githubApps,omitempty"`
+	GlobalRules        []tuf.GlobalRule           `json:"globalRules,omitempty"`
+	Propagations       []tuf.PropagationDirective `json:"propagations,omitempty"`
+	MultiRepository    *MultiRepository           `json:"multiRepository,omitempty"`
+	Hooks              map[tuf.HookStage][]*Hook  `json:"hooks,omitempty"`
+}
+
+// NewRootMetadata returns a new instance of RootMetadata.
+func NewRootMetadata() *RootMetadata {
+	return &RootMetadata{
+		Type:    "root",
+		Version: RootVersion,
+	}
+}
+
+// SetExpires sets the expiry date of the RootMetadata to the value passed in.
+func (r *RootMetadata) SetExpires(expires string) {
+	r.Expires = expires
+}
+
+// SchemaVersion returns the metadata schema version.
+func (r *RootMetadata) SchemaVersion() string {
+	return r.Version
+}
+
+// GetRepositoryLocation returns the canonical location of the Git repository.
+func (r *RootMetadata) GetRepositoryLocation() string {
+	return r.RepositoryLocation
+}
+
+// SetRepositoryLocation sets the specified repository location in the root
+// metadata.
+func (r *RootMetadata) SetRepositoryLocation(location string) {
+	r.RepositoryLocation = location
+}
+
+// AddRootPrincipal adds the specified principal to the root metadata and
+// authorizes the principal for the root role.
+func (r *RootMetadata) AddRootPrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// Add principal to metadata
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+
+	rootRole, ok := r.Roles[tuf.RootRoleName]
+	if !ok {
+		// Create a new root role entry with this principal
+		r.addRole(tuf.RootRoleName, Role{
+			PrincipalIDs: set.NewSetFromItems(principal.ID()),
+			Threshold:    1,
+		})
+
+		return nil
+	}
+
+	// Add principal ID to the root role if it's not already in it
+	rootRole.PrincipalIDs.Add(principal.ID())
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// DeleteRootPrincipal removes principalID from the list of trusted Root
+// principals in rootMetadata. It does not remove the principal entry itself as
+// it does not check if other roles can be verified using the same principal.
+func (r *RootMetadata) DeleteRootPrincipal(principalID string) error {
+	rootRole, has := r.Roles[tuf.RootRoleName]
+	if !has {
+		return tuf.ErrInvalidRootMetadata
+	}
+
+	if rootRole.PrincipalIDs.Len() <= rootRole.Threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	rootRole.PrincipalIDs.Remove(principalID)
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// AddPrimaryRuleFilePrincipal adds the 'principal' as a trusted signer in
+// 'rootMetadata' for the top level Targets role.
+func (r *RootMetadata) AddPrimaryRuleFilePrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// Add principal to the metadata file
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		// Create a new targets role entry with this principal
+		r.addRole(tuf.TargetsRoleName, Role{
+			PrincipalIDs: set.NewSetFromItems(principal.ID()),
+			Threshold:    1,
+		})
+
+		return nil
+	}
+
+	targetsRole.PrincipalIDs.Add(principal.ID())
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+
+	return nil
+}
+
+// DeletePrimaryRuleFilePrincipal removes the principal matching 'principalID'
+// from trusted principals for top level Targets role in 'rootMetadata'. Note:
+// It doesn't remove the principal entry itself as it doesn't check if other
+// roles can use the same principal.
+func (r *RootMetadata) DeletePrimaryRuleFilePrincipal(principalID string) error {
+	if principalID == "" {
+		return tuf.ErrInvalidPrincipalID
+	}
+
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		return tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	if targetsRole.PrincipalIDs.Len() <= targetsRole.Threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	targetsRole.PrincipalIDs.Remove(principalID)
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+	return nil
+}
+
+// AddGitHubAppPrincipal adds the 'principal' as a trusted principal in
+// 'rootMetadata' for the special GitHub app role. This key is used to verify
+// GitHub pull request approval attestation signatures.
+func (r *RootMetadata) AddGitHubAppPrincipal(name string, principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	// TODO: support multiple principals / threshold for app
+	if err := r.addPrincipal(principal); err != nil {
+		return err
+	}
+	entry := &GitHubApp{
+		PrincipalIDs: set.NewSetFromItems(principal.ID()),
+		Threshold:    1,
+	}
+
+	if r.GitHubApps == nil {
+		r.GitHubApps = map[string]*GitHubApp{}
+	}
+	r.GitHubApps[name] = entry
+	return nil
+}
+
+// DeleteGitHubAppPrincipal removes the special GitHub app role from the root
+// metadata.
+func (r *RootMetadata) DeleteGitHubAppPrincipal(name string) {
+	if r.GitHubApps == nil {
+		return
+	}
+
+	delete(r.GitHubApps, name)
+}
+
+// EnableGitHubAppApprovals sets GitHubApprovalsTrusted to true in the
+// root metadata.
+func (r *RootMetadata) EnableGitHubAppApprovals(appName string) {
+	if appEntry, has := r.GitHubApps[appName]; has {
+		appEntry.Trusted = true
+	}
+}
+
+// DisableGitHubAppApprovals sets GitHubApprovalsTrusted to false in the root
+// metadata.
+func (r *RootMetadata) DisableGitHubAppApprovals(appName string) {
+	if appEntry, has := r.GitHubApps[appName]; has {
+		appEntry.Trusted = false
+	}
+}
+
+func (r *RootMetadata) GetGitHubAppEntries() (map[string]tuf.GitHubApp, error) {
+	if len(r.GitHubApps) == 0 {
+		return nil, nil
+	}
+
+	githubApps := map[string]tuf.GitHubApp{}
+	for name, app := range r.GitHubApps {
+		githubApps[name] = app
+	}
+	return githubApps, nil
+}
+
+// UpdateRootThreshold sets the threshold for the Root role.
+func (r *RootMetadata) UpdateRootThreshold(threshold int) error {
+	rootRole, ok := r.Roles[tuf.RootRoleName]
+	if !ok {
+		return tuf.ErrInvalidRootMetadata
+	}
+
+	if rootRole.PrincipalIDs.Len() < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+	rootRole.Threshold = threshold
+	r.Roles[tuf.RootRoleName] = rootRole
+	return nil
+}
+
+// UpdatePrimaryRuleFileThreshold sets the threshold for the top level Targets
+// role.
+func (r *RootMetadata) UpdatePrimaryRuleFileThreshold(threshold int) error {
+	targetsRole, ok := r.Roles[tuf.TargetsRoleName]
+	if !ok {
+		return tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	if targetsRole.PrincipalIDs.Len() < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+	targetsRole.Threshold = threshold
+	r.Roles[tuf.TargetsRoleName] = targetsRole
+	return nil
+}
+
+// GetPrincipals returns all the principals in the root metadata.
+func (r *RootMetadata) GetPrincipals() map[string]tuf.Principal {
+	return r.Principals
+}
+
+// GetRootThreshold returns the threshold of principals that must sign the root
+// of trust metadata.
+func (r *RootMetadata) GetRootThreshold() (int, error) {
+	role, hasRole := r.Roles[tuf.RootRoleName]
+	if !hasRole {
+		return -1, tuf.ErrInvalidRootMetadata
+	}
+
+	return role.Threshold, nil
+}
+
+// GetRootPrincipals returns the principals trusted for the root of trust
+// metadata.
+func (r *RootMetadata) GetRootPrincipals() ([]tuf.Principal, error) {
+	role, hasRole := r.Roles[tuf.RootRoleName]
+	if !hasRole {
+		return nil, tuf.ErrInvalidRootMetadata
+	}
+
+	principals := make([]tuf.Principal, 0, role.PrincipalIDs.Len())
+	for _, id := range role.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+// GetPrimaryRuleFileThreshold returns the threshold of principals that must
+// sign the primary rule file.
+func (r *RootMetadata) GetPrimaryRuleFileThreshold() (int, error) {
+	role, hasRole := r.Roles[tuf.TargetsRoleName]
+	if !hasRole {
+		return -1, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	return role.Threshold, nil
+}
+
+// GetPrimaryRuleFilePrincipals returns the principals trusted for the primary
+// rule file.
+func (r *RootMetadata) GetPrimaryRuleFilePrincipals() ([]tuf.Principal, error) {
+	role, hasRole := r.Roles[tuf.TargetsRoleName]
+	if !hasRole {
+		return nil, tuf.ErrPrimaryRuleFileInformationNotFoundInRoot
+	}
+
+	principals := make([]tuf.Principal, 0, role.PrincipalIDs.Len())
+	for _, id := range role.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+// IsGitHubAppApprovalTrusted indicates if the GitHub app is trusted.
+//
+// TODO: this needs to be generalized across tools
+func (r *RootMetadata) IsGitHubAppApprovalTrusted(appName string) bool {
+	if appEntry, has := r.GitHubApps[appName]; has {
+		return appEntry.Trusted
+	}
+	return false
+}
+
+// GetGitHubAppPrincipals returns the principals trusted for the GitHub app
+// attestations.
+//
+// TODO: this needs to be generalized across tools
+func (r *RootMetadata) GetGitHubAppPrincipals(appName string) ([]tuf.Principal, error) {
+	entry, hasEntry := r.GitHubApps[appName]
+	if !hasEntry {
+		return nil, tuf.ErrGitHubAppInformationNotFoundInRoot
+	}
+
+	principals := make([]tuf.Principal, 0, entry.PrincipalIDs.Len())
+	for _, id := range entry.PrincipalIDs.Contents() {
+		principals = append(principals, r.Principals[id])
+	}
+
+	return principals, nil
+}
+
+func (r *RootMetadata) UnmarshalJSON(data []byte) error {
+	// this type _has_ to be a copy of RootMetadata, minus the use of
+	// json.RawMessage in place of tuf interfaces
+	type tempType struct {
+		Type               string                     `json:"type"`
+		Version            string                     `json:"schemaVersion"`
+		Expires            string                     `json:"expires"`
+		RepositoryLocation string                     `json:"repositoryLocation,omitempty"`
+		Principals         map[string]json.RawMessage `json:"principals"`
+		Roles              map[string]Role            `json:"roles"`
+		GitHubApps         map[string]*GitHubApp      `json:"githubApps,omitempty"`
+		GlobalRules        []json.RawMessage          `json:"globalRules,omitempty"`
+		Propagations       []json.RawMessage          `json:"propagations,omitempty"`
+		MultiRepository    *MultiRepository           `json:"multiRepository,omitempty"`
+		Hooks              map[tuf.HookStage][]*Hook  `json:"hooks,omitempty"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	r.Type = temp.Type
+	r.Version = temp.Version
+	r.Expires = temp.Expires
+	r.RepositoryLocation = temp.RepositoryLocation
+
+	r.Principals = make(map[string]tuf.Principal)
+	for principalID, principalBytes := range temp.Principals {
+		tempPrincipal := map[string]any{}
+		if err := json.Unmarshal(principalBytes, &tempPrincipal); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		if _, has := tempPrincipal["keyid"]; has {
+			// this is *Key
+			key := &Key{}
+			if err := json.Unmarshal(principalBytes, key); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.Principals[principalID] = key
+			continue
+		}
+
+		if _, has := tempPrincipal["personID"]; has {
+			// this is *Person
+			person := &Person{}
+			if err := json.Unmarshal(principalBytes, person); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.Principals[principalID] = person
+			continue
+		}
+
+		if _, has := tempPrincipal["teamID"]; has {
+			// this is *Team
+			team := &Team{}
+			if err := json.Unmarshal(principalBytes, team); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.Principals[principalID] = team
+			continue
+		}
+
+		return fmt.Errorf("unrecognized principal type '%s'", string(principalBytes))
+	}
+
+	r.Roles = temp.Roles
+	r.GitHubApps = temp.GitHubApps
+
+	r.GlobalRules = []tuf.GlobalRule{}
+	for _, globalRuleBytes := range temp.GlobalRules {
+		tempGlobalRule := map[string]any{}
+		if err := json.Unmarshal(globalRuleBytes, &tempGlobalRule); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		switch tempGlobalRule["type"] {
+		case tuf.GlobalRuleThresholdType:
+			globalRule := &GlobalRuleThreshold{}
+			if err := json.Unmarshal(globalRuleBytes, globalRule); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.GlobalRules = append(r.GlobalRules, globalRule)
+
+		case tuf.GlobalRuleBlockForcePushesType:
+			globalRule := &GlobalRuleBlockForcePushes{}
+			if err := json.Unmarshal(globalRuleBytes, globalRule); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			r.GlobalRules = append(r.GlobalRules, globalRule)
+
+		default:
+			return tuf.ErrUnknownGlobalRuleType
+		}
+	}
+
+	r.Propagations = []tuf.PropagationDirective{}
+	for _, propagationDirectiveBytes := range temp.Propagations {
+		propagationDirective := &PropagationDirective{}
+		if err := json.Unmarshal(propagationDirectiveBytes, propagationDirective); err != nil {
+			return fmt.Errorf("unable to unmarshal json for propagation directive: %w", err)
+		}
+
+		r.Propagations = append(r.Propagations, propagationDirective)
+	}
+
+	r.MultiRepository = temp.MultiRepository
+
+	r.Hooks = temp.Hooks
+
+	return nil
+}
+
+// AddGlobalRule adds a new global rule to RootMetadata.
+func (r *RootMetadata) AddGlobalRule(globalRule tuf.GlobalRule) error {
+	allGlobalRules := r.GlobalRules
+	if allGlobalRules == nil {
+		allGlobalRules = []tuf.GlobalRule{}
+	}
+
+	// check for duplicates
+	for _, rule := range allGlobalRules {
+		if rule.GetName() == globalRule.GetName() {
+			return tuf.ErrGlobalRuleAlreadyExists
+		}
+	}
+
+	allGlobalRules = append(allGlobalRules, globalRule)
+	r.GlobalRules = allGlobalRules
+	return nil
+}
+
+// DeleteGlobalRule removes the specified global rule from the RootMetadata.
+func (r *RootMetadata) DeleteGlobalRule(ruleName string) error {
+	allGlobalRules := r.GlobalRules
+	updatedGlobalRules := []tuf.GlobalRule{}
+
+	if len(allGlobalRules) == 0 {
+		return tuf.ErrGlobalRuleNotFound
+	}
+
+	for _, rule := range allGlobalRules {
+		if rule.GetName() != ruleName {
+			updatedGlobalRules = append(updatedGlobalRules, rule)
+		}
+	}
+	r.GlobalRules = updatedGlobalRules
+	return nil
+}
+
+// UpdateGlobalRule updates the specified global rule from the RootMetadata.
+func (r *RootMetadata) UpdateGlobalRule(globalRule tuf.GlobalRule) error {
+	allGlobalRules := r.GlobalRules
+	updatedGlobalRules := []tuf.GlobalRule{}
+	found := false
+
+	if len(allGlobalRules) == 0 {
+		return tuf.ErrGlobalRuleNotFound
+	}
+
+	for _, oldGlobalRule := range allGlobalRules {
+		if oldGlobalRule.GetName() == globalRule.GetName() {
+			switch oldGlobalRule.(type) {
+			case *GlobalRuleThreshold:
+				if _, ok := globalRule.(*GlobalRuleThreshold); !ok {
+					return tuf.ErrCannotUpdateGlobalRuleType
+				}
+			case *GlobalRuleBlockForcePushes:
+				if _, ok := globalRule.(*GlobalRuleBlockForcePushes); !ok {
+					return tuf.ErrCannotUpdateGlobalRuleType
+				}
+			}
+			found = true
+			updatedGlobalRules = append(updatedGlobalRules, globalRule)
+		} else {
+			updatedGlobalRules = append(updatedGlobalRules, oldGlobalRule)
+		}
+	}
+
+	if !found {
+		return tuf.ErrGlobalRuleNotFound
+	}
+
+	r.GlobalRules = updatedGlobalRules
+
+	return nil
+}
+
+// GetGlobalRules returns all the global rules in the root metadata.
+func (r *RootMetadata) GetGlobalRules() []tuf.GlobalRule {
+	return r.GlobalRules
+}
+
+// AddPropagationDirective adds a propagation directive to the root metadata.
+func (r *RootMetadata) AddPropagationDirective(directive tuf.PropagationDirective) error {
+	for _, existing := range r.Propagations {
+		if existing.GetUpstreamRepository() == directive.GetUpstreamRepository() &&
+			existing.GetUpstreamReference() == directive.GetUpstreamReference() &&
+			existing.GetUpstreamPath() == directive.GetUpstreamPath() &&
+			existing.GetDownstreamReference() == directive.GetDownstreamReference() &&
+			existing.GetDownstreamPath() == directive.GetDownstreamPath() {
+			return tuf.ErrPropagationDirectiveAlreadyExists
+		}
+	}
+
+	r.Propagations = append(r.Propagations, directive)
+	return nil
+}
+
+// UpdatePropagationDirective updates a propagation directive in the root
+// metadata.
+func (r *RootMetadata) UpdatePropagationDirective(directive tuf.PropagationDirective) error {
+	updatedPropagationDirectives := []tuf.PropagationDirective{}
+	found := false
+
+	if len(r.Propagations) == 0 {
+		return tuf.ErrPropagationDirectiveNotFound
+	}
+
+	for _, oldPropagationDirective := range r.Propagations {
+		if oldPropagationDirective.GetName() == directive.GetName() {
+			found = true
+			updatedPropagationDirectives = append(updatedPropagationDirectives, directive)
+		} else {
+			updatedPropagationDirectives = append(updatedPropagationDirectives, oldPropagationDirective)
+		}
+	}
+
+	if !found {
+		return tuf.ErrPropagationDirectiveNotFound
+	}
+
+	r.Propagations = updatedPropagationDirectives
+
+	return nil
+}
+
+// GetPropagationDirectives returns the propagation directives found in the root
+// metadata.
+func (r *RootMetadata) GetPropagationDirectives() []tuf.PropagationDirective {
+	return r.Propagations
+}
+
+// DeletePropagationDirective removes a propagation directive from the root
+// metadata.
+func (r *RootMetadata) DeletePropagationDirective(name string) error {
+	index := -1
+	for i, directive := range r.Propagations {
+		if directive.GetName() == name {
+			index = i
+			break
+		}
+	}
+
+	if index == -1 {
+		return tuf.ErrPropagationDirectiveNotFound
+	}
+
+	r.Propagations = append(r.Propagations[:index], r.Propagations[index+1:]...)
+	return nil
+}
+
+// IsController indicates if the repository serves as the controller for a
+// multi-repository gittuf network.
+func (r *RootMetadata) IsController() bool {
+	if r.MultiRepository == nil {
+		return false
+	}
+
+	return r.MultiRepository.IsController()
+}
+
+// EnableController marks the current repository as a controller repository.
+func (r *RootMetadata) EnableController() error {
+	if r.MultiRepository == nil {
+		r.MultiRepository = &MultiRepository{}
+	}
+
+	r.MultiRepository.Controller = true
+	return nil // TODO: what if it's already a controller? noop?
+}
+
+// DisableController marks the current repository as not-a-controller.
+func (r *RootMetadata) DisableController() error {
+	if r.MultiRepository == nil {
+		// nothing to do
+		return nil
+	}
+
+	r.MultiRepository.Controller = false
+	// TODO: should we remove the network repository entries?
+	return nil
+}
+
+// AddControllerRepository adds the specified repository as a controller for the
+// current repository.
+func (r *RootMetadata) AddControllerRepository(name, location string, initialRootPrincipals []tuf.Principal) error {
+	if r.MultiRepository == nil {
+		r.MultiRepository = &MultiRepository{ControllerRepositories: []*OtherRepository{}}
+	}
+
+	for _, repo := range r.MultiRepository.ControllerRepositories {
+		if repo.Name == name || repo.Location == location {
+			return tuf.ErrDuplicateControllerRepository
+		}
+	}
+
+	newKeyIDs := make([]tuf.Principal, 0, len(initialRootPrincipals))
+	for _, principal := range initialRootPrincipals {
+		switch p := principal.(type) {
+		case *Key:
+			newKeyIDs = append(newKeyIDs, p)
+		case *Person:
+			// don't need to be checked for duplicates skip
+		case *Team:
+			// don't need to be checked for duplicates skip
+		default:
+			return tuf.ErrInvalidPrincipalType
+		}
+	}
+
+	for _, repo := range r.MultiRepository.ControllerRepositories {
+		existingKeyIDSet := set.NewSet[string]()
+		for _, existingPrincipal := range repo.InitialRootPrincipals {
+			if key, isKey := existingPrincipal.(*Key); isKey {
+				existingKeyIDSet.Add(key.KeyID)
+			}
+		}
+
+		newKeyIDSet := set.NewSet[string]()
+		for _, principal := range newKeyIDs {
+			if key, isKey := principal.(*Key); isKey {
+				newKeyIDSet.Add(key.KeyID)
+			}
+		}
+
+		if newKeyIDSet.Equal(existingKeyIDSet) {
+			return tuf.ErrDuplicateControllerRepository
+		}
+	}
+
+	otherRepository := &OtherRepository{
+		Name:                  name,
+		Location:              location,
+		InitialRootPrincipals: make([]tuf.Principal, 0, len(initialRootPrincipals)),
+	}
+
+	for _, principal := range initialRootPrincipals {
+		switch p := principal.(type) {
+		case *Key:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		case *Person:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		case *Team:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		default:
+			return tuf.ErrInvalidPrincipalType
+		}
+	}
+
+	r.MultiRepository.ControllerRepositories = append(r.MultiRepository.ControllerRepositories, otherRepository)
+
+	return nil
+}
+
+// AddNetworkRepository adds the specified repository as part of the network for
+// which the current repository is a controller. The current repository must be
+// marked as a controller before this can be used.
+func (r *RootMetadata) AddNetworkRepository(name, location string, initialRootPrincipals []tuf.Principal) error {
+	if r.MultiRepository == nil || !r.MultiRepository.Controller {
+		// EnableController must be called first
+		return tuf.ErrNotAControllerRepository
+	}
+
+	if r.MultiRepository.NetworkRepositories == nil {
+		r.MultiRepository.NetworkRepositories = []*OtherRepository{}
+	}
+
+	for _, repo := range r.MultiRepository.NetworkRepositories {
+		if repo.Name == name || repo.Location == location {
+			return tuf.ErrDuplicateNetworkRepository
+		}
+	}
+
+	newKeyIDs := make([]tuf.Principal, 0, len(initialRootPrincipals))
+	for _, principal := range initialRootPrincipals {
+		switch p := principal.(type) {
+		case *Key:
+			newKeyIDs = append(newKeyIDs, p)
+		case *Person:
+			// don't need to be checked for duplicates skip
+		case *Team:
+			// don't need to be checked for duplicates skip
+		default:
+			return tuf.ErrInvalidPrincipalType
+		}
+	}
+
+	for _, repo := range r.MultiRepository.NetworkRepositories {
+		existingKeyIDSet := set.NewSet[string]()
+		for _, existingPrincipal := range repo.InitialRootPrincipals {
+			if key, isKey := existingPrincipal.(*Key); isKey {
+				existingKeyIDSet.Add(key.KeyID)
+			}
+		}
+
+		newKeyIDSet := set.NewSet[string]()
+		for _, principal := range newKeyIDs {
+			if key, isKey := principal.(*Key); isKey {
+				newKeyIDSet.Add(key.KeyID)
+			}
+		}
+
+		if newKeyIDSet.Equal(existingKeyIDSet) {
+			return tuf.ErrDuplicateNetworkRepository
+		}
+	}
+
+	otherRepository := &OtherRepository{
+		Name:                  name,
+		Location:              location,
+		InitialRootPrincipals: make([]tuf.Principal, 0, len(initialRootPrincipals)),
+	}
+
+	for _, principal := range initialRootPrincipals {
+		switch p := principal.(type) {
+		case *Key:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		case *Person:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		case *Team:
+			otherRepository.InitialRootPrincipals = append(otherRepository.InitialRootPrincipals, p)
+		default:
+			return tuf.ErrInvalidPrincipalType
+		}
+	}
+
+	r.MultiRepository.NetworkRepositories = append(r.MultiRepository.NetworkRepositories, otherRepository)
+
+	return nil
+}
+
+// GetControllerRepositories returns the repositories that serve as the
+// controllers for the networks the current repository is a part of.
+func (r *RootMetadata) GetControllerRepositories() []tuf.OtherRepository {
+	if r.MultiRepository == nil {
+		return nil
+	}
+
+	return r.MultiRepository.GetControllerRepositories()
+}
+
+// GetNetworkRepositories returns the repositories that are part of the network
+// for which the current repository is a controller. IsController must return
+// true for this to be set.
+func (r *RootMetadata) GetNetworkRepositories() []tuf.OtherRepository {
+	if r.MultiRepository == nil {
+		return nil
+	}
+
+	return r.MultiRepository.GetNetworkRepositories()
+}
+
+// addPrincipal adds a principal to the RootMetadata instance. v03 of the
+// metadata supports Key, Person, and Team as supported principal types.
+func (r *RootMetadata) addPrincipal(principal tuf.Principal) error {
+	if r.Principals == nil {
+		r.Principals = map[string]tuf.Principal{}
+	}
+	switch principal := principal.(type) {
+	case *Key, *Person, *Team:
+		r.Principals[principal.ID()] = principal
+	default:
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	return nil
+}
+
+// addRole adds a role object and associates it with roleName in the
+// RootMetadata instance.
+func (r *RootMetadata) addRole(roleName string, role Role) {
+	if r.Roles == nil {
+		r.Roles = map[string]Role{}
+	}
+
+	r.Roles[roleName] = role
+}
+
+type GlobalRuleThreshold = tufv01.GlobalRuleThreshold
+type GlobalRuleBlockForcePushes = tufv01.GlobalRuleBlockForcePushes
+
+var NewGlobalRuleThreshold = tufv01.NewGlobalRuleThreshold
+var NewGlobalRuleBlockForcePushes = tufv01.NewGlobalRuleBlockForcePushes
+
+type PropagationDirective = tufv01.PropagationDirective
+
+func NewPropagationDirective(name, upstreamRepository, upstreamReference, upstreamPath, downstreamReference, downstreamPath string) tuf.PropagationDirective {
+	return &PropagationDirective{
+		Name:                name,
+		UpstreamRepository:  upstreamRepository,
+		UpstreamReference:   upstreamReference,
+		UpstreamPath:        upstreamPath,
+		DownstreamReference: downstreamReference,
+		DownstreamPath:      downstreamPath,
+	}
+}
+
+type MultiRepository struct {
+	Controller             bool               `json:"controller"`
+	ControllerRepositories []*OtherRepository `json:"controllerRepositories,omitempty"`
+	NetworkRepositories    []*OtherRepository `json:"networkRepositories,omitempty"`
+}
+
+func (m *MultiRepository) IsController() bool {
+	return m.Controller
+}
+
+func (m *MultiRepository) GetControllerRepositories() []tuf.OtherRepository {
+	controllerRepositories := []tuf.OtherRepository{}
+	for _, repository := range m.ControllerRepositories {
+		controllerRepositories = append(controllerRepositories, repository)
+	}
+	return controllerRepositories
+}
+
+func (m *MultiRepository) GetNetworkRepositories() []tuf.OtherRepository {
+	if !m.Controller {
+		return nil
+	}
+
+	networkRepositories := []tuf.OtherRepository{}
+	for _, repository := range m.NetworkRepositories {
+		networkRepositories = append(networkRepositories, repository)
+	}
+	return networkRepositories
+}
+
+type OtherRepository struct {
+	Name                  string          `json:"name"`
+	Location              string          `json:"location"`
+	InitialRootPrincipals []tuf.Principal `json:"initialRootPrincipals"`
+}
+
+func (o *OtherRepository) GetName() string {
+	return o.Name
+}
+
+func (o *OtherRepository) GetLocation() string {
+	return o.Location
+}
+
+func (o *OtherRepository) GetInitialRootPrincipals() []tuf.Principal {
+	return o.InitialRootPrincipals
+}
+
+func (o *OtherRepository) UnmarshalJSON(data []byte) error {
+	type tempType struct {
+		Name                  string            `json:"name"`
+		Location              string            `json:"location"`
+		InitialRootPrincipals []json.RawMessage `json:"initialRootPrincipals"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	o.Name = temp.Name
+	o.Location = temp.Location
+
+	o.InitialRootPrincipals = make([]tuf.Principal, 0, len(temp.InitialRootPrincipals))
+	for _, principalBytes := range temp.InitialRootPrincipals {
+		tempPrincipal := map[string]any{}
+		if err := json.Unmarshal(principalBytes, &tempPrincipal); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		if _, has := tempPrincipal["keyid"]; has {
+			// this is *Key
+			key := &Key{}
+			if err := json.Unmarshal(principalBytes, key); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			o.InitialRootPrincipals = append(o.InitialRootPrincipals, key)
+			continue
+		}
+
+		if _, has := tempPrincipal["personID"]; has {
+			// this is *Person
+			person := &Person{}
+			if err := json.Unmarshal(principalBytes, person); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			o.InitialRootPrincipals = append(o.InitialRootPrincipals, person)
+			continue
+		}
+
+		if _, has := tempPrincipal["teamID"]; has {
+			// this is *Team
+			team := &Team{}
+			if err := json.Unmarshal(principalBytes, team); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			o.InitialRootPrincipals = append(o.InitialRootPrincipals, team)
+			continue
+		}
+
+		return fmt.Errorf("unrecognized principal type '%s'", string(principalBytes))
+	}
+
+	return nil
+}
+
+type Hook = tufv01.Hook
+
+// AddHook adds the specified hook to the metadata.
+func (r *RootMetadata) AddHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, timeout int) (tuf.Hook, error) {
+	// TODO: Check if principal exists in RootMetadata/TargetsMetadata
+
+	newHook := &Hook{
+		Name:         hookName,
+		PrincipalIDs: set.NewSetFromItems(principalIDs...),
+		Hashes:       hashes,
+		Environment:  environment,
+		Timeout:      timeout,
+	}
+
+	if r.Hooks == nil {
+		r.Hooks = map[tuf.HookStage][]*Hook{}
+	}
+
+	for _, stage := range stages {
+		if err := stage.IsValid(); err != nil {
+			return nil, err
+		}
+		if r.Hooks[stage] == nil {
+			r.Hooks[stage] = []*Hook{}
+		} else {
+			for _, existingHook := range r.Hooks[stage] {
+				if existingHook.Name == hookName {
+					return nil, tuf.ErrDuplicatedHookName
+				}
+			}
+		}
+
+		r.Hooks[stage] = append(r.Hooks[stage], newHook)
+	}
+
+	return tuf.Hook(newHook), nil
+}
+
+// UpdateHook updates the hook specified by stage and hookName with the new
+// principalIDs, hashes, environment, and timeout.
+func (r *RootMetadata) UpdateHook(stages []tuf.HookStage, hookName string, principalIDs []string, hashes map[string]string, environment tuf.HookEnvironment, timeout int) error {
+	if r.Hooks == nil {
+		return tuf.ErrNoHooksDefined
+	}
+
+	var found bool
+
+	for _, stage := range stages {
+		for i, hook := range r.Hooks[stage] {
+			if hook.Name == hookName {
+				r.Hooks[stage][i].PrincipalIDs = set.NewSetFromItems(principalIDs...)
+				for key, value := range hashes {
+					r.Hooks[stage][i].Hashes[key] = value
+				}
+				r.Hooks[stage][i].Environment = environment
+				r.Hooks[stage][i].Timeout = timeout
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return tuf.ErrHookNotFound
+	}
+
+	return nil
+}
+
+// RemoveHook removes the hook specified by stage and hookName.
+func (r *RootMetadata) RemoveHook(stages []tuf.HookStage, hookName string) error {
+	if r.Hooks == nil {
+		return tuf.ErrNoHooksDefined
+	}
+
+	for _, stage := range stages {
+		hooks := []*Hook{}
+		for _, hook := range r.Hooks[stage] {
+			if hook.Name != hookName {
+				hooks = append(hooks, hook)
+			}
+		}
+
+		r.Hooks[stage] = hooks
+	}
+
+	return nil
+}
+
+// GetHooks returns the hooks for the specified stage.
+func (r *RootMetadata) GetHooks(stage tuf.HookStage) ([]tuf.Hook, error) {
+	if r.Hooks == nil {
+		return nil, tuf.ErrNoHooksDefined
+	}
+
+	hooks := []tuf.Hook{}
+	for _, hook := range r.Hooks[stage] {
+		hooks = append(hooks, hook)
+	}
+	return hooks, nil
+}
+
+type GitHubApp = tufv01.GitHubApp

--- a/internal/tuf/v03/targets.go
+++ b/internal/tuf/v03/targets.go
@@ -1,0 +1,436 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/danwakefield/fnmatch"
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+const (
+	TargetsVersion = "http://gittuf.dev/policy/rule-file/v0.3"
+)
+
+var ErrTargetsNotEmpty = errors.New("`targets` field in gittuf Targets metadata must be empty")
+
+// TargetsMetadata defines the schema of TUF's Targets role.
+type TargetsMetadata struct {
+	Type        string         `json:"type"`
+	Version     string         `json:"schemaVersion"`
+	Expires     string         `json:"expires"`
+	Targets     map[string]any `json:"targets"`
+	Delegations *Delegations   `json:"delegations"`
+}
+
+// NewTargetsMetadata returns a new instance of TargetsMetadata.
+func NewTargetsMetadata() *TargetsMetadata {
+	return &TargetsMetadata{
+		Type:        "targets",
+		Version:     TargetsVersion,
+		Delegations: &Delegations{Roles: []*Delegation{AllowRule()}},
+	}
+}
+
+// SetExpires sets the expiry date of the TargetsMetadata to the value passed
+// in.
+func (t *TargetsMetadata) SetExpires(expires string) {
+	t.Expires = expires
+}
+
+// SchemaVersion returns the metadata schema version.
+func (t *TargetsMetadata) SchemaVersion() string {
+	return t.Version
+}
+
+// Validate ensures the instance of TargetsMetadata matches gittuf expectations.
+func (t *TargetsMetadata) Validate() error {
+	if len(t.Targets) != 0 {
+		return ErrTargetsNotEmpty
+	}
+	return nil
+}
+
+// AddRule adds a new delegation to TargetsMetadata.
+func (t *TargetsMetadata) AddRule(ruleName string, authorizedPrincipalIDs, rulePatterns []string, threshold int) error {
+	if strings.HasPrefix(ruleName, tuf.GittufPrefix) {
+		return tuf.ErrCannotManipulateRulesWithGittufPrefix
+	}
+
+	for _, principalID := range authorizedPrincipalIDs {
+		if _, has := t.Delegations.Principals[principalID]; !has {
+			return tuf.ErrPrincipalNotFound
+		}
+	}
+
+	if len(authorizedPrincipalIDs) < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	allDelegations := t.Delegations.Roles
+	if allDelegations == nil {
+		allDelegations = []*Delegation{}
+	}
+
+	newDelegation := &Delegation{
+		Name:        ruleName,
+		Paths:       rulePatterns,
+		Terminating: false,
+		Role: Role{
+			PrincipalIDs: set.NewSetFromItems(authorizedPrincipalIDs...),
+			Threshold:    threshold,
+		},
+	}
+	allDelegations = append(allDelegations[:len(allDelegations)-1], newDelegation, AllowRule())
+	t.Delegations.Roles = allDelegations
+	return nil
+}
+
+// UpdateRule is used to amend a delegation in TargetsMetadata.
+func (t *TargetsMetadata) UpdateRule(ruleName string, authorizedPrincipalIDs, rulePatterns []string, threshold int) error {
+	if strings.HasPrefix(ruleName, tuf.GittufPrefix) {
+		return tuf.ErrCannotManipulateRulesWithGittufPrefix
+	}
+
+	for _, principalID := range authorizedPrincipalIDs {
+		if _, has := t.Delegations.Principals[principalID]; !has {
+			return tuf.ErrPrincipalNotFound
+		}
+	}
+
+	if len(authorizedPrincipalIDs) < threshold {
+		return tuf.ErrCannotMeetThreshold
+	}
+
+	allDelegations := []*Delegation{}
+	for _, delegation := range t.Delegations.Roles {
+		if delegation.ID() == tuf.AllowRuleName {
+			break
+		}
+
+		if delegation.ID() != ruleName {
+			allDelegations = append(allDelegations, delegation)
+			continue
+		}
+
+		if delegation.Name == ruleName {
+			delegation.Paths = rulePatterns
+			delegation.Role = Role{
+				PrincipalIDs: set.NewSetFromItems(authorizedPrincipalIDs...),
+				Threshold:    threshold,
+			}
+		}
+
+		allDelegations = append(allDelegations, delegation)
+	}
+	allDelegations = append(allDelegations, AllowRule())
+	t.Delegations.Roles = allDelegations
+	return nil
+}
+
+// ReorderRules changes the order of delegations, and the new order is specified
+// in `ruleNames []string`.
+func (t *TargetsMetadata) ReorderRules(ruleNames []string) error {
+	// Create a map of all existing delegations for quick look up
+	rolesMap := make(map[string]*Delegation)
+
+	// Create a set of current rules in metadata, skipping the allow rule
+	currentRules := set.NewSet[string]()
+	for _, delegation := range t.Delegations.Roles {
+		if delegation.Name == tuf.AllowRuleName {
+			continue
+		}
+		rolesMap[delegation.Name] = delegation
+		currentRules.Add(delegation.Name)
+	}
+
+	specifiedRules := set.NewSet[string]()
+	for _, name := range ruleNames {
+		if specifiedRules.Has(name) {
+			return fmt.Errorf("%w: '%s'", tuf.ErrDuplicatedRuleName, name)
+		}
+		specifiedRules.Add(name)
+	}
+
+	if !currentRules.Equal(specifiedRules) {
+		onlyInSpecifiedRules := specifiedRules.Minus(currentRules)
+		if onlyInSpecifiedRules.Len() != 0 {
+			if onlyInSpecifiedRules.Has(tuf.AllowRuleName) {
+				return fmt.Errorf("%w: do not specify allow rule", tuf.ErrCannotManipulateRulesWithGittufPrefix)
+			}
+			contents := onlyInSpecifiedRules.Contents()
+			return fmt.Errorf("%w: rules '%s' do not exist in current rule file", tuf.ErrRuleNotFound, strings.Join(contents, ", "))
+		}
+
+		onlyInCurrentRules := currentRules.Minus(specifiedRules)
+		if onlyInCurrentRules.Len() != 0 {
+			contents := onlyInCurrentRules.Contents()
+			return fmt.Errorf("%w: rules '%s' not specified", tuf.ErrMissingRules, strings.Join(contents, ", "))
+		}
+	}
+
+	// Create newDelegations and set it in the targetsMetadata after adding allow rule
+	newDelegations := make([]*Delegation, 0, len(rolesMap)+1)
+	for _, ruleName := range ruleNames {
+		newDelegations = append(newDelegations, rolesMap[ruleName])
+	}
+	newDelegations = append(newDelegations, AllowRule())
+	t.Delegations.Roles = newDelegations
+	return nil
+}
+
+// RemoveRule deletes a delegation entry from TargetsMetadata.
+func (t *TargetsMetadata) RemoveRule(ruleName string) error {
+	if strings.HasPrefix(ruleName, tuf.GittufPrefix) {
+		return tuf.ErrCannotManipulateRulesWithGittufPrefix
+	}
+
+	allDelegations := t.Delegations.Roles
+	updatedDelegations := []*Delegation{}
+
+	for _, delegation := range allDelegations {
+		if delegation.Name != ruleName {
+			updatedDelegations = append(updatedDelegations, delegation)
+		}
+	}
+	t.Delegations.Roles = updatedDelegations
+	return nil
+}
+
+// GetRules returns all the rules in the metadata.
+func (t *TargetsMetadata) GetRules() []tuf.Rule {
+	if t.Delegations == nil {
+		return nil
+	}
+
+	rules := make([]tuf.Rule, 0, len(t.Delegations.Roles))
+	for _, delegation := range t.Delegations.Roles {
+		rules = append(rules, delegation)
+	}
+
+	return rules
+}
+
+// GetPrincipals returns all the principals in the rule file.
+func (t *TargetsMetadata) GetPrincipals() map[string]tuf.Principal {
+	principals := map[string]tuf.Principal{}
+	for id, principal := range t.Delegations.Principals {
+		principals[id] = principal
+	}
+
+	return principals
+}
+
+// AddPrincipal adds a principal to the metadata.
+//
+// TODO: this isn't associated with a specific rule; with the removal of
+// verify-commit and verify-tag, it may not make sense anymore
+func (t *TargetsMetadata) AddPrincipal(principal tuf.Principal) error {
+	return t.Delegations.addPrincipal(principal)
+}
+
+// UpdatePrincipal updates an existing principal in the metadata.
+func (t *TargetsMetadata) UpdatePrincipal(principal tuf.Principal) error {
+	return t.Delegations.updatePrincipal(principal)
+}
+
+// RemovePrincipal removes a principal from the metadata.
+func (t *TargetsMetadata) RemovePrincipal(principalID string) error {
+	return t.Delegations.removePrincipal(principalID)
+}
+
+// Delegations defines the schema for specifying delegations in TUF's Targets
+// metadata.
+type Delegations struct {
+	Principals map[string]tuf.Principal `json:"principals"`
+	Roles      []*Delegation            `json:"roles"`
+}
+
+func (d *Delegations) UnmarshalJSON(data []byte) error {
+	// this type _has_ to be a copy of Delegations, minus the use of
+	// json.RawMessage in place of tuf.Principal
+	type tempType struct {
+		Principals map[string]json.RawMessage `json:"principals"`
+		Roles      []*Delegation              `json:"roles"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	d.Principals = make(map[string]tuf.Principal)
+	for principalID, principalBytes := range temp.Principals {
+		tempPrincipal := map[string]any{}
+		if err := json.Unmarshal(principalBytes, &tempPrincipal); err != nil {
+			return fmt.Errorf("unable to unmarshal json: %w", err)
+		}
+
+		if _, has := tempPrincipal["keyid"]; has {
+			// this is *Key
+			key := &Key{}
+			if err := json.Unmarshal(principalBytes, key); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			d.Principals[principalID] = key
+			continue
+		}
+
+		if _, has := tempPrincipal["personID"]; has {
+			// this is *Person
+			person := &Person{}
+			if err := json.Unmarshal(principalBytes, person); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			d.Principals[principalID] = person
+			continue
+		}
+
+		if _, has := tempPrincipal["teamID"]; has {
+			// this is *Team
+			team := &Team{}
+			if err := json.Unmarshal(principalBytes, team); err != nil {
+				return fmt.Errorf("unable to unmarshal json: %w", err)
+			}
+
+			d.Principals[principalID] = team
+			continue
+		}
+
+		return fmt.Errorf("unrecognized principal type '%s'", string(principalBytes))
+	}
+
+	d.Roles = temp.Roles
+	return nil
+}
+
+// addPrincipal adds a delegations key, person or team. v03 supports Key,
+// Person, and Team as principal types.
+func (d *Delegations) addPrincipal(principal tuf.Principal) error {
+	if d.Principals == nil {
+		d.Principals = map[string]tuf.Principal{}
+	}
+
+	switch principal := principal.(type) {
+	case *Key, *Person, *Team:
+		d.Principals[principal.ID()] = principal
+	default:
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	return nil
+}
+
+// updatePrincipal updates an existing principal in the metadata. v03 supports
+// Key, Person, and Team as principal types.
+func (d *Delegations) updatePrincipal(principal tuf.Principal) error {
+	if principal == nil {
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	principalID := principal.ID()
+	if _, exists := d.Principals[principalID]; !exists {
+		return tuf.ErrPrincipalNotFound
+	}
+
+	switch principal := principal.(type) {
+	case *Key, *Person, *Team:
+		d.Principals[principalID] = principal
+	default:
+		return tuf.ErrInvalidPrincipalType
+	}
+
+	return nil
+}
+
+// removePrincipal removes a delegations key, person, or team. v03 supports Key,
+// Person, and Team as principal types.
+func (d *Delegations) removePrincipal(principalID string) error {
+	if d.Principals == nil {
+		return tuf.ErrPrincipalNotFound
+	}
+	if principalID == "" {
+		return tuf.ErrInvalidPrincipalID
+	}
+	for _, curRole := range d.Roles {
+		if curRole.GetPrincipalIDs() != nil && curRole.GetPrincipalIDs().Has(principalID) {
+			return tuf.ErrPrincipalStillInUse
+		}
+	}
+	delete(d.Principals, principalID)
+	return nil
+}
+
+// AllowRule returns the default, last rule for all policy files.
+func AllowRule() *Delegation {
+	return &Delegation{
+		Name:        tuf.AllowRuleName,
+		Paths:       []string{"*"},
+		Terminating: true,
+		Role: Role{
+			Threshold: 1,
+		},
+	}
+}
+
+// Delegation defines the schema for a single delegation entry. It differs from
+// the standard TUF schema by allowing a `custom` field to record details
+// pertaining to the delegation. It implements the tuf.Rule interface.
+type Delegation struct {
+	Name        string           `json:"name"`
+	Paths       []string         `json:"paths"`
+	Terminating bool             `json:"terminating"`
+	Custom      *json.RawMessage `json:"custom,omitempty"`
+	Role
+}
+
+// ID returns the identifier of the delegation, its name.
+func (d *Delegation) ID() string {
+	return d.Name
+}
+
+// Matches checks if any of the delegation's patterns match the target.
+func (d *Delegation) Matches(target string) bool {
+	for _, pattern := range d.Paths {
+		// We validate pattern when it's added to / updated in the metadata
+		if matches := fnmatch.Match(pattern, target, 0); matches {
+			return true
+		}
+	}
+	return false
+}
+
+// GetPrincipalIDs returns the identifiers of the principals that are listed as
+// trusted by the rule.
+func (d *Delegation) GetPrincipalIDs() *set.Set[string] {
+	return d.PrincipalIDs
+}
+
+// GetThreshold returns the threshold of principals that must approve to meet
+// the rule.
+func (d *Delegation) GetThreshold() int {
+	return d.Threshold
+}
+
+// IsLastTrustedInRuleFile indicates that subsequent rules in the rule file are
+// not to be trusted if the current rule matches the namespace under
+// verification (similar to TUF's terminating behavior). However, the current
+// rule's delegated rules as well as other rules already in the queue are
+// trusted.
+func (d *Delegation) IsLastTrustedInRuleFile() bool {
+	return d.Terminating
+}
+
+// GetProtectedNamespaces returns the set of namespaces protected by the
+// delegation.
+func (d *Delegation) GetProtectedNamespaces() []string {
+	return d.Paths
+}

--- a/internal/tuf/v03/targets_test.go
+++ b/internal/tuf/v03/targets_test.go
@@ -1,0 +1,571 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTargetsMetadataAndDelegations(t *testing.T) {
+	targetsMetadata := NewTargetsMetadata()
+
+	t.Run("test SetExpires", func(t *testing.T) {
+		d := time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC)
+		targetsMetadata.SetExpires(d.Format(time.RFC3339))
+		assert.Equal(t, "1995-10-26T09:00:00Z", targetsMetadata.Expires)
+	})
+
+	t.Run("test Validate", func(t *testing.T) {
+		err := targetsMetadata.Validate()
+		assert.Nil(t, err)
+
+		targetsMetadata.Targets = map[string]any{"test": true}
+		err = targetsMetadata.Validate()
+		assert.ErrorIs(t, err, ErrTargetsNotEmpty)
+		targetsMetadata.Targets = nil
+	})
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+	team := &Team{
+		TeamID:     "frontend",
+		PublicKeys: []*Key{key},
+		Members:    []*Person{person},
+		Threshold:  1,
+	}
+
+	t.Run("test addPrincipal", func(t *testing.T) {
+		delegations := &Delegations{}
+		assert.Nil(t, delegations.Principals)
+
+		err := delegations.addPrincipal(key)
+		assert.Nil(t, err)
+		assert.Equal(t, key, delegations.Principals[key.KeyID])
+
+		err = delegations.addPrincipal(person)
+		assert.Nil(t, err)
+		assert.Equal(t, person, delegations.Principals[person.PersonID])
+
+		err = delegations.addPrincipal(team)
+		assert.Nil(t, err)
+		assert.Equal(t, team, delegations.Principals[team.TeamID])
+	})
+
+	t.Run("test removePrincipal", func(t *testing.T) {
+		delegations := &Delegations{}
+
+		err := delegations.addPrincipal(key)
+		assert.Nil(t, err)
+		assert.Equal(t, key, delegations.Principals[key.KeyID])
+
+		err = delegations.addPrincipal(person)
+		assert.Nil(t, err)
+		assert.Equal(t, person, delegations.Principals[person.PersonID])
+
+		err = delegations.addPrincipal(team)
+		assert.Nil(t, err)
+		assert.Equal(t, team, delegations.Principals[team.TeamID])
+
+		assert.NotEmpty(t, delegations.Principals)
+
+		err = delegations.removePrincipal(key.KeyID)
+		assert.Nil(t, err)
+		_, exists := delegations.Principals[key.KeyID]
+		assert.False(t, exists)
+
+		err = delegations.removePrincipal(person.PersonID)
+		assert.Nil(t, err)
+		_, exists = delegations.Principals[person.PersonID]
+		assert.False(t, exists)
+
+		err = delegations.removePrincipal(team.TeamID)
+		assert.Nil(t, err)
+		_, exists = delegations.Principals[team.TeamID]
+		assert.False(t, exists)
+
+		assert.Empty(t, delegations.Principals)
+	})
+}
+
+func TestDelegation(t *testing.T) {
+	t.Run("matches", func(t *testing.T) {
+		tests := map[string]struct {
+			patterns []string
+			target   string
+			expected bool
+		}{
+			"full path, matches": {
+				patterns: []string{"foo"},
+				target:   "foo",
+				expected: true,
+			},
+			"artifact in directory, matches": {
+				patterns: []string{"foo/*"},
+				target:   "foo/bar",
+				expected: true,
+			},
+			"artifact in directory, does not match": {
+				patterns: []string{"foo/*.txt"},
+				target:   "foo/bar.tgz",
+				expected: false,
+			},
+			"artifact in directory, one pattern matches": {
+				patterns: []string{"foo/*.txt", "foo/*.tgz"},
+				target:   "foo/bar.tgz",
+				expected: true,
+			},
+			"artifact in subdirectory, matches": {
+				patterns: []string{"foo/*"},
+				target:   "foo/bar/foobar",
+				expected: true,
+			},
+			"artifact in subdirectory with specified extension, matches": {
+				patterns: []string{"foo/*.tgz"},
+				target:   "foo/bar/foobar.tgz",
+				expected: true,
+			},
+			"pattern with single character selector, matches": {
+				patterns: []string{"foo/?.tgz"},
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, matches": {
+				patterns: []string{"foo/[abc].tgz"},
+				target:   "foo/a.tgz",
+				expected: true,
+			},
+			"pattern with character sequence, does not match": {
+				patterns: []string{"foo/[abc].tgz"},
+				target:   "foo/x.tgz",
+				expected: false,
+			},
+			"pattern with negative character sequence, matches": {
+				patterns: []string{"foo/[!abc].tgz"},
+				target:   "foo/x.tgz",
+				expected: true,
+			},
+			"pattern with negative character sequence, does not match": {
+				patterns: []string{"foo/[!abc].tgz"},
+				target:   "foo/a.tgz",
+				expected: false,
+			},
+			"artifact in arbitrary directory, matches": {
+				patterns: []string{"*/*.txt"},
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with specific name in arbitrary directory, matches": {
+				patterns: []string{"*/foobar.txt"},
+				target:   "foo/bar/foobar.txt",
+				expected: true,
+			},
+			"artifact with arbitrary subdirectories, matches": {
+				patterns: []string{"foo/*/foobar.txt"},
+				target:   "foo/bar/baz/foobar.txt",
+				expected: true,
+			},
+			"artifact in arbitrary directory, does not match": {
+				patterns: []string{"*.txt"},
+				target:   "foo/bar/foobar.txtfile",
+				expected: false,
+			},
+			"arbitrary directory, does not match": {
+				patterns: []string{"*_test"},
+				target:   "foo/bar_test/foobar",
+				expected: false,
+			},
+			"no patterns": {
+				patterns: nil,
+				target:   "foo",
+				expected: false,
+			},
+			"pattern with multiple consecutive wildcards, matches": {
+				patterns: []string{"foo/*/*/*.txt"},
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with multiple non-consecutive wildcards, matches": {
+				patterns: []string{"foo/*/baz/*.txt"},
+				target:   "foo/bar/baz/qux.txt",
+				expected: true,
+			},
+			"pattern with gittuf git prefix, matches": {
+				patterns: []string{"git:refs/heads/*"},
+				target:   "git:refs/heads/main",
+				expected: true,
+			},
+			"pattern with gittuf file prefix for all recursive contents, matches": {
+				patterns: []string{"file:src/signatures/*"},
+				target:   "file:src/signatures/rsa/rsa.go",
+				expected: true,
+			},
+		}
+
+		for name, test := range tests {
+			delegation := Delegation{Paths: test.patterns}
+			got := delegation.Matches(test.target)
+			assert.Equal(t, test.expected, got, fmt.Sprintf("unexpected result in test '%s'", name))
+		}
+	})
+
+	t.Run("threshold", func(t *testing.T) {
+		delegation := &Delegation{}
+
+		threshold := delegation.GetThreshold()
+		assert.Equal(t, 0, threshold)
+
+		delegation.Threshold = 1
+		threshold = delegation.GetThreshold()
+		assert.Equal(t, 1, threshold)
+	})
+
+	t.Run("terminating", func(t *testing.T) {
+		delegation := &Delegation{}
+
+		isTerminating := delegation.IsLastTrustedInRuleFile()
+		assert.False(t, isTerminating)
+
+		delegation.Terminating = true
+		isTerminating = delegation.IsLastTrustedInRuleFile()
+		assert.True(t, isTerminating)
+	})
+
+	t.Run("protected namespaces", func(t *testing.T) {
+		delegation := &Delegation{
+			Paths: []string{"1", "2"},
+		}
+
+		protected := delegation.GetProtectedNamespaces()
+		assert.Equal(t, []string{"1", "2"}, protected)
+	})
+
+	t.Run("principal IDs", func(t *testing.T) {
+		keyIDs := set.NewSetFromItems("1", "2")
+		delegation := &Delegation{
+			Role: Role{PrincipalIDs: keyIDs},
+		}
+
+		principalIDs := delegation.GetPrincipalIDs()
+		assert.Equal(t, keyIDs, principalIDs)
+	})
+}
+
+func TestAddRuleAndGetRules(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key1.KeyID: key1},
+	}
+	team := &Team{
+		TeamID:     "frontend",
+		PublicKeys: []*Key{key1},
+		Members:    []*Person{person},
+		Threshold:  1,
+	}
+
+	if err := targetsMetadata.AddPrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+	if err := targetsMetadata.AddPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+	if err := targetsMetadata.AddPrincipal(person); err != nil {
+		t.Fatal(err)
+	}
+	if err := targetsMetadata.AddPrincipal(team); err != nil {
+		t.Fatal(err)
+	}
+
+	err := targetsMetadata.AddRule("test-rule", []string{key1.KeyID, key2.KeyID, person.PersonID, team.TeamID}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key2.KeyID)
+	assert.Equal(t, key2, targetsMetadata.Delegations.Principals[key2.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, person.PersonID)
+	assert.Equal(t, person, targetsMetadata.Delegations.Principals[person.PersonID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, team.TeamID)
+	assert.Equal(t, team, targetsMetadata.Delegations.Principals[team.TeamID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+
+	rule := &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID, person.PersonID, team.TeamID), Threshold: 1},
+	}
+	assert.Equal(t, rule, targetsMetadata.Delegations.Roles[0])
+
+	rules := targetsMetadata.GetRules()
+	assert.Equal(t, 2, len(rules))
+	assert.Equal(t, []tuf.Rule{rule, AllowRule()}, rules)
+}
+
+func TestUpdateDelegation(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	if err := targetsMetadata.AddPrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+	err := targetsMetadata.AddRule("test-rule", []string{key1.KeyID}, []string{"test/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Equal(t, &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID), Threshold: 1},
+	}, targetsMetadata.Delegations.Roles[0])
+
+	if err := targetsMetadata.AddPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+	err = targetsMetadata.UpdateRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key2.KeyID)
+	assert.Equal(t, key2, targetsMetadata.Delegations.Principals[key2.KeyID])
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Equal(t, &Delegation{
+		Name:        "test-rule",
+		Paths:       []string{"test/"},
+		Terminating: false,
+		Role:        Role{PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID), Threshold: 1},
+	}, targetsMetadata.Delegations.Roles[0])
+}
+
+func TestReorderRules(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	if err := targetsMetadata.AddPrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+	if err := targetsMetadata.AddPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+
+	err := targetsMetadata.AddRule("rule-1", []string{key1.KeyID}, []string{"path1/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = targetsMetadata.AddRule("rule-2", []string{key2.KeyID}, []string{"path2/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = targetsMetadata.AddRule("rule-3", []string{key1.KeyID, key2.KeyID}, []string{"path3/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		ruleNames     []string
+		expected      []string
+		expectedError error
+	}{
+		"reverse order (valid input)": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1"},
+			expected:      []string{"rule-3", "rule-2", "rule-1", tuf.AllowRuleName},
+			expectedError: nil,
+		},
+		"rule not specified in new order": {
+			ruleNames:     []string{"rule-3", "rule-2"},
+			expectedError: tuf.ErrMissingRules,
+		},
+		"rule repeated in the new order": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1", "rule-3"},
+			expectedError: tuf.ErrDuplicatedRuleName,
+		},
+		"unknown rule in the new order": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-1", "rule-4"},
+			expectedError: tuf.ErrRuleNotFound,
+		},
+		"unknown rule in the new order (with correct length)": {
+			ruleNames:     []string{"rule-3", "rule-2", "rule-4"},
+			expectedError: tuf.ErrRuleNotFound,
+		},
+		"allow rule appears in the new order": {
+			ruleNames:     []string{"rule-2", "rule-3", "rule-1", tuf.AllowRuleName},
+			expectedError: tuf.ErrCannotManipulateRulesWithGittufPrefix,
+		},
+	}
+
+	for name, test := range tests {
+		err = targetsMetadata.ReorderRules(test.ruleNames)
+		if test.expectedError != nil {
+			assert.ErrorIs(t, err, test.expectedError, fmt.Sprintf("unexpected error in test '%s'", name))
+		} else {
+			assert.Nil(t, err, fmt.Sprintf("unexpected error in test '%s'", name))
+			assert.Equal(t, len(test.expected), len(targetsMetadata.Delegations.Roles),
+				fmt.Sprintf("expected %d rules in test '%s', but got %d rules",
+					len(test.expected), name, len(targetsMetadata.Delegations.Roles)))
+			for i, ruleName := range test.expected {
+				assert.Equal(t, ruleName, targetsMetadata.Delegations.Roles[i].Name,
+					fmt.Sprintf("expected rule '%s' at index %d in test '%s', but got '%s'",
+						ruleName, i, name, targetsMetadata.Delegations.Roles[i].Name))
+			}
+		}
+	}
+}
+
+func TestRemoveRule(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	if err := targetsMetadata.AddPrincipal(key); err != nil {
+		t.Fatal(err)
+	}
+
+	err := targetsMetadata.AddRule("test-rule", []string{key.KeyID}, []string{"test/"}, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, 2, len(targetsMetadata.Delegations.Roles))
+
+	err = targetsMetadata.RemoveRule("test-rule")
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(targetsMetadata.Delegations.Roles))
+	assert.Contains(t, targetsMetadata.Delegations.Roles, AllowRule())
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key.KeyID)
+}
+
+func TestUpdatePrincipal(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+
+	// Test updating non-existent principal
+	err := targetsMetadata.UpdatePrincipal(key1)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalNotFound)
+
+	// Add a principal and then update it
+	err = targetsMetadata.AddPrincipal(key1)
+	assert.Nil(t, err)
+	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
+
+	err = targetsMetadata.UpdatePrincipal(key2)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalNotFound)
+
+	// Test updating with nil principal
+	err = targetsMetadata.UpdatePrincipal(nil)
+	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalType)
+
+	// Test updating person
+	person1 := &Person{
+		PersonID: "jane.doe",
+		PublicKeys: map[string]*Key{
+			key1.KeyID: key1,
+		},
+	}
+	err = targetsMetadata.AddPrincipal(person1)
+	assert.Nil(t, err)
+
+	person2 := &Person{
+		PersonID: person1.PersonID,
+		PublicKeys: map[string]*Key{
+			key2.KeyID: key2,
+		},
+	}
+	err = targetsMetadata.UpdatePrincipal(person2)
+	assert.Nil(t, err)
+	assert.Equal(t, person2, targetsMetadata.Delegations.Principals[person1.PersonID])
+
+	// Test updating team
+	team1 := &Team{
+		TeamID:     "frontend",
+		PublicKeys: []*Key{key1},
+		Members:    []*Person{person1},
+		Threshold:  1,
+	}
+	err = targetsMetadata.AddPrincipal(team1)
+	assert.Nil(t, err)
+
+	team2 := &Team{
+		TeamID:     team1.TeamID,
+		PublicKeys: []*Key{key1, key2},
+		Members:    []*Person{person1, person2},
+		Threshold:  2,
+	}
+	err = targetsMetadata.UpdatePrincipal(team2)
+	assert.Nil(t, err)
+	assert.Equal(t, team2, targetsMetadata.Delegations.Principals[team1.TeamID])
+}
+
+func TestGetPrincipals(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	if err := targetsMetadata.AddPrincipal(key1); err != nil {
+		t.Fatal(err)
+	}
+
+	principals := targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1}, principals)
+
+	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
+	if err := targetsMetadata.AddPrincipal(key2); err != nil {
+		t.Fatal(err)
+	}
+
+	principals = targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1, key2.KeyID: key2}, principals)
+
+	person := &Person{
+		PersonID: "jane.doe",
+		PublicKeys: map[string]*Key{
+			key1.KeyID: key1,
+		},
+	}
+	if err := targetsMetadata.AddPrincipal(person); err != nil {
+		t.Fatal(err)
+	}
+	principals = targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1, key2.KeyID: key2, person.PersonID: person}, principals)
+
+	team := &Team{
+		TeamID:     "frontend",
+		PublicKeys: []*Key{key1},
+		Members:    []*Person{person},
+		Threshold:  1,
+	}
+	if err := targetsMetadata.AddPrincipal(team); err != nil {
+		t.Fatal(err)
+	}
+	principals = targetsMetadata.GetPrincipals()
+	assert.Equal(t, map[string]tuf.Principal{key1.KeyID: key1, key2.KeyID: key2, person.PersonID: person, team.TeamID: team}, principals)
+}
+
+func TestAllowRule(t *testing.T) {
+	allowRule := AllowRule()
+	assert.Equal(t, tuf.AllowRuleName, allowRule.Name)
+	assert.Equal(t, []string{"*"}, allowRule.Paths)
+	assert.True(t, allowRule.Terminating)
+	assert.Empty(t, allowRule.PrincipalIDs)
+	assert.Equal(t, 1, allowRule.Threshold)
+}

--- a/internal/tuf/v03/tuf.go
+++ b/internal/tuf/v03/tuf.go
@@ -1,0 +1,89 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"os"
+
+	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/dev"
+	v01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	v02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+)
+
+const AllowV03MetadataKey = "GITTUF_ALLOW_V03_POLICY"
+
+// AllowV03Metadata returns true if gittuf is in developer mode and
+// GITTUF_ALLOW_V03_POLICY = 1.
+func AllowV03Metadata() bool {
+	return dev.InDevMode() && os.Getenv(AllowV03MetadataKey) == "1"
+}
+
+// Key defines the structure for how public keys are stored in TUF metadata. It
+// implements the tuf.Principal and is used for backwards compatibility where a
+// Principal is always represented directly by a signing key or identity.
+type Key = v01.Key
+
+// NewKeyFromSSLibKey converts the signerverifier.SSLibKey into a Key object.
+func NewKeyFromSSLibKey(key *signerverifier.SSLibKey) *Key {
+	k := Key(*key)
+	return &k
+}
+
+// Person defines the structure for how a person identity is stored in policy
+// metadata. It implements tuf.Principal.
+type Person = v02.Person
+
+// Team defines the structure for how a team identity is stored in policy
+// metadata. It implements tuf.Principal.
+type Team struct {
+	// TeamID is a unique name or identifier for a team.
+	TeamID string `json:"teamID"`
+	// PublicKeys stores all public keys for all members of a team.
+	PublicKeys []*Key `json:"keys"`
+	// Metadata stores custom metadata for a team.
+	Metadata map[string]string `json:"custom"`
+	// Members stores references to individual persons of a team.
+	Members []*Person `json:"members"`
+	// Threshold defines the minimum number required for a team to reach
+	// agreement.
+	Threshold int `json:"threshold"`
+}
+
+// ID returns the team ID of a team.
+func (t *Team) ID() string {
+	return t.TeamID
+}
+
+// Keys returns all keys of a team.
+func (t *Team) Keys() []*signerverifier.SSLibKey {
+	keys := make([]*signerverifier.SSLibKey, 0, len(t.PublicKeys))
+	for _, key := range t.PublicKeys {
+		key := signerverifier.SSLibKey(*key)
+		keys = append(keys, &key)
+	}
+
+	return keys
+}
+
+// CustomMetadata returns the custom metadata of a team.
+func (t *Team) CustomMetadata() map[string]string {
+	return t.Metadata
+}
+
+func (t *Team) GetMembers() []*Person {
+	return t.Members
+}
+
+func (t *Team) GetThreshold() int {
+	return t.Threshold
+}
+
+// Role records common characteristics recorded in a role entry in Root metadata
+// and in a delegation entry.
+type Role struct {
+	PrincipalIDs *set.Set[string] `json:"principalIDs"`
+	Threshold    int              `json:"threshold"`
+}

--- a/internal/tuf/v03/tuf_test.go
+++ b/internal/tuf/v03/tuf_test.go
@@ -1,0 +1,42 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v03
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTeam(t *testing.T) {
+	keyR := ssh.NewKeyFromBytes(t, rootPubKeyBytes)
+	key := NewKeyFromSSLibKey(keyR)
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+	team := &Team{
+		TeamID:     "example-team",
+		PublicKeys: []*Key{key},
+		Members:    []*Person{person},
+		Threshold:  1,
+	}
+
+	id := team.ID()
+	assert.Equal(t, team.TeamID, id)
+
+	keys := team.Keys()
+	assert.Equal(t, []*signerverifier.SSLibKey{keyR}, keys)
+
+	customMetadata := team.CustomMetadata()
+	assert.Nil(t, customMetadata)
+
+	members := team.GetMembers()
+	assert.Equal(t, team.Members, members)
+
+	threshold := team.GetThreshold()
+	assert.Equal(t, team.Threshold, threshold)
+}


### PR DESCRIPTION
This commit introduces v03 of the gittuf policy metadata schema, with a new `Team` Principal type.