### PR TITLE
tui: add loading screen with spinner on startup while repo loads

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gittuf/gittuf/experimental/gittuf"
@@ -21,7 +22,8 @@ import (
 type screen int
 
 const (
-	screenChoice              screen = iota // Initial menu
+	screenLoading             screen = iota // Loading screen shown on startup
+	screenChoice                            // Initial menu
 	screenPolicy                            // Menu for Policy operations
 	screenPolicyRules                       // Rule management screen
 	screenPolicyAddRule                     // Form: add a new policy rule
@@ -49,6 +51,7 @@ func (i item) FilterValue() string { return i.title }
 type model struct {
 	ctx              context.Context
 	screen           screen
+	spinner          spinner.Model
 	choiceList       list.Model
 	policyScreenList list.Model
 	trustScreenList  list.Model
@@ -68,6 +71,17 @@ type model struct {
 	readOnly         bool
 	confirmDelete    bool
 	deleteTarget     string
+}
+
+// initDoneMsg carries the result of the asynchronous TUI initialization.
+type initDoneMsg struct {
+	repo        *gittuf.Repository
+	signer      dsse.SignerVerifier
+	rules       []rule
+	globalRules []globalRule
+	readOnly    bool
+	footer      string
+	err         error
 }
 
 // inputField describes a single text input's placeholder and prompt label.
@@ -121,43 +135,21 @@ func initInputs(fields []inputField) []textinput.Model {
 	return inputs
 }
 
-// initialModel returns the initial model for the Terminal UI.
-func initialModel(ctx context.Context, o *options) (model, error) {
-	repo, err := gittuf.LoadRepository(".")
-	if err != nil {
-		return model{}, err
-	}
-
-	// Determine if we are in read-only mode. (read-only mode specified, or no signing key found)
-	readOnly := o.readOnly
-	var signer dsse.SignerVerifier
-	var footer string
-
-	if !readOnly {
-		signer, err = gittuf.LoadSigner(repo, o.p.SigningKey)
-		if err != nil {
-			if !errors.Is(err, gittuf.ErrSigningKeyNotSpecified) {
-				return model{}, fmt.Errorf("failed to load signing key from Git config: %w", err)
-			}
-			readOnly = true
-			footer = "No signing key found in Git config, running in read-only mode."
-		}
-	}
+// initialModel returns a lightweight loading model for the Terminal UI.
+// All heavy work (repo I/O, signing key, rules) is deferred to loadRepoCmd.
+func initialModel(ctx context.Context, o *options) model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
 
 	delegate := newDelegate()
 
 	m := model{
-		ctx:         ctx,
-		screen:      screenChoice,
-		cursorMode:  cursor.CursorBlink,
-		repo:        repo,
-		signer:      signer,
-		policyName:  o.policyName,
-		rules:       getCurrRules(ctx, o),
-		globalRules: getGlobalRules(ctx, o),
-		options:     o,
-		readOnly:    readOnly,
-		footer:      footer,
+		ctx:        ctx,
+		screen:     screenLoading,
+		spinner:    s,
+		cursorMode: cursor.CursorBlink,
+		policyName: o.policyName,
+		options:    o,
 
 		choiceList: newMenuList("gittuf TUI", []list.Item{
 			item{title: "Policy", desc: "View and manage gittuf Policy"},
@@ -173,12 +165,47 @@ func initialModel(ctx context.Context, o *options) (model, error) {
 		globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
 	}
 
-	return m, nil
+	return m
 }
 
-// Init initializes the input field.
+// loadRepoCmd performs all heavy TUI initialization asynchronously and sends
+// an initDoneMsg back to the program when complete.
+func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
+	return func() tea.Msg {
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			return initDoneMsg{err: err}
+		}
+
+		readOnly := o.readOnly
+		var signer dsse.SignerVerifier
+		var footer string
+
+		if !readOnly {
+			signer, err = gittuf.LoadSigner(repo, o.p.SigningKey)
+			if err != nil {
+				if !errors.Is(err, gittuf.ErrSigningKeyNotSpecified) {
+					return initDoneMsg{err: fmt.Errorf("failed to load signing key from Git config: %w", err)}
+				}
+				readOnly = true
+				footer = "No signing key found in Git config, running in read-only mode."
+			}
+		}
+
+		return initDoneMsg{
+			repo:        repo,
+			signer:      signer,
+			rules:       getCurrRules(ctx, o),
+			globalRules: getGlobalRules(ctx, o),
+			readOnly:    readOnly,
+			footer:      footer,
+		}
+	}
+}
+
+// Init starts the spinner tick and kicks off async repo loading.
 func (m model) Init() tea.Cmd {
-	return textinput.Blink
+	return tea.Batch(textinput.Blink, m.spinner.Tick, loadRepoCmd(m.ctx, m.options))
 }
 
 // initRuleInputs initializes the input fields for (policy) rule forms.

--- a/internal/cmd/tui/tui.go
+++ b/internal/cmd/tui/tui.go
@@ -63,13 +63,10 @@ func New(persistent *persistent.Options) *cobra.Command {
 
 // startTUI intitializes a new model for the TUI
 func startTUI(ctx context.Context, o *options) error {
-	m, err := initialModel(ctx, o)
-	if err != nil {
-		return err
-	}
+	m := initialModel(ctx, o)
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
-	_, err = p.Run()
+	_, err := p.Run()
 
 	return err
 }

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/gittuf/gittuf/internal/tuf"
@@ -18,6 +19,29 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
+	case initDoneMsg:
+		if msg.err != nil {
+			m.errorMsg = fmt.Sprintf("Initialization failed: %v", msg.err)
+			// Stay on the loading screen so the error is visible; user can press q to quit.
+			return m, nil
+		}
+		m.repo = msg.repo
+		m.signer = msg.signer
+		m.rules = msg.rules
+		m.globalRules = msg.globalRules
+		m.readOnly = msg.readOnly
+		m.footer = msg.footer
+		m.updateRuleList()
+		m.updateGlobalRuleList()
+		m.screen = screenChoice
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.screen == screenLoading {
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+
 	case tea.WindowSizeMsg:
 		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
 		m.choiceList.SetSize(msg.Width-h, msg.Height-v)

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -119,6 +119,18 @@ func renderDeleteOverlay(target string) string {
 // View renders the TUI.
 func (m model) View() string {
 	switch m.screen {
+	case screenLoading:
+		if m.errorMsg != "" {
+			return renderWithMargin(
+				titleStyle.Render("gittuf TUI") + "\n\n" +
+					renderErrorMsg(m.errorMsg) + "\n\n" +
+					lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render("Press Q or Ctrl+C to quit."),
+			)
+		}
+		return renderWithMargin(
+			titleStyle.Render("gittuf TUI") + "\n\n" +
+				m.spinner.View() + " Loading, please wait...\n",
+		)
 	case screenChoice:
 		return renderWithMargin(m.choiceList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
 	case screenPolicy:


### PR DESCRIPTION
fixes https://github.com/gittuf/gittuf/issues/1218
## Description

Adds a loading screen to the gittuf TUI that is displayed on startup
while the application initialises. 

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used an LLM as a reference while working with the Bubble Tea and
Bubbles libraries, as I am new to them. I manually reviewed all  suggested code
## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x]  By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).


<img width="378" height="102" alt="image" src="https://github.com/user-attachments/assets/875c9d8c-f0f6-481e-a107-9798a4f012cf" />
