### PR TITLE
ci: Drop test release from workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,38 +3,11 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-permissions: read-all
+permissions:
+  contents: write
+  id-token: write
 jobs:
-  test-release:
-    if: github.event_name == 'pull_request'
-    permissions:
-      id-token: write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0 # fetch full history for previous tag information
-          persist-credentials: false
-      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
-        with:
-          go-version: '1.26'
-          cache: true
-      - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad
-      - uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29
-        with:
-          distribution: goreleaser-pro
-          version: latest
-          args: release --snapshot --clean --skip=winget
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
-
   release:
-    if: github.event_name == 'push'
-    permissions:
-      contents: write
-      id-token: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
This drops the `test-release` workflow from CI. This wasn't really helpful in its current incarnation and the Cosign signing steps would frequently fail for some odd reason.