### PR TITLE
ci: Generate SBOMs for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,14 @@ on:
   push:
     tags:
       - 'v*'
-permissions:
-  contents: write
-  id-token: write
+permissions: read-all
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -19,12 +21,22 @@ jobs:
           go-version: '1.26'
           cache: true
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
+      - uses: anchore/sbom-action/download-syft@43a17d6e7add2b5535efe4dcae9952337c479a93
       - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29
         with:
           distribution: goreleaser-pro
           version: latest
-          args: release --clean
+          args: release --clean --snapshot --skip=winget
         env:
           WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+      # Attest the output SBOM
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: dist/git**/**
+          sbom-path: dist/gittuf.src.tar.gz.sbom.json
+      # Generate SLSA build provenance attestations
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
+        with:
+          subject-path: dist/git**/**

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
 version: 2
 
 project_name: gittuf
@@ -130,6 +132,9 @@ gomod:
 changelog:
   disable: true
 
+checksum:
+  name_template: "checksums.txt"
+
 signs:
 - cmd: cosign
   env:
@@ -139,8 +144,17 @@ signs:
   - sign-blob
   - '${artifact}'
   - '--bundle=${signature}'
-  artifacts: binary
+  artifacts: checksum
   output: true
+
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}.src"
+
+sboms:
+  - artifacts: archive
+  - id: source
+    artifacts: source
 
 release:
   prerelease: allow


### PR DESCRIPTION
This helps us fulfill the baseline requirement [OSPS-QA-02.02](https://baseline.openssf.org/versions/2025-10-10#osps-qa-0202).