### PR TITLE
cmd, display: Filter rsl log for one or more references

### DIFF
--- a/docs/cli/gittuf_rsl_log.md
+++ b/docs/cli/gittuf_rsl_log.md
@@ -13,7 +13,8 @@ gittuf rsl log [flags]
 ### Options
 
 ```
-  -h, --help   help for log
+  -h, --help              help for log
+      --ref stringArray   only display RSL entries for the specified references
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/rsl/log/log.go
+++ b/internal/cmd/rsl/log/log.go
@@ -11,9 +11,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type options struct{}
+type options struct {
+	refs []string
+}
 
-func (o *options) AddFlags(_ *cobra.Command) {}
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringArrayVar(
+		&o.refs,
+		"ref",
+		nil,
+		"only display RSL entries for the specified references",
+	)
+}
 
 func (o *options) Run(_ *cobra.Command, _ []string) error {
 	repo, err := gittuf.LoadRepository(".")
@@ -21,7 +30,7 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return display.RSLLog(repo.GetGitRepository(), display.NewDisplayWriter(os.Stdout))
+	return display.RSLLog(repo.GetGitRepository(), display.NewDisplayWriter(os.Stdout), display.WithReferences(o.refs))
 }
 
 func New() *cobra.Command {

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -10,13 +10,31 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 )
 
+type options struct {
+	refs *set.Set[string]
+}
+
+type Option func(*options)
+
+func WithReferences(refs []string) Option {
+	return func(o *options) {
+		o.refs = set.NewSetFromItems(refs...)
+	}
+}
+
 // RSLLog implements the display function for `gittuf rsl log`.
-func RSLLog(repo *gitinterface.Repository, writer io.WriteCloser) error {
+func RSLLog(repo *gitinterface.Repository, writer io.WriteCloser, opts ...Option) error {
 	defer writer.Close() //nolint:errcheck
+
+	options := &options{refs: set.NewSet[string]()}
+	for _, fn := range opts {
+		fn(options)
+	}
 
 	annotationsMap := make(map[string][]*rsl.AnnotationEntry)
 
@@ -40,6 +58,15 @@ func RSLLog(repo *gitinterface.Repository, writer io.WriteCloser) error {
 
 		switch iteratorEntry := iteratorEntry.(type) {
 		case *rsl.ReferenceEntry:
+			if options.refs.Len() != 0 && !options.refs.Has(iteratorEntry.RefName) {
+				// Skip this entry if it's not for the specified ref. Note that
+				// we still want to track annotation entries for this entry (if
+				// there are any) since they may apply to other entries that we
+				// do want to display.
+				slog.Debug(fmt.Sprintf("Skipping reference entry '%s' since it is for ref '%s'...", iteratorEntry.ID.String(), iteratorEntry.RefName))
+				break
+			}
+
 			slog.Debug(fmt.Sprintf("Writing reference entry '%s'...", iteratorEntry.ID.String()))
 			if err := writeRSLReferenceEntry(writer, iteratorEntry, annotationsMap[iteratorEntry.ID.String()], hasParent); err != nil {
 				// We return nil here to avoid noisy output when the writer is
@@ -59,6 +86,15 @@ func RSLLog(repo *gitinterface.Repository, writer io.WriteCloser) error {
 			}
 
 		case *rsl.PropagationEntry:
+			if options.refs.Len() != 0 && !options.refs.Has(iteratorEntry.RefName) {
+				// Skip this entry if it's not for the specified ref. Note that
+				// we still want to track annotation entries for this entry (if
+				// there are any) since they may apply to other entries that we
+				// do want to display.
+				slog.Debug(fmt.Sprintf("Skipping propagation entry '%s' since it is for ref '%s'...", iteratorEntry.ID.String(), iteratorEntry.RefName))
+				break
+			}
+
 			slog.Debug(fmt.Sprintf("Writing propagation entry '%s'...", iteratorEntry.ID.String()))
 			if err := writeRSLPropagationEntry(writer, iteratorEntry, hasParent); err != nil {
 				// We return nil here to avoid noisy output when

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -14,50 +14,51 @@ import (
 )
 
 func TestRSLLog(t *testing.T) {
-	tmpDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+	t.Run("without filtering refs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-	// add first entry
-	if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// add first entry
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo)
-	if err != nil {
-		t.Fatal(err)
-	}
+		entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// skip annotation
-	if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, true, "msg").Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// skip annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, true, "msg").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	// add another entry
-	if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// add another entry
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	// add another entry
-	if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// add another entry
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	entry, _, err = rsl.GetLatestReferenceUpdaterEntry(repo)
-	if err != nil {
-		t.Fatal(err)
-	}
+		entry, _, err = rsl.GetLatestReferenceUpdaterEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	// skip annotation
-	if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, true, "msg").Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// skip annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, true, "msg").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	// non-skip annotation
-	if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, false, "msg").Commit(repo, false); err != nil {
-		t.Fatal(err)
-	}
+		// non-skip annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, false, "msg").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
 
-	expectedOutput := `entry 2d21a6b9fb1f3e432e0776eac63acdc23a57b538 (skipped)
+		expectedOutput := `entry 2d21a6b9fb1f3e432e0776eac63acdc23a57b538 (skipped)
 
   Ref:    refs/heads/main
   Target: 0000000000000000000000000000000000000000
@@ -94,11 +95,67 @@ entry ae4467eaa656782fe9d04eaabfa30db47e9ea24b (skipped)
       msg
 `
 
-	output := &bytes.Buffer{}
-	writer := &noopwritecloser{writer: output}
-	err = RSLLog(repo, writer)
-	assert.Nil(t, err)
-	assert.Equal(t, expectedOutput, output.String())
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		err = RSLLog(repo, writer)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("with filtering refs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		// add first entry
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// skip annotation
+		if err := rsl.NewAnnotationEntry([]gitinterface.Hash{entry.GetID()}, true, "msg").Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// add another entry -- not for main
+		if err := rsl.NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// add another entry
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedOutput := `entry 916d8f11c106d58ac48143cfb2cd4ff43ec82dd7
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 4
+
+entry ae4467eaa656782fe9d04eaabfa30db47e9ea24b (skipped)
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+
+    Annotation ID: f79156492abec45bb2e1dbc518999a83b31a069c
+    Skip:          yes
+    Number:        2
+    Message:
+      msg
+`
+
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		err = RSLLog(repo, writer, WithReferences([]string{"refs/heads/main"}))
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
 }
 
 func TestWriteRSLReferenceEntry(t *testing.T) {


### PR DESCRIPTION
## Description

Support filtering the output of gittuf rsl log by one or more references.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

N/A

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
