### PR TITLE
ci: Update goreleaser winget configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,9 +67,9 @@ winget:
     url_template: "https://github.com/gittuf/gittuf/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     skip_upload: auto
     release_notes: "https://github.com/gittuf/gittuf/blob/main/CHANGELOG.md#v{{ .Major }}{{ .Minor }}{{ .Patch }}"
+    ids:
+      - gittuf
     tags:
-      - cli
-      - access-control
       - git
       - git-security
       - gittuf
@@ -81,6 +81,40 @@ winget:
       owner: gittuf
       name: winget-pkgs
       branch: "gittuf-{{.Version}}"
+      token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+  - name: git-remote-gittuf
+    publisher: gittuf
+    license: Apache-2.0
+    license_url: "https://github.com/gittuf/gittuf/blob/main/LICENSE"
+    copyright: The gittuf Authors
+    homepage: https://gittuf.dev/
+    short_description: "gittuf's custom Git remote transfer protocol binary"
+    publisher_support_url: "https://github.com/gittuf/gittuf/issues"
+    package_identifier: "gittuf.git-remote-gittuf"
+    url_template: "https://github.com/gittuf/gittuf/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    skip_upload: auto
+    release_notes: "https://github.com/gittuf/gittuf/blob/main/CHANGELOG.md#v{{ .Major }}{{ .Minor }}{{ .Patch }}"
+    ids:
+      - git-remote-gittuf
+    tags:
+      - git
+      - git-security
+      - gittuf
+    commit_author:
+      name: openssf-robot
+      email: openssf-robot@openssf.org
+    goamd64: v1
+    repository:
+      owner: gittuf
+      name: winget-pkgs
+      branch: "git-remote-gittuf-{{.Version}}"
       token: "{{ .Env.WINGET_GITHUB_TOKEN }}"
       pull_request:
         enabled: true


### PR DESCRIPTION
We now also have the gittuf transport up on winget, so this adds it to the release pipeline, as well as makes changes that (hopefully) get automated winget releasing to work.