### PR TITLE
go: Bump go version to 1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gittuf/gittuf
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/ProtonMail/go-crypto v1.3.0


### PR DESCRIPTION
This addresses a CVE apparently present in go's stdlib. Based on Kusari Bot's suggestion: https://github.com/gittuf/gittuf/pull/1190#issuecomment-3873144487