### PR TITLE
fix: git remote prune

### DIFF
--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -123,15 +123,21 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 			// ls-refs is a command to upload-pack. Like list and list
 			// for-push, it enumerates the refs and their states on the remote.
 			// Unlike those commands, this must be passed to upload-pack.
-			// Further, ls-refs must be parametrized with ref-prefixes. We add
+			// Further, ls-refs can be parametrized with ref-prefixes. We add
 			// refs/gittuf/ as a prefix to learn about the gittuf refs on the
-			// remote during fetches.
+			// remote during fetches, but only if the client already has
+			// ref-prefixes set.
+			hasRefPrefix := false
 			for stdInScanner.Scan() {
 				input = stdInScanner.Bytes()
 
+				if bytes.Contains(input, []byte("ref-prefix")) {
+					hasRefPrefix = true
+				}
+
 				// Add ref-prefix refs/gittuf/ to the ls-refs command before
-				// flush
-				if bytes.Equal(input, flushPkt) {
+				// flush, but only if the client sent ref-prefixes
+				if bytes.Equal(input, flushPkt) && hasRefPrefix {
 					log("adding ref-prefix for refs/gittuf/")
 					gittufRefPrefixCommand := fmt.Sprintf("ref-prefix %s\n", gittufRefPrefix)
 					if _, err := helperStdIn.Write(packetEncode(gittufRefPrefixCommand)); err != nil {

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -203,12 +203,17 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 
 			// In protocol v2, this should now go to our parent process
 			// requesting ls-refs
+			hasRefPrefix := false
 			for stdInScanner.Scan() {
 				input = stdInScanner.Bytes()
 
+				if bytes.Contains(input, []byte("ref-prefix")) {
+					hasRefPrefix = true
+				}
+
 				// Add ref-prefix refs/gittuf/ to the ls-refs command before
-				// flush
-				if bytes.Equal(input, flushPkt) {
+				// flush, but only if the client sent ref-prefixes
+				if bytes.Equal(input, flushPkt) && hasRefPrefix {
 					log("adding ref-prefix for refs/gittuf/")
 					gittufRefPrefixCommand := fmt.Sprintf("ref-prefix %s\n", gittufRefPrefix)
 					if _, err := helperStdIn.Write(packetEncode(gittufRefPrefixCommand)); err != nil {


### PR DESCRIPTION
## Description                                                                                                                        
                                                                                                                                      
`git remote prune` deletes all remote-tracking branches when using the gittuf transport.    
                                                                                                                                                                               
The transport was unconditionally adding `ref-prefix refs/gittuf` to `ls-refs`. In protocol v2, if no `ref-prefix` is set the server returns all refs, but once you add one, it only returns matching refs. So prune only saw gittuf refs, thought all branches were gone, and pruned everything.                                                                                                               
                                                                                                                 
Fixed by only adding the gittuf ref-prefix when the client already has ref-prefixes set.                                              
                                                                                                                                      
Fixes #1236                                                                                                                           
                                                                                                                                   
### Before fix
`git remote prune origin` prunes all branches: 
```Pruning origin
URL: gittuf::https://github.com/gittuf/gittuf
 * [pruned] origin/add-hook-attestations
 * [pruned] origin/add-recovery-docs
 * [pruned] origin/add-role-name-to-targets
 * [pruned] origin/add-verify-ref-root-key-opt
 * [pruned] origin/arcanum-gap
 * [pruned] origin/automated-recovery
 * [pruned] origin/dependabot/go_modules/all-33166cd105
 * [pruned] origin/drop-legacy-format
 * [pruned] origin/eval-hacks-2
 * [pruned] origin/evaluation-hacks
 * [pruned] origin/export-attestations
 * [pruned] origin/file-branch-cmds
 * [pruned] origin/file-rules-branches
 * [pruned] origin/generate-vsa
 * [pruned] origin/gitinterface-utils
 * [pruned] origin/gittuf-git
 * [pruned] origin/gittuf-transport-refactor
 * [pruned] origin/go-routine-propagation
 * [pruned] origin/guppies-gap
 * [pruned] origin/hash-agility
 * [pruned] origin/main
 * [pruned] origin/more-transport-debugs
 * [pruned] origin/multi-repository
 * [pruned] origin/sf-eval
 * [pruned] origin/transport-enable-verification
 * [pruned] origin/verified-states-caching
 * [pruned] origin/verify-relative-changes-withsearcher
 * [pruned] origin/verify-relative-logic-annotations
 * [pruned] origin/verifyref-from
 * [pruned] origin/versioning-policy
 * [pruned] origin/vsa
 refs/remotes/origin/HEAD has become dangling after refs/remotes/origin/main was deleted
```

### After fix
                                                                                                                                      
`git remote prune origin` only prunes stale branches:                                                                                 
```
Pruning origin
URL: gittuf::https://github.com/gittuf/gittuf
 * [pruned] origin/fake-branch
```                                                                                                                                     
                                                                                                                                      
## AI Usage                                                                                                                           
                                                                                                                                      
- [ ] I **did not** use generative AI at all in making the content of this pull                                                       
  request.                                                                                                                         
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.                                                                                  
                                                                                                                                      
Used AI to help understand the git protocol v2 flow. The fix and testing were done by me.                       
                                                                                                                                      
## Contributor Checklist                                                                                                           

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.                                                                                 
- [x] The changes introduced are documented and have tests included if                                                                
  applicable.                                                                                                                         
- [x] My changes do not infringe on copyright/trademarks/etc.                                                                         
- [x] All commits in this pull request include a [DCO                                                                              
  Signoff](https://wiki.linuxfoundation.org/dco).                                                                                     
- [x] By submitting this pull request, I agree to follow the gittuf [Code of                                                          
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).          