### PR TITLE
ci: Disable prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - gosec
     - importas
     - misspell
-    - prealloc
     - revive
     - staticcheck
     - tparallel


### PR DESCRIPTION
This PR fixes the linting issues we're getting recently by disabling the `prealloc` linter.

I tried to make the changes it suggested, but there were frequent issues with:

 - disabling it in cases where determining the number of elements to allocate was difficult (leading to lots of `//nolint:prealloc` annotations), or,
 - tests failing because elements not always used meant `nil` entries, which didn't align with the expected slices

FWIW we can open an issue on adding this, but I don't think it's worth the development time right this moment...