### PR TITLE
Prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## v0.13.0
+
+### Added
+
+- Added support for signing gittuf metadata with GPG keys
+- Added a new read-only mode to the TUI to allow viewing gittuf metadata
+- Added support for listing propagation directives and a duplicate check
+- Added documentation on extracting gittuf attestations data from the repository
+
+### Updated
+
+- Updated Sigstore dependency
+- Fixed Git GPG key configuration parsing issue
+- Added check to prevent reinitializing gittuf metadata when it already exists
+- Updated documentation for OSPS Baseline compliance
+- Updated the getting started guide
+- Updated documentation with various quality fixes
+- Updated various dependencies and CI workflows
+
+### Removed
+
+- Removed support for online verification from Sigstore, as it was removed
+  upstream
+
 ## v0.12.0
 
 ### Added

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -25,7 +25,7 @@ ARCH=amd64
 # One of: linux, darwin, freebsd
 OS=linux
 # See https://github.com/gittuf/gittuf/releases for the latest version
-VERSION=0.12.0
+VERSION=0.13.0
 cd $(mktemp -d)
 
 curl -LO https://github.com/gittuf/gittuf/releases/download/v${VERSION}/gittuf_${VERSION}_${OS}_${ARCH}
@@ -58,15 +58,15 @@ winget install gittuf
 #### Manual installation
 
 Copy and paste these commands in PowerShell to install gittuf. Please remember
-to change the version number (0.12.0 in this example) and architecture
+to change the version number (0.13.0 in this example) and architecture
 (amd64 in this example) according to your use-case and system.
 
 ```powershell
-curl "https://github.com/gittuf/gittuf/releases/download/v0.12.0/gittuf_0.12.0_windows_amd64.exe" -O "gittuf_0.12.0_windows_amd64.exe"
-curl "https://github.com/gittuf/gittuf/releases/download/v0.12.0/gittuf_0.12.0_windows_amd64.exe.sig" -O "gittuf_0.12.0_windows_amd64.exe.sig"
-curl "https://github.com/gittuf/gittuf/releases/download/v0.12.0/gittuf_0.12.0_windows_amd64.exe.pem" -O "gittuf_0.12.0_windows_amd64.exe.pem"
+curl "https://github.com/gittuf/gittuf/releases/download/v0.13.0/gittuf_0.13.0_windows_amd64.exe" -O "gittuf_0.13.0_windows_amd64.exe"
+curl "https://github.com/gittuf/gittuf/releases/download/v0.13.0/gittuf_0.13.0_windows_amd64.exe.sig" -O "gittuf_0.13.0_windows_amd64.exe.sig"
+curl "https://github.com/gittuf/gittuf/releases/download/v0.13.0/gittuf_0.13.0_windows_amd64.exe.pem" -O "gittuf_0.13.0_windows_amd64.exe.pem"
 
-cosign verify-blob --certificate gittuf_0.12.0_windows_amd64.exe.pem --signature gittuf_0.12.0_windows_amd64.exe.sig --certificate-identity https://github.com/gittuf/gittuf/.github/workflows/release.yml@refs/tags/v0.12.0 --certificate-oidc-issuer https://token.actions.githubusercontent.com gittuf_0.12.0_windows_amd64.exe
+cosign verify-blob --certificate gittuf_0.13.0_windows_amd64.exe.pem --signature gittuf_0.13.0_windows_amd64.exe.sig --certificate-identity https://github.com/gittuf/gittuf/.github/workflows/release.yml@refs/tags/v0.13.0 --certificate-oidc-issuer https://token.actions.githubusercontent.com gittuf_0.13.0_windows_amd64.exe
 ```
 
 The gittuf binary is now verified on your system. You can run it from the


### PR DESCRIPTION
Opening this to prepare the `v0.13.0` release. I've tagged the changes made in https://github.com/gittuf/gittuf/pull/1124 as `[WIP]` since I think they'd be a nice bit to have for our next release, but we can also release without them if others think that's the better approach.