### PR TITLE
trust: add add-root-person command to support persons in root metadata

### DIFF
--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -35,6 +35,7 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
 * [gittuf trust add-policy-key](gittuf_trust_add-policy-key.md)	 - Add Policy key to gittuf root of trust
 * [gittuf trust add-propagation-directive](gittuf_trust_add-propagation-directive.md)	 - Add propagation directive into gittuf root of trust
 * [gittuf trust add-root-key](gittuf_trust_add-root-key.md)	 - Add Root key to gittuf root of trust
+* [gittuf trust add-root-person](gittuf_trust_add-root-person.md)	 - Add a trusted person to gittuf root of trust
 * [gittuf trust apply](gittuf_trust_apply.md)	 - Validate and apply changes from policy-staging to policy
 * [gittuf trust disable-github-app-approvals](gittuf_trust_disable-github-app-approvals.md)	 - Mark GitHub app approvals as untrusted henceforth
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth

--- a/docs/cli/gittuf_trust_add-root-person.md
+++ b/docs/cli/gittuf_trust_add-root-person.md
@@ -1,0 +1,38 @@
+## gittuf trust add-root-person
+
+Add a trusted person to gittuf root of trust
+
+### Synopsis
+
+The 'add-root-person' command adds a trusted person to the repository's root of trust. A person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom'). Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". Optionally, the change can be recorded in the RSL.
+
+```
+gittuf trust add-root-person [flags]
+```
+
+### Options
+
+```
+      --associated-identity stringArray   identities on code review platforms in the form 'providerID::identity' (e.g., 'https://gittuf.dev/github-app::<username>+<user ID>')
+      --custom stringArray                additional custom metadata in the form KEY=VALUE
+  -h, --help                              help for add-root-person
+      --person-ID string                  person ID
+      --public-key stringArray            authorized public key for person
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+

--- a/experimental/gittuf/root.go
+++ b/experimental/gittuf/root.go
@@ -202,6 +202,47 @@ func (r *Repository) AddRootKey(ctx context.Context, signer sslibdsse.SignerVeri
 	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, options.CreateRSLEntry, signCommit)
 }
 
+// AddRootPerson is the interface for the user to add an authorized person
+// for the Root role.
+func (r *Repository) AddRootPerson(ctx context.Context, signer sslibdsse.SignerVerifier, person tuf.Principal, signCommit bool, opts ...trustpolicyopts.Option) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		err := r.r.CanSign()
+		if err != nil {
+			return err
+		}
+	}
+
+	options := &trustpolicyopts.Options{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	rootKeyID, err := signer.KeyID()
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyStagingRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := r.loadRootMetadata(state, rootKeyID)
+	if err != nil {
+		return err
+	}
+
+	slog.Debug("Adding root person...")
+	if err := rootMetadata.AddRootPrincipal(person); err != nil {
+		return err
+	}
+
+	commitMessage := fmt.Sprintf("Add root person '%s' to root", person.ID())
+	return r.updateRootMetadata(ctx, state, signer, rootMetadata, commitMessage, options.CreateRSLEntry, signCommit)
+}
+
 // RemoveRootKey is the interface for the user to de-authorize a key
 // trusted to sign the Root role.
 func (r *Repository) RemoveRootKey(ctx context.Context, signer sslibdsse.SignerVerifier, keyID string, signCommit bool, opts ...trustpolicyopts.Option) error {

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -273,6 +273,107 @@ func TestAddRootKey(t *testing.T) {
 	})
 }
 
+func TestAddRootPerson(t *testing.T) {
+	r := createTestRepositoryWithRoot(t, "")
+
+	sv := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+	originalKeyID, err := sv.KeyID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	personKey := tufv02.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
+	person := &tufv02.Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*tufv02.Key{personKey.ID(): personKey},
+	}
+
+	err = r.AddRootPerson(testCtx, sv, person, false)
+	assert.Nil(t, err)
+	err = r.StagePolicy(testCtx, "", true, false)
+	require.Nil(t, err)
+
+	state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	assert.Nil(t, err)
+
+	assert.Equal(t, originalKeyID, state.Metadata.RootEnvelope.Signatures[0].KeyID)
+	assert.True(t, getRootPrincipalIDs(t, rootMetadata).Has(person.PersonID))
+
+	_, err = dsse.VerifyEnvelope(testCtx, state.Metadata.RootEnvelope, []sslibdsse.Verifier{sv}, 1)
+	assert.Nil(t, err)
+
+	t.Run("unauthorized signer", func(t *testing.T) {
+		r := createTestRepositoryWithRoot(t, "")
+		unauthorizedSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
+
+		personKey := tufv02.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
+		person := &tufv02.Person{
+			PersonID:   "jane.doe",
+			PublicKeys: map[string]*tufv02.Key{personKey.ID(): personKey},
+		}
+
+		err := r.AddRootPerson(testCtx, unauthorizedSigner, person, false)
+		assert.ErrorIs(t, err, ErrUnauthorizedKey)
+	})
+
+	t.Run("with associated identities and custom metadata", func(t *testing.T) {
+		r := createTestRepositoryWithRoot(t, "")
+		sv := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		personKey := tufv02.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
+		person := &tufv02.Person{
+			PersonID:             "jane.doe",
+			PublicKeys:           map[string]*tufv02.Key{personKey.ID(): personKey},
+			AssociatedIdentities: map[string]string{"github": "janedoe+12345"},
+			Custom:               map[string]string{"team": "security"},
+		}
+
+		err := r.AddRootPerson(testCtx, sv, person, false)
+		assert.Nil(t, err)
+		err = r.StagePolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+
+		state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rootMetadata, err := state.GetRootMetadata(false)
+		assert.Nil(t, err)
+		assert.True(t, getRootPrincipalIDs(t, rootMetadata).Has(person.PersonID))
+	})
+
+	t.Run("with signCommit", func(t *testing.T) {
+		r := createTestRepositoryWithRoot(t, "")
+		sv := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		personKey := tufv02.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targetsPubKeyBytes))
+		person := &tufv02.Person{
+			PersonID:   "jane.doe",
+			PublicKeys: map[string]*tufv02.Key{personKey.ID(): personKey},
+		}
+
+		err := r.AddRootPerson(testCtx, sv, person, true)
+		assert.Nil(t, err)
+		err = r.StagePolicy(testCtx, "", true, false)
+		require.Nil(t, err)
+
+		state, err := policy.LoadCurrentState(testCtx, r.r, policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rootMetadata, err := state.GetRootMetadata(false)
+		assert.Nil(t, err)
+		assert.True(t, getRootPrincipalIDs(t, rootMetadata).Has(person.PersonID))
+	})
+}
+
 func TestRemoveRootKey(t *testing.T) {
 	r := createTestRepositoryWithRoot(t, "")
 

--- a/internal/cmd/trust/addrootperson/addrootperson.go
+++ b/internal/cmd/trust/addrootperson/addrootperson.go
@@ -1,0 +1,122 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package addrootperson
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p                    *persistent.Options
+	personID             string
+	publicKeys           []string
+	associatedIdentities []string
+	customMetadata       []string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.personID,
+		"person-ID",
+		"",
+		"person ID",
+	)
+	cmd.MarkFlagRequired("person-ID") //nolint:errcheck
+
+	cmd.Flags().StringArrayVar(
+		&o.publicKeys,
+		"public-key",
+		[]string{},
+		"authorized public key for person",
+	)
+	cmd.MarkFlagRequired("public-key") //nolint:errcheck
+
+	cmd.Flags().StringArrayVar(
+		&o.associatedIdentities,
+		"associated-identity",
+		[]string{},
+		fmt.Sprintf("identities on code review platforms in the form 'providerID::identity' (e.g., '%s::<username>+<user ID>')", tuf.GitHubAppRoleName),
+	)
+
+	cmd.Flags().StringArrayVar(
+		&o.customMetadata,
+		"custom",
+		[]string{},
+		"additional custom metadata in the form KEY=VALUE",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+
+	publicKeys := map[string]*tufv02.Key{}
+	for _, key := range o.publicKeys {
+		key, err := gittuf.LoadPublicKey(key)
+		if err != nil {
+			return err
+		}
+		publicKeys[key.ID()] = key.(*tufv02.Key)
+	}
+
+	associatedIdentities := map[string]string{}
+	for _, associatedIdentity := range o.associatedIdentities {
+		split := strings.Split(associatedIdentity, "::")
+		if len(split) != 2 {
+			return fmt.Errorf("invalid format for associated identity '%s'", associatedIdentity)
+		}
+		associatedIdentities[split[0]] = split[1]
+	}
+
+	custom := map[string]string{}
+	for _, customEntry := range o.customMetadata {
+		split := strings.Split(customEntry, "=")
+		if len(split) != 2 {
+			return fmt.Errorf("invalid format for custom metadata '%s'", customEntry)
+		}
+		custom[split[0]] = split[1]
+	}
+
+	person := &tufv02.Person{
+		PersonID:             o.personID,
+		PublicKeys:           publicKeys,
+		AssociatedIdentities: associatedIdentities,
+		Custom:               custom,
+	}
+
+	opts := []trustpolicyopts.Option{}
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+	return repo.AddRootPerson(cmd.Context(), signer, person, true, opts...)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "add-root-person",
+		Short:             "Add a trusted person to gittuf root of trust",
+		Long:              `The 'add-root-person' command adds a trusted person to the repository's root of trust. A person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom'). Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". Optionally, the change can be recorded in the RSL.`,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpolicykey"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addpropagationdirective"
 	"github.com/gittuf/gittuf/internal/cmd/trust/addrootkey"
+	"github.com/gittuf/gittuf/internal/cmd/trust/addrootperson"
 	"github.com/gittuf/gittuf/internal/cmd/trust/disablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
@@ -59,6 +60,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addpolicykey.New(o))
 	cmd.AddCommand(addpropagationdirective.New(o))
 	cmd.AddCommand(addrootkey.New(o))
+	cmd.AddCommand(addrootperson.New(o))
 	cmd.AddCommand(apply.New())
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))


### PR DESCRIPTION
Adds a new `add-root-person` subcommand under `gittuf trust` to support
adding persons to root metadata, resolving #1143.

## Description

The current CLI only supported adding keys to root metadata via
`add-root-key`. This PR adds a new `add-root-person` command that allows
adding a `tufv02.Person` (with an ID, public keys, optional associated
identities, and optional custom metadata) as a trusted principal in the
root of trust.

### Changes

**`experimental/gittuf/root.go`** — Added `AddRootPerson()` method at
the repository API layer. It follows the exact same flow as `AddRootKey`:
authorize the signer, load root metadata, call
`rootMetadata.AddRootPrincipal(person)`, and commit the update. No
changes were needed at the TUF metadata layer since `AddRootPrincipal`
already accepts any `tuf.Principal`, which `Person` implements.

**`internal/cmd/trust/addrootperson/addrootperson.go`** — New CLI
command package. Accepts `--person-ID` (required), `--public-key`
(required, repeatable), `--associated-identity` (optional, format
`providerID::identity`), and `--custom` (optional, format `KEY=VALUE`).
Builds a `tufv02.Person` from the flags and calls `repo.AddRootPerson()`.

**`internal/cmd/trust/trust.go`** — Registered the new command.

**`experimental/gittuf/root_test.go`** — Added `TestAddRootPerson` with
4 subtests: success case, unauthorized signer, person with associated
identities and custom metadata, and signCommit.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of
  this pull request. I have described my use of AI below.

I used AI as a learning aid to understand the repository
structure and the existing patterns (such as `add-root-key` and
`add-person`).

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in
  this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a
  [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf
  [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
