### PR TITLE
fix:honor gpg.program in LoadPublicKeyFromGitConfig

### DIFF
--- a/experimental/gittuf/keys.go
+++ b/experimental/gittuf/keys.go
@@ -38,6 +38,8 @@ var (
 	ErrUnsupportedX509Method    = errors.New("unsupported X509 certificate specified in Git configuration")
 )
 
+const defaultGPGProgram = "gpg"
+
 // LoadPublicKey returns a signerverifier.SSLibKey object for a PGP / Sigstore
 // Fulcio / SSH (on-disk) key for use in gittuf metadata.
 func LoadPublicKey(keyRef string) (tuf.Principal, error) {
@@ -50,7 +52,15 @@ func LoadPublicKey(keyRef string) (tuf.Principal, error) {
 	case strings.HasPrefix(keyRef, GPGKeyPrefix):
 		fingerprint := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(keyRef, GPGKeyPrefix)))
 
-		command := exec.Command("gpg", "--export", "--armor", fingerprint)
+		program := defaultGPGProgram
+		configCommand := exec.Command("git", "config", "--get", "gpg.program")
+		if stdOut, err := configCommand.Output(); err == nil {
+			if configuredProgram := strings.TrimSpace(string(stdOut)); configuredProgram != "" {
+				program = configuredProgram
+			}
+		}
+
+		command := exec.Command(program, "--export", "--armor", fingerprint) //nolint:gosec
 		stdOut, err := command.Output()
 		if err != nil {
 			return nil, err

--- a/experimental/gittuf/keys.go
+++ b/experimental/gittuf/keys.go
@@ -16,6 +16,7 @@ import (
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 )
 
@@ -40,7 +41,7 @@ var (
 
 // LoadPublicKey returns a signerverifier.SSLibKey object for a PGP / Sigstore
 // Fulcio / SSH (on-disk) key for use in gittuf metadata.
-func LoadPublicKey(keyRef string) (tuf.Principal, error) {
+func LoadPublicKey(repo *Repository, keyRef string) (tuf.Principal, error) {
 	var (
 		keyObj *signerverifier.SSLibKey
 		err    error
@@ -50,7 +51,24 @@ func LoadPublicKey(keyRef string) (tuf.Principal, error) {
 	case strings.HasPrefix(keyRef, GPGKeyPrefix):
 		fingerprint := strings.ToLower(strings.TrimSpace(strings.TrimPrefix(keyRef, GPGKeyPrefix)))
 
-		command := exec.Command("gpg", "--export", "--armor", fingerprint)
+		program := gpg.DefaultGPGProgram
+		var config map[string]string
+		if repo != nil {
+			config, err = gitinterface.GetGitConfig(repo.r.GetGitDir())
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			config, err = gitinterface.GetGitConfig("")
+			if err != nil {
+				return nil, err
+			}
+		}
+		if value, has := config["gpg.program"]; has {
+			program = value
+		}
+
+		command := exec.Command(program, "--export", "--armor", fingerprint) //nolint:gosec
 		stdOut, err := command.Output()
 		if err != nil {
 			return nil, err
@@ -89,7 +107,7 @@ func LoadPublicKey(keyRef string) (tuf.Principal, error) {
 // LoadPublicKeyFromGitConfig loads a public key as with LoadPublicKey above,
 // but from the key specified in the Git configuration of the target repository.
 func LoadPublicKeyFromGitConfig(repo *Repository) (tuf.Principal, error) {
-	config, err := repo.r.GetGitConfig()
+	config, err := gitinterface.GetGitConfig(repo.r.GetGitDir())
 	if err != nil {
 		return nil, err
 	}
@@ -120,17 +138,17 @@ func LoadPublicKeyFromGitConfig(repo *Repository) (tuf.Principal, error) {
 	case signingMethodGPG:
 		// GPG
 		// Load a GPG signer from the specified key
-		return LoadPublicKey(fmt.Sprintf("%s:%s", "gpg", signingKey))
+		return LoadPublicKey(repo, fmt.Sprintf("%s:%s", "gpg", signingKey))
 	case signingMethodSSH:
 		// SSH
 		// Load an SSH signer from the specified key
-		return LoadPublicKey(signingKey)
+		return LoadPublicKey(repo, signingKey)
 	case signingMethodX509:
 		// X.509
 		// We only support sigstore X.509, so check that gitsign is specified
 		if config["gpg.x509.program"] == "gitsign" {
 			// gitsign
-			return LoadPublicKey(fmt.Sprintf("%s:%s", "fulcio", signingKey))
+			return LoadPublicKey(repo, fmt.Sprintf("%s:%s", "fulcio", signingKey))
 		}
 		return nil, ErrUnsupportedX509Method
 	default:
@@ -152,16 +170,14 @@ func LoadSigner(repo *Repository, key string) (sslibdsse.SignerVerifier, error) 
 	case strings.HasPrefix(key, GPGKeyPrefix):
 		keyID := strings.TrimPrefix(key, GPGKeyPrefix)
 
-		gitRepo := repo.GetGitRepository()
-		config, err := gitRepo.GetGitConfig()
+		config, err := gitinterface.GetGitConfig(repo.GetGitRepository().GetGitDir())
 		if err != nil {
 			return nil, err
 		}
 
 		return gpg.NewSignerFromKeyID(keyID, getGPGOptions(config)...)
 	case strings.HasPrefix(key, FulcioPrefix):
-		gitRepo := repo.GetGitRepository()
-		config, err := gitRepo.GetGitConfig()
+		config, err := gitinterface.GetGitConfig(repo.GetGitRepository().GetGitDir())
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +191,7 @@ func LoadSigner(repo *Repository, key string) (sslibdsse.SignerVerifier, error) 
 // LoadSignerFromGitConfig loads a metadata signer for the signing key specified
 // in the Git configuration of the target repository.
 func LoadSignerFromGitConfig(repo *Repository) (sslibdsse.SignerVerifier, error) {
-	config, err := repo.r.GetGitConfig()
+	config, err := gitinterface.GetGitConfig(repo.r.GetGitDir())
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/gittuf/keys_test.go
+++ b/experimental/gittuf/keys_test.go
@@ -168,31 +168,148 @@ func TestLoadPublicKey(t *testing.T) {
 		t.Run("fulcio valid", func(t *testing.T) {
 			keyRef := "fulcio:test@email.com::issuer"
 
-			key, err := LoadPublicKey(keyRef)
+			key, err := LoadPublicKey(nil, keyRef)
 			require.Nil(t, err)
 			require.NotNil(t, key)
 
 			assert.Equal(t, "test@email.com::issuer", key.ID())
 		})
 		t.Run("fulcio invalid", func(t *testing.T) {
-			_, err := LoadPublicKey("fulcio:invalid")
+			_, err := LoadPublicKey(nil, "fulcio:invalid")
 			assert.ErrorContains(t, err, "incorrect format for fulcio identity")
 		})
 	})
 
 	t.Run("gpg", func(t *testing.T) {
 		t.Run("invalid key", func(t *testing.T) {
-			_, err := LoadPublicKey("gpg:nonexistentkey123")
+			_, err := LoadPublicKey(nil, "gpg:nonexistentkey123")
 			assert.Error(t, err)
 		})
 	})
 
 	t.Run("ssh", func(t *testing.T) {
 		t.Run("invalid path", func(t *testing.T) {
-			_, err := LoadPublicKey("/non/existent/path")
+			_, err := LoadPublicKey(nil, "/non/existent/path")
 			assert.Error(t, err)
 		})
 	})
+}
+
+func TestLoadPublicKeyFromGitConfig(t *testing.T) {
+	t.Run("gpg", func(t *testing.T) {
+		// Make a test GPG keyring in tempdir to use for tests
+		gpg.SetupTestGPGHomeDir(t, artifacts.GPGKey1Private, artifacts.GPGKey2Private)
+
+		// Test GPG key fingerprints
+		fingerprintGPG1 := "157507bbe151e378ce8126c1dcfe043cdd2db96e"
+		fingerprintGPG2 := "7707e87f10df498472babc32e517e211cb23a9e9"
+
+		t.Run("no signing method specified", func(t *testing.T) {
+			// Test no configuration, this means GPG
+			tmpDir := t.TempDir()
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.r.SetGitConfig("user.signingkey", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			// No signingkey specified -> error
+			_, err := LoadPublicKeyFromGitConfig(repo)
+			assert.ErrorIs(t, err, ErrSigningKeyNotSpecified)
+		})
+
+		t.Run("method specified but no signing key specified", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.r.SetGitConfig("user.signingkey", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadPublicKeyFromGitConfig(repo)
+			assert.ErrorIs(t, err, ErrSigningKeyNotSpecified)
+		})
+
+		t.Run("no method specified but signing key specified", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.r.SetGitConfig("user.signingkey", fingerprintGPG1); err != nil {
+				t.Fatal(err)
+			}
+
+			key, err := LoadPublicKeyFromGitConfig(repo)
+			assert.Nil(t, err)
+
+			keyID := key.ID()
+			require.Nil(t, err)
+			assert.Equal(t, fingerprintGPG1, keyID)
+		})
+
+		t.Run("method and signing key specified", func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.r.SetGitConfig("user.signingkey", fingerprintGPG2); err != nil {
+				t.Fatal(err)
+			}
+
+			key, err := LoadPublicKeyFromGitConfig(repo)
+			assert.Nil(t, err)
+
+			keyID := key.ID()
+			require.Nil(t, err)
+			assert.Equal(t, fingerprintGPG2, keyID)
+		})
+	})
+
+	t.Run("ssh", func(t *testing.T) {
+		t.Run("ssh key configured, but no signing key specified", func(t *testing.T) {
+			// Test misconfiguration of SSH
+			tmpDir := t.TempDir()
+			// CreateTestGitRepository sets up the repository to use ssh by default
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			if err := repo.r.SetGitConfig("user.signingkey", ""); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadPublicKeyFromGitConfig(repo)
+			assert.ErrorIs(t, err, ErrSigningKeyNotSpecified)
+		})
+
+		t.Run("ssh key specified", func(t *testing.T) {
+			// Test a working SSH key configured
+			tmpDir := t.TempDir()
+			// CreateTestGitRepository sets up the repository to use ssh by default
+			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+
+			key, err := LoadPublicKeyFromGitConfig(repo)
+			assert.Nil(t, err)
+
+			compareKey := artifacts.SSHRSAPrivate
+
+			comparePublic := ssh.NewKeyFromBytes(t, compareKey)
+			require.Nil(t, err)
+			signerKeyID := key.ID()
+			require.Nil(t, err)
+			assert.Equal(t, comparePublic.KeyID, signerKeyID)
+		})
+	})
+
+	// We can't test sigstore due to it being online...
 }
 
 func TestGetSigstoreOptions(t *testing.T) {

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -48,7 +48,7 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 	expectedRootKeys := make([]tuf.Principal, len(o.expectedRootKeys))
 
 	for index, keyPath := range o.expectedRootKeys {
-		key, err := gittuf.LoadPublicKey(keyPath)
+		key, err := gittuf.LoadPublicKey(nil, keyPath)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -48,7 +48,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	authorizedKeys := []tuf.Principal{}
 	for _, key := range o.authorizedKeys {
-		key, err := gittuf.LoadPublicKey(key)
+		key, err := gittuf.LoadPublicKey(repo, key)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/addperson/addperson.go
+++ b/internal/cmd/policy/addperson/addperson.go
@@ -77,7 +77,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	publicKeys := map[string]*tufv02.Key{}
 	for _, key := range o.publicKeys {
-		key, err := gittuf.LoadPublicKey(key)
+		key, err := gittuf.LoadPublicKey(repo, key)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -82,7 +82,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	authorizedPrincipalIDs := []string{}
 	for _, key := range o.authorizedKeys {
-		key, err := gittuf.LoadPublicKey(key)
+		key, err := gittuf.LoadPublicKey(repo, key)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/addrule/addrule_test.go
+++ b/internal/cmd/policy/addrule/addrule_test.go
@@ -142,7 +142,7 @@ func TestAddRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -204,7 +204,7 @@ func TestAddRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -266,7 +266,7 @@ func TestAddRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/listprincipals/listprincipals_test.go
+++ b/internal/cmd/policy/listprincipals/listprincipals_test.go
@@ -76,7 +76,7 @@ func TestListPrincipals(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,7 +147,7 @@ func TestListPrincipals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/listrules/listrules_test.go
+++ b/internal/cmd/policy/listrules/listrules_test.go
@@ -77,7 +77,7 @@ func TestListRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/removekey/removekey_test.go
+++ b/internal/cmd/policy/removekey/removekey_test.go
@@ -76,7 +76,7 @@ func TestRemoveKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -146,7 +146,7 @@ func TestRemoveKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/removeperson/removeperson_test.go
+++ b/internal/cmd/policy/removeperson/removeperson_test.go
@@ -77,7 +77,7 @@ func TestRemovePerson(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func TestRemovePerson(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/removerule/removerule_test.go
+++ b/internal/cmd/policy/removerule/removerule_test.go
@@ -76,7 +76,7 @@ func TestRemoveRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,7 +152,7 @@ func TestRemoveRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -302,7 +302,7 @@ func TestRemoveRule(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/reorderrules/reorderrules_test.go
+++ b/internal/cmd/policy/reorderrules/reorderrules_test.go
@@ -76,7 +76,7 @@ func TestReorderRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -167,7 +167,7 @@ func TestReorderRules(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -320,7 +320,7 @@ func TestReorderRules(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -371,7 +371,7 @@ func TestReorderRules(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -422,7 +422,7 @@ func TestReorderRules(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/sign/sign_test.go
+++ b/internal/cmd/policy/sign/sign_test.go
@@ -84,7 +84,7 @@ func TestSign(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +162,7 @@ func TestSign(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/updateperson/updateperson.go
+++ b/internal/cmd/policy/updateperson/updateperson.go
@@ -77,7 +77,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	// Process public keys
 	publicKeys := make(map[string]*tufv02.Key)
 	for _, key := range o.publicKeys {
-		publicKey, err := gittuf.LoadPublicKey(key)
+		publicKey, err := gittuf.LoadPublicKey(repo, key)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/updateperson/updateperson_test.go
+++ b/internal/cmd/policy/updateperson/updateperson_test.go
@@ -78,7 +78,7 @@ func TestUpdatePerson(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +163,7 @@ func TestUpdatePerson(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -395,7 +395,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -82,7 +82,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	authorizedPrincipalIDs := []string{}
 	for _, key := range o.authorizedKeys {
-		key, err := gittuf.LoadPublicKey(key)
+		key, err := gittuf.LoadPublicKey(repo, key)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/policy/updaterule/updaterule_test.go
+++ b/internal/cmd/policy/updaterule/updaterule_test.go
@@ -76,7 +76,7 @@ func TestUpdateRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -163,7 +163,7 @@ func TestUpdateRule(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -310,7 +310,7 @@ func TestUpdateRule(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -362,7 +362,7 @@ func TestUpdateRule(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -419,7 +419,7 @@ func TestUpdateRule(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -476,7 +476,7 @@ func TestUpdateRule(t *testing.T) {
 		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
 			t.Fatal(err)
 		}
-		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		newKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
@@ -57,7 +57,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	initialRootPrincipals := []tuf.Principal{}
 	for _, principalRef := range o.initialRootPrincipals {
-		principal, err := gittuf.LoadPublicKey(principalRef)
+		principal, err := gittuf.LoadPublicKey(repo, principalRef)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/trust/addgithubapp/addgithubapp.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp.go
@@ -47,7 +47,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	appKey, err := gittuf.LoadPublicKey(o.appKey)
+	appKey, err := gittuf.LoadPublicKey(repo, o.appKey)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
@@ -57,7 +57,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 
 	initialRootPrincipals := []tuf.Principal{}
 	for _, principalRef := range o.initialRootPrincipals {
-		principal, err := gittuf.LoadPublicKey(principalRef)
+		principal, err := gittuf.LoadPublicKey(repo, principalRef)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -36,7 +36,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	targetsKey, err := gittuf.LoadPublicKey(o.targetsKey)
+	targetsKey, err := gittuf.LoadPublicKey(repo, o.targetsKey)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -36,7 +36,7 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	newRootKey, err := gittuf.LoadPublicKey(o.newRootKey)
+	newRootKey, err := gittuf.LoadPublicKey(repo, o.newRootKey)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
@@ -137,7 +137,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		key, err := gittuf.LoadPublicKey(keyPath)
+		key, err := gittuf.LoadPublicKey(repo, keyPath)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -208,7 +208,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		key, err := gittuf.LoadPublicKey(keyPath)
+		key, err := gittuf.LoadPublicKey(repo, keyPath)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
@@ -168,7 +168,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		appKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -227,7 +227,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		appKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -283,7 +283,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		appKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/trust/removepolicykey/removepolicykey_test.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey_test.go
@@ -107,14 +107,14 @@ func TestRemovePolicyKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		targetsKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Also add the signer's own public key as a targets key so that after
 		// removing targetsKey, at least one key remains to meet the threshold.
-		signerPubKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		signerPubKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -180,14 +180,14 @@ func TestRemovePolicyKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		targetsKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		// Also add the signer's own public key as a targets key so that after
 		// removing targetsKey, at least one key remains to meet the threshold.
-		signerPubKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		signerPubKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/trust/removerootkey/removerootkey_test.go
+++ b/internal/cmd/trust/removerootkey/removerootkey_test.go
@@ -107,7 +107,7 @@ func TestRemoveRootKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rootKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		rootKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -170,7 +170,7 @@ func TestRemoveRootKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		rootKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
+		rootKey, err := gittuf.LoadPublicKey(repo, newKeyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
@@ -102,7 +102,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		targetsKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -156,7 +156,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		targetsKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		targetsKey, err := gittuf.LoadPublicKey(repo, keyPath+".pub")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/git-remote-gittuf/helpers.go
+++ b/internal/git-remote-gittuf/helpers.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
 )
 
 type logWriteCloser struct {
@@ -164,7 +165,7 @@ func getSSHCommand(repo *gittuf.Repository) ([]string, error) {
 		return []string{sshCmd}, nil
 	}
 
-	config, err := repo.GetGitRepository().GetGitConfig()
+	config, err := gitinterface.GetGitConfig(repo.GetGitRepository().GetGitDir())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/policy/signature.go
+++ b/internal/policy/signature.go
@@ -159,7 +159,7 @@ func (v *SignatureVerifier) Verify(ctx context.Context, gitObjectID gitinterface
 				case sigstore.KeyType:
 					slog.Debug(fmt.Sprintf("Found Sigstore key '%s'...", key.KeyID))
 					opts := []sigstoreverifieropts.Option{}
-					config, err := v.repository.GetGitConfig()
+					config, err := gitinterface.GetGitConfig(v.repository.GetGitDir())
 					if err != nil {
 						return nil, err
 					}

--- a/internal/signerverifier/gpg/gpg.go
+++ b/internal/signerverifier/gpg/gpg.go
@@ -24,7 +24,7 @@ import (
 const (
 	KeyType = "gpg"
 
-	defaultGPGProgram = "gpg"
+	DefaultGPGProgram = "gpg"
 )
 
 // Verifier is a dsse.Verifier implementation for GPG keys.
@@ -98,7 +98,7 @@ func (s *Signer) Sign(_ context.Context, data []byte) ([]byte, error) {
 }
 
 func NewSignerFromKeyID(keyID string, opts ...SignerOption) (*Signer, error) {
-	options := &SignerOptions{program: defaultGPGProgram}
+	options := &SignerOptions{program: DefaultGPGProgram}
 	for _, fn := range opts {
 		fn(options)
 	}

--- a/pkg/gitinterface/commit.go
+++ b/pkg/gitinterface/commit.go
@@ -65,7 +65,7 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 // developer mode. In standard workflows, Commit() must be used instead which
 // infers the signing key from the user's Git config.
 func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message string, signingKeyPEMBytes []byte) (Hash, error) {
-	gitConfig, err := r.GetGitConfig()
+	gitConfig, err := GetGitConfig(r.gitDirPath)
 	if err != nil {
 		return ZeroHash, err
 	}

--- a/pkg/gitinterface/config.go
+++ b/pkg/gitinterface/config.go
@@ -5,15 +5,29 @@ package gitinterface
 
 import (
 	"fmt"
+	"os/exec"
 	"strings"
 )
 
-// GetGitConfig reads the applicable Git config for a repository and returns
-// it. The "keys" for each config are normalized to lowercase.
-func (r *Repository) GetGitConfig() (map[string]string, error) {
-	stdOut, err := r.executor("config", "--get-regexp", `.*`).executeString()
-	if err != nil {
-		return nil, fmt.Errorf("unable to read Git config: %w", err)
+// GetGitConfig reads the applicable Git config for a repository and returns it.
+// If the supplied repository is nil, the system or global Git config will be
+// used as per https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration.
+// The "keys" for each config are normalized to lowercase.
+func GetGitConfig(repo string) (map[string]string, error) {
+	var stdOut string
+
+	if repo != "" {
+		output, err := exec.Command("git", "-C", repo, "config", "--get-regexp", `.*`).Output()
+		if err != nil {
+			return nil, fmt.Errorf("unable to read Git config: %w", err)
+		}
+		stdOut = string(output)
+	} else {
+		output, err := exec.Command("git", "config", "--get-regexp", `.*`).Output()
+		if err != nil {
+			return nil, fmt.Errorf("unable to read Git config: %w", err)
+		}
+		stdOut = string(output)
 	}
 
 	config := map[string]string{}

--- a/pkg/gitinterface/config_test.go
+++ b/pkg/gitinterface/config_test.go
@@ -15,7 +15,7 @@ func TestGetGitConfig(t *testing.T) {
 	repo := CreateTestGitRepository(t, tmpDir, false)
 
 	// CreateTestGitRepository sets our test config
-	config, err := repo.GetGitConfig()
+	config, err := GetGitConfig(repo.gitDirPath)
 	assert.Nil(t, err)
 	assert.Equal(t, testName, config["user.name"])
 	assert.Equal(t, testEmail, config["user.email"])
@@ -34,7 +34,7 @@ func TestSetGitConfig(t *testing.T) {
 		err = repo.SetGitConfig("user.email", email)
 		require.NoError(t, err)
 
-		config, err := repo.GetGitConfig()
+		config, err := GetGitConfig(repo.gitDirPath)
 		require.NoError(t, err)
 		assert.Equal(t, name, config["user.name"])
 		assert.Equal(t, email, config["user.email"])
@@ -48,7 +48,7 @@ func TestSetGitConfig(t *testing.T) {
 		err = repo.SetGitConfig("user.email", "")
 		require.NoError(t, err)
 
-		config, err := repo.GetGitConfig()
+		config, err := GetGitConfig(repo.gitDirPath)
 		require.NoError(t, err)
 		assert.Equal(t, "", config["user.name"])
 		assert.Equal(t, "", config["user.email"])
@@ -60,14 +60,14 @@ func TestSetGitConfig(t *testing.T) {
 		err := repo.SetGitConfig("gpg.format", "gpg")
 		require.NoError(t, err)
 
-		config, err := repo.GetGitConfig()
+		config, err := GetGitConfig(repo.gitDirPath)
 		require.NoError(t, err)
 		assert.Equal(t, "gpg", config["gpg.format"])
 
 		err = repo.SetGitConfig("gpg.format", "")
 		require.NoError(t, err)
 
-		config, err = repo.GetGitConfig()
+		config, err = GetGitConfig(repo.gitDirPath)
 		require.NoError(t, err)
 		assert.Equal(t, "", config["gpg.format"])
 	})

--- a/pkg/gitinterface/signature.go
+++ b/pkg/gitinterface/signature.go
@@ -51,7 +51,7 @@ var (
 // CanSign inspects the Git configuration to determine if commit / tag signing
 // is possible.
 func (r *Repository) CanSign() error {
-	config, err := r.GetGitConfig()
+	config, err := GetGitConfig(r.gitDirPath)
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func verifyGitsignSignature(ctx context.Context, repo *Repository, key *signerve
 
 	rekorURL := rekorPublicGoodInstance
 	// Check git config to see if rekor server must be overridden
-	config, err := repo.GetGitConfig()
+	config, err := GetGitConfig(repo.gitDirPath)
 	if err != nil {
 		return errors.Join(ErrVerifyingSigstoreSignature, err)
 	}

--- a/pkg/gitinterface/tag.go
+++ b/pkg/gitinterface/tag.go
@@ -28,7 +28,7 @@ var (
 // gittuf is not expected to be used to create tags in developer workflows,
 // though this may change with command compatibility.
 func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, signingKeyPEMBytes []byte) (Hash, error) {
-	gitConfig, err := r.GetGitConfig()
+	gitConfig, err := GetGitConfig(r.gitDirPath)
 	if err != nil {
 		return ZeroHash, err
 	}


### PR DESCRIPTION
## Description
Fixes #1261.

LoadPublicKeyFromGitConfig previously ignored gpg.program and always executed gpg from PATH.  
LoadSignerFromGitConfig already honored gpg.program, which caused inconsistent behavior in minimal PATH environments.

This PR:
- Updates the GPG public-key loading path used by LoadPublicKeyFromGitConfig to respect gpg.program when configured.
- Keeps default behavior when gpg.program is not set.
- Adds a regression test that simulates restricted PATH and verifies both signer loading and public-key loading work when gpg.program is configured.

Testing performed:
- go test -count=1 -run TestLoadPublicKeyFromGitConfig ./experimental/gittuf -v
- go test -count=1 -race -run TestLoadPublicKeyFromGitConfig ./experimental/gittuf -v
- go test -count=1 ./experimental/gittuf -v
- go test -count=1 ./...

## AI Usage

- [x] I did not use generative AI at all in making the content of this pull request.
- [ ] I did use generative AI in some form in making the content of this pull request. I have described my use of AI below.


## Contributor Checklist

- [x] I have manually reviewed all content submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a DCO Signoff.
- [x] By submitting this pull request, I agree to follow the gittuf Code of Conduct.