### PR TITLE
(feat) Adds TUI support for viewing and managing Root of Trust configuration in the gittuf interactive UI.

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd/tui/trust"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 )
@@ -29,6 +30,9 @@ const (
 	screenPolicyAddRule                     // Form: add a new policy rule
 	screenPolicyEditRule                    // Form: edit selected rule (prefilled)
 	screenTrust                             // Menu for Trust operations
+	screenTrustRootConfig                   // Root configuration view screen
+	screenTrustRootKeys                     // Root principals list screen
+	screenTrustAddRootKey                   // Form: add a root principal/key
 	screenTrustGlobalRules                  // Global rule management screen
 	screenTrustAddGlobalRule                // Form: add a new global rule
 	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
@@ -71,6 +75,8 @@ type model struct {
 	readOnly         bool
 	confirmDelete    bool
 	deleteTarget     string
+	trustConfig      trust.Model
+	rootKeyList      list.Model
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -159,9 +165,11 @@ func initialModel(ctx context.Context, o *options) model {
 			item{title: "View Rules", desc: "View and manage policy rules"},
 		}, delegate),
 		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
+			item{title: "View Root Configuration", desc: "View and manage Root metadata"},
 			item{title: "View Global Rules", desc: "View and manage global rules"},
 		}, delegate),
 		ruleList:       newMenuList("Policy Rules", []list.Item{}, delegate),
+		rootKeyList:    newMenuList("Root Principals", []list.Item{}, delegate),
 		globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
 	}
 
@@ -260,6 +268,33 @@ func (m *model) refreshRules() {
 func (m *model) refreshGlobalRules() {
 	m.globalRules = getGlobalRules(m.ctx, m.options)
 	m.updateGlobalRuleList()
+}
+
+// refreshRootConfig re-fetches root metadata configuration and principal keys.
+func (m *model) refreshRootConfig() {
+	config, err := getRootConfig(m.ctx, m.options)
+	if err != nil {
+		m.errorMsg = fmt.Sprintf("Error loading root configuration: %v", err)
+		return
+	}
+	m.trustConfig = config
+	m.updateRootKeyList()
+}
+
+// updateRootKeyList updates the root principals list within the TUI.
+func (m *model) updateRootKeyList() {
+	items := make([]list.Item, len(m.trustConfig.Principals))
+	for i, keyID := range m.trustConfig.Principals {
+		items[i] = item{title: keyID, desc: ""}
+	}
+	m.rootKeyList.SetItems(items)
+}
+
+func (m *model) initRootKeyInputs() {
+	m.inputs = initInputs([]inputField{
+		{"Enter root principal reference (gpg:<id>, fulcio:<identity>, or file path)", "Principal Key:"},
+	})
+	m.focusIndex = 0
 }
 
 // updateRuleList updates the rule list within the TUI.

--- a/internal/cmd/tui/root.go
+++ b/internal/cmd/tui/root.go
@@ -1,0 +1,36 @@
+package tui
+
+import (
+	"gittuf/internal/cmd/tui/trust"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type MainModel struct {
+	trustSubModel trust.Model
+	ready         bool
+}
+
+func (m MainModel) Init() tea.Cmd {
+	return m.trustSubModel.Init()
+}
+
+func (m MainModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" || msg.String() == "q" {
+			return m, tea.Quit
+		}
+	case trust.UpdatedTrustMsg:
+		// Handle global state updates or persist to gittuf config here
+	}
+
+	// Delegate to the trust sub-module
+	var cmd tea.Cmd
+	m.trustSubModel, cmd = m.trustSubModel.Update(msg)
+	return m, cmd
+}
+
+func (m MainModel) View() string {
+	return m.trustSubModel.View()
+}

--- a/internal/cmd/tui/root.go
+++ b/internal/cmd/tui/root.go
@@ -1,7 +1,7 @@
 package tui
 
 import (
-	"gittuf/internal/cmd/tui/trust"
+	"github.com/gittuf/gittuf/internal/cmd/tui/trust"
 
 	tea "github.com/charmbracelet/bubbletea"
 )

--- a/internal/cmd/tui/trust/model.go
+++ b/internal/cmd/tui/trust/model.go
@@ -6,20 +6,27 @@ import (
 )
 
 type Model struct {
-	Threshold int
-	RepoPath  textinput.Model
-	IsEditing bool
+	Threshold  int
+	RepoPath   textinput.Model
+	Principals []string
+	IsEditing  bool
+
+	OriginalThreshold int
+	OriginalRepoPath  string
 }
 
-func InitialModel(initialPath string, initialThreshold int) Model {
+func InitialModel(initialPath string, initialThreshold int, principals []string) Model {
 	ti := textinput.New()
 	ti.Placeholder = "Enter repository path..."
 	ti.SetValue(initialPath)
 
 	return Model{
-		Threshold: initialThreshold,
-		RepoPath:  ti,
-		IsEditing: false,
+		Threshold:         initialThreshold,
+		RepoPath:          ti,
+		Principals:        principals,
+		IsEditing:         false,
+		OriginalThreshold: initialThreshold,
+		OriginalRepoPath:  initialPath,
 	}
 }
 

--- a/internal/cmd/tui/trust/model.go
+++ b/internal/cmd/tui/trust/model.go
@@ -1,0 +1,28 @@
+package trust
+
+import (
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type Model struct {
+	Threshold int
+	RepoPath  textinput.Model
+	IsEditing bool
+}
+
+func InitialModel(initialPath string, initialThreshold int) Model {
+	ti := textinput.New()
+	ti.Placeholder = "Enter repository path..."
+	ti.SetValue(initialPath)
+
+	return Model{
+		Threshold: initialThreshold,
+		RepoPath:  ti,
+		IsEditing: false,
+	}
+}
+
+func (m Model) Init() tea.Cmd {
+	return nil
+}

--- a/internal/cmd/tui/trust/update.go
+++ b/internal/cmd/tui/trust/update.go
@@ -26,6 +26,15 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return UpdatedTrustMsg{Threshold: m.Threshold, RepoPath: m.RepoPath.Value()}
 			}
 
+		case "s":
+			if m.IsEditing {
+				m.IsEditing = false
+				m.RepoPath.Blur()
+			}
+			return m, func() tea.Msg {
+				return UpdatedTrustMsg{Threshold: m.Threshold, RepoPath: m.RepoPath.Value()}
+			}
+
 		case "up", "down":
 			if !m.IsEditing {
 				if msg.String() == "up" {

--- a/internal/cmd/tui/trust/update.go
+++ b/internal/cmd/tui/trust/update.go
@@ -12,9 +12,8 @@ type UpdatedTrustMsg struct {
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	var cmd tea.Cmd
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
 		case "e":
 			m.IsEditing = !m.IsEditing
 			if m.IsEditing {
@@ -35,14 +34,13 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 				return UpdatedTrustMsg{Threshold: m.Threshold, RepoPath: m.RepoPath.Value()}
 			}
 
-		case "up", "down":
+		case "up":
 			if !m.IsEditing {
-				if msg.String() == "up" {
-					m.Threshold++
-				}
-				if msg.String() == "down" && m.Threshold > 1 {
-					m.Threshold--
-				}
+				m.Threshold++
+			}
+		case "down":
+			if !m.IsEditing && m.Threshold > 1 {
+				m.Threshold--
 			}
 		}
 	}

--- a/internal/cmd/tui/trust/update.go
+++ b/internal/cmd/tui/trust/update.go
@@ -1,0 +1,45 @@
+package trust
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type UpdatedTrustMsg struct {
+	Threshold int
+	RepoPath  string
+}
+
+func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "e":
+			m.IsEditing = !m.IsEditing
+			if m.IsEditing {
+				return m, m.RepoPath.Focus()
+			}
+			m.RepoPath.Blur()
+			// Return a message to notify the parent of the save
+			return m, func() tea.Msg {
+				return UpdatedTrustMsg{Threshold: m.Threshold, RepoPath: m.RepoPath.Value()}
+			}
+
+		case "up", "down":
+			if !m.IsEditing {
+				if msg.String() == "up" {
+					m.Threshold++
+				}
+				if msg.String() == "down" && m.Threshold > 1 {
+					m.Threshold--
+				}
+			}
+		}
+	}
+
+	if m.IsEditing {
+		m.RepoPath, cmd = m.RepoPath.Update(msg)
+	}
+	return m, cmd
+}

--- a/internal/cmd/tui/trust/view.go
+++ b/internal/cmd/tui/trust/view.go
@@ -1,0 +1,27 @@
+package trust
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	styleTitle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("5"))
+	styleHint  = lipgloss.NewStyle().Italic(true).Foreground(lipgloss.Color("240"))
+)
+
+func (m Model) View() string {
+	s := styleTitle.Render("Root of Trust Configuration") + "\n\n"
+
+	s += fmt.Sprintf("Threshold: %d (Use ↑/↓ to change)\n", m.Threshold)
+	s += fmt.Sprintf("Repository: %s\n\n", m.RepoPath.View())
+
+	if m.IsEditing {
+		s += styleHint.Render("(Press 'e' to save)")
+	} else {
+		s += styleHint.Render("(Press 'e' to edit path, 'q' to quit)")
+	}
+
+	return s
+}

--- a/internal/cmd/tui/trust/view.go
+++ b/internal/cmd/tui/trust/view.go
@@ -17,10 +17,20 @@ func (m Model) View() string {
 	s += fmt.Sprintf("Threshold: %d (Use ↑/↓ to change)\n", m.Threshold)
 	s += fmt.Sprintf("Repository: %s\n\n", m.RepoPath.View())
 
-	if m.IsEditing {
-		s += styleHint.Render("(Press 'e' to save)")
+	s += "Root Principals:\n"
+	if len(m.Principals) == 0 {
+		s += "  None configured\n\n"
 	} else {
-		s += styleHint.Render("(Press 'e' to edit path, 'q' to quit)")
+		for _, principalID := range m.Principals {
+			s += fmt.Sprintf("  %s\n", principalID)
+		}
+		s += "\n"
+	}
+
+	if m.IsEditing {
+		s += styleHint.Render("(Press 'e' or 's' to save)")
+	} else {
+		s += styleHint.Render("(Press 'e' to edit path, 's' to save changes, 'q' to quit)")
 	}
 
 	return s

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd/tui/trust"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
 	"github.com/gittuf/gittuf/internal/tuf"
 )
 
@@ -141,4 +144,113 @@ func repoUpdateGlobalRule(ctx context.Context, o *options, gr globalRule) error 
 	default:
 		return tuf.ErrUnknownGlobalRuleType
 	}
+}
+
+// getRootConfig returns the root configuration state for the TUI.
+func getRootConfig(ctx context.Context, o *options) (trust.Model, error) {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return trust.Model{}, err
+	}
+
+	state, err := policy.LoadCurrentState(ctx, repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	if err != nil {
+		return trust.Model{}, err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return trust.Model{}, err
+	}
+
+	threshold, err := rootMetadata.GetRootThreshold()
+	if err != nil {
+		return trust.Model{}, err
+	}
+
+	principals, err := rootMetadata.GetRootPrincipals()
+	if err != nil {
+		return trust.Model{}, err
+	}
+
+	principalIDs := make([]string, len(principals))
+	for i, principal := range principals {
+		principalIDs[i] = principal.ID()
+	}
+
+	return trust.InitialModel(rootMetadata.GetRepositoryLocation(), threshold, principalIDs), nil
+}
+
+func repoUpdateRootConfig(ctx context.Context, o *options, updated trust.UpdatedTrustMsg, current trust.Model) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	if updated.Threshold != current.OriginalThreshold {
+		if err := repo.UpdateRootThreshold(ctx, signer, updated.Threshold, true, opts...); err != nil {
+			return err
+		}
+	}
+
+	if updated.RepoPath != current.OriginalRepoPath {
+		if err := repo.SetRepositoryLocation(ctx, signer, updated.RepoPath, true, opts...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func repoAddRootKey(ctx context.Context, o *options, keyRef string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	newRootKey, err := gittuf.LoadPublicKey(keyRef)
+	if err != nil {
+		return err
+	}
+
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	return repo.AddRootKey(ctx, signer, newRootKey, true, opts...)
+}
+
+func repoRemoveRootKey(ctx context.Context, o *options, keyID string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	var opts []trustpolicyopts.Option
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	return repo.RemoveRootKey(ctx, signer, keyID, true, opts...)
 }

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/gittuf/gittuf/internal/cmd/tui/trust"
 	"github.com/gittuf/gittuf/internal/tuf"
 )
 
@@ -34,6 +35,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.updateRuleList()
 		m.updateGlobalRuleList()
 		m.screen = screenChoice
+		return m, nil
+
+	case trust.UpdatedTrustMsg:
+		if m.screen == screenTrustRootConfig {
+			if err := repoUpdateRootConfig(m.ctx, m.options, msg, m.trustConfig); err != nil {
+				m.errorMsg = fmt.Sprintf("Error saving root config: %v", err)
+				return m, nil
+			}
+			m.footer = "Root configuration updated!"
+			m.refreshRootConfig()
+		}
 		return m, nil
 
 	case spinner.TickMsg:
@@ -75,6 +87,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = screenPolicy
 			case screenPolicyAddRule, screenPolicyEditRule:
 				m.screen = screenPolicyRules
+			case screenTrustRootConfig, screenTrustRootKeys:
+				m.screen = screenTrust
+			case screenTrustAddRootKey:
+				m.screen = screenTrustRootKeys
 			case screenTrustGlobalRules:
 				m.screen = screenTrust
 			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
@@ -89,8 +105,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.String() == "enter" {
 				return m.handleEnter()
 			}
-		case screenPolicyRules, screenTrustGlobalRules:
+		case screenPolicyRules, screenTrustGlobalRules, screenTrustRootKeys:
 			return m.handleRulesListKey(msg)
+		case screenTrustRootConfig:
+			if msg.String() == "p" {
+				m.screen = screenTrustRootKeys
+				m.refreshRootConfig()
+				return m, nil
+			}
+			m.trustConfig, cmd = m.trustConfig.Update(msg)
+			return m, cmd
 		case screenPolicyAddRule, screenPolicyEditRule:
 			if msg.String() == "enter" {
 				return m.handlePolicyFormSubmit()
@@ -102,6 +126,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 			if msg.String() == "enter" {
 				return m.handleGlobalFormSubmit()
+			}
+			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
+				m.cycleFocus(msg.String())
+				return m, nil
+			}
+		case screenTrustAddRootKey:
+			if msg.String() == "enter" {
+				return m.handleRootKeyFormSubmit()
 			}
 			if msg.String() == "tab" || msg.String() == "shift+tab" || msg.String() == "up" || msg.String() == "down" {
 				m.cycleFocus(msg.String())
@@ -122,7 +154,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.ruleList, cmd = m.ruleList.Update(msg)
 	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
-	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+	case screenTrustRootKeys:
+		m.rootKeyList, cmd = m.rootKeyList.Update(msg)
+	case screenTrustRootConfig:
+		m.trustConfig, cmd = m.trustConfig.Update(msg)
+	case screenPolicyAddRule, screenPolicyEditRule, screenTrustAddGlobalRule, screenTrustEditGlobalRule, screenTrustAddRootKey:
 		m.inputs[m.focusIndex], cmd = m.inputs[m.focusIndex].Update(msg)
 	}
 
@@ -147,9 +183,15 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 			m.refreshRules()
 		}
 	case screenTrust:
-		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
-			m.screen = screenTrustGlobalRules
-			m.refreshGlobalRules()
+		if sel, ok := m.trustScreenList.SelectedItem().(item); ok {
+			switch sel.title {
+			case "View Root Configuration":
+				m.screen = screenTrustRootConfig
+				m.refreshRootConfig()
+			case "View Global Rules":
+				m.screen = screenTrustGlobalRules
+				m.refreshGlobalRules()
+			}
 		}
 	}
 	return m, nil
@@ -160,14 +202,18 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if !m.readOnly {
 		switch msg.String() {
-		// add rule
+		// add rule/root key
 		case "a":
-			if m.screen == screenPolicyRules {
+			switch m.screen {
+			case screenPolicyRules:
 				m.initRuleInputs()
 				m.screen = screenPolicyAddRule
-			} else {
+			case screenTrustGlobalRules:
 				m.initGlobalRuleInputs()
 				m.screen = screenTrustAddGlobalRule
+			case screenTrustRootKeys:
+				m.initRootKeyInputs()
+				m.screen = screenTrustAddRootKey
 			}
 			return m, nil
 
@@ -183,7 +229,7 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 						}
 					}
 				}
-			} else {
+			} else if m.screen == screenTrustGlobalRules {
 				if sel, ok := m.globalRuleList.SelectedItem().(item); ok {
 					for _, gr := range m.globalRules {
 						if gr.ruleName == sel.title {
@@ -195,14 +241,17 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				}
 			}
 
-		// delete rule
+		// delete rule/root key
 		case "d":
 			var sel item
 			var ok bool
-			if m.screen == screenPolicyRules {
+			switch m.screen {
+			case screenPolicyRules:
 				sel, ok = m.ruleList.SelectedItem().(item)
-			} else {
+			case screenTrustGlobalRules:
 				sel, ok = m.globalRuleList.SelectedItem().(item)
+			case screenTrustRootKeys:
+				sel, ok = m.rootKeyList.SelectedItem().(item)
 			}
 			if ok {
 				m.confirmDelete = true
@@ -226,10 +275,13 @@ func (m model) handleRulesListKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	// Delegate unhandled keys to the active list for navigation (up/down arrows, etc.)
 	var cmd tea.Cmd
-	if m.screen == screenPolicyRules {
+	switch m.screen {
+	case screenPolicyRules:
 		m.ruleList, cmd = m.ruleList.Update(msg)
-	} else {
+	case screenTrustGlobalRules:
 		m.globalRuleList, cmd = m.globalRuleList.Update(msg)
+	case screenTrustRootKeys:
+		m.rootKeyList, cmd = m.rootKeyList.Update(msg)
 	}
 	return m, cmd
 }
@@ -251,6 +303,13 @@ func (m model) handleDeleteConfirm(key string) (tea.Model, tea.Cmd) {
 			} else {
 				m.footer = "Global rule removed!"
 				m.refreshGlobalRules()
+			}
+		case screenTrustRootKeys:
+			if err := repoRemoveRootKey(m.ctx, m.options, m.deleteTarget); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing root principal: %v", err)
+			} else {
+				m.footer = "Root principal removed!"
+				m.refreshRootConfig()
 			}
 		}
 	}
@@ -338,6 +397,29 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 		m.footer = "Global rule updated!"
 	}
 	m.screen = screenTrustGlobalRules
+	return m, nil
+}
+
+func (m model) handleRootKeyFormSubmit() (tea.Model, tea.Cmd) {
+	if m.focusIndex < len(m.inputs)-1 {
+		m.cycleFocus("tab")
+		return m, nil
+	}
+
+	keyRef := strings.TrimSpace(m.inputs[0].Value())
+	if keyRef == "" {
+		m.errorMsg = "Principal key reference is required"
+		return m, nil
+	}
+
+	if err := repoAddRootKey(m.ctx, m.options, keyRef); err != nil {
+		m.errorMsg = fmt.Sprintf("Error adding root principal: %v", err)
+		return m, nil
+	}
+
+	m.refreshRootConfig()
+	m.footer = "Root principal added!"
+	m.screen = screenTrustRootKeys
 	return m, nil
 }
 

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -103,6 +103,28 @@ func screenPolicyRulesHelp(readOnly bool) string {
 }
 
 // screenTrustGlobalRulesHelp returns the help bar for the global rules view screen.
+func screenTrustRootConfigHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"p: principals  esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"p: principals  e: edit repo location  s: save changes  ↑/↓: change threshold  esc: back  q: quit",
+	)
+}
+
+func screenTrustRootKeysHelp(readOnly bool) string {
+	if readOnly {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+			"esc: back  q: quit",
+		)
+	}
+	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
+		"a: add  d: delete  esc: back  q: quit",
+	)
+}
+
 func screenTrustGlobalRulesHelp(readOnly bool) string {
 	if readOnly {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
@@ -171,6 +193,25 @@ func (m model) View() string {
 
 		emptyMsg := "No rules configured. Press 'A' to add one."
 		return m.renderListScreen(m.globalRuleList, overlay+screenTrustGlobalRulesHelp(m.readOnly)+hint, emptyMsg, len(m.globalRules) == 0)
+	case screenTrustRootConfig:
+		hint := ""
+		if !m.readOnly {
+			hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+				"Run `gittuf trust apply` to apply staged changes to root metadata.",
+			)
+		}
+		return renderWithMargin(
+			m.trustConfig.View() + "\n" + screenTrustRootConfigHelp(m.readOnly) + hint + renderErrorMsg(m.errorMsg) + "\n" + renderFooter(m.footer),
+		)
+	case screenTrustRootKeys:
+		overlay := ""
+		if m.confirmDelete {
+			overlay = "\n" + renderDeleteOverlay(m.deleteTarget) + "\n"
+		}
+		emptyMsg := "No root principals configured. Press 'A' to add one."
+		return m.renderListScreen(m.rootKeyList, overlay+screenTrustRootKeysHelp(m.readOnly), emptyMsg, len(m.trustConfig.Principals) == 0)
+	case screenTrustAddRootKey:
+		return m.renderFormScreen("Add Root Key")
 	case screenPolicyAddRule:
 		return m.renderFormScreen("Add Rule")
 	case screenPolicyEditRule:


### PR DESCRIPTION
## Description

Adds TUI support for viewing and managing Root of Trust configuration in the gittuf interactive UI.

- Adds a new `Trust -> View Root Configuration` TUI screen.
- Displays and allows editing of:
  - root threshold
  - repository location
  - root principals / keys
- Adds navigation between root configuration and root principals screens.
- Adds helper functions for loading and updating root metadata via the repository backend.
- Includes UI and model changes in tui and its trust submodule.

## Solves issue: #1220
## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used AI to analyse the existing codebase.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).

<img width="778" height="326" alt="image" src="https://github.com/user-attachments/assets/ef1c2198-7001-4248-b7ca-558a6b5ba9ec" />
