### PR TITLE
rsl: add tests for unused GetLatestReferenceUpdaterEntry option combinations and options

### DIFF
--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -156,6 +156,12 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Nil(t, annotations)
 		assert.Equal(t, rslRef, entry.GetID())
 
+		// Reference entry + ref filter
+		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, IsReferenceEntry(), ForReference(refName))
+		assert.Nil(t, err)
+		assert.Nil(t, annotations)
+		assert.Equal(t, rslRef, entry.GetID())
+
 		if err := NewReferenceEntry(otherRefName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
@@ -211,6 +217,33 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Nil(t, annotations)
 		assert.Nil(t, entry)
 		assert.ErrorIs(t, err, ErrInvalidGetLatestReferenceUpdaterEntryOptions)
+	})
+
+	t.Run("with until entry ID", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		firstEntry, err := GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, UntilEntryID(firstEntry.GetID()))
+		assert.Nil(t, err)
+		assert.Nil(t, annotations)
+		latestEntry, err := GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, latestEntry.GetID(), entry.GetID())
 	})
 
 	t.Run("with ref name and until entry number", func(t *testing.T) {
@@ -648,6 +681,23 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 	})
 
+	t.Run("with unskipped and non gittuf option", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		latestEntry, err := GetLatestEntry(repo)
+		assert.Nil(t, err)
+
+		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, IsUnskipped(), ForNonGittufReference())
+		assert.Nil(t, err)
+		assert.Empty(t, annotations)
+		assert.Equal(t, latestEntry.GetID(), entry.GetID())
+	})
+
 	t.Run("with non gittuf option, mix of gittuf and non gittuf entries", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
@@ -692,6 +742,11 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedLatestEntry, latestEntry)
 		assertAnnotationsReferToEntry(t, latestEntry, annotations)
+
+		// Ref and non gittuf option
+		latestEntry, _, err = GetLatestReferenceUpdaterEntry(repo, ForNonGittufReference(), ForReference("refs/heads/main"))
+		assert.Nil(t, err)
+		assert.Equal(t, expectedLatestEntry.GetID(), latestEntry.GetID())
 	})
 
 	t.Run("with non gittuf option, only gittuf entries", func(t *testing.T) {
@@ -713,6 +768,29 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 
 		_, _, err = GetLatestReferenceUpdaterEntry(repo, ForNonGittufReference())
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+	})
+
+	t.Run("with before entry number", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedEntry, err := GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, BeforeEntryNumber(2))
+		assert.Nil(t, err)
+		assert.Nil(t, annotations)
+		assert.Equal(t, expectedEntry.GetID(), entry.GetID())
 	})
 
 	t.Run("transitioning from no numbers to numbers", func(t *testing.T) {


### PR DESCRIPTION
## Description
This PR adds test coverage for previously unused option combinations in `GetLatestReferenceUpdaterEntry`.

Added coverage for:
- Combined filters:
  - `ForNonGittufReference` + `ForReference`
  - `IsReferenceEntry` + `ForReference`
  - `IsUnskipped` + `ForNonGittufReference`
- The `UntilEntryID` option
- Valid usage of `BeforeEntryNumber`

These tests cover the combinations and options I was able to identify and implement, helping improve coverage of option interactions and previously untested edge cases. All existing tests were passing prior to this change, and this PR does not modify existing behavior.

---

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used generative AI to help locate relevant functions in the codebase, understand the structure of the repository, and assist in drafting explanations for this pull request. All code changes, test cases, and final validations were written and verified by me.
---
## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).