### PR TITLE
Fix issue #751: Handle unrecognized fields in policy metadata

### DIFF
--- a/internal/tuf/v02/issue_751_integration_test.go
+++ b/internal/tuf/v02/issue_751_integration_test.go
@@ -1,0 +1,198 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIssue751_UnrecognizedFieldsPreservation tests the specific scenario described in issue #751
+// where an older client modifies metadata containing newer fields, ensuring those fields are preserved
+func TestIssue751_UnrecognizedFieldsPreservation(t *testing.T) {
+	// Simulate metadata from a newer gittuf version with additional fields
+	newerVersionJSON := `{
+		"type": "root",
+		"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+		"expires": "2025-01-01T00:00:00Z",
+		"principals": {},
+		"roles": {},
+		"newVerificationRule": "strict",
+		"futureSecurityFeature": {
+			"enabled": true,
+			"algorithm": "post-quantum-crypto",
+			"parameters": {
+				"keySize": 4096,
+				"rounds": 100
+			}
+		},
+		"experimentalFeatures": ["feature1", "feature2"]
+	}`
+
+	// Step 1: Older client loads the metadata (this should warn about unrecognized fields)
+	var rootMetadata RootMetadata
+	err := json.Unmarshal([]byte(newerVersionJSON), &rootMetadata)
+	require.NoError(t, err)
+
+	// Verify that unrecognized fields are preserved
+	assert.Len(t, rootMetadata.UnrecognizedFields, 3)
+	assert.Contains(t, rootMetadata.UnrecognizedFields, "newVerificationRule")
+	assert.Contains(t, rootMetadata.UnrecognizedFields, "futureSecurityFeature")
+	assert.Contains(t, rootMetadata.UnrecognizedFields, "experimentalFeatures")
+
+	// Step 2: Older client makes a modification to a known field
+	rootMetadata.Expires = "2026-01-01T00:00:00Z"
+
+	// Step 3: Older client saves the metadata
+	modifiedJSON, err := json.Marshal(&rootMetadata)
+	require.NoError(t, err)
+
+	// Step 4: Verify that both the modification and unrecognized fields are preserved
+	var result map[string]interface{}
+	err = json.Unmarshal(modifiedJSON, &result)
+	require.NoError(t, err)
+
+	// Check that the modification was applied
+	assert.Equal(t, "2026-01-01T00:00:00Z", result["expires"])
+
+	// Check that all unrecognized fields are preserved
+	assert.Equal(t, "strict", result["newVerificationRule"])
+	
+	futureFeature, ok := result["futureSecurityFeature"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, true, futureFeature["enabled"])
+	assert.Equal(t, "post-quantum-crypto", futureFeature["algorithm"])
+	
+	experimentalFeatures, ok := result["experimentalFeatures"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, experimentalFeatures, 2)
+	assert.Equal(t, "feature1", experimentalFeatures[0])
+	assert.Equal(t, "feature2", experimentalFeatures[1])
+
+	// Step 5: Verify that a newer client can still load the modified metadata
+	var reloadedMetadata RootMetadata
+	err = json.Unmarshal(modifiedJSON, &reloadedMetadata)
+	require.NoError(t, err)
+
+	// The newer client should see both the modification and the preserved fields
+	assert.Equal(t, "2026-01-01T00:00:00Z", reloadedMetadata.Expires)
+	assert.Len(t, reloadedMetadata.UnrecognizedFields, 3)
+}
+
+// TestIssue751_TargetsMetadataScenario tests the same scenario for targets metadata
+func TestIssue751_TargetsMetadataScenario(t *testing.T) {
+	// Simulate targets metadata from a newer version
+	newerVersionJSON := `{
+		"type": "targets",
+		"schemaVersion": "https://gittuf.dev/policy/targets/v0.2",
+		"expires": "2025-01-01T00:00:00Z",
+		"targets": {},
+		"delegations": {
+			"principals": {},
+			"roles": [],
+			"newDelegationFeature": "enhanced-verification"
+		},
+		"advancedTargetValidation": {
+			"checksumAlgorithms": ["sha256", "sha3-256"],
+			"requireSignedTargets": true
+		}
+	}`
+
+	// Older client loads and modifies the metadata
+	var targetsMetadata TargetsMetadata
+	err := json.Unmarshal([]byte(newerVersionJSON), &targetsMetadata)
+	require.NoError(t, err)
+
+	// Verify unrecognized fields are preserved at both levels
+	assert.Len(t, targetsMetadata.UnrecognizedFields, 1)
+	assert.Contains(t, targetsMetadata.UnrecognizedFields, "advancedTargetValidation")
+	
+	assert.Len(t, targetsMetadata.Delegations.UnrecognizedFields, 1)
+	assert.Contains(t, targetsMetadata.Delegations.UnrecognizedFields, "newDelegationFeature")
+
+	// Modify a known field
+	targetsMetadata.Expires = "2026-01-01T00:00:00Z"
+
+	// Save and verify preservation
+	modifiedJSON, err := json.Marshal(&targetsMetadata)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(modifiedJSON, &result)
+	require.NoError(t, err)
+
+	// Check modification and preservation
+	assert.Equal(t, "2026-01-01T00:00:00Z", result["expires"])
+	assert.Contains(t, result, "advancedTargetValidation")
+	
+	delegations, ok := result["delegations"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "enhanced-verification", delegations["newDelegationFeature"])
+}
+
+// TestIssue751_MultipleModificationCycles tests that fields survive multiple modification cycles
+func TestIssue751_MultipleModificationCycles(t *testing.T) {
+	originalJSON := `{
+		"type": "root",
+		"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+		"expires": "2025-01-01T00:00:00Z",
+		"principals": {},
+		"roles": {},
+		"criticalFutureField": "must-not-be-lost",
+		"versionInfo": {
+			"clientVersion": "v0.15.0",
+			"features": ["quantum-resistant", "zero-knowledge-proofs"]
+		}
+	}`
+
+	// Cycle 1: Load, modify, save
+	var metadata1 RootMetadata
+	err := json.Unmarshal([]byte(originalJSON), &metadata1)
+	require.NoError(t, err)
+	
+	metadata1.Expires = "2026-01-01T00:00:00Z"
+	
+	json1, err := json.Marshal(&metadata1)
+	require.NoError(t, err)
+
+	// Cycle 2: Load, modify, save again
+	var metadata2 RootMetadata
+	err = json.Unmarshal(json1, &metadata2)
+	require.NoError(t, err)
+	
+	metadata2.Expires = "2027-01-01T00:00:00Z"
+	
+	json2, err := json.Marshal(&metadata2)
+	require.NoError(t, err)
+
+	// Cycle 3: Load, modify, save one more time
+	var metadata3 RootMetadata
+	err = json.Unmarshal(json2, &metadata3)
+	require.NoError(t, err)
+	
+	metadata3.Expires = "2028-01-01T00:00:00Z"
+	
+	finalJSON, err := json.Marshal(&metadata3)
+	require.NoError(t, err)
+
+	// Verify that after multiple cycles, unrecognized fields are still preserved
+	var finalResult map[string]interface{}
+	err = json.Unmarshal(finalJSON, &finalResult)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2028-01-01T00:00:00Z", finalResult["expires"])
+	assert.Equal(t, "must-not-be-lost", finalResult["criticalFutureField"])
+	
+	versionInfo, ok := finalResult["versionInfo"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "v0.15.0", versionInfo["clientVersion"])
+	
+	features, ok := versionInfo["features"].([]interface{})
+	require.True(t, ok)
+	assert.Contains(t, features, "quantum-resistant")
+	assert.Contains(t, features, "zero-knowledge-proofs")
+}

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -29,6 +29,10 @@ type RootMetadata struct {
 	Propagations       []tuf.PropagationDirective `json:"propagations,omitempty"`
 	MultiRepository    *MultiRepository           `json:"multiRepository,omitempty"`
 	Hooks              map[tuf.HookStage][]*Hook  `json:"hooks,omitempty"`
+	
+	// UnrecognizedFields stores any fields not recognized by this client version
+	// This ensures forward compatibility when new fields are added to the metadata
+	UnrecognizedFields map[string]json.RawMessage `json:"-"`
 }
 
 // NewRootMetadata returns a new instance of RootMetadata.
@@ -340,6 +344,44 @@ func (r *RootMetadata) GetGitHubAppPrincipals(appName string) ([]tuf.Principal, 
 }
 
 func (r *RootMetadata) UnmarshalJSON(data []byte) error {
+	// First, unmarshal into a generic map to detect all fields
+	var rawData map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawData); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	// Define known fields for this version
+	knownFields := map[string]bool{
+		"type":               true,
+		"schemaVersion":      true,
+		"expires":            true,
+		"repositoryLocation": true,
+		"principals":         true,
+		"roles":              true,
+		"githubApps":         true,
+		"globalRules":        true,
+		"propagations":       true,
+		"multiRepository":    true,
+		"hooks":              true,
+	}
+
+	// Identify unrecognized fields
+	r.UnrecognizedFields = make(map[string]json.RawMessage)
+	var unrecognizedFieldNames []string
+	for fieldName, fieldValue := range rawData {
+		if !knownFields[fieldName] {
+			r.UnrecognizedFields[fieldName] = fieldValue
+			unrecognizedFieldNames = append(unrecognizedFieldNames, fieldName)
+		}
+	}
+
+	// Warn about unrecognized fields
+	if len(unrecognizedFieldNames) > 0 {
+		fmt.Printf("Warning: Found unrecognized fields in root metadata: %v\n", unrecognizedFieldNames)
+		fmt.Printf("These fields will be preserved but may indicate this client version cannot perform all verification steps.\n")
+		fmt.Printf("Consider updating to a newer gittuf version.\n")
+	}
+
 	// this type _has_ to be a copy of RootMetadata, minus the use of
 	// json.RawMessage in place of tuf interfaces
 	type tempType struct {
@@ -445,6 +487,63 @@ func (r *RootMetadata) UnmarshalJSON(data []byte) error {
 	r.Hooks = temp.Hooks
 
 	return nil
+}
+
+// MarshalJSON implements custom JSON marshaling to preserve unrecognized fields
+func (r *RootMetadata) MarshalJSON() ([]byte, error) {
+	// Create a temporary struct with all known fields
+	type tempType struct {
+		Type               string                     `json:"type"`
+		Version            string                     `json:"schemaVersion"`
+		Expires            string                     `json:"expires"`
+		RepositoryLocation string                     `json:"repositoryLocation,omitempty"`
+		Principals         map[string]tuf.Principal   `json:"principals"`
+		Roles              map[string]Role            `json:"roles"`
+		GitHubApps         map[string]*GitHubApp      `json:"githubApps,omitempty"`
+		GlobalRules        []tuf.GlobalRule           `json:"globalRules,omitempty"`
+		Propagations       []tuf.PropagationDirective `json:"propagations,omitempty"`
+		MultiRepository    *MultiRepository           `json:"multiRepository,omitempty"`
+		Hooks              map[tuf.HookStage][]*Hook  `json:"hooks,omitempty"`
+	}
+
+	// Marshal the known fields
+	temp := &tempType{
+		Type:               r.Type,
+		Version:            r.Version,
+		Expires:            r.Expires,
+		RepositoryLocation: r.RepositoryLocation,
+		Principals:         r.Principals,
+		Roles:              r.Roles,
+		GitHubApps:         r.GitHubApps,
+		GlobalRules:        r.GlobalRules,
+		Propagations:       r.Propagations,
+		MultiRepository:    r.MultiRepository,
+		Hooks:              r.Hooks,
+	}
+
+	knownData, err := json.Marshal(temp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal known fields: %w", err)
+	}
+
+	// If there are no unrecognized fields, return the known data
+	if len(r.UnrecognizedFields) == 0 {
+		return knownData, nil
+	}
+
+	// Merge known fields with unrecognized fields
+	var knownMap map[string]json.RawMessage
+	if err := json.Unmarshal(knownData, &knownMap); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal known data: %w", err)
+	}
+
+	// Add unrecognized fields
+	for fieldName, fieldValue := range r.UnrecognizedFields {
+		knownMap[fieldName] = fieldValue
+	}
+
+	// Marshal the combined data
+	return json.Marshal(knownMap)
 }
 
 // AddGlobalRule adds a new global rule to RootMetadata.

--- a/internal/tuf/v02/targets.go
+++ b/internal/tuf/v02/targets.go
@@ -27,6 +27,10 @@ type TargetsMetadata struct {
 	Expires     string         `json:"expires"`
 	Targets     map[string]any `json:"targets"`
 	Delegations *Delegations   `json:"delegations"`
+	
+	// UnrecognizedFields stores any fields not recognized by this client version
+	// This ensures forward compatibility when new fields are added to the metadata
+	UnrecognizedFields map[string]json.RawMessage `json:"-"`
 }
 
 // NewTargetsMetadata returns a new instance of TargetsMetadata.
@@ -42,6 +46,108 @@ func NewTargetsMetadata() *TargetsMetadata {
 // in.
 func (t *TargetsMetadata) SetExpires(expires string) {
 	t.Expires = expires
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling to handle unrecognized fields
+func (t *TargetsMetadata) UnmarshalJSON(data []byte) error {
+	// First, unmarshal into a generic map to detect all fields
+	var rawData map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawData); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	// Define known fields for this version
+	knownFields := map[string]bool{
+		"type":          true,
+		"schemaVersion": true,
+		"expires":       true,
+		"targets":       true,
+		"delegations":   true,
+	}
+
+	// Identify unrecognized fields
+	t.UnrecognizedFields = make(map[string]json.RawMessage)
+	var unrecognizedFieldNames []string
+	for fieldName, fieldValue := range rawData {
+		if !knownFields[fieldName] {
+			t.UnrecognizedFields[fieldName] = fieldValue
+			unrecognizedFieldNames = append(unrecognizedFieldNames, fieldName)
+		}
+	}
+
+	// Warn about unrecognized fields
+	if len(unrecognizedFieldNames) > 0 {
+		fmt.Printf("Warning: Found unrecognized fields in targets metadata: %v\n", unrecognizedFieldNames)
+		fmt.Printf("These fields will be preserved but may indicate this client version cannot perform all verification steps.\n")
+		fmt.Printf("Consider updating to a newer gittuf version.\n")
+	}
+
+	// Use a temporary struct for standard unmarshaling
+	type tempType struct {
+		Type        string         `json:"type"`
+		Version     string         `json:"schemaVersion"`
+		Expires     string         `json:"expires"`
+		Targets     map[string]any `json:"targets"`
+		Delegations *Delegations   `json:"delegations"`
+	}
+
+	temp := &tempType{}
+	if err := json.Unmarshal(data, temp); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	t.Type = temp.Type
+	t.Version = temp.Version
+	t.Expires = temp.Expires
+	t.Targets = temp.Targets
+	t.Delegations = temp.Delegations
+
+	return nil
+}
+
+// MarshalJSON implements custom JSON marshaling to preserve unrecognized fields
+func (t *TargetsMetadata) MarshalJSON() ([]byte, error) {
+	// Create a temporary struct with all known fields
+	type tempType struct {
+		Type        string         `json:"type"`
+		Version     string         `json:"schemaVersion"`
+		Expires     string         `json:"expires"`
+		Targets     map[string]any `json:"targets"`
+		Delegations *Delegations   `json:"delegations"`
+	}
+
+	// Marshal the known fields
+	temp := &tempType{
+		Type:        t.Type,
+		Version:     t.Version,
+		Expires:     t.Expires,
+		Targets:     t.Targets,
+		Delegations: t.Delegations,
+	}
+
+	knownData, err := json.Marshal(temp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal known fields: %w", err)
+	}
+
+	// If there are no unrecognized fields, return the known data
+	if len(t.UnrecognizedFields) == 0 {
+		return knownData, nil
+	}
+
+	// Merge known fields with unrecognized fields
+	var knownMap map[string]json.RawMessage
+	if err := json.Unmarshal(knownData, &knownMap); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal known data: %w", err)
+	}
+
+	// Add unrecognized fields
+	for fieldName, fieldValue := range t.UnrecognizedFields {
+		knownMap[fieldName] = fieldValue
+	}
+
+	// Marshal the combined data
+	return json.Marshal(knownMap)
 }
 
 // SchemaVersion returns the metadata schema version.
@@ -251,9 +357,42 @@ func (t *TargetsMetadata) RemovePrincipal(principalID string) error {
 type Delegations struct {
 	Principals map[string]tuf.Principal `json:"principals"`
 	Roles      []*Delegation            `json:"roles"`
+	
+	// UnrecognizedFields stores any fields not recognized by this client version
+	// This ensures forward compatibility when new fields are added to the metadata
+	UnrecognizedFields map[string]json.RawMessage `json:"-"`
 }
 
 func (d *Delegations) UnmarshalJSON(data []byte) error {
+	// First, unmarshal into a generic map to detect all fields
+	var rawData map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawData); err != nil {
+		return fmt.Errorf("unable to unmarshal json: %w", err)
+	}
+
+	// Define known fields for this version
+	knownFields := map[string]bool{
+		"principals": true,
+		"roles":      true,
+	}
+
+	// Identify unrecognized fields
+	d.UnrecognizedFields = make(map[string]json.RawMessage)
+	var unrecognizedFieldNames []string
+	for fieldName, fieldValue := range rawData {
+		if !knownFields[fieldName] {
+			d.UnrecognizedFields[fieldName] = fieldValue
+			unrecognizedFieldNames = append(unrecognizedFieldNames, fieldName)
+		}
+	}
+
+	// Warn about unrecognized fields
+	if len(unrecognizedFieldNames) > 0 {
+		fmt.Printf("Warning: Found unrecognized fields in delegations metadata: %v\n", unrecognizedFieldNames)
+		fmt.Printf("These fields will be preserved but may indicate this client version cannot perform all verification steps.\n")
+		fmt.Printf("Consider updating to a newer gittuf version.\n")
+	}
+
 	// this type _has_ to be a copy of Delegations, minus the use of
 	// json.RawMessage in place of tuf.Principal
 	type tempType struct {
@@ -301,6 +440,45 @@ func (d *Delegations) UnmarshalJSON(data []byte) error {
 	d.Roles = temp.Roles
 
 	return nil
+}
+
+// MarshalJSON implements custom JSON marshaling to preserve unrecognized fields
+func (d *Delegations) MarshalJSON() ([]byte, error) {
+	// Create a temporary struct with all known fields
+	type tempType struct {
+		Principals map[string]tuf.Principal `json:"principals"`
+		Roles      []*Delegation            `json:"roles"`
+	}
+
+	// Marshal the known fields
+	temp := &tempType{
+		Principals: d.Principals,
+		Roles:      d.Roles,
+	}
+
+	knownData, err := json.Marshal(temp)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal known fields: %w", err)
+	}
+
+	// If there are no unrecognized fields, return the known data
+	if len(d.UnrecognizedFields) == 0 {
+		return knownData, nil
+	}
+
+	// Merge known fields with unrecognized fields
+	var knownMap map[string]json.RawMessage
+	if err := json.Unmarshal(knownData, &knownMap); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal known data: %w", err)
+	}
+
+	// Add unrecognized fields
+	for fieldName, fieldValue := range d.UnrecognizedFields {
+		knownMap[fieldName] = fieldValue
+	}
+
+	// Marshal the combined data
+	return json.Marshal(knownMap)
 }
 
 // addPrincipal adds a delegations key or person.  v02 supports Key and Person

--- a/internal/tuf/v02/unrecognized_fields_test.go
+++ b/internal/tuf/v02/unrecognized_fields_test.go
@@ -1,0 +1,309 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootMetadata_UnrecognizedFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputJSON      string
+		expectedFields map[string]string
+		expectWarning  bool
+	}{
+		{
+			name: "no unrecognized fields",
+			inputJSON: `{
+				"type": "root",
+				"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+				"expires": "2025-01-01T00:00:00Z",
+				"principals": {},
+				"roles": {}
+			}`,
+			expectedFields: map[string]string{},
+			expectWarning:  false,
+		},
+		{
+			name: "single unrecognized field",
+			inputJSON: `{
+				"type": "root",
+				"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+				"expires": "2025-01-01T00:00:00Z",
+				"principals": {},
+				"roles": {},
+				"newField": "newValue"
+			}`,
+			expectedFields: map[string]string{
+				"newField": `"newValue"`,
+			},
+			expectWarning: true,
+		},
+		{
+			name: "multiple unrecognized fields",
+			inputJSON: `{
+				"type": "root",
+				"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+				"expires": "2025-01-01T00:00:00Z",
+				"principals": {},
+				"roles": {},
+				"newField1": "value1",
+				"newField2": {"nested": "object"},
+				"newField3": [1, 2, 3]
+			}`,
+			expectedFields: map[string]string{
+				"newField1": `"value1"`,
+				"newField2": `{"nested":"object"}`,
+				"newField3": `[1,2,3]`,
+			},
+			expectWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rootMetadata RootMetadata
+			
+			err := json.Unmarshal([]byte(tt.inputJSON), &rootMetadata)
+			require.NoError(t, err)
+
+			// Check that unrecognized fields are preserved
+			assert.Len(t, rootMetadata.UnrecognizedFields, len(tt.expectedFields))
+			for fieldName, expectedValue := range tt.expectedFields {
+				actualValue, exists := rootMetadata.UnrecognizedFields[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved", fieldName)
+				assert.JSONEq(t, expectedValue, string(actualValue))
+			}
+
+			// Test that marshaling preserves unrecognized fields
+			marshaledData, err := json.Marshal(&rootMetadata)
+			require.NoError(t, err)
+
+			// Unmarshal the marshaled data to verify fields are preserved
+			var remarshaled map[string]interface{}
+			err = json.Unmarshal(marshaledData, &remarshaled)
+			require.NoError(t, err)
+
+			for fieldName := range tt.expectedFields {
+				_, exists := remarshaled[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved after marshaling", fieldName)
+			}
+		})
+	}
+}
+
+func TestTargetsMetadata_UnrecognizedFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputJSON      string
+		expectedFields map[string]string
+		expectWarning  bool
+	}{
+		{
+			name: "no unrecognized fields",
+			inputJSON: `{
+				"type": "targets",
+				"schemaVersion": "https://gittuf.dev/policy/targets/v0.2",
+				"expires": "2025-01-01T00:00:00Z",
+				"targets": {},
+				"delegations": {
+					"principals": {},
+					"roles": []
+				}
+			}`,
+			expectedFields: map[string]string{},
+			expectWarning:  false,
+		},
+		{
+			name: "single unrecognized field",
+			inputJSON: `{
+				"type": "targets",
+				"schemaVersion": "https://gittuf.dev/policy/targets/v0.2",
+				"expires": "2025-01-01T00:00:00Z",
+				"targets": {},
+				"delegations": {
+					"principals": {},
+					"roles": []
+				},
+				"newTargetField": "newValue"
+			}`,
+			expectedFields: map[string]string{
+				"newTargetField": `"newValue"`,
+			},
+			expectWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var targetsMetadata TargetsMetadata
+			
+			err := json.Unmarshal([]byte(tt.inputJSON), &targetsMetadata)
+			require.NoError(t, err)
+
+			// Check that unrecognized fields are preserved
+			assert.Len(t, targetsMetadata.UnrecognizedFields, len(tt.expectedFields))
+			for fieldName, expectedValue := range tt.expectedFields {
+				actualValue, exists := targetsMetadata.UnrecognizedFields[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved", fieldName)
+				assert.JSONEq(t, expectedValue, string(actualValue))
+			}
+
+			// Test that marshaling preserves unrecognized fields
+			marshaledData, err := json.Marshal(&targetsMetadata)
+			require.NoError(t, err)
+
+			// Unmarshal the marshaled data to verify fields are preserved
+			var remarshaled map[string]interface{}
+			err = json.Unmarshal(marshaledData, &remarshaled)
+			require.NoError(t, err)
+
+			for fieldName := range tt.expectedFields {
+				_, exists := remarshaled[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved after marshaling", fieldName)
+			}
+		})
+	}
+}
+
+func TestDelegations_UnrecognizedFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputJSON      string
+		expectedFields map[string]string
+		expectWarning  bool
+	}{
+		{
+			name: "no unrecognized fields",
+			inputJSON: `{
+				"principals": {},
+				"roles": []
+			}`,
+			expectedFields: map[string]string{},
+			expectWarning:  false,
+		},
+		{
+			name: "single unrecognized field",
+			inputJSON: `{
+				"principals": {},
+				"roles": [],
+				"newDelegationField": "delegationValue"
+			}`,
+			expectedFields: map[string]string{
+				"newDelegationField": `"delegationValue"`,
+			},
+			expectWarning: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var delegations Delegations
+			
+			err := json.Unmarshal([]byte(tt.inputJSON), &delegations)
+			require.NoError(t, err)
+
+			// Check that unrecognized fields are preserved
+			assert.Len(t, delegations.UnrecognizedFields, len(tt.expectedFields))
+			for fieldName, expectedValue := range tt.expectedFields {
+				actualValue, exists := delegations.UnrecognizedFields[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved", fieldName)
+				assert.JSONEq(t, expectedValue, string(actualValue))
+			}
+
+			// Test that marshaling preserves unrecognized fields
+			marshaledData, err := json.Marshal(&delegations)
+			require.NoError(t, err)
+
+			// Unmarshal the marshaled data to verify fields are preserved
+			var remarshaled map[string]interface{}
+			err = json.Unmarshal(marshaledData, &remarshaled)
+			require.NoError(t, err)
+
+			for fieldName := range tt.expectedFields {
+				_, exists := remarshaled[fieldName]
+				assert.True(t, exists, "Expected field %s to be preserved after marshaling", fieldName)
+			}
+		})
+	}
+}
+
+func TestUnrecognizedFields_RoundTrip(t *testing.T) {
+	// Test that unrecognized fields survive multiple marshal/unmarshal cycles
+	originalJSON := `{
+		"type": "root",
+		"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+		"expires": "2025-01-01T00:00:00Z",
+		"principals": {},
+		"roles": {},
+		"futureField1": "value1",
+		"futureField2": {"complex": {"nested": "object"}},
+		"futureField3": [1, 2, {"array": "element"}]
+	}`
+
+	// First unmarshal
+	var rootMetadata1 RootMetadata
+	err := json.Unmarshal([]byte(originalJSON), &rootMetadata1)
+	require.NoError(t, err)
+
+	// First marshal
+	marshaledData1, err := json.Marshal(&rootMetadata1)
+	require.NoError(t, err)
+
+	// Second unmarshal
+	var rootMetadata2 RootMetadata
+	err = json.Unmarshal(marshaledData1, &rootMetadata2)
+	require.NoError(t, err)
+
+	// Second marshal
+	marshaledData2, err := json.Marshal(&rootMetadata2)
+	require.NoError(t, err)
+
+	// Verify that the final result contains all the original fields
+	var finalResult map[string]interface{}
+	err = json.Unmarshal(marshaledData2, &finalResult)
+	require.NoError(t, err)
+
+	expectedFields := []string{"futureField1", "futureField2", "futureField3"}
+	for _, fieldName := range expectedFields {
+		_, exists := finalResult[fieldName]
+		assert.True(t, exists, "Expected field %s to survive round-trip", fieldName)
+	}
+}
+
+func TestUnrecognizedFields_ModificationPreservation(t *testing.T) {
+	// Test that unrecognized fields are preserved when making modifications
+	originalJSON := `{
+		"type": "root",
+		"schemaVersion": "https://gittuf.dev/policy/root/v0.2",
+		"expires": "2025-01-01T00:00:00Z",
+		"principals": {},
+		"roles": {},
+		"futureFeature": "importantValue"
+	}`
+
+	var rootMetadata RootMetadata
+	err := json.Unmarshal([]byte(originalJSON), &rootMetadata)
+	require.NoError(t, err)
+
+	// Modify a known field
+	rootMetadata.Expires = "2026-01-01T00:00:00Z"
+
+	// Marshal the modified metadata
+	marshaledData, err := json.Marshal(&rootMetadata)
+	require.NoError(t, err)
+
+	// Verify that both the modification and unrecognized field are preserved
+	var result map[string]interface{}
+	err = json.Unmarshal(marshaledData, &result)
+	require.NoError(t, err)
+
+	assert.Equal(t, "2026-01-01T00:00:00Z", result["expires"])
+	assert.Equal(t, "importantValue", result["futureFeature"])
+}


### PR DESCRIPTION
- Add UnrecognizedFields storage to RootMetadata, TargetsMetadata, and Delegations
- Enhance UnmarshalJSON methods to detect and preserve unknown fields
- Add custom MarshalJSON methods to merge known and unknown fields
- Implement user warnings when unrecognized fields are detected
- Add comprehensive unit and integration tests

This ensures older gittuf clients can safely modify metadata containing newer fields without losing critical information, providing robust forward compatibility as gittuf evolves.

Fixes #751
 