### PR TITLE
tui: add propagation directive management

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -22,16 +22,19 @@ import (
 type screen int
 
 const (
-	screenLoading             screen = iota // Loading screen shown on startup
-	screenChoice                            // Initial menu
-	screenPolicy                            // Menu for Policy operations
-	screenPolicyRules                       // Rule management screen
-	screenPolicyAddRule                     // Form: add a new policy rule
-	screenPolicyEditRule                    // Form: edit selected rule (prefilled)
-	screenTrust                             // Menu for Trust operations
-	screenTrustGlobalRules                  // Global rule management screen
-	screenTrustAddGlobalRule                // Form: add a new global rule
-	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
+	screenLoading                       screen = iota // Loading screen shown on startup
+	screenChoice                                      // Initial menu
+	screenPolicy                                      // Menu for Policy operations
+	screenPolicyRules                                 // Rule management screen
+	screenPolicyAddRule                               // Form: add a new policy rule
+	screenPolicyEditRule                              // Form: edit selected rule (prefilled)
+	screenTrust                                       // Menu for Trust operations
+	screenTrustGlobalRules                            // Global rule management screen
+	screenTrustAddGlobalRule                          // Form: add a new global rule
+	screenTrustEditGlobalRule                         // Form: edit selected global rule (prefilled)
+	screenTrustPropagationDirectives                  // Propagation directive management screen
+	screenTrustAddPropagationDirective                // Form: add a new propagation directive
+	screenTrustEditPropagationDirective               // Form: edit selected propagation directive (prefilled)
 )
 
 type item struct {
@@ -49,39 +52,42 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type model struct {
-	ctx              context.Context
-	screen           screen
-	spinner          spinner.Model
-	choiceList       list.Model
-	policyScreenList list.Model
-	trustScreenList  list.Model
-	rules            []rule
-	ruleList         list.Model
-	globalRules      []globalRule
-	globalRuleList   list.Model
-	inputs           []textinput.Model
-	focusIndex       int
-	cursorMode       cursor.Mode
-	repo             *gittuf.Repository
-	signer           dsse.SignerVerifier
-	policyName       string
-	options          *options
-	footer           string
-	errorMsg         string
-	readOnly         bool
-	confirmDelete    bool
-	deleteTarget     string
+	ctx                   context.Context
+	screen                screen
+	spinner               spinner.Model
+	choiceList            list.Model
+	policyScreenList      list.Model
+	trustScreenList       list.Model
+	rules                 []rule
+	ruleList              list.Model
+	globalRules           []globalRule
+	globalRuleList        list.Model
+	propagationDirectives []propagationDirective
+	propagationList       list.Model
+	inputs                []textinput.Model
+	focusIndex            int
+	cursorMode            cursor.Mode
+	repo                  *gittuf.Repository
+	signer                dsse.SignerVerifier
+	policyName            string
+	options               *options
+	footer                string
+	errorMsg              string
+	readOnly              bool
+	confirmDelete         bool
+	deleteTarget          string
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
 type initDoneMsg struct {
-	repo        *gittuf.Repository
-	signer      dsse.SignerVerifier
-	rules       []rule
-	globalRules []globalRule
-	readOnly    bool
-	footer      string
-	err         error
+	repo                  *gittuf.Repository
+	signer                dsse.SignerVerifier
+	rules                 []rule
+	globalRules           []globalRule
+	propagationDirectives []propagationDirective
+	readOnly              bool
+	footer                string
+	err                   error
 }
 
 // inputField describes a single text input's placeholder and prompt label.
@@ -160,9 +166,11 @@ func initialModel(ctx context.Context, o *options) model {
 		}, delegate),
 		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
 			item{title: "View Global Rules", desc: "View and manage global rules"},
+			item{title: "View Propagation Directives", desc: "View and manage propagation directives"},
 		}, delegate),
-		ruleList:       newMenuList("Policy Rules", []list.Item{}, delegate),
-		globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
+		ruleList:        newMenuList("Policy Rules", []list.Item{}, delegate),
+		globalRuleList:  newMenuList("Global Rules", []list.Item{}, delegate),
+		propagationList: newMenuList("Propagation Directives", []list.Item{}, delegate),
 	}
 
 	return m
@@ -193,12 +201,13 @@ func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
 		}
 
 		return initDoneMsg{
-			repo:        repo,
-			signer:      signer,
-			rules:       getCurrRules(ctx, o),
-			globalRules: getGlobalRules(ctx, o),
-			readOnly:    readOnly,
-			footer:      footer,
+			repo:                  repo,
+			signer:                signer,
+			rules:                 getCurrRules(ctx, o),
+			globalRules:           getGlobalRules(ctx, o),
+			propagationDirectives: getPropagationDirectives(ctx, o),
+			readOnly:              readOnly,
+			footer:                footer,
 		}
 	}
 }
@@ -286,4 +295,50 @@ func (m *model) updateGlobalRuleList() {
 		items[i] = item{title: gr.ruleName, desc: desc}
 	}
 	m.globalRuleList.SetItems(items)
+}
+
+// initPropagationInputs initializes the input fields for propagation directive forms.
+func (m *model) initPropagationInputs() {
+	m.inputs = initInputs([]inputField{
+		{"Enter directive name", "Name:"},
+		{"Enter upstream repository URL or path", "From Repository:"},
+		{"Enter upstream reference (e.g. refs/heads/main)", "From Reference:"},
+		{"Enter upstream path (optional)", "From Path:"},
+		{"Enter downstream reference", "Into Reference:"},
+		{"Enter downstream path", "Into Path:"},
+	})
+	m.focusIndex = 0
+}
+
+// initPropagationInputsPrefilled initializes propagation inputs prefilled with existing values.
+func (m *model) initPropagationInputsPrefilled(pd propagationDirective) {
+	m.initPropagationInputs()
+	m.inputs[0].SetValue(pd.name)
+	m.inputs[1].SetValue(pd.upstreamRepository)
+	m.inputs[2].SetValue(pd.upstreamReference)
+	m.inputs[3].SetValue(pd.upstreamPath)
+	m.inputs[4].SetValue(pd.downstreamReference)
+	m.inputs[5].SetValue(pd.downstreamPath)
+}
+
+// refreshPropagationDirectives re-fetches propagation directives and rebuilds the list.
+func (m *model) refreshPropagationDirectives() {
+	m.propagationDirectives = getPropagationDirectives(m.ctx, m.options)
+	m.updatePropagationList()
+}
+
+// updatePropagationList updates the propagation directive list within the TUI.
+func (m *model) updatePropagationList() {
+	items := make([]list.Item, len(m.propagationDirectives))
+	for i, pd := range m.propagationDirectives {
+		desc := fmt.Sprintf(
+			"From: %s @ %s\nInto: %s at %s",
+			pd.upstreamRepository,
+			pd.upstreamReference,
+			pd.downstreamReference,
+			pd.downstreamPath,
+		)
+		items[i] = item{title: pd.name, desc: desc}
+	}
+	m.propagationList.SetItems(items)
 }

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -142,3 +142,97 @@ func repoUpdateGlobalRule(ctx context.Context, o *options, gr globalRule) error 
 		return tuf.ErrUnknownGlobalRuleType
 	}
 }
+
+type propagationDirective struct {
+	name                string
+	upstreamRepository  string
+	upstreamReference   string
+	upstreamPath        string
+	downstreamReference string
+	downstreamPath      string
+}
+
+// getPropagationDirectives returns a slice of propagationDirective for the TUI.
+func getPropagationDirectives(ctx context.Context, o *options) []propagationDirective {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return nil
+	}
+
+	directives, err := repo.ListPropagationDirectives(ctx, o.targetRef)
+	if err != nil {
+		return nil
+	}
+
+	out := make([]propagationDirective, len(directives))
+	for i, d := range directives {
+		out[i] = propagationDirective{
+			name:                d.GetName(),
+			upstreamRepository:  d.GetUpstreamRepository(),
+			upstreamReference:   d.GetUpstreamReference(),
+			upstreamPath:        d.GetUpstreamPath(),
+			downstreamReference: d.GetDownstreamReference(),
+			downstreamPath:      d.GetDownstreamPath(),
+		}
+	}
+	return out
+}
+
+// repoAddPropagationDirective adds a propagation directive.
+func repoAddPropagationDirective(ctx context.Context, o *options, pd propagationDirective) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	return repo.AddPropagationDirective(
+		ctx, signer,
+		pd.name, pd.upstreamRepository, pd.upstreamReference, pd.upstreamPath, pd.downstreamReference, pd.downstreamPath,
+		true, opts...,
+	)
+}
+
+// repoRemovePropagationDirective removes a propagation directive by name.
+func repoRemovePropagationDirective(ctx context.Context, o *options, name string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	return repo.RemovePropagationDirective(ctx, signer, name, true, opts...)
+}
+
+// repoUpdatePropagationDirective updates an existing propagation directive.
+func repoUpdatePropagationDirective(ctx context.Context, o *options, pd propagationDirective) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	return repo.UpdatePropagationDirective(
+		ctx, signer,
+		pd.name, pd.upstreamRepository, pd.upstreamReference, pd.upstreamPath, pd.downstreamReference, pd.downstreamPath,
+		true, opts...,
+	)
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -29,10 +29,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.signer = msg.signer
 		m.rules = msg.rules
 		m.globalRules = msg.globalRules
+		m.propagationDirectives = msg.propagationDirectives
 		m.readOnly = msg.readOnly
 		m.footer = msg.footer
 		m.updateRuleList()
 		m.updateGlobalRuleList()
+		m.updatePropagationList()
 		m.screen = screenChoice
 		return m, nil
 
@@ -49,6 +51,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.trustScreenList.SetSize(msg.Width-h, msg.Height-v)
 		m.ruleList.SetSize(msg.Width-h, msg.Height-v)
 		m.globalRuleList.SetSize(msg.Width-h, msg.Height-v)
+		m.propagationList.SetSize(msg.Width-h, msg.Height-v)
 
 	case tea.KeyMsg:
 		// Delete confirmation overlay intercepts all keys
@@ -63,7 +66,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
-				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
+				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
+				m.screen != screenTrustAddPropagationDirective && m.screen != screenTrustEditPropagationDirective {
 				return m, tea.Quit
 			}
 		case "esc":
@@ -79,6 +83,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = screenTrust
 			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 				m.screen = screenTrustGlobalRules
+			case screenTrustPropagationDirectives:
+				m.screen = screenTrust
+			case screenTrustAddPropagationDirective, screenTrustEditPropagationDirective:
+				m.screen = screenTrustPropagationDirectives
 			}
 			return m, nil
 		}
@@ -89,7 +97,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.String() == "enter" {
 				return m.handleEnter()
 			}
-		case screenPolicyRules, screenTrustGlobalRules:
+		case screenPolicyRules, screenTrustGlobalRules, screenTrustPropagationDirectives:
 			return m.handleRulesListKey(msg)
 		case screenPolicyAddRule, screenPolicyEditRule:
 			if msg.String() == "enter" {
@@ -102,6 +110,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 			if msg.String() == "enter" {
 				return m.handleGlobalFormSubmit()
+			}
+			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
+				m.cycleFocus(msg.String())
+				return m, nil
+			}
+		case screenTrustAddPropagationDirective, screenTrustEditPropagationDirective:
+			if msg.String() == "enter" {
+				return m.handlePropagationFormSubmit()
 			}
 			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
 				m.cycleFocus(msg.String())
@@ -122,7 +138,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ruleList, cmd = m.ruleList.Update(msg)
 	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
-	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+	case screenTrustPropagationDirectives:
+		m.propagationList, cmd = m.propagationList.Update(msg)
+	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule,
+		screenTrustAddPropagationDirective, screenTrustEditPropagationDirective:
 		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
 	}
 
@@ -147,9 +166,15 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 			m.refreshRules()
 		}
 	case screenTrust:
-		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
-			m.screen = screenTrustGlobalRules
-			m.refreshGlobalRules()
+		if i, ok := m.trustScreenList.SelectedItem().(item); ok {
+			switch i.title {
+			case "View Global Rules":
+				m.screen = screenTrustGlobalRules
+				m.refreshGlobalRules()
+			case "View Propagation Directives":
+				m.screen = screenTrustPropagationDirectives
+				m.refreshPropagationDirectives()
+			}
 		}
 	}
 	return m, nil
@@ -162,18 +187,23 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		// add rule
 		case "a":
-			if m.screen == screenPolicyRules {
+			switch m.screen {
+			case screenPolicyRules:
 				m.initRuleInputs()
 				m.screen = screenPolicyAddRule
-			} else {
+			case screenTrustGlobalRules:
 				m.initGlobalRuleInputs()
 				m.screen = screenTrustAddGlobalRule
+			case screenTrustPropagationDirectives:
+				m.initPropagationInputs()
+				m.screen = screenTrustAddPropagationDirective
 			}
 			return m, nil
 
 		// edit rule
 		case "e":
-			if m.screen == screenPolicyRules {
+			switch m.screen {
+			case screenPolicyRules:
 				if sel, ok := m.ruleList.SelectedItem().(item); ok {
 					for _, r := range m.rules {
 						if r.name == sel.title {
@@ -183,12 +213,22 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						}
 					}
 				}
-			} else {
+			case screenTrustGlobalRules:
 				if sel, ok := m.globalRuleList.SelectedItem().(item); ok {
 					for _, gr := range m.globalRules {
 						if gr.ruleName == sel.title {
 							m.initGlobalRuleInputsPrefilled(gr)
 							m.screen = screenTrustEditGlobalRule
+							return m, nil
+						}
+					}
+				}
+			case screenTrustPropagationDirectives:
+				if sel, ok := m.propagationList.SelectedItem().(item); ok {
+					for _, pd := range m.propagationDirectives {
+						if pd.name == sel.title {
+							m.initPropagationInputsPrefilled(pd)
+							m.screen = screenTrustEditPropagationDirective
 							return m, nil
 						}
 					}
@@ -199,10 +239,13 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case "d":
 			var sel item
 			var ok bool
-			if m.screen == screenPolicyRules {
+			switch m.screen {
+			case screenPolicyRules:
 				sel, ok = m.ruleList.SelectedItem().(item)
-			} else {
+			case screenTrustGlobalRules:
 				sel, ok = m.globalRuleList.SelectedItem().(item)
+			case screenTrustPropagationDirectives:
+				sel, ok = m.propagationList.SelectedItem().(item)
 			}
 			if ok {
 				m.confirmDelete = true
@@ -226,10 +269,13 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Delegate unhandled keys to the active list for navigation (up/down arrows, etc.)
 	var cmd tea.Cmd
-	if m.screen == screenPolicyRules {
+	switch m.screen {
+	case screenPolicyRules:
 		m.ruleList, cmd = m.ruleList.Update(msg)
-	} else {
+	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
+	case screenTrustPropagationDirectives:
+		m.propagationList, cmd = m.propagationList.Update(msg)
 	}
 	return m, cmd
 }
@@ -251,6 +297,13 @@ func (m model) handleDeleteConfirm(key string) (tea.Model, tea.Cmd) {
 			} else {
 				m.footer = "Global rule removed!"
 				m.refreshGlobalRules()
+			}
+		case screenTrustPropagationDirectives:
+			if err := repoRemovePropagationDirective(m.ctx, m.options, m.deleteTarget); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing propagation directive: %v", err)
+			} else {
+				m.footer = "Propagation directive removed!"
+				m.refreshPropagationDirectives()
 			}
 		}
 	}
@@ -406,4 +459,43 @@ func splitAndTrim(s string) []string {
 		parts[i] = strings.TrimSpace(parts[i])
 	}
 	return parts
+}
+
+// handlePropagationFormSubmit handles enter on propagation directive add/edit form screens.
+func (m model) handlePropagationFormSubmit() (tea.Model, tea.Cmd) {
+	if m.focusIndex < len(m.inputs)-1 {
+		m.cycleFocus("tab")
+		return m, nil
+	}
+
+	pd := propagationDirective{
+		name:                strings.TrimSpace(m.inputs[0].Value()),
+		upstreamRepository:  strings.TrimSpace(m.inputs[1].Value()),
+		upstreamReference:   strings.TrimSpace(m.inputs[2].Value()),
+		upstreamPath:        strings.TrimSpace(m.inputs[3].Value()),
+		downstreamReference: strings.TrimSpace(m.inputs[4].Value()),
+		downstreamPath:      strings.TrimSpace(m.inputs[5].Value()),
+	}
+
+	var err error
+	switch m.screen {
+	case screenTrustAddPropagationDirective:
+		err = repoAddPropagationDirective(m.ctx, m.options, pd)
+	case screenTrustEditPropagationDirective:
+		err = repoUpdatePropagationDirective(m.ctx, m.options, pd)
+	}
+
+	if err != nil {
+		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		return m, nil
+	}
+
+	m.refreshPropagationDirectives()
+	if m.screen == screenTrustAddPropagationDirective {
+		m.footer = "Propagation directive added!"
+	} else {
+		m.footer = "Propagation directive updated!"
+	}
+	m.screen = screenTrustPropagationDirectives
+	return m, nil
 }

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -114,6 +114,18 @@ func screenTrustGlobalRulesHelp(readOnly bool) string {
 	)
 }
 
+// screenTrustPropagationDirectivesHelp returns the help bar for the propagation directives view screen.
+func screenTrustPropagationDirectivesHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"a: add  e: edit  d: delete  esc: back  q: quit",
+	)
+}
+
 // renderDeleteOverlay renders the delete confirmation prompt.
 func renderDeleteOverlay(target string) string {
 	return lipgloss.NewStyle().
@@ -179,6 +191,24 @@ func (m model) View() string {
 		return m.renderFormScreen("Add Global Rule")
 	case screenTrustEditGlobalRule:
 		return m.renderFormScreen("Edit Global Rule")
+	case screenTrustPropagationDirectives:
+		overlay := ""
+		if m.confirmDelete {
+			overlay = "\n" + renderDeleteOverlay(m.deleteTarget) + "\n"
+		}
+		hint := ""
+		if !m.readOnly {
+			hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+				"Run `gittuf trust apply` to apply staged changes.",
+			)
+		}
+
+		emptyMsg := "No propagation directives configured. Press 'A' to add one."
+		return m.renderListScreen(m.propagationList, overlay+screenTrustPropagationDirectivesHelp(m.readOnly)+hint, emptyMsg, len(m.propagationDirectives) == 0)
+	case screenTrustAddPropagationDirective:
+		return m.renderFormScreen("Add Propagation Directive")
+	case screenTrustEditPropagationDirective:
+		return m.renderFormScreen("Edit Propagation Directive")
 	default:
 		return "Unknown screen"
 	}


### PR DESCRIPTION
Fixes #899

## Description

Add propagation directive management to the TUI under Trust > View Propagation Directives. Supports listing, adding, editing, and removing propagation directives. Follows the same patterns used for global rules.

- Built against the refactored TUI architecture (split across model.go, trusthelpers.go, update.go, view.go)
- Uses the existing high-level `repo.ListPropagationDirectives` and `repo.UpdatePropagationDirective` APIs (no changes to experimental/)
- Includes all 6 directive fields including `upstreamPath`
- Delete confirmation overlay consistent with existing rule deletion
- Hint text correctly uses `gittuf trust apply` (propagation directives are root of trust metadata)

### Changes

- **model.go**: Added 3 new screen states, `propagationDirective` fields to model and `initDoneMsg`, propagation input/refresh/list helpers, trust menu now includes "View Propagation Directives"
- **trusthelpers.go**: Added `propagationDirective` struct, `getPropagationDirectives`, `repoAddPropagationDirective`, `repoRemovePropagationDirective`, `repoUpdatePropagationDirective`
- **update.go**: Wired propagation screens into key handling (q, esc, enter, a/e/d), form submission via `handlePropagationFormSubmit`, delete confirmation, trust menu routing
- **view.go**: Added `screenTrustPropagationDirectivesHelp`, propagation list/form rendering with delete overlay and apply hint

## AI Usage

- [x] I did use generative AI in some form in making the content of this pull request. I have described my use of AI below.

Used AI to explore the codebase structure and understand the existing TUI patterns for global rules. All code was manually reviewed, tested with go build and go test, and formatted with gofmt.

## Contributor Checklist

- [x] I have manually reviewed all content submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a DCO Signoff.
- [x] By submitting this pull request