### PR TITLE
trust: add add-root-person command

### DIFF
--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -35,6 +35,7 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
 * [gittuf trust add-policy-key](gittuf_trust_add-policy-key.md)	 - Add Policy key to gittuf root of trust
 * [gittuf trust add-propagation-directive](gittuf_trust_add-propagation-directive.md)	 - Add propagation directive into gittuf root of trust
 * [gittuf trust add-root-key](gittuf_trust_add-root-key.md)	 - Add Root key to gittuf root of trust
+* [gittuf trust add-root-person](gittuf_trust_add-root-person.md)	 - Add Root person to gittuf root of trust
 * [gittuf trust apply](gittuf_trust_apply.md)	 - Validate and apply changes from policy-staging to policy
 * [gittuf trust disable-github-app-approvals](gittuf_trust_disable-github-app-approvals.md)	 - Mark GitHub app approvals as untrusted henceforth
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth
@@ -59,4 +60,3 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
 * [gittuf trust update-policy-threshold](gittuf_trust_update-policy-threshold.md)	 - Update Policy threshold in the gittuf root of trust
 * [gittuf trust update-propagation-directive](gittuf_trust_update-propagation-directive.md)	 - Update propagation directive in the root of trust (developer mode only, set GITTUF_DEV=1)
 * [gittuf trust update-root-threshold](gittuf_trust_update-root-threshold.md)	 - Update Root threshold in the gittuf root of trust
-

--- a/docs/cli/gittuf_trust_add-root-person.md
+++ b/docs/cli/gittuf_trust_add-root-person.md
@@ -1,0 +1,37 @@
+## gittuf trust add-root-person
+
+Add Root person to gittuf root of trust
+
+### Synopsis
+
+The 'add-root-person' command allows users to add a new root person to the repository's root of trust. In gittuf, a person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom') for tracking additional attributes. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". Optionally, the change can be recorded in the RSL.
+
+```
+gittuf trust add-root-person [flags]
+```
+
+### Options
+
+```
+      --associated-identity stringArray   identities on code review platforms in the form 'providerID::identity' (e.g., 'https://gittuf.dev/github-app::<username>+<user ID>')
+      --custom stringArray                additional custom metadata in the form KEY=VALUE
+  -h, --help                              help for add-root-person
+      --person-ID string                  person ID
+      --public-key stringArray            authorized public key for person
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust

--- a/internal/cmd/trust/addrootperson/addrootperson.go
+++ b/internal/cmd/trust/addrootperson/addrootperson.go
@@ -1,7 +1,7 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package trust
+package addrootperson
 
 import (
 	"fmt"
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type addRootPersonOptions struct {
+type options struct {
 	p                    *persistent.Options
 	personID             string
 	publicKeys           []string
@@ -23,7 +23,7 @@ type addRootPersonOptions struct {
 	customMetadata       []string
 }
 
-func (o *addRootPersonOptions) AddFlags(cmd *cobra.Command) {
+func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.personID,
 		"person-ID",
@@ -55,7 +55,7 @@ func (o *addRootPersonOptions) AddFlags(cmd *cobra.Command) {
 	)
 }
 
-func (o *addRootPersonOptions) Run(cmd *cobra.Command, _ []string) error {
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -105,21 +105,18 @@ func (o *addRootPersonOptions) Run(cmd *cobra.Command, _ []string) error {
 	if o.p.WithRSLEntry {
 		opts = append(opts, trustpolicyopts.WithRSLEntry())
 	}
-
-	return repo.AddRootKey(cmd.Context(), signer, person, true, opts...)
+	return repo.AddRootPerson(cmd.Context(), signer, person, true, opts...)
 }
 
-func newAddRootPersonCommand(p *persistent.Options) *cobra.Command {
-	o := &addRootPersonOptions{p: p}
-
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "add-root-person",
-		Short:             "Add a trusted person to the gittuf root of trust",
-		Long:              `The 'add-root-person' command allows users to add a new trusted person as a principal in the repository's root of trust. A person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom') for tracking additional attributes. The keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Short:             "Add Root person to gittuf root of trust",
+		Long:              `The 'add-root-person' command allows users to add a new root person to the repository's root of trust. In gittuf, a person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom') for tracking additional attributes. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". Optionally, the change can be recorded in the RSL.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}
-
 	o.AddFlags(cmd)
 
 	return cmd

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpolicykey"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpropagationdirective"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addrootkey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/addrootperson"
 	"github.com/gittuf/gittuf/internal/cmd/trust/disablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
@@ -59,7 +60,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addpolicykey.New(o))
 	cmd.AddCommand(addpropagationdirective.New(o))
 	cmd.AddCommand(addrootkey.New(o))
-	cmd.AddCommand(newAddRootPersonCommand(o))
+	cmd.AddCommand(addrootperson.New(o))
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))


### PR DESCRIPTION
Add a new gittuf trust add-root-person subcommand to register a Person principal in the root metadata.
-The command accepts --person-ID, one or more --public-key values, optional --associated-identity, and optional --custom metadata.
-Internally it constructs a tufv02.Person and calls Repository.AddRootKey so the person is authorized for the root role.
Testing
go test ./... 