### PR TITLE
test: improve coverage for internal/cache 

### DIFF
--- a/internal/cache/attestations_test.go
+++ b/internal/cache/attestations_test.go
@@ -1,0 +1,152 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindAttestationsEntryNumberForEntry(t *testing.T) {
+	t.Run("no entries", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{},
+		}
+
+		index, _ := p.FindAttestationsEntryNumberForEntry(uint64(1))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 0}, index)
+	})
+
+	t.Run("target entry exists", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		index, _ := p.FindAttestationsEntryNumberForEntry(uint64(2))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}, index)
+	})
+
+	t.Run("target entry doesn't exist and there are no entries before it", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+		index, _ := p.FindAttestationsEntryNumberForEntry(uint64(1))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 0}, index) // when the target entry doesn't exist and there is no entry in the cache before the target, the function returns entryNumber 0
+	})
+
+	t.Run("target entry doesn't exist and there are entries before it", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		index, _ := p.FindAttestationsEntryNumberForEntry(uint64(2))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}, index) // when the target entry doesn't exist but there are entries in the cache before the target entry number, the function returs the entry just before the target number
+	})
+}
+
+func TestInsertAttestationEntryNumber(t *testing.T) {
+	t.Run("zero entry", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{},
+		}
+
+		p.InsertAttestationEntryNumber(uint64(0), gitinterface.ZeroHash)
+		assert.Equal(t, []RSLEntryIndex{}, p.AttestationEntries) // inserting entry number 0 should result in noop
+	})
+
+	t.Run("inserting in empty cache", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+		p.InsertAttestationEntryNumber(uint64(1), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+		}, p.AttestationEntries)
+	})
+
+	t.Run("inserting at end", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48d7914")
+		p.InsertAttestationEntryNumber(uint64(5), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			{EntryNumber: 5, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48d7914"},
+		}, p.AttestationEntries)
+	})
+
+	t.Run("inserting at insertion point", func(t *testing.T) {
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c1234")
+		p.InsertAttestationEntryNumber(uint64(2), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		}, p.AttestationEntries)
+	})
+}
+
+func TestSetAddedAttestationsBeforeNumber(t *testing.T) {
+	p := Persistent{
+		AddedAttestationsBeforeNumber: 1,
+	}
+
+	p.SetAddedAttestationsBeforeNumber(uint64(2))
+	assert.Equal(t, uint64(2), p.AddedAttestationsBeforeNumber) // number bigger than the current value will be assigned
+
+	p.SetAddedAttestationsBeforeNumber(uint64(1))
+	assert.Equal(t, uint64(2), p.AddedAttestationsBeforeNumber) // number smaller than the current value will be ignored
+}
+
+func TestGetAttestationsEntries(t *testing.T) {
+	p := &Persistent{
+		AttestationEntries: []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		},
+	}
+
+	values := p.GetAttestationsEntries()
+	assert.Equal(t, p.AttestationEntries, values)
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,279 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/attestations"
+	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommit(t *testing.T) {
+	t.Run("empty cache", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		p := &Persistent{}
+		err := p.Commit(repo)
+		assert.Nil(t, err) // an empty cache should do nothing
+
+		_, err = repo.GetReference(Ref)
+		assert.Error(t, err) // no reference should be created for an empty cache
+	})
+
+	t.Run("non-empty cache", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			},
+		}
+
+		err := p.Commit(repo)
+		require.Nil(t, err) // there should be no error for non-empty cache
+
+		refID, err := repo.GetReference(Ref)
+		require.Nil(t, err)             // a reference should be created for a non-empty cache
+		assert.False(t, refID.IsZero()) // the reference should not be zero
+	})
+
+	t.Run("no changes causes noop", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			},
+		}
+
+		err := p.Commit(repo)
+		require.Nil(t, err)
+
+		firstRef, err := repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		err = p.Commit(repo)
+		require.Nil(t, err)
+
+		secondRef, err := repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		assert.Equal(t, firstRef, secondRef) // the references should be equal to each other because noop
+	})
+
+	t.Run("cache changes causes new commit", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		p := &Persistent{
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			},
+		}
+
+		err := p.Commit(repo)
+		require.Nil(t, err)
+
+		firstRef, err := repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		p.PolicyEntries = append(p.PolicyEntries, RSLEntryIndex{
+			EntryNumber: 2,
+			EntryID:     "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234",
+		})
+
+		err = p.Commit(repo)
+		require.Nil(t, err)
+
+		secondRef, err := repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		assert.NotEqual(t, firstRef, secondRef) // the reference should not be equal when data changes
+	})
+}
+
+func TestBinarySearch(t *testing.T) {
+	t.Run("equals", func(t *testing.T) {
+		a := RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}
+		b := RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}
+
+		c := RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+		d := RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+
+		res := binarySearch(a, b)
+		assert.Equal(t, 0, res) // the result should be 0 for equal entry numbers and unequal IDs
+
+		res = binarySearch(c, d)
+		assert.Equal(t, 0, res) // the result should be 0 for equal entry numbers and equal IDs
+	})
+
+	t.Run("precedes", func(t *testing.T) {
+		a := RSLEntryIndex{EntryNumber: 0, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}
+		b := RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}
+
+		c := RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+		d := RSLEntryIndex{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+
+		res := binarySearch(a, b)
+		assert.Equal(t, -1, res) // the result should be -1 for cases with unequal IDs but first entry number is smaller than the second
+
+		res = binarySearch(c, d)
+		assert.Equal(t, -1, res) // the result should be -1 for cases with equal IDs but first entry number is smaller than the second
+	})
+
+	t.Run("succeeds", func(t *testing.T) {
+		a := RSLEntryIndex{EntryNumber: 0, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}
+		b := RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}
+
+		c := RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+		d := RSLEntryIndex{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"}
+
+		res := binarySearch(b, a)
+		assert.Equal(t, 1, res) // the result should be 1 for cases with unequal IDs but second entry number is smaller than the first
+
+		res = binarySearch(d, c)
+		assert.Equal(t, 1, res) // the result should be 1 for cases with equal IDs but second entry number is smaller than the first
+	})
+}
+
+func TestPopulatePersistentCache(t *testing.T) {
+	t.Run("repo with reference and policy", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		require.Nil(t, err)
+
+		err = PopulatePersistentCache(repo)
+		assert.Nil(t, err)
+
+		sampleCache := Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "a2f603abf945588e8ad0d6b1f71a37bdcaf87e13"},
+			},
+			AttestationEntries:            []RSLEntryIndex{},
+			AddedAttestationsBeforeNumber: 1,
+		}
+		cache, err := LoadPersistentCache(repo)
+		require.Nil(t, err)
+		assert.Equal(t, &sampleCache, cache)
+	})
+
+	t.Run("empty repo", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := PopulatePersistentCache(repo) // since this empty repo has no references or commits yet so it should throw an error
+		require.Error(t, err)
+	})
+}
+
+func TestLoadPersistantCache(t *testing.T) {
+	t.Run("empty repo", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		_, err := LoadPersistentCache(repo)
+		require.ErrorIs(t, ErrNoPersistentCache, err) // empty repo with no reference throws ErrNoPersistentCache error
+	})
+
+	t.Run("repo with policy reference", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		require.Nil(t, err)
+
+		err = PopulatePersistentCache(repo)
+		require.Nil(t, err)
+
+		_, err = repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		persistentCache, err := LoadPersistentCache(repo)
+		require.Nil(t, err)
+		assert.NotNil(t, persistentCache) // the cache should be loaded successfully if the persistentCache exists
+
+		sampleCache := Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "a2f603abf945588e8ad0d6b1f71a37bdcaf87e13"},
+			},
+			AttestationEntries:            []RSLEntryIndex{},
+			AddedAttestationsBeforeNumber: 1,
+		}
+		assert.Equal(t, &sampleCache, persistentCache)
+	})
+
+	t.Run("repo with attestation reference", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := rsl.NewReferenceEntry(attestations.Ref, gitinterface.ZeroHash).Commit(repo, false)
+		require.Nil(t, err)
+
+		err = PopulatePersistentCache(repo)
+		require.Nil(t, err)
+
+		_, err = repo.GetReference(Ref)
+		require.Nil(t, err)
+
+		persistentCache, err := LoadPersistentCache(repo)
+		require.Nil(t, err)
+		assert.NotNil(t, persistentCache)
+
+		sampleCache := Persistent{
+			PolicyEntries: []RSLEntryIndex{},
+			AttestationEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "4f6fd1c67daa2acf4f2dd8626ddd8d6a51fcd026"},
+			},
+			AddedAttestationsBeforeNumber: 1,
+		}
+		assert.Equal(t, &sampleCache, persistentCache)
+	})
+}
+
+func TestDeletePersistentCache(t *testing.T) {
+	t.Run("delete cache for empty repo", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := DeletePersistentCache(repo)
+		require.ErrorIs(t, ErrNoPersistentCache, err)
+	})
+
+	t.Run("delete existing cache", func(t *testing.T) {
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		require.Nil(t, err)
+
+		err = PopulatePersistentCache(repo)
+		require.Nil(t, err)
+
+		err = DeletePersistentCache(repo)
+		assert.Nil(t, err)
+
+		_, err = repo.GetReference(Ref)
+		assert.ErrorIs(t, gitinterface.ErrReferenceNotFound, err)
+	})
+}
+
+func TestRSLEntryMethods(t *testing.T) {
+	r := RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}
+
+	number := r.GetEntryNumber()
+	assert.Equal(t, uint64(1), number)
+
+	id := r.GetEntryID()
+	expectedID, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+	assert.Equal(t, expectedID, id)
+}

--- a/internal/cache/policy_test.go
+++ b/internal/cache/policy_test.go
@@ -1,0 +1,219 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasPolicyEntryNumber(t *testing.T) {
+	t.Run("no entries", func(t *testing.T) {
+		p := &Persistent{}
+		hash, has := p.HasPolicyEntryNumber(1)
+		assert.False(t, has)
+		assert.Equal(t, gitinterface.ZeroHash, hash)
+	})
+
+	t.Run("entries exist", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		} // these hashes are random values that are used all accorss tests
+
+		hash, has := p.HasPolicyEntryNumber(uint64(1))
+		validHash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+		assert.True(t, has)
+		assert.Equal(t, validHash, hash) // function retures the valid hash when a valid EntryNumber is given to it
+	})
+
+	t.Run("entry doesn't exist", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		} // these hashes are random values that are used all accorss tests
+
+		hash, has := p.HasPolicyEntryNumber(uint64(1))
+		assert.False(t, has)
+		assert.Equal(t, gitinterface.ZeroHash, hash) // function returns ZeroHash when entry doesn't exist
+	})
+}
+
+func TestFindPolicyEntryNumberForEntry(t *testing.T) {
+	t.Run("no entries", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{},
+		}
+		index := p.FindPolicyEntryNumberForEntry(uint64(1))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 0}, index)
+	})
+
+	t.Run("target entry exists", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		index := p.FindPolicyEntryNumberForEntry(uint64(2))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}, index)
+	})
+
+	t.Run("target entry doesn't exist and there are no entries before it", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+		index := p.FindPolicyEntryNumberForEntry(uint64(1))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 0}, index) // when the target entry doesn't exist and there is no entry in the cache before the target, the function returns entryNumber 0
+	})
+
+	t.Run("target entry doesn't exist and there are entries before it", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		index := p.FindPolicyEntryNumberForEntry(uint64(2))
+		assert.Equal(t, RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}, index) // when the target entry doesn't exist but there are entries in the cache before the target entry number, the function returs the entry just before the target number
+	})
+}
+
+func TestFindPolicyEntriesInRange(t *testing.T) {
+	t.Run("no entries", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{},
+		}
+
+		indices, err := p.FindPolicyEntriesInRange(uint64(1), uint64(3))
+		assert.Nil(t, indices)
+		assert.ErrorIs(t, ErrNoPersistentCache, err)
+	})
+
+	t.Run("entries exist in range", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		indices, err := p.FindPolicyEntriesInRange(uint64(2), uint64(4)) // checking range with both limits in bound
+		require.Nil(t, err)
+		require.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		}, indices)
+
+		indices, err = p.FindPolicyEntriesInRange(uint64(2), uint64(6)) // checking range with last number outside bound
+		require.Nil(t, err)
+		require.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		}, indices)
+	})
+}
+
+func TestInsertPolicyEntryNumber(t *testing.T) {
+	t.Run("zero entry", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{},
+		}
+
+		p.InsertPolicyEntryNumber(uint64(0), gitinterface.ZeroHash)
+		assert.Equal(t, []RSLEntryIndex{}, p.PolicyEntries) // inserting entry number 0 should result in noop
+	})
+
+	t.Run("inserting in empty cache", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+		p.InsertPolicyEntryNumber(uint64(1), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+		}, p.PolicyEntries)
+	})
+
+	t.Run("inserting at end", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48d7914")
+		p.InsertPolicyEntryNumber(uint64(5), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			{EntryNumber: 5, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48d7914"},
+		}, p.PolicyEntries)
+	})
+
+	t.Run("inserting at insertion point", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+				{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c1234")
+		p.InsertPolicyEntryNumber(uint64(2), hash)
+
+		assert.Equal(t, []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		}, p.PolicyEntries)
+	})
+}
+
+func TestGetPolicyEntries(t *testing.T) {
+	p := &Persistent{
+		PolicyEntries: []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			{EntryNumber: 3, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c0980"},
+			{EntryNumber: 4, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c9080"},
+		},
+	}
+
+	entries := p.GetPolicyEntries()
+	assert.Equal(t, p.PolicyEntries, entries)
+}

--- a/internal/cache/verification_test.go
+++ b/internal/cache/verification_test.go
@@ -1,0 +1,82 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/attestations"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetLastVerifiedEntryForRef(t *testing.T) {
+	p := &Persistent{
+		PolicyEntries: []RSLEntryIndex{
+			{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+			{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+		},
+	}
+
+	hash1, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c1234")
+	p.SetLastVerifiedEntryForRef(policyRef, uint64(2), hash1)
+
+	value, has := p.LastVerifiedEntryForRef[policyRef]
+	assert.True(t, has)
+	assert.Equal(t, RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}, value) // value set successfully
+
+	hash2, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+	p.SetLastVerifiedEntryForRef(policyRef, uint64(1), hash2)
+
+	value = p.LastVerifiedEntryForRef[policyRef]
+	assert.NotEqual(t, RSLEntryIndex{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"}, value) // since an entry withn a bigger entry number exist, entry number 1 doesn't get set
+	assert.Equal(t, RSLEntryIndex{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"}, value)
+}
+
+func TestGetLastVerifiedEntryForRef(t *testing.T) {
+	t.Run("map doesn't exist", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			},
+		}
+
+		number, id := p.GetLastVerifiedEntryForRef(policyRef)
+		assert.Equal(t, uint64(0), number)
+		assert.Equal(t, gitinterface.ZeroHash, id) // if the map doesn't exist, should return 0 for entry number and zero hash for entry id
+	})
+
+	t.Run("entry for ref doesn't exist", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c1234")
+		p.SetLastVerifiedEntryForRef(policyRef, uint64(2), hash)
+
+		number, id := p.GetLastVerifiedEntryForRef(attestations.Ref)
+		assert.Equal(t, uint64(0), number)
+		assert.Equal(t, gitinterface.ZeroHash, id)
+	})
+
+	t.Run("entry for ref exists", func(t *testing.T) {
+		p := &Persistent{
+			PolicyEntries: []RSLEntryIndex{
+				{EntryNumber: 1, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"},
+				{EntryNumber: 2, EntryID: "e69de29bb2d1d6434b8b29ae775ad8c2e48c1234"},
+			},
+		}
+
+		hash, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
+		p.SetLastVerifiedEntryForRef(policyRef, uint64(2), hash)
+
+		number, id := p.GetLastVerifiedEntryForRef(policyRef)
+		assert.Equal(t, uint64(2), number)
+		assert.Equal(t, hash, id)
+	})
+}


### PR DESCRIPTION
## Description
Closes #1245 

I have added tests for all the files in `internal/cache` directory. This PR adds 84.8% coverage for the directory. 

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
