### PR TITLE
gittuf: Handle delayed GitHub API response

### DIFF
--- a/experimental/gittuf/attestations.go
+++ b/experimental/gittuf/attestations.go
@@ -407,7 +407,7 @@ func (r *Repository) AddGitHubPullRequestApprover(ctx context.Context, signer ss
 		return ErrNoGitHubToken
 	}
 
-	baseRef, fromID, toID, err := getGitHubPullRequestReviewDetails(ctx, currentAttestations, options.GitHubBaseURL, token, owner, repository, pullRequestNumber, reviewID)
+	baseRef, fromID, toID, err := r.getGitHubPullRequestReviewDetails(ctx, currentAttestations, options.GitHubBaseURL, token, owner, repository, pullRequestNumber, reviewID, options.UseGitHubAPI)
 	if err != nil {
 		return err
 	}
@@ -642,7 +642,7 @@ func indexPathToComponents(indexPath string) (string, string, string) {
 	return base, from, to
 }
 
-func getGitHubPullRequestReviewDetails(ctx context.Context, currentAttestations *attestations.Attestations, githubBaseURL, githubToken, owner, repository string, pullRequestNumber int, reviewID int64) (string, string, string, error) {
+func (r *Repository) getGitHubPullRequestReviewDetails(ctx context.Context, currentAttestations *attestations.Attestations, githubBaseURL, githubToken, owner, repository string, pullRequestNumber int, reviewID int64, useGitHubAPI bool) (string, string, string, error) {
 	indexPath, has, err := currentAttestations.GetGitHubPullRequestApprovalIndexPathForReviewID(githubBaseURL, reviewID)
 	if err != nil {
 		return "", "", "", err
@@ -672,21 +672,56 @@ func getGitHubPullRequestReviewDetails(ctx context.Context, currentAttestations 
 		return "", "", "", err
 	}
 
+	// We have to fetch the base ref name via the API response, we don't have a choice
 	baseRef := gitinterface.BranchReferenceName(pullRequest.GetBase().GetRef())
 
-	referenceDetails, _, err := client.Git.GetRef(ctx, owner, repository, baseRef)
-	if err != nil {
-		return "", "", "", err
-	}
-	fromID := referenceDetails.GetObject().GetSHA() // current tip of base ref
+	// For the rest we have a choice. If useGitHubAPI is true, pull all
+	// information from the API. Otherwise, compute it.
 
-	// GitHub has already computed a merge commit, use that tree ID as target
-	// tree ID
-	commit, _, err := client.Git.GetCommit(ctx, owner, repository, pullRequest.GetMergeCommitSHA())
-	if err != nil {
-		return "", "", "", err
+	var fromID, toID string
+
+	if useGitHubAPI {
+		referenceDetails, _, err := client.Git.GetRef(ctx, owner, repository, baseRef)
+		if err != nil {
+			return "", "", "", err
+		}
+
+		fromID = referenceDetails.GetObject().GetSHA() // current tip of base ref
+
+		commit, _, err := client.Git.GetCommit(ctx, owner, repository, pullRequest.GetMergeCommitSHA())
+		if err != nil {
+			return "", "", "", err
+		}
+
+		toID = commit.GetTree().GetSHA()
+	} else {
+		// Check the RSL instead for from ID.
+		entry, _, err := rsl.GetLatestReferenceUpdaterEntry(r.r, rsl.ForReference(baseRef), rsl.IsUnskipped())
+		if err != nil {
+			return "", "", "", err
+		}
+
+		fromID = entry.GetTargetID().String()
+
+		// The API seems not to be outdated for the head commit, but we should
+		// monitor this. For now, use the API to get the head commit ID to avoid
+		// having to fetch the actual ref...
+		headHash, err := gitinterface.NewHash(pullRequest.GetHead().GetSHA())
+		if err != nil {
+			return "", "", "", err
+		}
+		if err := r.r.FetchObject(pullRequest.GetHead().GetRepo().GetCloneURL(), headHash); err != nil {
+			return "", "", "", err
+		}
+
+		// Now compute the merge tree ID
+		mergeTreeID, err := r.r.GetMergeTree(entry.GetTargetID(), headHash)
+		if err != nil {
+			return "", "", "", err
+		}
+
+		toID = mergeTreeID.String()
 	}
-	toID := commit.GetTree().GetSHA()
 
 	return baseRef, fromID, toID, nil
 }

--- a/experimental/gittuf/options/github/github.go
+++ b/experimental/gittuf/options/github/github.go
@@ -24,6 +24,7 @@ type Options struct {
 	GitHubTokenSource TokenSource
 	GitHubBaseURL     string
 	CreateRSLEntry    bool
+	UseGitHubAPI      bool
 }
 
 var DefaultOptions = &Options{
@@ -52,6 +53,12 @@ func WithGitHubBaseURL(baseURL string) Option {
 func WithRSLEntry() Option {
 	return func(o *Options) {
 		o.CreateRSLEntry = true
+	}
+}
+
+func WithUseGitHubAPI() Option {
+	return func(o *Options) {
+		o.UseGitHubAPI = true
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

The API response can have outdated information for several hours. This impacts the gittuf app when recording attestations for pull request attestations. The app attestation records outdated from and merge tree IDs. This commit adds the option of using the API response for fewer data points. We might need to reduce reliance on the API response further.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
