### PR TITLE
fix: use --topo-order in GetCommitsBetweenRange instead of hash sort

### DIFF
--- a/pkg/gitinterface/log.go
+++ b/pkg/gitinterface/log.go
@@ -5,18 +5,18 @@ package gitinterface
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 )
 
 // GetCommitsBetweenRange returns the IDs of the commits that exist between the
-// specified new and old commit identifiers.
+// specified new and old commit identifiers. Commits are returned in
+// topological order, where each commit appears before its parents.
 func (r *Repository) GetCommitsBetweenRange(commitNewID, commitOldID Hash) ([]Hash, error) {
 	var args []string
 	if commitOldID.IsZero() {
-		args = []string{"rev-list", commitNewID.String()}
+		args = []string{"rev-list", "--topo-order", commitNewID.String()}
 	} else {
-		args = []string{"rev-list", fmt.Sprintf("%s..%s", commitOldID.String(), commitNewID.String())}
+		args = []string{"rev-list", "--topo-order", fmt.Sprintf("%s..%s", commitOldID.String(), commitNewID.String())}
 	}
 
 	commitRangeString, err := r.executor(args...).executeString()
@@ -37,17 +37,6 @@ func (r *Repository) GetCommitsBetweenRange(commitNewID, commitOldID Hash) ([]Ha
 		}
 		commitRange = append(commitRange, hash)
 	}
-
-	// FIXME: we should ideally be sorting this in the order of occurrence
-	// rather than by commit ID. The only reason this is happening is because
-	// the ordering of commitRange by default is not deterministic. Rather than
-	// walking through them and identifying the right order, we're sorting by
-	// commit ID. The intended use case of this function is to get a list of
-	// commits that are then checked for the changes they introduce. At that
-	// point, they must be diffed with their parent directly.
-	sort.Slice(commitRange, func(i, j int) bool {
-		return commitRange[i].String() < commitRange[j].String()
-	})
 
 	return commitRange, nil
 }

--- a/pkg/gitinterface/log_test.go
+++ b/pkg/gitinterface/log_test.go
@@ -5,7 +5,6 @@ package gitinterface
 
 import (
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,11 +39,8 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 		commits, err := repo.GetCommitsBetweenRange(allCommits[4], allCommits[0])
 		assert.Nil(t, err)
 
+		// Linear history: topo-order is deterministic (newest first)
 		expectedCommits := []Hash{allCommits[4], allCommits[3], allCommits[2], allCommits[1]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
 		assert.Equal(t, expectedCommits, commits)
 	})
 
@@ -109,32 +105,23 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 		// Check merge to first commit in main branch (not initial common commit)
 		expectedCommits := append([]Hash{mergeCommit}, mainBranchCommits[1:]...)
 		expectedCommits = append(expectedCommits, featureBranchCommits...)
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
 		commits, err := repo.GetCommitsBetweenRange(mergeCommit, mainBranchCommits[0])
 		assert.Nil(t, err)
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, expectedCommits, commits)
 
 		// Check merge to first commit in feature branch (not initial common commit)
 		expectedCommits = append([]Hash{mergeCommit}, featureBranchCommits[1:]...)
 		expectedCommits = append(expectedCommits, mainBranchCommits...)
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
 		commits, err = repo.GetCommitsBetweenRange(mergeCommit, featureBranchCommits[0])
 		assert.Nil(t, err)
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, expectedCommits, commits)
 
 		// Check merge to initial common commit
 		expectedCommits = append([]Hash{mergeCommit}, mainBranchCommits...)
 		expectedCommits = append(expectedCommits, featureBranchCommits...)
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
 		commits, err = repo.GetCommitsBetweenRange(mergeCommit, commonCommit)
 		assert.Nil(t, err)
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, expectedCommits, commits)
 
 		// Set both branches to merge commit, diverge again
 		if err := repo.SetReference(mainBranch, mergeCommit); err != nil {
@@ -172,22 +159,16 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 		// Check range between two merge commits
 		expectedCommits = append([]Hash{newMergeCommit}, mainBranchCommits...)
 		expectedCommits = append(expectedCommits, featureBranchCommits...)
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
 		commits, err = repo.GetCommitsBetweenRange(newMergeCommit, mergeCommit)
 		assert.Nil(t, err)
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, expectedCommits, commits)
 	})
 
 	t.Run("Get all commits", func(t *testing.T) {
 		commits, err := repo.GetCommitsBetweenRange(allCommits[4], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := allCommits
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
+		// Linear history: topo-order is deterministic (newest first)
+		expectedCommits := []Hash{allCommits[4], allCommits[3], allCommits[2], allCommits[1], allCommits[0]}
 		assert.Equal(t, expectedCommits, commits)
 	})
 
@@ -264,65 +245,35 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 		// commit 2 is the first child of commit 1, so only it and commit 1 should be returned
 		commits, err := repo.GetCommitsBetweenRange(commitIDs[1], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := []Hash{commitIDs[1], commitIDs[0]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, []Hash{commitIDs[1], commitIDs[0]}, commits)
 	})
 
 	t.Run("Test commit 3", func(t *testing.T) {
 		// commit 3 is the second child of commit 1, so only it and commit 1 should be returned
 		commits, err := repo.GetCommitsBetweenRange(commitIDs[2], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := []Hash{commitIDs[0], commitIDs[2]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, []Hash{commitIDs[0], commitIDs[2]}, commits)
 	})
 
 	t.Run("Test commit 4", func(t *testing.T) {
 		// commit 4 is the child of commit 2, so only it, commit 2, and commit 2's parent commit 1 should be returned
 		commits, err := repo.GetCommitsBetweenRange(commitIDs[3], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := []Hash{commitIDs[1], commitIDs[0], commitIDs[3]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, []Hash{commitIDs[1], commitIDs[0], commitIDs[3]}, commits)
 	})
 
 	t.Run("Test commit 5, the merge commit", func(t *testing.T) {
 		// commit 5 is the merge commit of commit 2 and commit 3, so it should return commit 5, commit 2, commit 3, and commit 1 (the parent of commit 2 and commit 3)
 		commits, err := repo.GetCommitsBetweenRange(commitIDs[4], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := []Hash{commitIDs[4], commitIDs[1], commitIDs[0], commitIDs[2]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, []Hash{commitIDs[4], commitIDs[1], commitIDs[0], commitIDs[2]}, commits)
 	})
 
 	t.Run("Test commit 6", func(t *testing.T) {
 		// commit 6 is the child of commit 3, so it should return commit 6, commit 3, and commit 1 (the parent of commit 3)
 		commits, err := repo.GetCommitsBetweenRange(commitIDs[5], ZeroHash)
 		assert.Nil(t, err)
-
-		expectedCommits := []Hash{commitIDs[0], commitIDs[5], commitIDs[2]}
-		sort.Slice(expectedCommits, func(i, j int) bool {
-			return expectedCommits[i].String() < expectedCommits[j].String()
-		})
-
-		assert.Equal(t, expectedCommits, commits)
+		assert.ElementsMatch(t, []Hash{commitIDs[0], commitIDs[5], commitIDs[2]}, commits)
 	})
 }
 


### PR DESCRIPTION
## Description

`GetCommitsBetweenRange` was sorting commits by their hash string instead of preserving topological order. There was a FIXME comment in the code acknowledging this.

This PR:
- Adds `--topo-order` to the `git rev-list` call and removes the `sort.Slice` workaround
- Updates the doc comment to document the topological ordering contract
- Fixes tests that were sorting expected results by hash (which hid the issue), linear cases now assert exact topo-order with `assert.Equal`, branch/merge cases use `assert.ElementsMatch`

Fixes #1254

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull request.
- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

Used AI to help explore the codebase and suggest an initial approach. I wrote and reviewed the final code myself.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
