### PR TITLE
tests: improve coverage for keys.go (fulcio, ssh, gpg, sigstore options)

### DIFF
--- a/experimental/gittuf/keys_test.go
+++ b/experimental/gittuf/keys_test.go
@@ -162,3 +162,66 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 
 	// We can't test sigstore due to it being online...
 }
+
+func TestLoadPublicKey(t *testing.T) {
+	t.Run("sigstore", func(t *testing.T) {
+		t.Run("fulcio valid", func(t *testing.T) {
+			keyRef := "fulcio:test@email.com::issuer"
+
+			key, err := LoadPublicKey(keyRef)
+			require.Nil(t, err)
+			require.NotNil(t, key)
+
+			assert.Equal(t, "test@email.com::issuer", key.ID())
+		})
+		t.Run("fulcio invalid", func(t *testing.T) {
+			_, err := LoadPublicKey("fulcio:invalid")
+			assert.ErrorContains(t, err, "incorrect format for fulcio identity")
+		})
+	})
+
+	t.Run("gpg", func(t *testing.T) {
+		t.Run("invalid key", func(t *testing.T) {
+			_, err := LoadPublicKey("gpg:nonexistentkey123")
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("ssh", func(t *testing.T) {
+		t.Run("invalid path", func(t *testing.T) {
+			_, err := LoadPublicKey("/non/existent/path")
+			assert.Error(t, err)
+		})
+	})
+}
+
+func TestGetSigstoreOptions(t *testing.T) {
+	t.Run("full config", func(t *testing.T) {
+		config := map[string]string{
+			"gitsign.issuer":      "issuer",
+			"gitsign.clientid":    "client",
+			"gitsign.fulcio":      "fulcio-url",
+			"gitsign.rekor":       "rekor-url",
+			"gitsign.redirecturl": "redirect-url",
+		}
+
+		opts := getSigstoreOptions(config)
+		require.Len(t, opts, 5)
+	})
+
+	t.Run("partial config", func(t *testing.T) {
+		config := map[string]string{
+			"gitsign.issuer": "issuer",
+		}
+
+		opts := getSigstoreOptions(config)
+		require.Len(t, opts, 1)
+	})
+
+	t.Run("empty config", func(t *testing.T) {
+		config := map[string]string{}
+
+		opts := getSigstoreOptions(config)
+		assert.Empty(t, opts)
+	})
+}


### PR DESCRIPTION
## Description

Related to #1259 

Adds unit tests to improve coverage for key loading and Sigstore-related configuration logic in `experimental/gittuf/keys.go`.

The tests cover:
- Fulcio key parsing (valid and invalid formats)
- Error handling for GPG and SSH key loading
- Sigstore configuration option parsing (`getSigstoreOptions`) for full, partial, and empty configs

Sigstore-related tests focus on local parsing and configuration behavior only, since signing and verification involve external services (e.g., Rekor/Fulcio) and should not be exercised in unit tests.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used generative AI in a limited capacity for general guidance while exploring test coverage approaches. All code and tests were written, reviewed, and understood by me before submission.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
