### PR TITLE
test: add basic TUI tests using teatest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.6
 require (
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/x/exp/teatest v0.0.0-20260430013151-79116d1f37bd
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/go-git/go-git/v5 v5.17.0
 	github.com/google/go-github/v61 v61.0.0
@@ -23,6 +24,11 @@ require (
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/crypto v0.49.0
 	google.golang.org/protobuf v1.36.11
+)
+
+require (
+	github.com/aymanbagabas/go-udiff v0.3.1 // indirect
+	github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/charmbracelet/x/cellbuf v0.0.15 h1:ur3pZy0o6z/R7EylET877CBxaiE1Sp1GMx
 github.com/charmbracelet/x/cellbuf v0.0.15/go.mod h1:J1YVbR7MUuEGIFPCaaZ96KDl5NoS0DAWkskup+mOY+Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260430013151-79116d1f37bd h1:ysun8GO23BE9uDi97YduU+KWBTS0H1jN1UWwkXO8aLw=
+github.com/charmbracelet/x/exp/teatest v0.0.0-20260430013151-79116d1f37bd/go.mod h1:aPVjFrBwbJgj5Qz1F0IXsnbcOVJcMKgu1ySUfTAxh7k=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -1,0 +1,117 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTUI(t *testing.T) {
+	tmpDir := t.TempDir()
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(currentDir) //nolint:errcheck
+
+	gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+	t.Run("Start and Quit", func(t *testing.T) {
+		o := &options{
+			readOnly: true,
+		}
+
+		m, err := initialModel(context.Background(), o)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+		tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*15))
+	})
+
+	t.Run("Policy UI Navigation", func(t *testing.T) {
+		o := &options{
+			readOnly: true,
+		}
+
+		m, err := initialModel(context.Background(), o)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+		// Wait for main menu to render
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			return strings.Contains(string(out), "Policy")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// Select "Policy" (already selected by default, so just press enter)
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+		// Now we should be on the Policy Operations screen.
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			return strings.Contains(string(out), "gittuf Policy Operations")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// Select "View Rules" (already selected by default)
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+		// Now we should be on the Policy Rules screen.
+		// We check for "Policy Rules" title OR the "No items." placeholder for an empty list
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			content := string(out)
+			return strings.Contains(content, "Policy Rules") || strings.Contains(content, "No items.")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// Send "q" to quit
+		tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*15))
+	})
+}
+
+func TestSplitAndTrim(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected []string
+	}{
+		"comma separated values": {
+			input:    "a, b, c",
+			expected: []string{"a", "b", "c"},
+		},
+		"single value": {
+			input:    "a",
+			expected: []string{"a"},
+		},
+		"values with extra spaces": {
+			input:    " a ,b, c ",
+			expected: []string{"a", "b", "c"},
+		},
+		"empty string": {
+			input:    "",
+			expected: []string{""},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := splitAndTrim(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
 Description

Adds basic tests for the TUI using the teatest framework.

Includes checks for initialization and quitting behavior, along with a unit test for helper logic. The scope is intentionally minimal to avoid fragile UI assertions and keep the tests stable.

Tests pass for the TUI package locally.

Fixes #1217

 AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI assistance for guidance on structuring tests and refining the approach. All code and changes were manually reviewed and adjusted.

Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
