### PR TITLE
Check server capabilities before requesting them

### DIFF
--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -38,10 +38,11 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 	stdOutWriter := &logWriteCloser{name: "git-remote-gittuf stdout", writeCloser: os.Stdout}
 
 	var (
-		helperStdOut   io.ReadCloser
-		helperStdIn    io.WriteCloser
-		gittufRefsTips = map[string]string{}
-		remoteRefTips  = map[string]string{}
+		helperStdOut       io.ReadCloser
+		helperStdIn        io.WriteCloser
+		gittufRefsTips     = map[string]string{}
+		remoteRefTips      = map[string]string{}
+		serverCapabilities = set.NewSet[string]()
 	)
 
 	for stdInScanner.Scan() {
@@ -474,7 +475,13 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					refAdSplit := strings.Split(refAd, " ")
 					ref := refAdSplit[1]
 					if i := strings.IndexByte(ref, '\x00'); i > 0 {
-						ref = ref[:i] // remove config string passed after null byte
+						for _, cap := range strings.Fields(ref[i+1:]) {
+							serverCapabilities.Add(cap)
+						}
+						for _, cap := range refAdSplit[2:] {
+							serverCapabilities.Add(cap)
+						}
+						ref = ref[:i] // remove capabilities string passed after null byte
 					}
 					tip := refAdSplit[0]
 
@@ -570,7 +577,12 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					// Note: we explicitly don't use the sideband here
 					// because of inconsistencies between receive-pack
 					// implementations in sending status messages.
-					// TODO: check that server advertises all of these
+					// Verify the server advertises the capabilities we require.
+					for _, cap := range []string{"report-status-v2", "atomic", "object-format=sha1"} {
+						if !serverCapabilities.Has(cap) {
+							return nil, false, fmt.Errorf("server does not advertise required capability %q", cap)
+						}
+					}
 					pushCmd = fmt.Sprintf("%s%s report-status-v2 atomic object-format=sha1 agent=git/%s", pushCmd, string('\x00'), gitVersion)
 				}
 				pushCmd += "\n"


### PR DESCRIPTION
## Description                                                                                                          
                                                                                                                        
There was a TODO at `internal/git-remote-gittuf/ssh.go:573` noting that we should check the server actually advertises the capabilities we request during a push. This PR does that it captures the capabilities from the server's ref advertisement and checks for `report-status-v2`, `atomic`, and `object-format=sha1` before we ask for them. If any are missing, we return                                              
a clear error instead of sending a request the server can't handle.                                                     
                                                                                                                        
## AI Usage                                                                                                             
                                                                                                                        
- [ ] I **did not** use generative AI at all in making the content of this pull request.                                                                                                              
- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.                                             
                                                                                                                                                                           
Used AI to help explore the codebase and suggest an initial approach. I wrote and reviewed the final code myself.                                                                                                            
                                                                                                                        
## Contributor Checklist                                                                                             

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.                                                                                                              
- [x] I fully understand the content I am submitting.                                                                   
- [x] The changes introduced are documented and have tests included if applicable.                                                                                                           
- [x] My changes do not infringe on copyright/trademarks/etc.                                                        
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).                                                                       
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).     