### PR TITLE
Added functionality to read and edit root principals and keys in TUI

### DIFF
--- a/experimental/gittuf/policy.go
+++ b/experimental/gittuf/policy.go
@@ -197,6 +197,26 @@ func (r *Repository) ListPrincipals(ctx context.Context, targetRef, policyName s
 	return metadata.GetPrincipals(), nil
 }
 
+// ListRootPrincipals returns the principals trusted for root metadata.
+func (r *Repository) ListRootPrincipals(ctx context.Context, targetRef string) ([]tuf.Principal, error) {
+	if !strings.HasPrefix(targetRef, "refs/gittuf/") {
+		targetRef = "refs/gittuf/" + targetRef
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, targetRef)
+	if err != nil {
+		return nil, err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return rootMetadata.GetRootPrincipals()
+}
+
 // ListGlobalRules returns a list of all global rules as an array of tuf.GlobalRules.
 func (r *Repository) ListGlobalRules(ctx context.Context, targetRef string) ([]tuf.GlobalRule, error) {
 	if !strings.HasPrefix(targetRef, "refs/gittuf/") {

--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -22,16 +22,18 @@ import (
 type screen int
 
 const (
-	screenLoading             screen = iota // Loading screen shown on startup
-	screenChoice                            // Initial menu
-	screenPolicy                            // Menu for Policy operations
-	screenPolicyRules                       // Rule management screen
-	screenPolicyAddRule                     // Form: add a new policy rule
-	screenPolicyEditRule                    // Form: edit selected rule (prefilled)
-	screenTrust                             // Menu for Trust operations
-	screenTrustGlobalRules                  // Global rule management screen
-	screenTrustAddGlobalRule                // Form: add a new global rule
-	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
+	screenLoading               screen = iota // Loading screen shown on startup
+	screenChoice                              // Initial menu
+	screenPolicy                              // Menu for Policy operations
+	screenPolicyRules                         // Rule management screen
+	screenPolicyAddRule                       // Form: add a new policy rule
+	screenPolicyEditRule                      // Form: edit selected rule (prefilled)
+	screenTrust                               // Menu for Trust operations
+	screenTrustRootPrincipals                 // Root principal management screen
+	screenTrustAddRootPrincipal               // Form: add a new root principal
+	screenTrustGlobalRules                    // Global rule management screen
+	screenTrustAddGlobalRule                  // Form: add a new global rule
+	screenTrustEditGlobalRule                 // Form: edit selected global rule (prefilled)
 )
 
 type item struct {
@@ -49,39 +51,42 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type model struct {
-	ctx              context.Context
-	screen           screen
-	spinner          spinner.Model
-	choiceList       list.Model
-	policyScreenList list.Model
-	trustScreenList  list.Model
-	rules            []rule
-	ruleList         list.Model
-	globalRules      []globalRule
-	globalRuleList   list.Model
-	inputs           []textinput.Model
-	focusIndex       int
-	cursorMode       cursor.Mode
-	repo             *gittuf.Repository
-	signer           dsse.SignerVerifier
-	policyName       string
-	options          *options
-	footer           string
-	errorMsg         string
-	readOnly         bool
-	confirmDelete    bool
-	deleteTarget     string
+	ctx               context.Context
+	screen            screen
+	spinner           spinner.Model
+	choiceList        list.Model
+	policyScreenList  list.Model
+	trustScreenList   list.Model
+	rootPrincipals    []rootPrincipal
+	rootPrincipalList list.Model
+	rules             []rule
+	ruleList          list.Model
+	globalRules       []globalRule
+	globalRuleList    list.Model
+	inputs            []textinput.Model
+	focusIndex        int
+	cursorMode        cursor.Mode
+	repo              *gittuf.Repository
+	signer            dsse.SignerVerifier
+	policyName        string
+	options           *options
+	footer            string
+	errorMsg          string
+	readOnly          bool
+	confirmDelete     bool
+	deleteTarget      string
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
 type initDoneMsg struct {
-	repo        *gittuf.Repository
-	signer      dsse.SignerVerifier
-	rules       []rule
-	globalRules []globalRule
-	readOnly    bool
-	footer      string
-	err         error
+	repo           *gittuf.Repository
+	signer         dsse.SignerVerifier
+	rootPrincipals []rootPrincipal
+	rules          []rule
+	globalRules    []globalRule
+	readOnly       bool
+	footer         string
+	err            error
 }
 
 // inputField describes a single text input's placeholder and prompt label.
@@ -159,10 +164,12 @@ func initialModel(ctx context.Context, o *options) model {
 			item{title: "View Rules", desc: "View and manage policy rules"},
 		}, delegate),
 		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
+			item{title: "View Root Principals", desc: "View and manage root principals/keys"},
 			item{title: "View Global Rules", desc: "View and manage global rules"},
 		}, delegate),
-		ruleList:       newMenuList("Policy Rules", []list.Item{}, delegate),
-		globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
+		rootPrincipalList: newMenuList("Root Principals", []list.Item{}, delegate),
+		ruleList:          newMenuList("Policy Rules", []list.Item{}, delegate),
+		globalRuleList:    newMenuList("Global Rules", []list.Item{}, delegate),
 	}
 
 	return m
@@ -193,12 +200,13 @@ func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
 		}
 
 		return initDoneMsg{
-			repo:        repo,
-			signer:      signer,
-			rules:       getCurrRules(ctx, o),
-			globalRules: getGlobalRules(ctx, o),
-			readOnly:    readOnly,
-			footer:      footer,
+			repo:           repo,
+			signer:         signer,
+			rootPrincipals: getRootPrincipals(ctx, o),
+			rules:          getCurrRules(ctx, o),
+			globalRules:    getGlobalRules(ctx, o),
+			readOnly:       readOnly,
+			footer:         footer,
 		}
 	}
 }
@@ -250,6 +258,21 @@ func (m *model) initGlobalRuleInputsPrefilled(gr globalRule) {
 	}
 }
 
+// initRootPrincipalInputs initializes the input field for root principal add form.
+func (m *model) initRootPrincipalInputs() {
+	m.inputs = initInputs([]inputField{
+		{"Enter Public Key Path Here", "Root Key Path:"},
+	})
+	m.inputs[0].CharLimit = 256
+	m.focusIndex = 0
+}
+
+// refreshRootPrincipals re-fetches root principals from the repo and rebuilds the list.
+func (m *model) refreshRootPrincipals() {
+	m.rootPrincipals = getRootPrincipals(m.ctx, m.options)
+	m.updateRootPrincipalList()
+}
+
 // refreshRules re-fetches rules from the repo and rebuilds the list.
 func (m *model) refreshRules() {
 	m.rules = getCurrRules(m.ctx, m.options)
@@ -260,6 +283,15 @@ func (m *model) refreshRules() {
 func (m *model) refreshGlobalRules() {
 	m.globalRules = getGlobalRules(m.ctx, m.options)
 	m.updateGlobalRuleList()
+}
+
+// updateRootPrincipalList updates the root principal list within the TUI.
+func (m *model) updateRootPrincipalList() {
+	items := make([]list.Item, len(m.rootPrincipals))
+	for i, principal := range m.rootPrincipals {
+		items[i] = item{title: principal.id, desc: principal.desc}
+	}
+	m.rootPrincipalList.SetItems(items)
 }
 
 // updateRuleList updates the rule list within the TUI.

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -6,6 +6,7 @@ package tui
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
@@ -17,6 +18,50 @@ type globalRule struct {
 	ruleType     string
 	rulePatterns []string
 	threshold    int
+}
+
+type rootPrincipal struct {
+	id   string
+	desc string
+}
+
+func principalDescription(keysCount int, keyTypes []string, customMetadata map[string]string) string {
+	desc := fmt.Sprintf("Keys: %d", keysCount)
+	if len(keyTypes) > 0 {
+		desc += fmt.Sprintf("\nKey types: %s", strings.Join(keyTypes, ", "))
+	}
+	if len(customMetadata) > 0 {
+		desc += fmt.Sprintf("\nCustom metadata entries: %d", len(customMetadata))
+	}
+	return desc
+}
+
+// getRootPrincipals returns a slice of rootPrincipal for the TUI.
+func getRootPrincipals(ctx context.Context, o *options) []rootPrincipal {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return nil
+	}
+
+	principals, err := repo.ListRootPrincipals(ctx, o.targetRef)
+	if err != nil {
+		return nil
+	}
+
+	currPrincipals := make([]rootPrincipal, len(principals))
+	for i, principal := range principals {
+		keyTypes := make([]string, 0, len(principal.Keys()))
+		for _, key := range principal.Keys() {
+			keyTypes = append(keyTypes, key.KeyType)
+		}
+
+		currPrincipals[i] = rootPrincipal{
+			id:   principal.ID(),
+			desc: principalDescription(len(principal.Keys()), keyTypes, principal.CustomMetadata()),
+		}
+	}
+
+	return currPrincipals
 }
 
 // getGlobalRules returns a slice of globalRule for the TUI
@@ -141,4 +186,49 @@ func repoUpdateGlobalRule(ctx context.Context, o *options, gr globalRule) error 
 	default:
 		return tuf.ErrUnknownGlobalRuleType
 	}
+}
+
+// repoAddRootPrincipal adds a root principal using a public key reference.
+func repoAddRootPrincipal(ctx context.Context, o *options, principalRef string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	principal, err := gittuf.LoadPublicKey(principalRef)
+	if err != nil {
+		return err
+	}
+
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	return repo.AddRootKey(ctx, signer, principal, true, opts...)
+}
+
+// repoRemoveRootPrincipal removes a root principal by principal ID.
+func repoRemoveRootPrincipal(ctx context.Context, o *options, principalID string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	return repo.RemoveRootKey(ctx, signer, strings.ToLower(principalID), true, opts...)
 }

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -27,10 +27,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.repo = msg.repo
 		m.signer = msg.signer
+		m.rootPrincipals = msg.rootPrincipals
 		m.rules = msg.rules
 		m.globalRules = msg.globalRules
 		m.readOnly = msg.readOnly
 		m.footer = msg.footer
+		m.updateRootPrincipalList()
 		m.updateRuleList()
 		m.updateGlobalRuleList()
 		m.screen = screenChoice
@@ -47,6 +49,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.choiceList.SetSize(msg.Width-h, msg.Height-v)
 		m.policyScreenList.SetSize(msg.Width-h, msg.Height-v)
 		m.trustScreenList.SetSize(msg.Width-h, msg.Height-v)
+		m.rootPrincipalList.SetSize(msg.Width-h, msg.Height-v)
 		m.ruleList.SetSize(msg.Width-h, msg.Height-v)
 		m.globalRuleList.SetSize(msg.Width-h, msg.Height-v)
 
@@ -63,6 +66,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
+				m.screen != screenTrustAddRootPrincipal &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
 				return m, tea.Quit
 			}
@@ -75,6 +79,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = screenPolicy
 			case screenPolicyAddRule, screenPolicyEditRule:
 				m.screen = screenPolicyRules
+			case screenTrustRootPrincipals:
+				m.screen = screenTrust
+			case screenTrustAddRootPrincipal:
+				m.screen = screenTrustRootPrincipals
 			case screenTrustGlobalRules:
 				m.screen = screenTrust
 			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
@@ -89,7 +97,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.String() == "enter" {
 				return m.handleEnter()
 			}
-		case screenPolicyRules, screenTrustGlobalRules:
+		case screenPolicyRules, screenTrustRootPrincipals, screenTrustGlobalRules:
 			return m.handleRulesListKey(msg)
 		case screenPolicyAddRule, screenPolicyEditRule:
 			if msg.String() == "enter" {
@@ -107,6 +115,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.cycleFocus(msg.String())
 				return m, nil
 			}
+		case screenTrustAddRootPrincipal:
+			if msg.String() == "enter" {
+				return m.handleRootPrincipalFormSubmit()
+			}
 		}
 	}
 
@@ -118,11 +130,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.policyScreenList, cmd = m.policyScreenList.Update(msg)
 	case screenTrust:
 		m.trustScreenList, cmd = m.trustScreenList.Update(msg)
+	case screenTrustRootPrincipals:
+		m.rootPrincipalList, cmd = m.rootPrincipalList.Update(msg)
 	case screenPolicyRules:
 		m.ruleList, cmd = m.ruleList.Update(msg)
 	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
-	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddRootPrincipal, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
 	}
 
@@ -147,9 +161,15 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 			m.refreshRules()
 		}
 	case screenTrust:
-		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
-			m.screen = screenTrustGlobalRules
-			m.refreshGlobalRules()
+		if i, ok := m.trustScreenList.SelectedItem().(item); ok {
+			switch i.title {
+			case "View Root Principals":
+				m.screen = screenTrustRootPrincipals
+				m.refreshRootPrincipals()
+			case "View Global Rules":
+				m.screen = screenTrustGlobalRules
+				m.refreshGlobalRules()
+			}
 		}
 	}
 	return m, nil
@@ -165,6 +185,9 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if m.screen == screenPolicyRules {
 				m.initRuleInputs()
 				m.screen = screenPolicyAddRule
+			} else if m.screen == screenTrustRootPrincipals {
+				m.initRootPrincipalInputs()
+				m.screen = screenTrustAddRootPrincipal
 			} else {
 				m.initGlobalRuleInputs()
 				m.screen = screenTrustAddGlobalRule
@@ -173,6 +196,9 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 		// edit rule
 		case "e":
+			if m.screen == screenTrustRootPrincipals {
+				break
+			}
 			if m.screen == screenPolicyRules {
 				if sel, ok := m.ruleList.SelectedItem().(item); ok {
 					for _, r := range m.rules {
@@ -201,6 +227,8 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			var ok bool
 			if m.screen == screenPolicyRules {
 				sel, ok = m.ruleList.SelectedItem().(item)
+			} else if m.screen == screenTrustRootPrincipals {
+				sel, ok = m.rootPrincipalList.SelectedItem().(item)
 			} else {
 				sel, ok = m.globalRuleList.SelectedItem().(item)
 			}
@@ -228,6 +256,8 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if m.screen == screenPolicyRules {
 		m.ruleList, cmd = m.ruleList.Update(msg)
+	} else if m.screen == screenTrustRootPrincipals {
+		m.rootPrincipalList, cmd = m.rootPrincipalList.Update(msg)
 	} else {
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
 	}
@@ -244,6 +274,13 @@ func (m model) handleDeleteConfirm(key string) (tea.Model, tea.Cmd) {
 			} else {
 				m.footer = "Rule removed successfully!"
 				m.refreshRules()
+			}
+		case screenTrustRootPrincipals:
+			if err := repoRemoveRootPrincipal(m.ctx, m.options, m.deleteTarget); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing root principal: %v", err)
+			} else {
+				m.footer = "Root principal removed!"
+				m.refreshRootPrincipals()
 			}
 		case screenTrustGlobalRules:
 			if err := repoRemoveGlobalRule(m.ctx, m.options, globalRule{ruleName: m.deleteTarget}); err != nil {
@@ -338,6 +375,25 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 		m.footer = "Global rule updated!"
 	}
 	m.screen = screenTrustGlobalRules
+	return m, nil
+}
+
+// handleRootPrincipalFormSubmit handles enter on root principal add form screen.
+func (m model) handleRootPrincipalFormSubmit() (tea.Model, tea.Cmd) {
+	keyRef := strings.TrimSpace(m.inputs[0].Value())
+	if keyRef == "" {
+		m.errorMsg = "Error: root key path cannot be empty"
+		return m, nil
+	}
+
+	if err := repoAddRootPrincipal(m.ctx, m.options, keyRef); err != nil {
+		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		return m, nil
+	}
+
+	m.refreshRootPrincipals()
+	m.footer = "Root principal added!"
+	m.screen = screenTrustRootPrincipals
 	return m, nil
 }
 

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -114,12 +114,24 @@ func screenTrustGlobalRulesHelp(readOnly bool) string {
 	)
 }
 
+// screenTrustRootPrincipalsHelp returns the help bar for the root principals view screen.
+func screenTrustRootPrincipalsHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"a: add  d: delete  esc: back  q: quit",
+	)
+}
+
 // renderDeleteOverlay renders the delete confirmation prompt.
 func renderDeleteOverlay(target string) string {
 	return lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FF0000")).
 		Bold(true).
-		Render(fmt.Sprintf("Delete rule %q? [y/n]", target))
+		Render(fmt.Sprintf("Delete %q? [y/n]", target))
 }
 
 // View renders the TUI.
@@ -143,6 +155,20 @@ func (m model) View() string {
 		return renderWithMargin(m.policyScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
 	case screenTrust:
 		return renderWithMargin(m.trustScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
+	case screenTrustRootPrincipals:
+		overlay := ""
+		if m.confirmDelete {
+			overlay = "\n" + renderDeleteOverlay(m.deleteTarget) + "\n"
+		}
+		hint := ""
+		if !m.readOnly {
+			hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+				"Run `gittuf trust apply` to apply staged changes to the selected policy file.",
+			)
+		}
+
+		emptyMsg := "No root principals configured. Press 'A' to add one."
+		return m.renderListScreen(m.rootPrincipalList, overlay+screenTrustRootPrincipalsHelp(m.readOnly)+hint, emptyMsg, len(m.rootPrincipals) == 0)
 	case screenPolicyRules:
 		overlay := ""
 		if m.confirmDelete {
@@ -179,6 +205,8 @@ func (m model) View() string {
 		return m.renderFormScreen("Add Global Rule")
 	case screenTrustEditGlobalRule:
 		return m.renderFormScreen("Edit Global Rule")
+	case screenTrustAddRootPrincipal:
+		return m.renderFormScreen("Add Root Principal")
 	default:
 		return "Unknown screen"
 	}


### PR DESCRIPTION
## Description
Addresses issue #1219 

Previously, the TUI Trust view only supported Global Rules. With this change, users can now view and modify root principals/keys from the same interface.

**What Changed**

- New screen: View Root Principals
- New actions: add and delete root principals
- Added form to add a root principal by key path/ref
- Added backend helpers to list/add/remove root principals
- Added repository API to list root principals from root metadata
- Kept existing read-only behavior and trust-apply workflow intact

<!-- Enter a description of what your pull request does. -->

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x]  I **did use** generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to understand the working of existing functions and structures. It helped to boost up my onboarding and reading the required files.
<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
