### PR TITLE
rsl/record: clarify expected Git reference argument in CLI help

### DIFF
--- a/docs/cli/gittuf_rsl.md
+++ b/docs/cli/gittuf_rsl.md
@@ -28,7 +28,7 @@ The 'rsl' subcommand provides tools for managing the repository's Reference Stat
 * [gittuf rsl annotate](gittuf_rsl_annotate.md)	 - Annotate prior RSL entries
 * [gittuf rsl log](gittuf_rsl_log.md)	 - Display the repository's Reference State Log
 * [gittuf rsl propagate](gittuf_rsl_propagate.md)	 - Propagate contents of remote repositories into local repository
-* [gittuf rsl record](gittuf_rsl_record.md)	 - Record latest state of a Git reference in the RSL
+* [gittuf rsl record](gittuf_rsl_record.md)	 - Record latest state of a Git reference (e.g., 'main') in the RSL
 * [gittuf rsl remote](gittuf_rsl_remote.md)	 - Tools for managing remote RSLs
 * [gittuf rsl skip-rewritten](gittuf_rsl_skip-rewritten.md)	 - Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref
 

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -1,10 +1,10 @@
 ## gittuf rsl record
 
-Record latest state of a Git reference in the RSL
+Record latest state of a Git reference (e.g., 'main') in the RSL
 
 ### Synopsis
 
-The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time for auditing and consistency.
+The 'record' command records the latest state of a Git reference in the repository's RSL. The argument must be a valid Git reference (such as 'main', 'HEAD', or a tag name). For example: 'gittuf rsl record --local-only main'. This command is used to capture and track changes to references over time for auditing and consistency.
 
 ```
 gittuf rsl record [flags]

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -73,8 +73,8 @@ func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
 		Use:               "record",
-		Short:             "Record latest state of a Git reference in the RSL",
-		Long:              "The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time for auditing and consistency.",
+		Short:             "Record latest state of a Git reference (e.g., 'main') in the RSL",
+		Long:              `The 'record' command records the latest state of a Git reference in the repository's RSL. The argument must be a valid Git reference (such as 'main', 'HEAD', or a tag name). For example: 'gittuf rsl record --local-only main'. This command is used to capture and track changes to references over time for auditing and consistency.`,
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
## Description

Currently, running a command like:
```
gittuf rsl record --local-only "Initial policy setup"
```
returns a generic error message:
```
requested Git reference not found
```

This PR improves the message by including the provided input, making it clearer that the command expects a valid Git reference (e.g., `main`, `master`) rather than a message-like argument.

This came up while following the getting-started flow, where it’s easy to assume `record` to behave similar to `git commit -m`. 
I'm also open to feedback in-case a different error style is preferred. 

Fixes: #1262 

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
