### PR TITLE
Parallelize upstream repository fetches in PropagateChangesFromUpstreamRepositories

### DIFF
--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -10,7 +10,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
 	"github.com/gittuf/gittuf/internal/common/set"
@@ -869,26 +871,120 @@ func (r *Repository) PropagateChangesFromUpstreamRepositories(ctx context.Contex
 		controllerRepositories = upstreamControllerRepositories
 	}
 
+	type upstreamRepositoryFetchTask struct {
+		repositoryURL string
+		directives    []tuf.PropagationDirective
+	}
+
+	type upstreamRepositoryFetchResult struct {
+		repositoryURL string
+		directives    []tuf.PropagationDirective
+		repository    *gitinterface.Repository
+		location      string
+		err           error
+	}
+
+	fetchTasks := make([]upstreamRepositoryFetchTask, 0, len(upstreamRepositoryDirectivesMapping))
 	for upstreamRepositoryURL, directives := range upstreamRepositoryDirectivesMapping {
-		slog.Debug(fmt.Sprintf("Propagating changes from repository '%s'...", upstreamRepositoryURL))
-		upstreamRepositoryLocation, err := os.MkdirTemp("", "gittuf-propagate-upstream")
-		if err != nil {
-			return err
-		}
-		defer os.RemoveAll(upstreamRepositoryLocation) //nolint:errcheck
+		fetchTasks = append(fetchTasks, upstreamRepositoryFetchTask{
+			repositoryURL: upstreamRepositoryURL,
+			directives:    directives,
+		})
+	}
 
-		fetchReferences := set.NewSetFromItems(rsl.Ref)
-		for _, directive := range directives {
-			fetchReferences.Add(directive.GetUpstreamReference())
+	if len(fetchTasks) == 0 {
+		return nil
+	}
+
+	workerCount := runtime.GOMAXPROCS(0)
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > len(fetchTasks) {
+		workerCount = len(fetchTasks)
+	}
+
+	fetchTaskCh := make(chan upstreamRepositoryFetchTask)
+	fetchResultCh := make(chan upstreamRepositoryFetchResult, len(fetchTasks))
+	var fetchWG sync.WaitGroup
+
+	for range workerCount {
+		fetchWG.Add(1)
+		go func() {
+			defer fetchWG.Done()
+
+			for fetchTask := range fetchTaskCh {
+				upstreamRepositoryLocation, err := os.MkdirTemp("", "gittuf-propagate-upstream")
+				if err != nil {
+					fetchResultCh <- upstreamRepositoryFetchResult{
+						repositoryURL: fetchTask.repositoryURL,
+						err:           err,
+					}
+					continue
+				}
+
+				fetchReferences := set.NewSetFromItems(rsl.Ref)
+				for _, directive := range fetchTask.directives {
+					fetchReferences.Add(directive.GetUpstreamReference())
+				}
+
+				upstreamRepository, err := gitinterface.CloneAndFetchRepository(fetchTask.repositoryURL, upstreamRepositoryLocation, "", fetchReferences.Contents(), true)
+				if err != nil {
+					_ = os.RemoveAll(upstreamRepositoryLocation)
+
+					// TODO: we see this error when required upstream ref isn't found, handle gracefully?
+					fetchResultCh <- upstreamRepositoryFetchResult{
+						repositoryURL: fetchTask.repositoryURL,
+						err:           fmt.Errorf("unable to fetch upstream repository '%s': %w", fetchTask.repositoryURL, err),
+					}
+					continue
+				}
+
+				fetchResultCh <- upstreamRepositoryFetchResult{
+					repositoryURL: fetchTask.repositoryURL,
+					directives:    fetchTask.directives,
+					repository:    upstreamRepository,
+					location:      upstreamRepositoryLocation,
+				}
+			}
+		}()
+	}
+
+	for _, fetchTask := range fetchTasks {
+		fetchTaskCh <- fetchTask
+	}
+	close(fetchTaskCh)
+
+	fetchWG.Wait()
+	close(fetchResultCh)
+
+	fetchResultsByRepository := map[string]upstreamRepositoryFetchResult{}
+	for fetchResult := range fetchResultCh {
+		fetchResultsByRepository[fetchResult.repositoryURL] = fetchResult
+	}
+
+	for _, fetchResult := range fetchResultsByRepository {
+		if fetchResult.location != "" {
+			defer os.RemoveAll(fetchResult.location) //nolint:errcheck
+		}
+	}
+
+	for _, fetchTask := range fetchTasks {
+		fetchResult, has := fetchResultsByRepository[fetchTask.repositoryURL]
+		if !has {
+			return fmt.Errorf("unable to fetch upstream repository '%s': missing fetch result", fetchTask.repositoryURL)
 		}
 
-		upstreamRepository, err := gitinterface.CloneAndFetchRepository(upstreamRepositoryURL, upstreamRepositoryLocation, "", fetchReferences.Contents(), true)
-		if err != nil {
-			// TODO: we see this error when required upstream ref isn't found, handle gracefully?
-			return fmt.Errorf("unable to fetch upstream repository '%s': %w", upstreamRepositoryURL, err)
+		if fetchResult.err != nil {
+			return fetchResult.err
 		}
+	}
 
-		if err := rsl.PropagateChangesFromUpstreamRepository(r.r, upstreamRepository, directives, sign); err != nil {
+	for _, fetchTask := range fetchTasks {
+		fetchResult := fetchResultsByRepository[fetchTask.repositoryURL]
+		slog.Debug(fmt.Sprintf("Propagating changes from repository '%s'...", fetchResult.repositoryURL))
+
+		if err := rsl.PropagateChangesFromUpstreamRepository(r.r, fetchResult.repository, fetchResult.directives, sign); err != nil {
 			// TODO: atomic? abort?
 			return err
 		}

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -1750,4 +1750,85 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		}
 		assert.Equal(t, propagationEntry2.GetID(), latestEntry.GetID())
 	})
+
+	t.Run("multiple upstream repos, one fetch failure aborts propagation", func(t *testing.T) {
+		upstreamRepoLocation := t.TempDir()
+		upstreamRepo := createTestRepositoryWithRoot(t, upstreamRepoLocation)
+
+		downstreamRepoLocation := t.TempDir()
+		downstreamRepo := createTestRepositoryWithRoot(t, downstreamRepoLocation)
+
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+		refName := "refs/heads/main"
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-valid", upstreamRepoLocation, refName, "", refName, "upstream", false); err != nil {
+			t.Fatal(err)
+		}
+
+		invalidUpstreamRepoLocation := filepath.Join(t.TempDir(), "missing-upstream")
+		if err := downstreamRepo.AddPropagationDirective(testCtx, signer, "test-missing", invalidUpstreamRepoLocation, refName, "", refName, "missing", false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := downstreamRepo.StagePolicy(testCtx, "", true, false); err != nil {
+			t.Fatal(err)
+		}
+		if err := downstreamRepo.ApplyPolicy(testCtx, "", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		upstreamBlobID, err := upstreamRepo.r.WriteBlob([]byte("upstream"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r)
+		upstreamRootTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+			gitinterface.NewEntryBlob("upstream.txt", upstreamBlobID),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := upstreamRepo.r.Commit(upstreamRootTreeID, refName, "Initial upstream commit\n", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := upstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		downstreamBlobID, err := downstreamRepo.r.WriteBlob([]byte("downstream"))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r)
+		downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+			gitinterface.NewEntryBlob("downstream.txt", downstreamBlobID),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := downstreamRepo.r.Commit(downstreamRootTreeID, refName, "Initial downstream commit\n", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := downstreamRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		entryBeforePropagation, err := rsl.GetLatestEntry(downstreamRepo.r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = downstreamRepo.PropagateChangesFromUpstreamRepositories(testCtx, false)
+		assert.ErrorContains(t, err, "unable to fetch upstream repository")
+
+		entryAfterPropagation, err := rsl.GetLatestEntry(downstreamRepo.r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, entryBeforePropagation.GetID(), entryAfterPropagation.GetID())
+	})
 }


### PR DESCRIPTION
**fixes: #1222** 
## Description

To improve performance in PropagateChangesFromUpstreamRepositories by parallelizing the network-bound operations (fetching from upstream repositories) while keeping the actual RSL writes sequential to prevent Git write locks and branch/reference race conditions.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).

### Key Changes
- **Task Queueing:** Grouped propagation directives by their upstream repository URL into structured fetch tasks.
- **Worker Pool Initialization:** Introduced a dynamically sized goroutine worker pool (optimized using `runtime.GOMAXPROCS`) to process the tasks.
- **Concurrent Fetching (Network I/O):** Moved `gitinterface.CloneAndFetchRepository` into the background workers. Synchronization and result tracking are safely handled using a `sync.WaitGroup` and Go channels (`fetchTaskCh` / `fetchResultCh`).
- **Sequential Execution (Disk I/O):** After all concurrent network fetches complete, `rsl.PropagateChangesFromUpstreamRepository` is invoked sequentially over the results to safely apply the changes without locking issues.
- **Safe Cleanup:** Added deferred execution to ensure all temporary directories created by the concurrent processes are properly cleaned up upon completion.

### Test Result:
<img width="1016" height="286" alt="image" src="https://github.com/user-attachments/assets/179e849d-9d04-4ab7-a74a-7478854af8a2" />
