### PR TITLE
tui: refactor to view-first flow

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -4,6 +4,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -20,17 +21,15 @@ import (
 type screen int
 
 const (
-	screenChoice screen = iota // initial screen
-	screenPolicy
-	screenTrust
-	screenAddRule
-	screenRemoveRule
-	screenListRules
-	screenReorderRules
-	screenListGlobalRules
-	screenAddGlobalRule
-	screenUpdateGlobalRule
-	screenRemoveGlobalRule
+	screenChoice              screen = iota // Initial menu
+	screenPolicy                            // Menu for Policy operations
+	screenPolicyRules                       // Rule management screen
+	screenPolicyAddRule                     // Form: add a new policy rule
+	screenPolicyEditRule                    // Form: edit selected rule (prefilled)
+	screenTrust                             // Menu for Trust operations
+	screenTrustGlobalRules                  // Global rule management screen
+	screenTrustAddGlobalRule                // Form: add a new global rule
+	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
 )
 
 type item struct {
@@ -38,16 +37,17 @@ type item struct {
 }
 
 // Note: virtual methods must be implemented for the item struct
-// Title returns the title of the item
+// Title returns the title of the item.
 func (i item) Title() string { return i.title }
 
-// Description returns the description of the item
+// Description returns the description of the item.
 func (i item) Description() string { return i.desc }
 
-// FilterValue returns the value to filter on
+// FilterValue returns the value to filter on.
 func (i item) FilterValue() string { return i.title }
 
 type model struct {
+	ctx              context.Context
 	screen           screen
 	choiceList       list.Model
 	policyScreenList list.Model
@@ -64,11 +64,65 @@ type model struct {
 	policyName       string
 	options          *options
 	footer           string
+	errorMsg         string
 	readOnly         bool
+	confirmDelete    bool
+	deleteTarget     string
 }
 
-// initialModel returns the initial model for the Terminal UI
-func initialModel(o *options) (model, error) {
+// inputField describes a single text input's placeholder and prompt label.
+type inputField struct {
+	placeholder string
+	prompt      string
+}
+
+// newDelegate creates a styled list delegate for use in all list.Model instances.
+func newDelegate() list.DefaultDelegate {
+	d := list.NewDefaultDelegate()
+	d.Styles.SelectedTitle = selectedItemStyle
+	d.Styles.SelectedDesc = selectedItemStyle
+	d.Styles.NormalTitle = itemStyle
+	d.Styles.NormalDesc = itemStyle
+	return d
+}
+
+// newMenuList creates a configured list.Model with default settings.
+func newMenuList(title string, items []list.Item, delegate list.DefaultDelegate) list.Model {
+	l := list.New(items, delegate, 0, 0)
+	l.Title = title
+	l.Styles.Title = titleStyle
+	l.SetShowStatusBar(false)
+	l.SetFilteringEnabled(false)
+	l.SetShowHelp(false)
+	return l
+}
+
+// initInputs creates a slice of text inputs from field definitions.
+// The first field is focused; the rest are blurred.
+func initInputs(fields []inputField) []textinput.Model {
+	inputs := make([]textinput.Model, len(fields))
+	for i, f := range fields {
+		t := textinput.New()
+		t.Cursor.Style = cursorStyle
+		t.CharLimit = 64
+		t.Placeholder = f.placeholder
+		t.Prompt = f.prompt
+		if i == 0 {
+			t.Focus()
+			t.PromptStyle = focusedStyle
+			t.TextStyle = focusedStyle
+		} else {
+			t.Blur()
+			t.PromptStyle = blurredStyle
+			t.TextStyle = blurredStyle
+		}
+		inputs[i] = t
+	}
+	return inputs
+}
+
+// initialModel returns the initial model for the Terminal UI.
+func initialModel(ctx context.Context, o *options) (model, error) {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return model{}, err
@@ -80,11 +134,9 @@ func initialModel(o *options) (model, error) {
 	var footer string
 
 	if !readOnly {
-		// Try to load signer. Uses Git config if signing key not explicitly provided
 		signer, err = gittuf.LoadSigner(repo, o.p.SigningKey)
 		if err != nil {
 			if !errors.Is(err, gittuf.ErrSigningKeyNotSpecified) {
-				// If a signing key was found but cannot be loaded, return error
 				return model{}, fmt.Errorf("failed to load signing key from Git config: %w", err)
 			}
 			readOnly = true
@@ -92,179 +144,107 @@ func initialModel(o *options) (model, error) {
 		}
 	}
 
-	// Initialize the model
+	delegate := newDelegate()
+
 	m := model{
+		ctx:         ctx,
 		screen:      screenChoice,
 		cursorMode:  cursor.CursorBlink,
 		repo:        repo,
 		signer:      signer,
 		policyName:  o.policyName,
-		rules:       getCurrRules(o),
-		globalRules: getGlobalRules(o),
+		rules:       getCurrRules(ctx, o),
+		globalRules: getGlobalRules(ctx, o),
 		options:     o,
 		readOnly:    readOnly,
 		footer:      footer,
-	}
 
-	// Set up choice screen list items
-	choiceItems := []list.Item{
-		item{title: "Policy", desc: "Manage gittuf Policy"},
-		item{title: "Trust", desc: "Manage gittuf Root of Trust"},
-	}
-
-	// Set up the policy screen list items
-	// In read-only mode, only non-mutating operations are available.
-	var policyItems []list.Item
-	if m.readOnly {
-		policyItems = []list.Item{
-			item{title: "List Rules", desc: "View all current policy rules"},
-		}
-	} else {
-		policyItems = []list.Item{
-			item{title: "Add Rule", desc: "Add a new policy rule"},
-			item{title: "Remove Rule", desc: "Remove an existing policy rule"},
-			item{title: "List Rules", desc: "View all current policy rules"},
-			item{title: "Reorder Rules", desc: "Change the order of policy rules"},
-		}
-	}
-
-	// Set up trust screen list items
-	var trustItems []list.Item
-	if m.readOnly {
-		trustItems = []list.Item{
-			item{title: "List Global Rules", desc: "View repository-wide global rules"},
-		}
-	} else {
-		trustItems = []list.Item{
-			item{title: "Add Global Rule", desc: "Add a new global rule"},
-			item{title: "Remove Global Rule", desc: "Remove a global rule"},
-			item{title: "Update Global Rule", desc: "Modify an existing global rule"},
-			item{title: "List Global Rules", desc: "View repository-wide global rules"},
-		}
-	}
-
-	// Set up the list delegate
-	delegate := list.NewDefaultDelegate()
-	delegate.Styles.SelectedTitle = selectedItemStyle
-	delegate.Styles.SelectedDesc = selectedItemStyle
-	delegate.Styles.NormalTitle = itemStyle
-	delegate.Styles.NormalDesc = itemStyle
-
-	// Set up choice screen list
-	m.choiceList = list.New(choiceItems, delegate, 0, 0)
-	m.choiceList.Title = "gittuf TUI"
-	m.choiceList.SetShowStatusBar(false)
-	m.choiceList.SetFilteringEnabled(false)
-	m.choiceList.Styles.Title = titleStyle
-	m.choiceList.SetShowHelp(false)
-
-	// Set up the policy screen list
-	m.policyScreenList = list.New(policyItems, delegate, 0, 0)
-	m.policyScreenList.Title = "gittuf Policy Operations"
-	m.policyScreenList.SetShowStatusBar(false)
-	m.policyScreenList.SetFilteringEnabled(false)
-	m.policyScreenList.Styles.Title = titleStyle
-	m.policyScreenList.SetShowHelp(false)
-
-	// Set up the trust screen list
-	m.trustScreenList = list.New(trustItems, delegate, 0, 0)
-	m.trustScreenList.Title = "gittuf Trust Operations"
-	m.trustScreenList.SetShowStatusBar(false)
-	m.trustScreenList.SetFilteringEnabled(false)
-	m.trustScreenList.Styles.Title = titleStyle
-	m.trustScreenList.SetShowHelp(false)
-
-	// Set up the rule list
-	m.ruleList = list.New([]list.Item{}, delegate, 0, 0)
-	m.ruleList.Title = "Current Rules"
-	m.ruleList.SetShowStatusBar(false)
-	m.ruleList.SetFilteringEnabled(false)
-	m.ruleList.Styles.Title = titleStyle
-	m.ruleList.SetShowHelp(false)
-
-	// set up global rule list
-	m.globalRuleList = list.New([]list.Item{}, delegate, 0, 0)
-	m.globalRuleList.Title = "Global Rules"
-	m.globalRuleList.SetShowStatusBar(false)
-	m.globalRuleList.SetFilteringEnabled(false)
-	m.globalRuleList.Styles.Title = titleStyle
-	m.globalRuleList.SetShowHelp(false)
-
-	// Set up the input fields
-	m.inputs = make([]textinput.Model, 3)
-	for i := range m.inputs {
-		t := textinput.New()
-		t.Cursor.Style = cursorStyle
-		t.CharLimit = 64
-
-		switch i {
-		case 0:
-			t.Placeholder = "Enter Rule Name Here"
-			t.Focus()
-			t.PromptStyle = focusedStyle
-			t.Prompt = "Rule Name:"
-			t.TextStyle = focusedStyle
-		case 1:
-			t.Placeholder = "Enter Pattern Here"
-			t.Prompt = "Pattern:"
-			t.PromptStyle = blurredStyle
-			t.TextStyle = blurredStyle
-		case 2:
-			t.Placeholder = "Enter Path to Key Here"
-			t.Prompt = "Authorize Key:"
-			t.PromptStyle = blurredStyle
-			t.TextStyle = blurredStyle
-		}
-
-		m.inputs[i] = t
+		choiceList: newMenuList("gittuf TUI", []list.Item{
+			item{title: "Policy", desc: "View and manage gittuf Policy"},
+			item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
+		}, delegate),
+		policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
+			item{title: "View Rules", desc: "View and manage policy rules"},
+		}, delegate),
+		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
+			item{title: "View Global Rules", desc: "View and manage global rules"},
+		}, delegate),
+		ruleList:       newMenuList("Policy Rules", []list.Item{}, delegate),
+		globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
 	}
 
 	return m, nil
 }
 
-// Init initializes the input field
+// Init initializes the input field.
 func (m model) Init() tea.Cmd {
 	return textinput.Blink
 }
 
-// reinitialize inputs for global rules
-func (m *model) initGlobalInputs() {
-	prompts := []struct{ placeholder, prompt string }{
+// initRuleInputs initializes the input fields for (policy) rule forms.
+func (m *model) initRuleInputs() {
+	m.inputs = initInputs([]inputField{
+		{"Enter Rule Name Here", "Rule Name:"},
+		{"Enter Rule Pattern Here", " Rule Pattern:"},
+		{"Enter Principal IDs Here (comma-separated)", "Authorized Principals:"},
+		{"Enter Threshold", "Threshold:"},
+	})
+	m.focusIndex = 0
+}
+
+// initRuleInputsPrefilled initializes rule inputs prefilled with an existing rule's values.
+func (m *model) initRuleInputsPrefilled(r rule) {
+	m.initRuleInputs()
+	m.inputs[0].SetValue(r.name)
+	m.inputs[1].SetValue(r.pattern)
+	m.inputs[2].SetValue(r.key)
+	m.inputs[3].SetValue(fmt.Sprintf("%d", r.threshold))
+}
+
+// initGlobalRuleInputs initializes the input fields for global rule forms.
+func (m *model) initGlobalRuleInputs() {
+	m.inputs = initInputs([]inputField{
 		{"Enter Global Rule Name Here", "Rule Name:"},
-		{"Enter Rule Type (threshold|block-force-pushes)", "Type:"},
+		{"Enter Global Rule Type (threshold|block-force-pushes)", "Type:"},
 		{"Enter Namespaces (comma-separated)", "Namespaces:"},
 		{"Enter Threshold (if threshold type)", "Threshold:"},
-	}
-	m.inputs = make([]textinput.Model, len(prompts))
-	for i, p := range prompts {
-		t := textinput.New()
-		t.Cursor.Style = cursorStyle
-		t.CharLimit = 64
-		t.Placeholder = p.placeholder
-		t.Prompt = p.prompt
-		if i == 0 {
-			t.Focus()
-			t.PromptStyle = focusedStyle
-			t.TextStyle = focusedStyle
-		} else {
-			t.Blur()
-			t.PromptStyle = blurredStyle
-			t.TextStyle = blurredStyle
-		}
-		m.inputs[i] = t
+	})
+	m.focusIndex = 0
+}
+
+// initGlobalRuleInputsPrefilled initializes global rule inputs prefilled with an existing global rule's values.
+func (m *model) initGlobalRuleInputsPrefilled(gr globalRule) {
+	m.initGlobalRuleInputs()
+	m.inputs[0].SetValue(gr.ruleName)
+	m.inputs[1].SetValue(gr.ruleType)
+	m.inputs[2].SetValue(strings.Join(gr.rulePatterns, ", "))
+	if gr.ruleType == tuf.GlobalRuleThresholdType {
+		m.inputs[3].SetValue(fmt.Sprintf("%d", gr.threshold))
 	}
 }
 
-// updateRuleList updates the rule list within TUI
+// refreshRules re-fetches rules from the repo and rebuilds the list.
+func (m *model) refreshRules() {
+	m.rules = getCurrRules(m.ctx, m.options)
+	m.updateRuleList()
+}
+
+// refreshGlobalRules re-fetches global rules from the repo and rebuilds the list.
+func (m *model) refreshGlobalRules() {
+	m.globalRules = getGlobalRules(m.ctx, m.options)
+	m.updateGlobalRuleList()
+}
+
+// updateRuleList updates the rule list within the TUI.
 func (m *model) updateRuleList() {
 	items := make([]list.Item, len(m.rules))
 	for i, rule := range m.rules {
-		items[i] = item{title: rule.name, desc: fmt.Sprintf("Pattern: %s, Key: %s", rule.pattern, rule.key)}
+		items[i] = item{title: rule.name, desc: fmt.Sprintf("Pattern: %s, Key: %s, Threshold: %d", rule.pattern, rule.key, rule.threshold)}
 	}
 	m.ruleList.SetItems(items)
 }
 
-// updateGlobalRuleList updates the global rule list within TUI
+// updateGlobalRuleList updates the global rule list within the TUI.
 func (m *model) updateGlobalRuleList() {
 	items := make([]list.Item, len(m.globalRules))
 	for i, gr := range m.globalRules {

--- a/internal/cmd/tui/policyhelpers.go
+++ b/internal/cmd/tui/policyhelpers.go
@@ -11,19 +11,20 @@ import (
 )
 
 type rule struct {
-	name    string
-	pattern string
-	key     string
+	name      string
+	pattern   string
+	key       string
+	threshold int
 }
 
-// getCurrRules returns the current rules from the policy file
-func getCurrRules(o *options) []rule {
+// getCurrRules returns the current rules from the policy file.
+func getCurrRules(ctx context.Context, o *options) []rule {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return nil
 	}
 
-	rules, err := repo.ListRules(context.Background(), o.targetRef)
+	rules, err := repo.ListRules(ctx, o.targetRef)
 	if err != nil {
 		return nil
 	}
@@ -31,16 +32,17 @@ func getCurrRules(o *options) []rule {
 	var currRules = make([]rule, len(rules))
 	for i, r := range rules {
 		currRules[i] = rule{
-			name:    r.Delegation.ID(),
-			pattern: strings.Join(r.Delegation.GetProtectedNamespaces(), ", "),
-			key:     strings.Join(r.Delegation.GetPrincipalIDs().Contents(), ", "),
+			name:      r.Delegation.ID(),
+			pattern:   strings.Join(r.Delegation.GetProtectedNamespaces(), ", "),
+			key:       strings.Join(r.Delegation.GetPrincipalIDs().Contents(), ", "),
+			threshold: r.Delegation.GetThreshold(),
 		}
 	}
 	return currRules
 }
 
-// repoAddRule adds a rule to the policy file
-func repoAddRule(o *options, rule rule, keyPath []string) error {
+// repoAddRule adds a rule to the policy file.
+func repoAddRule(ctx context.Context, o *options, rule rule, authorizedPrincipalIDs []string) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -51,22 +53,11 @@ func repoAddRule(o *options, rule rule, keyPath []string) error {
 		return err
 	}
 
-	authorizedPrincipalIDs := []string{}
-	for _, key := range keyPath {
-		key, err := gittuf.LoadPublicKey(key)
-		if err != nil {
-			return err
-		}
-
-		authorizedPrincipalIDs = append(authorizedPrincipalIDs, key.ID())
-	}
-	res := repo.AddDelegation(context.Background(), signer, o.policyName, rule.name, authorizedPrincipalIDs, []string{rule.pattern}, 1, true)
-
-	return res
+	return repo.AddDelegation(ctx, signer, o.policyName, rule.name, authorizedPrincipalIDs, []string{rule.pattern}, rule.threshold, true)
 }
 
-// repoRemoveRule removes a rule from the policy file
-func repoRemoveRule(o *options, rule rule) error {
+// repoUpdateRule updates an existing rule in the policy file.
+func repoUpdateRule(ctx context.Context, o *options, r rule, authorizedPrincipalIDs []string) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -76,11 +67,26 @@ func repoRemoveRule(o *options, rule rule) error {
 	if err != nil {
 		return err
 	}
-	return repo.RemoveDelegation(context.Background(), signer, o.policyName, rule.name, true)
+
+	return repo.UpdateDelegation(ctx, signer, o.policyName, r.name, authorizedPrincipalIDs, []string{r.pattern}, r.threshold, true)
 }
 
-// repoReorderRules reorders the rules in the policy file
-func repoReorderRules(o *options, rules []rule) error {
+// repoRemoveRule removes a rule from the policy file.
+func repoRemoveRule(ctx context.Context, o *options, rule rule) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	return repo.RemoveDelegation(ctx, signer, o.policyName, rule.name, true)
+}
+
+// repoReorderRules reorders the rules in the policy file.
+func repoReorderRules(ctx context.Context, o *options, rules []rule) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -96,5 +102,5 @@ func repoReorderRules(o *options, rules []rule) error {
 		ruleNames[i] = r.name
 	}
 
-	return repo.ReorderDelegations(context.Background(), signer, o.policyName, ruleNames, true)
+	return repo.ReorderDelegations(ctx, signer, o.policyName, ruleNames, true)
 }

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -20,13 +20,13 @@ type globalRule struct {
 }
 
 // getGlobalRules returns a slice of globalRule for the TUI
-func getGlobalRules(o *options) []globalRule {
+func getGlobalRules(ctx context.Context, o *options) []globalRule {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return nil
 	}
 
-	rules, err := repo.ListGlobalRules(context.Background(), o.targetRef)
+	rules, err := repo.ListGlobalRules(ctx, o.targetRef)
 	if err != nil {
 		return nil
 	}
@@ -53,7 +53,7 @@ func getGlobalRules(o *options) []globalRule {
 }
 
 // repoAddGlobalRule adds a global rule
-func repoAddGlobalRule(o *options, gr globalRule) error {
+func repoAddGlobalRule(ctx context.Context, o *options, gr globalRule) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func repoAddGlobalRule(o *options, gr globalRule) error {
 			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
 		}
 		return repo.AddGlobalRuleThreshold(
-			context.Background(), signer,
+			ctx, signer,
 			gr.ruleName, gr.rulePatterns,
 			gr.threshold, true, opts...,
 		)
@@ -81,7 +81,7 @@ func repoAddGlobalRule(o *options, gr globalRule) error {
 			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
 		}
 		return repo.AddGlobalRuleBlockForcePushes(
-			context.Background(), signer,
+			ctx, signer,
 			gr.ruleName, gr.rulePatterns,
 			true, opts...,
 		)
@@ -91,7 +91,7 @@ func repoAddGlobalRule(o *options, gr globalRule) error {
 }
 
 // repoRemoveGlobalRule removes a global rule
-func repoRemoveGlobalRule(o *options, gr globalRule) error {
+func repoRemoveGlobalRule(ctx context.Context, o *options, gr globalRule) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -105,12 +105,12 @@ func repoRemoveGlobalRule(o *options, gr globalRule) error {
 		opts = append(opts, trustpolicyopts.WithRSLEntry())
 	}
 	return repo.RemoveGlobalRule(
-		context.Background(), signer, gr.ruleName, true, opts...,
+		ctx, signer, gr.ruleName, true, opts...,
 	)
 }
 
 // repoUpdateGlobalRule updates a global rule
-func repoUpdateGlobalRule(o *options, gr globalRule) error {
+func repoUpdateGlobalRule(ctx context.Context, o *options, gr globalRule) error {
 	repo, err := gittuf.LoadRepository(".")
 	if err != nil {
 		return err
@@ -129,14 +129,14 @@ func repoUpdateGlobalRule(o *options, gr globalRule) error {
 			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleThresholdType)
 		}
 
-		return repo.UpdateGlobalRuleThreshold(context.Background(), signer, gr.ruleName, gr.rulePatterns, gr.threshold, true, opts...)
+		return repo.UpdateGlobalRuleThreshold(ctx, signer, gr.ruleName, gr.rulePatterns, gr.threshold, true, opts...)
 
 	case tuf.GlobalRuleBlockForcePushesType:
 		if len(gr.rulePatterns) == 0 {
 			return fmt.Errorf("namespaces not set for global rule type '%s'", tuf.GlobalRuleBlockForcePushesType)
 		}
 
-		return repo.UpdateGlobalRuleBlockForcePushes(context.Background(), signer, gr.ruleName, gr.rulePatterns, true, opts...)
+		return repo.UpdateGlobalRuleBlockForcePushes(ctx, signer, gr.ruleName, gr.rulePatterns, true, opts...)
 
 	default:
 		return tuf.ErrUnknownGlobalRuleType

--- a/internal/cmd/tui/tui.go
+++ b/internal/cmd/tui/tui.go
@@ -4,6 +4,8 @@
 package tui
 
 import (
+	"context"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 	"github.com/gittuf/gittuf/internal/policy"
@@ -40,8 +42,8 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	)
 }
 
-func (o *options) Run(_ *cobra.Command, _ []string) error {
-	return startTUI(o)
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	return startTUI(cmd.Context(), o)
 }
 
 func New(persistent *persistent.Options) *cobra.Command {
@@ -60,8 +62,8 @@ func New(persistent *persistent.Options) *cobra.Command {
 }
 
 // startTUI intitializes a new model for the TUI
-func startTUI(o *options) error {
-	m, err := initialModel(o)
+func startTUI(ctx context.Context, o *options) error {
+	m, err := initialModel(ctx, o)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -1,8 +1,6 @@
 // Copyright The gittuf Authors
 // SPDX-License-Identifier: Apache-2.0
 
-// This file handles TUI input handling.
-
 package tui
 
 import (
@@ -15,7 +13,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 )
 
-// Update updates the model based on the message received
+// Update updates the model based on the message received.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
@@ -26,241 +24,69 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.policyScreenList.SetSize(msg.Width-h, msg.Height-v)
 		m.trustScreenList.SetSize(msg.Width-h, msg.Height-v)
 		m.ruleList.SetSize(msg.Width-h, msg.Height-v)
+		m.globalRuleList.SetSize(msg.Width-h, msg.Height-v)
 
 	case tea.KeyMsg:
+		// Delete confirmation overlay intercepts all keys
+		if m.confirmDelete {
+			return m.handleDeleteConfirm(msg.String())
+		}
+
+		// Global handlers (quit, back navigation)
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
-		case "left":
+		case "q":
+			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
+			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
+				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
+				return m, tea.Quit
+			}
+		case "esc":
 			m.footer = ""
 			switch m.screen {
 			case screenPolicy, screenTrust:
 				m.screen = screenChoice
-			case screenAddRule, screenRemoveRule, screenListRules, screenReorderRules:
+			case screenPolicyRules:
 				m.screen = screenPolicy
-			case screenAddGlobalRule, screenRemoveGlobalRule, screenUpdateGlobalRule, screenListGlobalRules:
+			case screenPolicyAddRule, screenPolicyEditRule:
+				m.screen = screenPolicyRules
+			case screenTrustGlobalRules:
 				m.screen = screenTrust
+			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+				m.screen = screenTrustGlobalRules
 			}
 			return m, nil
-		case "enter":
-			switch m.screen {
-			case screenChoice:
-				i, ok := m.choiceList.SelectedItem().(item)
-				if ok {
-					switch i.title {
-					case "Policy":
-						m.screen = screenPolicy
-					case "Trust":
-						m.screen = screenTrust
-					}
-				}
-			case screenPolicy:
-				i, ok := m.policyScreenList.SelectedItem().(item)
-				if ok {
-					switch i.title {
-					case "Add Rule":
-						m.screen = screenAddRule
-						m.focusIndex = 0
-						m.inputs[0].Focus()
-					case "Remove Rule":
-						m.screen = screenRemoveRule
-						m.updateRuleList()
-					case "List Rules":
-						m.screen = screenListRules
-					case "Reorder Rules":
-						m.screen = screenReorderRules
-						m.updateRuleList()
-					}
-				}
-			case screenTrust:
-				i, ok := m.trustScreenList.SelectedItem().(item)
-				if ok {
-					switch i.title {
-					case "Add Global Rule":
-						m.screen = screenAddGlobalRule
-						m.initGlobalInputs()
-					case "Remove Global Rule":
-						m.screen = screenRemoveGlobalRule
-						m.updateGlobalRuleList()
-					case "Update Global Rule":
-						m.screen = screenUpdateGlobalRule
-						m.initGlobalInputs()
-					case "List Global Rules":
-						m.screen = screenListGlobalRules
-						m.updateGlobalRuleList()
-					}
-				}
-			case screenAddRule:
-				if m.focusIndex == len(m.inputs)-1 {
-					newRule := rule{
-						name:    m.inputs[0].Value(),
-						pattern: m.inputs[1].Value(),
-						key:     m.inputs[2].Value(),
-					}
-					authorizedKeys := []string{m.inputs[2].Value()}
-					err := repoAddRule(m.options, newRule, authorizedKeys)
-					if err != nil {
-						m.footer = fmt.Sprintf("Error adding rule: %v", err)
-						return m, nil
-					}
-					m.rules = append(m.rules, newRule)
-					m.updateRuleList()
-					m.footer = "Rule added successfully!"
-					m.screen = screenPolicy
-				}
-			case screenRemoveRule:
-				if i, ok := m.ruleList.SelectedItem().(item); ok {
-					err := repoRemoveRule(m.options, rule{name: i.title})
-					if err != nil {
-						m.footer = fmt.Sprintf("Error removing rule: %v", err)
-						return m, nil
-					}
-					for idx, rule := range m.rules {
-						if rule.name == i.title {
-							m.rules = append(m.rules[:idx], m.rules[idx+1:]...)
-							break
-						}
-					}
-					m.updateRuleList()
-					m.footer = "Rule removed successfully!"
-					m.screen = screenPolicy
-				}
-			case screenAddGlobalRule:
-				// parse comma-separated input into []string
-				if m.focusIndex == len(m.inputs)-1 {
-					raw := m.inputs[2].Value()
-					parts := strings.Split(raw, ",")
-					for i := range parts {
-						parts[i] = strings.TrimSpace(parts[i])
-					}
-					// parse threshold only if that type
-					thr := 0
-					if m.inputs[1].Value() == tuf.GlobalRuleThresholdType {
-						thr, _ = strconv.Atoi(m.inputs[3].Value())
-					}
-					newGR := globalRule{
-						ruleName:     m.inputs[0].Value(),
-						ruleType:     m.inputs[1].Value(),
-						rulePatterns: parts,
-						threshold:    thr,
-					}
-					if err := repoAddGlobalRule(m.options, newGR); err != nil {
-						m.footer = fmt.Sprintf("Error: %v", err)
-						return m, nil
-					}
-					m.globalRules = append(m.globalRules, newGR)
-					m.updateGlobalRuleList()
-					m.footer = "Global rule added!"
-					m.screen = screenTrust
-				}
-			case screenRemoveGlobalRule:
-				if sel, ok := m.globalRuleList.SelectedItem().(item); ok {
-					err := repoRemoveGlobalRule(m.options, globalRule{ruleName: sel.title})
-					if err != nil {
-						m.footer = fmt.Sprintf("Error removing global rule: %v", err)
-						return m, nil
-					}
-					for idx, gr := range m.globalRules {
-						if gr.ruleName == sel.title {
-							m.globalRules = append(m.globalRules[:idx], m.globalRules[idx+1:]...)
-							break
-						}
-					}
-					m.updateGlobalRuleList()
-					m.footer = "Global rule removed!"
-					m.screen = screenTrust
-				}
-			case screenUpdateGlobalRule:
-				if m.focusIndex == len(m.inputs)-1 {
-					// parse namespaces (split + TrimSpace)
-					parts := strings.Split(m.inputs[2].Value(), ",")
-					for i := range parts {
-						parts[i] = strings.TrimSpace(parts[i])
-					}
-					// parse threshold if needed
-					thr := 0
-					if m.inputs[1].Value() == tuf.GlobalRuleThresholdType {
-						thr, _ = strconv.Atoi(m.inputs[3].Value())
-					}
-					updated := globalRule{
-						ruleName:     m.inputs[0].Value(),
-						ruleType:     m.inputs[1].Value(),
-						rulePatterns: parts,
-						threshold:    thr,
-					}
-					if err := repoUpdateGlobalRule(m.options, updated); err != nil {
-						m.footer = fmt.Sprintf("Error updating global rule: %v", err)
-						return m, nil
-					}
-					for idx, gr := range m.globalRules {
-						if gr.ruleName == updated.ruleName {
-							m.globalRules[idx] = updated
-							break
-						}
-					}
-					m.updateGlobalRuleList()
-					m.footer = "Global rule updated!"
-					m.screen = screenTrust
-				}
-			}
-		case "u":
-			if m.screen == screenReorderRules {
-				if i := m.ruleList.Index(); i > 0 {
-					m.rules[i], m.rules[i-1] = m.rules[i-1], m.rules[i]
-					if err := repoReorderRules(m.options, m.rules); err != nil {
-						m.footer = fmt.Sprintf("Error reordering rules: %v", err)
-						return m, nil
-					}
-					m.updateRuleList()
-					m.footer = "Rules reordered successfully!"
-				}
-			}
-		case "d":
-			if m.screen == screenReorderRules {
-				if i := m.ruleList.Index(); i < len(m.rules)-1 {
-					m.rules[i], m.rules[i+1] = m.rules[i+1], m.rules[i]
-					if err := repoReorderRules(m.options, m.rules); err != nil {
-						m.footer = fmt.Sprintf("Error reordering rules: %v", err)
-						return m, nil
-					}
-					m.updateRuleList()
-					m.footer = "Rules reordered successfully!"
-				}
-			}
-		case "tab", "shift+tab", "up", "down":
-			if m.screen == screenAddRule || m.screen == screenAddGlobalRule || m.screen == screenUpdateGlobalRule {
-				s := msg.String()
-				if s == "up" || s == "shift+tab" {
-					if m.focusIndex > 0 {
-						m.focusIndex--
-						m.footer = ""
-					} else {
-						m.focusIndex = len(m.inputs) - 1
-					}
-				} else {
-					if m.focusIndex < len(m.inputs)-1 {
-						m.focusIndex++
-					} else {
-						m.focusIndex = 0
-					}
-				}
+		}
 
-				for i := 0; i <= len(m.inputs)-1; i++ {
-					if i == m.focusIndex {
-						m.inputs[i].Focus()
-						m.inputs[i].PromptStyle = focusedStyle
-						m.inputs[i].TextStyle = focusedStyle
-						continue
-					}
-					m.inputs[i].Blur()
-					m.inputs[i].PromptStyle = blurredStyle
-					m.inputs[i].TextStyle = blurredStyle
-				}
+		// Screen-specific input handling
+		switch m.screen {
+		case screenChoice, screenPolicy, screenTrust:
+			if msg.String() == "enter" {
+				return m.handleEnter()
+			}
+		case screenPolicyRules, screenTrustGlobalRules:
+			return m.handleRulesListKey(msg)
+		case screenPolicyAddRule, screenPolicyEditRule:
+			if msg.String() == "enter" {
+				return m.handlePolicyFormSubmit()
+			}
+			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
+				m.cycleFocus(msg.String())
+				return m, nil
+			}
+		case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+			if msg.String() == "enter" {
+				return m.handleGlobalFormSubmit()
+			}
+			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
+				m.cycleFocus(msg.String())
 				return m, nil
 			}
 		}
 	}
 
+	// Delegate to active bubbles component per screen
 	switch m.screen {
 	case screenChoice:
 		m.choiceList, cmd = m.choiceList.Update(msg)
@@ -268,15 +94,292 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.policyScreenList, cmd = m.policyScreenList.Update(msg)
 	case screenTrust:
 		m.trustScreenList, cmd = m.trustScreenList.Update(msg)
-	case screenAddRule:
-		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
-	case screenRemoveRule, screenReorderRules:
+	case screenPolicyRules:
 		m.ruleList, cmd = m.ruleList.Update(msg)
-	case screenAddGlobalRule, screenUpdateGlobalRule:
-		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
-	case screenListGlobalRules, screenRemoveGlobalRule:
+	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
+	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
 	}
 
 	return m, cmd
+}
+
+// handleEnter handles the enter key press on selection menu screens.
+func (m model) handleEnter() (tea.Model, tea.Cmd) {
+	switch m.screen {
+	case screenChoice:
+		if i, ok := m.choiceList.SelectedItem().(item); ok {
+			switch i.title {
+			case "Policy":
+				m.screen = screenPolicy
+			case "Trust":
+				m.screen = screenTrust
+			}
+		}
+	case screenPolicy:
+		if _, ok := m.policyScreenList.SelectedItem().(item); ok {
+			m.screen = screenPolicyRules
+			m.refreshRules()
+		}
+	case screenTrust:
+		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
+			m.screen = screenTrustGlobalRules
+			m.refreshGlobalRules()
+		}
+	}
+	return m, nil
+}
+
+// handleRulesListKey handles keybindings on rule list screens (rules and global rules).
+// For unhandled keys (including up/down arrows), it delegates to the active list for navigation.
+func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if !m.readOnly {
+		switch msg.String() {
+		// add rule
+		case "a":
+			if m.screen == screenPolicyRules {
+				m.initRuleInputs()
+				m.screen = screenPolicyAddRule
+			} else {
+				m.initGlobalRuleInputs()
+				m.screen = screenTrustAddGlobalRule
+			}
+			return m, nil
+
+		// edit rule
+		case "e":
+			if m.screen == screenPolicyRules {
+				if sel, ok := m.ruleList.SelectedItem().(item); ok {
+					for _, r := range m.rules {
+						if r.name == sel.title {
+							m.initRuleInputsPrefilled(r)
+							m.screen = screenPolicyEditRule
+							return m, nil
+						}
+					}
+				}
+			} else {
+				if sel, ok := m.globalRuleList.SelectedItem().(item); ok {
+					for _, gr := range m.globalRules {
+						if gr.ruleName == sel.title {
+							m.initGlobalRuleInputsPrefilled(gr)
+							m.screen = screenTrustEditGlobalRule
+							return m, nil
+						}
+					}
+				}
+			}
+
+		// delete rule
+		case "d":
+			var sel item
+			var ok bool
+			if m.screen == screenPolicyRules {
+				sel, ok = m.ruleList.SelectedItem().(item)
+			} else {
+				sel, ok = m.globalRuleList.SelectedItem().(item)
+			}
+			if ok {
+				m.confirmDelete = true
+				m.deleteTarget = sel.title
+				return m, nil
+			}
+
+		// reorder up
+		case "k":
+			if m.screen == screenPolicyRules {
+				return m.handleReorderUp()
+			}
+
+		// reorder down
+		case "j":
+			if m.screen == screenPolicyRules {
+				return m.handleReorderDown()
+			}
+		}
+	}
+
+	// Delegate unhandled keys to the active list for navigation (up/down arrows, etc.)
+	var cmd tea.Cmd
+	if m.screen == screenPolicyRules {
+		m.ruleList, cmd = m.ruleList.Update(msg)
+	} else {
+		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
+	}
+	return m, cmd
+}
+
+// handleDeleteConfirm handles the delete confirmation overlay.
+func (m model) handleDeleteConfirm(key string) (tea.Model, tea.Cmd) {
+	if key == "y" {
+		switch m.screen {
+		case screenPolicyRules:
+			if err := repoRemoveRule(m.ctx, m.options, rule{name: m.deleteTarget}); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing rule: %v", err)
+			} else {
+				m.footer = "Rule removed successfully!"
+				m.refreshRules()
+			}
+		case screenTrustGlobalRules:
+			if err := repoRemoveGlobalRule(m.ctx, m.options, globalRule{ruleName: m.deleteTarget}); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing global rule: %v", err)
+			} else {
+				m.footer = "Global rule removed!"
+				m.refreshGlobalRules()
+			}
+		}
+	}
+	m.confirmDelete = false
+	m.deleteTarget = ""
+	return m, nil
+}
+
+// handlePolicyFormSubmit handles enter on policy add/edit form screens.
+func (m model) handlePolicyFormSubmit() (tea.Model, tea.Cmd) {
+	if m.focusIndex < len(m.inputs)-1 {
+		// Not on last field yet - just advance focus
+		m.cycleFocus("tab")
+		return m, nil
+	}
+
+	thr, _ := strconv.Atoi(m.inputs[3].Value())
+	r := rule{
+		name:      m.inputs[0].Value(),
+		pattern:   m.inputs[1].Value(),
+		key:       m.inputs[2].Value(),
+		threshold: thr,
+	}
+	authorizedKeys := splitAndTrim(m.inputs[2].Value())
+
+	var err error
+	switch m.screen {
+	case screenPolicyAddRule:
+		err = repoAddRule(m.ctx, m.options, r, authorizedKeys)
+	case screenPolicyEditRule:
+		err = repoUpdateRule(m.ctx, m.options, r, authorizedKeys)
+	}
+
+	if err != nil {
+		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		return m, nil
+	}
+
+	m.refreshRules()
+	if m.screen == screenPolicyAddRule {
+		m.footer = "Rule added successfully!"
+	} else {
+		m.footer = "Rule updated successfully!"
+	}
+	m.screen = screenPolicyRules
+	return m, nil
+}
+
+// handleGlobalFormSubmit handles enter on global add/edit form screens.
+func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
+	if m.focusIndex < len(m.inputs)-1 {
+		m.cycleFocus("tab")
+		return m, nil
+	}
+
+	parts := splitAndTrim(m.inputs[2].Value())
+	thr := 0
+	if m.inputs[1].Value() == tuf.GlobalRuleThresholdType {
+		thr, _ = strconv.Atoi(m.inputs[3].Value())
+	}
+	gr := globalRule{
+		ruleName:     m.inputs[0].Value(),
+		ruleType:     m.inputs[1].Value(),
+		rulePatterns: parts,
+		threshold:    thr,
+	}
+
+	var err error
+	switch m.screen {
+	case screenTrustAddGlobalRule:
+		err = repoAddGlobalRule(m.ctx, m.options, gr)
+	case screenTrustEditGlobalRule:
+		err = repoUpdateGlobalRule(m.ctx, m.options, gr)
+	}
+
+	if err != nil {
+		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		return m, nil
+	}
+
+	m.refreshGlobalRules()
+	if m.screen == screenTrustAddGlobalRule {
+		m.footer = "Global rule added!"
+	} else {
+		m.footer = "Global rule updated!"
+	}
+	m.screen = screenTrustGlobalRules
+	return m, nil
+}
+
+// handleReorderUp moves the selected rule up in the list.
+func (m model) handleReorderUp() (tea.Model, tea.Cmd) {
+	if i := m.ruleList.Index(); i > 0 {
+		m.rules[i], m.rules[i-1] = m.rules[i-1], m.rules[i]
+		if err := repoReorderRules(m.ctx, m.options, m.rules); err != nil {
+			m.errorMsg = fmt.Sprintf("Error reordering rules: %v", err)
+			return m, nil
+		}
+		m.updateRuleList()
+		m.footer = "Rules reordered successfully!"
+	}
+	return m, nil
+}
+
+// handleReorderDown moves the selected rule down in the list.
+func (m model) handleReorderDown() (tea.Model, tea.Cmd) {
+	if i := m.ruleList.Index(); i < len(m.rules)-1 {
+		m.rules[i], m.rules[i+1] = m.rules[i+1], m.rules[i]
+		if err := repoReorderRules(m.ctx, m.options, m.rules); err != nil {
+			m.errorMsg = fmt.Sprintf("Error reordering rules: %v", err)
+			return m, nil
+		}
+		m.updateRuleList()
+		m.footer = "Rules reordered successfully!"
+	}
+	return m, nil
+}
+
+// cycleFocus moves focus (the cursor) between input fields in form screens.
+func (m *model) cycleFocus(key string) {
+	if key == "up" || key == "shift+tab" {
+		if m.focusIndex > 0 {
+			m.focusIndex--
+			m.footer = ""
+		} else {
+			m.focusIndex = len(m.inputs) - 1
+		}
+	} else {
+		if m.focusIndex < len(m.inputs)-1 {
+			m.focusIndex++
+		} else {
+			m.focusIndex = 0
+		}
+	}
+
+	for i := range m.inputs {
+		if i == m.focusIndex {
+			m.inputs[i].Focus()
+			m.inputs[i].PromptStyle = focusedStyle
+			m.inputs[i].TextStyle = focusedStyle
+		} else {
+			m.inputs[i].Blur()
+			m.inputs[i].PromptStyle = blurredStyle
+			m.inputs[i].TextStyle = blurredStyle
+		}
+	}
+}
+
+// splitAndTrim splits a comma-separated string and trims whitespace.
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	return parts
 }

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -16,6 +17,7 @@ const (
 	colorBlur        = "#A0A0A0"
 	colorFooter      = "#11ff00"
 	colorSubtext     = "#555555"
+	colorErrorMsg    = "#FF0000"
 )
 
 var (
@@ -44,101 +46,121 @@ var (
 			Foreground(lipgloss.Color(colorRegularText))
 )
 
-// View renders the TUI
+// renderWithMargin wraps content in the standard margin used by all screens.
+func renderWithMargin(content string) string {
+	return lipgloss.NewStyle().Margin(1, 2).Render(content)
+}
+
+// renderFooter returns the footer text styled in the footer color.
+func renderFooter(text string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(text)
+}
+
+// renderErrorMsg returns error messages styled in the error color.
+func renderErrorMsg(text string) string {
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorErrorMsg)).Render(text)
+}
+
+// renderFormScreen renders a form screen with a title, input fields, help text, and footer.
+func (m model) renderFormScreen(title string) string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(title) + "\n\n")
+	for _, input := range m.inputs {
+		b.WriteString(input.View() + "\n")
+	}
+	b.WriteString("\n" + "Press Tab to advance, Enter to advance/submit, and Esc to go back." + "\n")
+	b.WriteString(renderFooter(m.footer))
+	b.WriteString(renderErrorMsg(m.errorMsg))
+	return renderWithMargin(b.String())
+}
+
+// renderListScreen renders a list with help text and footer.
+func (m model) renderListScreen(l list.Model, helpText string) string {
+	return renderWithMargin(
+		l.View() + "\n\n" +
+			renderFooter(m.footer) +
+			renderErrorMsg(m.errorMsg) +
+			"\n" + helpText,
+	)
+}
+
+// screenPolicyRulesHelp returns the help bar for the policy rules view screen.
+func screenPolicyRulesHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"a: add  e: edit  d: delete  k: move-up  j: move-down  esc: back  q: quit",
+	)
+}
+
+// screenTrustGlobalRulesHelp returns the help bar for the global rules view screen.
+func screenTrustGlobalRulesHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"a: add  e: edit  d: delete  esc: back  q: quit",
+	)
+}
+
+// renderDeleteOverlay renders the delete confirmation prompt.
+func renderDeleteOverlay(target string) string {
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#FF0000")).
+		Bold(true).
+		Render(fmt.Sprintf("Delete rule %q? [y/n]", target))
+}
+
+// View renders the TUI.
 func (m model) View() string {
 	switch m.screen {
 	case screenChoice:
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.choiceList.View() + "\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer),
-		)
+		return renderWithMargin(m.choiceList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
 	case screenPolicy:
-		// Show apply hint only when not in read-only mode.
-		hint := ""
-		if !m.readOnly {
-			hint = "Run `gittuf policy apply` to apply staged changes to the selected policy file"
-		}
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.policyScreenList.View() + "\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\n" + hint,
-		)
+		return renderWithMargin(m.policyScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
 	case screenTrust:
+		return renderWithMargin(m.trustScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
+	case screenPolicyRules:
+		overlay := ""
+		if m.confirmDelete {
+			overlay = "\n" + renderDeleteOverlay(m.deleteTarget) + "\n"
+		}
 		hint := ""
 		if !m.readOnly {
-			hint = "Run `gittuf trust apply` to apply staged changes to the selected policy file"
-		}
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.trustScreenList.View() + "\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\n" + hint,
-		)
-	case screenAddRule:
-		var b strings.Builder
-		b.WriteString(titleStyle.Render("Add Rule") + "\n\n")
-		for _, input := range m.inputs {
-			b.WriteString(input.View() + "\n")
-		}
-		b.WriteString("\nPress Enter to add, Left Arrow to go back\n")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer))
-		return lipgloss.NewStyle().Margin(1, 2).Render(b.String())
-	case screenRemoveRule:
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.ruleList.View() + "\n\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\nPress Enter to remove selected rule, Left Arrow to go back",
-		)
-	case screenListRules:
-		var sb strings.Builder
-		sb.WriteString(titleStyle.Render("Current Rules") + "\n\n")
-		for _, rule := range m.rules {
-			fmt.Fprintf(&sb, "- %s\n  Pattern: %s\n  Key: %s\n\n",
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorRegularText)).Bold(true).Render(rule.name),
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(rule.pattern),
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(rule.key),
+			hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+				"Run `gittuf policy apply` to apply staged changes to the selected policy file.",
 			)
 		}
-		sb.WriteString("\nPress Left Arrow to go back")
-		return lipgloss.NewStyle().Margin(1, 2).Render(sb.String())
-	case screenReorderRules:
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.ruleList.View() + "\n\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\nUse 'u' to move up, 'd' to move down, Left Arrow to go back",
+		return m.renderListScreen(m.ruleList,
+			overlay+screenPolicyRulesHelp(m.readOnly)+hint,
 		)
-	case screenAddGlobalRule:
-		var b strings.Builder
-		b.WriteString(titleStyle.Render("Add Global Rule") + "\n\n")
-		for _, input := range m.inputs {
-			b.WriteString(input.View() + "\n")
+	case screenTrustGlobalRules:
+		overlay := ""
+		if m.confirmDelete {
+			overlay = "\n" + renderDeleteOverlay(m.deleteTarget) + "\n"
 		}
-		b.WriteString("\nPress Enter to add, Left Arrow to go back\n")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer))
-		return lipgloss.NewStyle().Margin(1, 2).Render(b.String())
-
-	case screenListGlobalRules:
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.globalRuleList.View() + "\n\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\nPress Left Arrow to go back",
-		)
-
-	case screenUpdateGlobalRule:
-		var b strings.Builder
-		b.WriteString(titleStyle.Render("Update Global Rule") + "\n\n")
-		for _, input := range m.inputs {
-			b.WriteString(input.View() + "\n")
+		hint := ""
+		if !m.readOnly {
+			hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+				"Run `gittuf trust apply` to apply staged changes to the selected policy file.",
+			)
 		}
-		b.WriteString("\nPress Enter to update, Left Arrow to go back\n")
-		b.WriteString(lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer))
-		return lipgloss.NewStyle().Margin(1, 2).Render(b.String())
-
-	case screenRemoveGlobalRule:
-		return lipgloss.NewStyle().Margin(1, 2).Render(
-			m.globalRuleList.View() + "\n\n" +
-				lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(m.footer) +
-				"\nPress Enter to remove selected global rule, Left Arrow to go back",
+		return m.renderListScreen(m.globalRuleList,
+			overlay+screenTrustGlobalRulesHelp(m.readOnly)+hint,
 		)
+	case screenPolicyAddRule:
+		return m.renderFormScreen("Add Rule")
+	case screenPolicyEditRule:
+		return m.renderFormScreen("Edit Rule")
+	case screenTrustAddGlobalRule:
+		return m.renderFormScreen("Add Global Rule")
+	case screenTrustEditGlobalRule:
+		return m.renderFormScreen("Edit Global Rule")
 	default:
 		return "Unknown screen"
 	}


### PR DESCRIPTION
The current TUI is a replica of the CLI and is not very different from just using the CLI. In attempt to make the TUI more intuitive, this PR introduces a view-first flow to the TUI. 
This means, for rules and globalrules, it enters a screen that views the existing state, and allows editing from there.

Warning: This is a big refactor of the TUI, and contains experimental changes.
Therefore I required `GITTUF_DEV` to be set.