### PR TITLE
Fix ssh url split panic

### DIFF
--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -426,6 +426,9 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 
 					refSpec := strings.TrimPrefix(pushCommandString, "push ")
 					refSpecSplit := strings.Split(refSpec, ":")
+					if len(refSpecSplit) < 2 {
+						return nil, false, fmt.Errorf("invalid refspec %q: expected format src:dst", refSpec)
+					}
 
 					srcRef := refSpecSplit[0]
 					srcRef = strings.TrimPrefix(srcRef, "+") // force push

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -28,6 +28,9 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 	url = strings.TrimPrefix(url, "ssh+git://")
 
 	urlSplit := strings.Split(url, ":") // 0 is the connection [user@]host, 1 is the repo
+	if len(urlSplit) < 2 {
+		return nil, false, fmt.Errorf("invalid SSH URL %q: expected format [user@]host:repository", url)
+	}
 	host := urlSplit[0]
 	repository := urlSplit[1]
 
@@ -249,7 +252,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					}
 
 					refAdSplit := strings.Split(refAd, " ")
-					if strings.HasPrefix(refAdSplit[1], gittufRefPrefix) {
+					if len(refAdSplit) >= 2 && strings.HasPrefix(refAdSplit[1], gittufRefPrefix) {
 						gittufRefsTips[refAdSplit[1]] = refAdSplit[0]
 					}
 				}
@@ -472,6 +475,9 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					refAd = strings.TrimSpace(refAd)
 
 					refAdSplit := strings.Split(refAd, " ")
+					if len(refAdSplit) < 2 {
+						continue
+					}
 					ref := refAdSplit[1]
 					if i := strings.IndexByte(ref, '\x00'); i > 0 {
 						ref = ref[:i] // remove config string passed after null byte
@@ -528,6 +534,9 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 			dstRefs := set.NewSet[string]()
 			for i, refSpec := range pushRefSpecs {
 				refSpecSplit := strings.Split(refSpec, ":")
+				if len(refSpecSplit) < 2 {
+					return nil, false, fmt.Errorf("invalid refspec %q: expected format src:dst", refSpec)
+				}
 
 				srcRef := refSpecSplit[0]
 				srcRef = strings.TrimPrefix(srcRef, "+")


### PR DESCRIPTION
## Description
While going through the transport code I noticed that several `strings.Split()` calls access index `[1]` without checking the slice length first. A malformed SSH URL (e.g., missing :) or an unexpected server response would cause a panic. I noticed, `curl.go` already has this check in one place (`len(refAdSplit) >= 2`), it just wasn't applied everywhere. This PR adds the same guard to the remaining 5 locations.                                                                                                                     

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used AI to help scan the codebase and identify the locations where bounds checks were missing. I reviewed each location manually to confirm the issue was real and wrote the fix myself. 

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
