### PR TITLE
Add synopsis sections for CLI docs (issue #1133)

### DIFF
--- a/docs/cli/gittuf_policy_apply.md
+++ b/docs/cli/gittuf_policy_apply.md
@@ -2,6 +2,10 @@
 
 Validate and apply changes from policy-staging to policy
 
+### Synopsis
+
+The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.
+
 ```
 gittuf policy apply [flags]
 ```

--- a/docs/cli/gittuf_policy_discard.md
+++ b/docs/cli/gittuf_policy_discard.md
@@ -2,6 +2,10 @@
 
 Discard the currently staged changes to policy
 
+### Synopsis
+
+The 'discard' command removes any currently staged policy changes. It is used to revert pending policy updates before they are applied to the repository.
+
 ```
 gittuf policy discard [flags]
 ```

--- a/docs/cli/gittuf_policy_remote.md
+++ b/docs/cli/gittuf_policy_remote.md
@@ -2,6 +2,10 @@
 
 Tools for managing remote policies
 
+### Synopsis
+
+The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.
+
 ### Options
 
 ```

--- a/docs/cli/gittuf_policy_remote_pull.md
+++ b/docs/cli/gittuf_policy_remote_pull.md
@@ -2,6 +2,10 @@
 
 Pull policy from the specified remote
 
+### Synopsis
+
+The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.
+
 ```
 gittuf policy remote pull <remote> [flags]
 ```

--- a/docs/cli/gittuf_policy_remote_push.md
+++ b/docs/cli/gittuf_policy_remote_push.md
@@ -2,6 +2,10 @@
 
 Push policy to the specified remote
 
+### Synopsis
+
+The 'push' command sends the repository's policy to the specified remote. It is used to publish local policy changes so that they are available for other users to pull down.
+
 ```
 gittuf policy remote push <remote> [flags]
 ```

--- a/docs/cli/gittuf_policy_stage.md
+++ b/docs/cli/gittuf_policy_stage.md
@@ -2,6 +2,10 @@
 
 Stage and push local policy-staging changes to remote repository
 
+### Synopsis
+
+The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.
+
 ```
 gittuf policy stage [flags]
 ```

--- a/docs/cli/gittuf_rsl.md
+++ b/docs/cli/gittuf_rsl.md
@@ -2,6 +2,10 @@
 
 Tools to manage the repository's reference state log
 
+### Synopsis
+
+The 'rsl' subcommand provides tools for managing the repository's Reference State Log (RSL). It is used to view, record, annotate, and synchronize RSL entries to track and audit reference state changes.
+
 ### Options
 
 ```

--- a/docs/cli/gittuf_rsl_annotate.md
+++ b/docs/cli/gittuf_rsl_annotate.md
@@ -2,6 +2,10 @@
 
 Annotate prior RSL entries
 
+### Synopsis
+
+The 'annotate' command adds annotations to prior RSL entries in the repository's RSL. It is used to add a message to an entry for additional context or mark an entry to be skipped, in cases where RSL recovery or reconciliation is needed.
+
 ```
 gittuf rsl annotate [flags]
 ```

--- a/docs/cli/gittuf_rsl_log.md
+++ b/docs/cli/gittuf_rsl_log.md
@@ -2,6 +2,10 @@
 
 Display the repository's Reference State Log
 
+### Synopsis
+
+The 'log' command displays the repository's RSL. It is used to view the history of reference state changes and inspect prior entries in the RSL.
+
 ```
 gittuf rsl log [flags]
 ```

--- a/docs/cli/gittuf_rsl_propagate.md
+++ b/docs/cli/gittuf_rsl_propagate.md
@@ -2,6 +2,10 @@
 
 Propagate contents of remote repositories into local repository
 
+### Synopsis
+
+The 'propagate' command propagates RSL contents from remote repositories defined in propagation directives into the local repository. It is used to record a snapshot of the propagated RSL and repository contents locally.
+
 ```
 gittuf rsl propagate [flags]
 ```

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -2,6 +2,10 @@
 
 Record latest state of a Git reference in the RSL
 
+### Synopsis
+
+The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time for auditing and consistency.
+
 ```
 gittuf rsl record [flags]
 ```

--- a/docs/cli/gittuf_rsl_remote.md
+++ b/docs/cli/gittuf_rsl_remote.md
@@ -2,6 +2,10 @@
 
 Tools for managing remote RSLs
 
+### Synopsis
+
+The 'remote' command provides tools for managing RSL interactions with remote repositories. It is used to organize and execute operations such as pulling, pushing, and the RSL between local and remote sources.
+
 ### Options
 
 ```

--- a/docs/cli/gittuf_rsl_remote_pull.md
+++ b/docs/cli/gittuf_rsl_remote_pull.md
@@ -2,6 +2,10 @@
 
 Pull RSL from the specified remote
 
+### Synopsis
+
+The 'pull' command retrieves updates to the RSL from the specified remote repository and updates the local RSL. It is used to synchronize the local RSL with the remote to ensure consistency.
+
 ```
 gittuf rsl remote pull <remote> [flags]
 ```

--- a/docs/cli/gittuf_rsl_remote_push.md
+++ b/docs/cli/gittuf_rsl_remote_push.md
@@ -2,6 +2,10 @@
 
 Push RSL to the specified remote
 
+### Synopsis
+
+The 'push' command sends new entries in the local RSL to the specified remote repository. It is used to publish local RSL updates so they are available for other users to pull down.
+
 ```
 gittuf rsl remote push <remote> [flags]
 ```

--- a/docs/cli/gittuf_trust_add-controller-repository.md
+++ b/docs/cli/gittuf_trust_add-controller-repository.md
@@ -2,6 +2,10 @@
 
 Add a controller repository
 
+### Synopsis
+
+The 'add-controller-repository' command registers a controller repository in the repository's root of trust. It is used to add and configure a controller repository, including its name, location, and initial root principals.
+
 ```
 gittuf trust add-controller-repository [flags]
 ```

--- a/docs/cli/gittuf_trust_add-network-repository.md
+++ b/docs/cli/gittuf_trust_add-network-repository.md
@@ -2,6 +2,10 @@
 
 Add a network repository
 
+### Synopsis
+
+The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to add and configure a network repository, including its name, location, and initial root principals.
+
 ```
 gittuf trust add-network-repository [flags]
 ```

--- a/docs/cli/gittuf_trust_add-propagation-directive.md
+++ b/docs/cli/gittuf_trust_add-propagation-directive.md
@@ -2,6 +2,10 @@
 
 Add propagation directive into gittuf root of trust
 
+### Synopsis
+
+The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are propagated into a downstream repository by specifying source and destination references and paths.
+
 ```
 gittuf trust add-propagation-directive [flags]
 ```

--- a/docs/cli/gittuf_trust_apply.md
+++ b/docs/cli/gittuf_trust_apply.md
@@ -2,6 +2,10 @@
 
 Validate and apply changes from policy-staging to policy
 
+### Synopsis
+
+The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.
+
 ```
 gittuf trust apply [flags]
 ```

--- a/docs/cli/gittuf_trust_init.md
+++ b/docs/cli/gittuf_trust_init.md
@@ -2,6 +2,10 @@
 
 Initialize gittuf root of trust for repository
 
+### Synopsis
+
+The 'init' command initializes the gittuf root of trust for a repository. It is used to initialize gittuf metadata with the user invoking the command trusted for root operations, and must be run before any other gittuf metadata command can be run.
+
 ```
 gittuf trust init [flags]
 ```

--- a/docs/cli/gittuf_trust_list-hooks.md
+++ b/docs/cli/gittuf_trust_list-hooks.md
@@ -2,6 +2,10 @@
 
 List gittuf hooks for the current policy state
 
+### Synopsis
+
+The 'list-hooks' command displays the configured gittuf hooks for the current policy state. It is used to inspect existing hooks and view their configuration.
+
 ```
 gittuf trust list-hooks [flags]
 ```

--- a/docs/cli/gittuf_trust_list-propagation-directives.md
+++ b/docs/cli/gittuf_trust_list-propagation-directives.md
@@ -2,6 +2,10 @@
 
 Lists propagation directives in the gittuf root of trust
 
+### Synopsis
+
+The 'list-propagation-directives' command displays the propagation directives configured in the repository's root of trust. It is used to inspect existing directives and review how content is propagated between repositories for a given policy reference.
+
 ```
 gittuf trust list-propagation-directives [flags]
 ```

--- a/docs/cli/gittuf_trust_make-controller.md
+++ b/docs/cli/gittuf_trust_make-controller.md
@@ -2,6 +2,10 @@
 
 Make current repository a controller
 
+### Synopsis
+
+The 'make-controller' command sets the current repository as a controller in the repository's root of trust. It is used to allow downstream repositories to reuse this repository's policy.
+
 ```
 gittuf trust make-controller [flags]
 ```

--- a/docs/cli/gittuf_trust_remote.md
+++ b/docs/cli/gittuf_trust_remote.md
@@ -2,6 +2,10 @@
 
 Tools for managing remote policies
 
+### Synopsis
+
+The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.
+
 ### Options
 
 ```

--- a/docs/cli/gittuf_trust_remote_pull.md
+++ b/docs/cli/gittuf_trust_remote_pull.md
@@ -2,6 +2,10 @@
 
 Pull policy from the specified remote
 
+### Synopsis
+
+The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.
+
 ```
 gittuf trust remote pull <remote> [flags]
 ```

--- a/docs/cli/gittuf_trust_remote_push.md
+++ b/docs/cli/gittuf_trust_remote_push.md
@@ -2,6 +2,10 @@
 
 Push policy to the specified remote
 
+### Synopsis
+
+The 'push' command sends the repository's policy to the specified remote. It is used to publish local policy changes so that they are available for other users to pull down.
+
 ```
 gittuf trust remote push <remote> [flags]
 ```

--- a/docs/cli/gittuf_trust_remove-github-app.md
+++ b/docs/cli/gittuf_trust_remove-github-app.md
@@ -2,6 +2,10 @@
 
 Remove GitHub app from gittuf root of trust
 
+### Synopsis
+
+The 'remove-github-app' command removes a GitHub app from the repository's root of trust. It is used to revoke trust for a previously registered GitHub app, identified by its name.
+
 ```
 gittuf trust remove-github-app [flags]
 ```

--- a/docs/cli/gittuf_trust_remove-hook.md
+++ b/docs/cli/gittuf_trust_remove-hook.md
@@ -2,6 +2,10 @@
 
 Remove a gittuf hook specified in the policy (developer mode only, set GITTUF_DEV=1)
 
+### Synopsis
+
+The 'remove-hook' command removes a configured gittuf hook from the repository's root of trust. It is used to delete an existing hook from the policy. It requires developer mode to be enabled by setting the environment variable GITTUF_DEV=1.
+
 ```
 gittuf trust remove-hook [flags]
 ```

--- a/docs/cli/gittuf_trust_remove-propagation-directive.md
+++ b/docs/cli/gittuf_trust_remove-propagation-directive.md
@@ -2,6 +2,10 @@
 
 Remove propagation directive from gittuf root of trust
 
+### Synopsis
+
+The 'remove-propagation-directive' command removes a propagation directive from the repository's root of trust. It is used to delete an existing directive and stop the propagation of content between repositories.
+
 ```
 gittuf trust remove-propagation-directive [flags]
 ```

--- a/docs/cli/gittuf_trust_remove-root-key.md
+++ b/docs/cli/gittuf_trust_remove-root-key.md
@@ -2,6 +2,10 @@
 
 Remove Root key from gittuf root of trust
 
+### Synopsis
+
+The 'remove-root-key' command removes a root key from the repository's root of trust. It is used to revoke trust for an existing root key, identified by its ID.
+
 ```
 gittuf trust remove-root-key [flags]
 ```

--- a/docs/cli/gittuf_trust_set-repository-location.md
+++ b/docs/cli/gittuf_trust_set-repository-location.md
@@ -2,6 +2,10 @@
 
 Set repository location
 
+### Synopsis
+
+The 'set-repository-location' command updates the canonical location of a repository in the repository's root of trust. It is used to encode the canonical location of the repository inside gittuf metadata.
+
 ```
 gittuf trust set-repository-location [flags]
 ```

--- a/docs/cli/gittuf_trust_stage.md
+++ b/docs/cli/gittuf_trust_stage.md
@@ -2,6 +2,10 @@
 
 Stage and push local policy-staging changes to remote repository
 
+### Synopsis
+
+The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.
+
 ```
 gittuf trust stage [flags]
 ```

--- a/docs/cli/gittuf_trust_update-propagation-directive.md
+++ b/docs/cli/gittuf_trust_update-propagation-directive.md
@@ -2,6 +2,10 @@
 
 Update propagation directive in the root of trust (developer mode only, set GITTUF_DEV=1)
 
+### Synopsis
+
+The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to update how content is propagated between repositories by changing the source, destination, or associated parameters of a directive.
+
 ```
 gittuf trust update-propagation-directive [flags]
 ```

--- a/docs/cli/gittuf_verify-mergeable.md
+++ b/docs/cli/gittuf_verify-mergeable.md
@@ -2,6 +2,10 @@
 
 Tools for verifying mergeability using gittuf policies
 
+### Synopsis
+
+The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check policy compliance for a proposed merge by comparing the specified base and feature branches, optionally bypassing the RSL when determining the current state.
+
 ```
 gittuf verify-mergeable [flags]
 ```

--- a/docs/cli/gittuf_verify-network.md
+++ b/docs/cli/gittuf_verify-network.md
@@ -2,6 +2,10 @@
 
 Verify state of network repositories
 
+### Synopsis
+
+The 'verify-network' command verifies the state of network repositories configured in the repository's root of trust. It is used to check the integrity and consistency of network repositories against the expected trust configuration.
+
 ```
 gittuf verify-network [flags]
 ```

--- a/docs/cli/gittuf_version.md
+++ b/docs/cli/gittuf_version.md
@@ -2,6 +2,10 @@
 
 Version of gittuf
 
+### Synopsis
+
+The 'version' command displays the current version of gittuf.
+
 ```
 gittuf version [flags]
 ```

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -71,6 +71,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "annotate",
 		Short:             "Annotate prior RSL entries",
+		Long:              "The 'annotate' command adds annotations to prior RSL entries in the repository's RSL. It is used to add a message to an entry for additional context or mark an entry to be skipped, in cases where RSL recovery or reconciliation is needed.",
 		Args:              cobra.MinimumNArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/log/log.go
+++ b/internal/cmd/rsl/log/log.go
@@ -29,6 +29,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "log",
 		Short:             "Display the repository's Reference State Log",
+		Long:              "The 'log' command displays the repository's RSL. It is used to view the history of reference state changes and inspect prior entries in the RSL.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/propagate/propagate.go
+++ b/internal/cmd/rsl/propagate/propagate.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "propagate",
 		Short:             `Propagate contents of remote repositories into local repository`,
+		Long:              "The 'propagate' command propagates RSL contents from remote repositories defined in propagation directives into the local repository. It is used to record a snapshot of the propagated RSL and repository contents locally.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -74,6 +74,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "record",
 		Short:             "Record latest state of a Git reference in the RSL",
+		Long:              "The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time for auditing and consistency.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/pull/pull.go
+++ b/internal/cmd/rsl/remote/pull/pull.go
@@ -25,6 +25,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "pull <remote>",
 		Short:             "Pull RSL from the specified remote",
+		Long:              "The 'pull' command retrieves updates to the RSL from the specified remote repository and updates the local RSL. It is used to synchronize the local RSL with the remote to ensure consistency.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/push/push.go
+++ b/internal/cmd/rsl/remote/push/push.go
@@ -25,6 +25,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "push <remote>",
 		Short:             "Push RSL to the specified remote",
+		Long:              "The 'push' command sends new entries in the local RSL to the specified remote repository. It is used to publish local RSL updates so they are available for other users to pull down.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/remote.go
+++ b/internal/cmd/rsl/remote/remote.go
@@ -14,6 +14,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remote",
 		Short:             "Tools for managing remote RSLs",
+		Long:              "The 'remote' command provides tools for managing RSL interactions with remote repositories. It is used to organize and execute operations such as pulling, pushing, and the RSL between local and remote sources.",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/rsl/rsl.go
+++ b/internal/cmd/rsl/rsl.go
@@ -17,6 +17,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "rsl",
 		Short:             "Tools to manage the repository's reference state log",
+		Long:              "The 'rsl' subcommand provides tools for managing the repository's Reference State Log (RSL). It is used to view, record, annotate, and synchronize RSL entries to track and audit reference state changes.",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
@@ -77,6 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-controller-repository",
 		Short:             `Add a controller repository`,
+		Long:              "The 'add-controller-repository' command registers a controller repository in the repository's root of trust. It is used to add and configure a controller repository, including its name, location, and initial root principals.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
@@ -77,6 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-network-repository",
 		Short:             `Add a network repository`,
+		Long:              "The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to add and configure a network repository, including its name, location, and initial root principals.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
@@ -92,6 +92,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-propagation-directive",
 		Short:             `Add propagation directive into gittuf root of trust`,
+		Long:              "The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are propagated into a downstream repository by specifying source and destination references and paths.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -47,6 +47,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize gittuf root of trust for repository",
+		Long:              "The 'init' command initializes the gittuf root of trust for a repository. It is used to initialize gittuf metadata with the user invoking the command trusted for root operations, and must be run before any other gittuf metadata command can be run.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/listhooks/listhooks.go
+++ b/internal/cmd/trust/listhooks/listhooks.go
@@ -69,6 +69,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list-hooks",
 		Short:             "List gittuf hooks for the current policy state",
+		Long:              "The 'list-hooks' command displays the configured gittuf hooks for the current policy state. It is used to inspect existing hooks and view their configuration.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives.go
+++ b/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives.go
@@ -52,6 +52,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list-propagation-directives",
 		Short:             "Lists propagation directives in the gittuf root of trust",
+		Long:              "The 'list-propagation-directives' command displays the propagation directives configured in the repository's root of trust. It is used to inspect existing directives and review how content is propagated between repositories for a given policy reference.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/makecontroller/makecontroller.go
+++ b/internal/cmd/trust/makecontroller/makecontroller.go
@@ -40,6 +40,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "make-controller",
 		Short:             `Make current repository a controller`,
+		Long:              "The 'make-controller' command sets the current repository as a controller in the repository's root of trust. It is used to allow downstream repositories to reuse this repository's policy.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removegithubapp/removegithubapp.go
+++ b/internal/cmd/trust/removegithubapp/removegithubapp.go
@@ -48,6 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-github-app",
 		Short:             "Remove GitHub app from gittuf root of trust",
+		Long:              "The 'remove-github-app' command removes a GitHub app from the repository's root of trust. It is used to revoke trust for a previously registered GitHub app, identified by its name.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removehook/removehook.go
+++ b/internal/cmd/trust/removehook/removehook.go
@@ -84,6 +84,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-hook",
 		Short:             fmt.Sprintf("Remove a gittuf hook specified in the policy (developer mode only, set %s=1)", dev.DevModeKey),
+		Long:              fmt.Sprintf("The 'remove-hook' command removes a configured gittuf hook from the repository's root of trust. It is used to delete an existing hook from the policy. It requires developer mode to be enabled by setting the environment variable %s=1.", dev.DevModeKey),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removepropagationdirective/removepropagationdirective.go
+++ b/internal/cmd/trust/removepropagationdirective/removepropagationdirective.go
@@ -48,6 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-propagation-directive",
 		Short:             `Remove propagation directive from gittuf root of trust`,
+		Long:              "The 'remove-propagation-directive' command removes a propagation directive from the repository's root of trust. It is used to delete an existing directive and stop the propagation of content between repositories.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removerootkey/removerootkey.go
+++ b/internal/cmd/trust/removerootkey/removerootkey.go
@@ -50,6 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-root-key",
 		Short:             "Remove Root key from gittuf root of trust",
+		Long:              "The 'remove-root-key' command removes a root key from the repository's root of trust. It is used to revoke trust for an existing root key, identified by its ID.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/setrepositorylocation/setrepositorylocation.go
+++ b/internal/cmd/trust/setrepositorylocation/setrepositorylocation.go
@@ -48,6 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "set-repository-location",
 		Short:             "Set repository location",
+		Long:              "The 'set-repository-location' command updates the canonical location of a repository in the repository's root of trust. It is used to encode the canonical location of the repository inside gittuf metadata.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective.go
+++ b/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective.go
@@ -94,6 +94,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-propagation-directive",
 		Short:             fmt.Sprintf("Update propagation directive in the root of trust (developer mode only, set %s=1)", dev.DevModeKey),
+		Long:              "The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to update how content is propagated between repositories by changing the source, destination, or associated parameters of a directive.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trustpolicy/apply/apply.go
+++ b/internal/cmd/trustpolicy/apply/apply.go
@@ -40,6 +40,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Validate and apply changes from policy-staging to policy",
+		Long:  "The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.",
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)

--- a/internal/cmd/trustpolicy/discard/discard.go
+++ b/internal/cmd/trustpolicy/discard/discard.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "discard",
 		Short:             "Discard the currently staged changes to policy",
+		Long:              "The 'discard' command removes any currently staged policy changes. It is used to revert pending policy updates before they are applied to the repository.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trustpolicy/remote/pull/pull.go
+++ b/internal/cmd/trustpolicy/remote/pull/pull.go
@@ -25,6 +25,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "pull <remote>",
 		Short:             "Pull policy from the specified remote",
+		Long:              "The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trustpolicy/remote/push/push.go
+++ b/internal/cmd/trustpolicy/remote/push/push.go
@@ -25,6 +25,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "push <remote>",
 		Short:             "Push policy to the specified remote",
+		Long:              "The 'push' command sends the repository's policy to the specified remote. It is used to publish local policy changes so that they are available for other users to pull down.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trustpolicy/remote/remote.go
+++ b/internal/cmd/trustpolicy/remote/remote.go
@@ -13,6 +13,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remote",
 		Short:             "Tools for managing remote policies",
+		Long:              "The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/trustpolicy/stage/stage.go
+++ b/internal/cmd/trustpolicy/stage/stage.go
@@ -40,6 +40,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stage",
 		Short: "Stage and push local policy-staging changes to remote repository",
+		Long:  "The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.",
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)

--- a/internal/cmd/verifymergeable/verifymergeable.go
+++ b/internal/cmd/verifymergeable/verifymergeable.go
@@ -60,6 +60,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "verify-mergeable",
 		Short:             "Tools for verifying mergeability using gittuf policies",
+		Long:              "The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check policy compliance for a proposed merge by comparing the specified base and feature branches, optionally bypassing the RSL when determining the current state.",
 		Args:              cobra.ExactArgs(0),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/verifynetwork/verifynetwork.go
+++ b/internal/cmd/verifynetwork/verifynetwork.go
@@ -26,6 +26,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "verify-network",
 		Short:             "Verify state of network repositories",
+		Long:              "The 'verify-network' command verifies the state of network repositories configured in the repository's root of trust. It is used to check the integrity and consistency of network repositories against the expected trust configuration.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -34,6 +34,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "version",
 		Short:             "Version of gittuf",
+		Long:              "The 'version' command displays the current version of gittuf.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}


### PR DESCRIPTION
## Description
PR 1226 adds Long descriptions to the cli commands in the corresponding .go files. These fields are used to generate documentation.

## AI Usage
- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

AI was used to help draft initial descriptions. All code was manally reviewed to ensure correctness and consistency with the current documentation style.

## Contributor Checklist
- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).