### PR TITLE
tui: Split main screen into choice between policy and trust operations

### DIFF
--- a/internal/cmd/tui/policyhelpers.go
+++ b/internal/cmd/tui/policyhelpers.go
@@ -5,25 +5,15 @@ package tui
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
-	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
-	"github.com/gittuf/gittuf/internal/tuf"
 )
 
 type rule struct {
 	name    string
 	pattern string
 	key     string
-}
-
-type globalRule struct {
-	ruleName     string
-	ruleType     string
-	rulePatterns []string
-	threshold    int
 }
 
 // getCurrRules returns the current rules from the policy file
@@ -107,128 +97,4 @@ func repoReorderRules(o *options, rules []rule) error {
 	}
 
 	return repo.ReorderDelegations(context.Background(), signer, o.policyName, ruleNames, true)
-}
-
-// getGlobalRules returns a slice of globalRule for the TUI
-func getGlobalRules(o *options) []globalRule {
-	repo, err := gittuf.LoadRepository(".")
-	if err != nil {
-		return nil
-	}
-
-	rules, err := repo.ListGlobalRules(context.Background(), o.targetRef)
-	if err != nil {
-		return nil
-	}
-
-	var currRules = make([]globalRule, len(rules))
-	for i, r := range rules {
-		switch gRule := r.(type) {
-		case tuf.GlobalRuleThreshold:
-			currRules[i] = globalRule{
-				ruleName:     gRule.GetName(),
-				ruleType:     tuf.GlobalRuleThresholdType,
-				rulePatterns: gRule.GetProtectedNamespaces(),
-				threshold:    gRule.GetThreshold(),
-			}
-		case tuf.GlobalRuleBlockForcePushes:
-			currRules[i] = globalRule{
-				ruleName:     gRule.GetName(),
-				ruleType:     tuf.GlobalRuleBlockForcePushesType,
-				rulePatterns: gRule.GetProtectedNamespaces(),
-			}
-		}
-	}
-	return currRules
-}
-
-// repoAddGlobalRule adds a global rule
-func repoAddGlobalRule(o *options, gr globalRule) error {
-	repo, err := gittuf.LoadRepository(".")
-	if err != nil {
-		return err
-	}
-	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
-	if err != nil {
-		return err
-	}
-	var opts []trustpolicyopts.Option
-	if o.p.WithRSLEntry {
-		opts = append(opts, trustpolicyopts.WithRSLEntry())
-	}
-	switch gr.ruleType {
-	case tuf.GlobalRuleThresholdType:
-		if len(gr.rulePatterns) == 0 {
-			return fmt.Errorf("required flag --rule-pattern not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
-		}
-		return repo.AddGlobalRuleThreshold(
-			context.Background(), signer,
-			gr.ruleName, gr.rulePatterns,
-			gr.threshold, true, opts...,
-		)
-	case tuf.GlobalRuleBlockForcePushesType:
-		if len(gr.rulePatterns) == 0 {
-			return fmt.Errorf("required flag --rule-pattern not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
-		}
-		return repo.AddGlobalRuleBlockForcePushes(
-			context.Background(), signer,
-			gr.ruleName, gr.rulePatterns,
-			true, opts...,
-		)
-	default:
-		return fmt.Errorf("unknown global-rule type %q", gr.ruleType)
-	}
-}
-
-// repoRemoveGlobalRule removes a global rule
-func repoRemoveGlobalRule(o *options, gr globalRule) error {
-	repo, err := gittuf.LoadRepository(".")
-	if err != nil {
-		return err
-	}
-	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
-	if err != nil {
-		return err
-	}
-	var opts []trustpolicyopts.Option
-	if o.p.WithRSLEntry {
-		opts = append(opts, trustpolicyopts.WithRSLEntry())
-	}
-	return repo.RemoveGlobalRule(
-		context.Background(), signer, gr.ruleName, true, opts...,
-	)
-}
-
-// repoUpdateGlobalRule updates a global rule
-func repoUpdateGlobalRule(o *options, gr globalRule) error {
-	repo, err := gittuf.LoadRepository(".")
-	if err != nil {
-		return err
-	}
-	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
-	if err != nil {
-		return err
-	}
-	var opts []trustpolicyopts.Option
-	if o.p.WithRSLEntry {
-		opts = append(opts, trustpolicyopts.WithRSLEntry())
-	}
-	switch gr.ruleType {
-	case tuf.GlobalRuleThresholdType:
-		if len(gr.rulePatterns) == 0 {
-			return fmt.Errorf("required flag --rule-pattern not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
-		}
-
-		return repo.UpdateGlobalRuleThreshold(context.Background(), signer, gr.ruleName, gr.rulePatterns, gr.threshold, true, opts...)
-
-	case tuf.GlobalRuleBlockForcePushesType:
-		if len(gr.rulePatterns) == 0 {
-			return fmt.Errorf("required flag --rule-pattern not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
-		}
-
-		return repo.UpdateGlobalRuleBlockForcePushes(context.Background(), signer, gr.ruleName, gr.rulePatterns, true, opts...)
-
-	default:
-		return tuf.ErrUnknownGlobalRuleType
-	}
 }

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -1,0 +1,144 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+type globalRule struct {
+	ruleName     string
+	ruleType     string
+	rulePatterns []string
+	threshold    int
+}
+
+// getGlobalRules returns a slice of globalRule for the TUI
+func getGlobalRules(o *options) []globalRule {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return nil
+	}
+
+	rules, err := repo.ListGlobalRules(context.Background(), o.targetRef)
+	if err != nil {
+		return nil
+	}
+
+	var currRules = make([]globalRule, len(rules))
+	for i, r := range rules {
+		switch gRule := r.(type) {
+		case tuf.GlobalRuleThreshold:
+			currRules[i] = globalRule{
+				ruleName:     gRule.GetName(),
+				ruleType:     tuf.GlobalRuleThresholdType,
+				rulePatterns: gRule.GetProtectedNamespaces(),
+				threshold:    gRule.GetThreshold(),
+			}
+		case tuf.GlobalRuleBlockForcePushes:
+			currRules[i] = globalRule{
+				ruleName:     gRule.GetName(),
+				ruleType:     tuf.GlobalRuleBlockForcePushesType,
+				rulePatterns: gRule.GetProtectedNamespaces(),
+			}
+		}
+	}
+	return currRules
+}
+
+// repoAddGlobalRule adds a global rule
+func repoAddGlobalRule(o *options, gr globalRule) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	switch gr.ruleType {
+	case tuf.GlobalRuleThresholdType:
+		if len(gr.rulePatterns) == 0 {
+			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
+		}
+		return repo.AddGlobalRuleThreshold(
+			context.Background(), signer,
+			gr.ruleName, gr.rulePatterns,
+			gr.threshold, true, opts...,
+		)
+	case tuf.GlobalRuleBlockForcePushesType:
+		if len(gr.rulePatterns) == 0 {
+			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
+		}
+		return repo.AddGlobalRuleBlockForcePushes(
+			context.Background(), signer,
+			gr.ruleName, gr.rulePatterns,
+			true, opts...,
+		)
+	default:
+		return fmt.Errorf("unknown global rule type %q", gr.ruleType)
+	}
+}
+
+// repoRemoveGlobalRule removes a global rule
+func repoRemoveGlobalRule(o *options, gr globalRule) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	return repo.RemoveGlobalRule(
+		context.Background(), signer, gr.ruleName, true, opts...,
+	)
+}
+
+// repoUpdateGlobalRule updates a global rule
+func repoUpdateGlobalRule(o *options, gr globalRule) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	switch gr.ruleType {
+	case tuf.GlobalRuleThresholdType:
+		if len(gr.rulePatterns) == 0 {
+			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
+		}
+
+		return repo.UpdateGlobalRuleThreshold(context.Background(), signer, gr.ruleName, gr.rulePatterns, gr.threshold, true, opts...)
+
+	case tuf.GlobalRuleBlockForcePushesType:
+		if len(gr.rulePatterns) == 0 {
+			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
+		}
+
+		return repo.UpdateGlobalRuleBlockForcePushes(context.Background(), signer, gr.ruleName, gr.rulePatterns, true, opts...)
+
+	default:
+		return tuf.ErrUnknownGlobalRuleType
+	}
+}

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -47,14 +47,29 @@ var (
 // View renders the TUI
 func (m model) View() string {
 	switch m.screen {
-	case screenMain:
+	case screenChoice:
+		return lipgloss.NewStyle().Margin(1, 2).Render(
+			m.choiceList.View() + "\n" +
+				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer),
+		)
+	case screenPolicy:
 		// Show apply hint only when not in read-only mode.
 		hint := ""
 		if !m.readOnly {
 			hint = "Run `gittuf policy apply` to apply staged changes to the selected policy file"
 		}
 		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.mainList.View() + "\n" +
+			m.policyScreenList.View() + "\n" +
+				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
+				"\n" + hint,
+		)
+	case screenTrust:
+		hint := ""
+		if !m.readOnly {
+			hint = "Run `gittuf trust apply` to apply staged changes to the selected policy file"
+		}
+		return lipgloss.NewStyle().Margin(1, 2).Render(
+			m.trustScreenList.View() + "\n" +
 				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
 				"\n" + hint,
 		)


### PR DESCRIPTION
This PR introduces a new main screen `screenChoice` in the TUI that allows you to choose between Policy or Trust operations.

I also moved the global rule operations (`add`, `remove`, `update`, `list`) under Trust.