### PR TITLE
policy: Drop support for legacy securesystemslib key formats

### DIFF
--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -20,7 +20,6 @@ import (
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
-	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 )
 
 type SignatureVerifier struct {
@@ -170,27 +169,6 @@ func (v *SignatureVerifier) Verify(ctx context.Context, gitObjectID gitinterface
 					}
 
 					dsseVerifier = sigstore.NewVerifierFromIdentityAndIssuer(key.KeyVal.Identity, key.KeyVal.Issuer, opts...)
-				case signerverifier.ED25519KeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy ED25519 key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewED25519SignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
-				case signerverifier.RSAKeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy RSA key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewRSAPSSSignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
-				case signerverifier.ECDSAKeyType:
-					// These are only used to verify old policy metadata signed before the ssh-signer was added
-					slog.Debug(fmt.Sprintf("Found legacy ECDSA key '%s' in custom securesystemslib format...", key.KeyID))
-					dsseVerifier, err = signerverifier.NewECDSASignerVerifierFromSSLibKey(key)
-					if err != nil {
-						return nil, err
-					}
 				default:
 					return nil, common.ErrUnknownKeyType
 				}


### PR DESCRIPTION
## Description

We dropped support in gittuf for signing data using the legacy securesystemslib key format quite some time ago, but we kept support for verifying these changes. Our previous gittuf metadata utilized this legacy format, but after reinitialization, we no longer use this format.

This PR is a sketch of how dropping suppport for this entirely would look like. If merged, this would mean `v0.13.1` would be the last release of gittuf which can verify the legacy key metadata.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [X] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
