### PR TITLE
reject invalid (zero or negative) thresholds at write time, and added error message(for invalid threshold) in TUI 

### DIFF
--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -267,7 +267,14 @@ func (m model) handlePolicyFormSubmit() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	thr, _ := strconv.Atoi(m.inputs[3].Value())
+	var err error
+
+	parsedThr, err := strconv.ParseInt(m.inputs[3].Value(), 10, 0)
+	thr := int(parsedThr)
+	if err != nil {
+		m.errorMsg = "Invalid value specified; threshold must be a positive integer."
+		return m, nil
+	}
 	r := rule{
 		name:      m.inputs[0].Value(),
 		pattern:   m.inputs[1].Value(),
@@ -276,7 +283,6 @@ func (m model) handlePolicyFormSubmit() (tea.Model, tea.Cmd) {
 	}
 	authorizedKeys := splitAndTrim(m.inputs[2].Value())
 
-	var err error
 	switch m.screen {
 	case screenPolicyAddRule:
 		err = repoAddRule(m.ctx, m.options, r, authorizedKeys)
@@ -308,8 +314,14 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 
 	parts := splitAndTrim(m.inputs[2].Value())
 	thr := 0
+	var err error
 	if m.inputs[1].Value() == tuf.GlobalRuleThresholdType {
-		thr, _ = strconv.Atoi(m.inputs[3].Value())
+		parsedThr, err := strconv.ParseInt(m.inputs[3].Value(), 10, 0)
+		thr = int(parsedThr)
+		if err != nil {
+			m.errorMsg = "Invalid value specified; threshold must be a positive integer."
+			return m, nil
+		}
 	}
 	gr := globalRule{
 		ruleName:     m.inputs[0].Value(),
@@ -318,7 +330,6 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 		threshold:    thr,
 	}
 
-	var err error
 	switch m.screen {
 	case screenTrustAddGlobalRule:
 		err = repoAddGlobalRule(m.ctx, m.options, gr)

--- a/internal/tuf/tuf.go
+++ b/internal/tuf/tuf.go
@@ -61,6 +61,7 @@ var (
 	ErrMissingRules                                    = errors.New("some rules are missing")
 	ErrCannotManipulateRulesWithGittufPrefix           = errors.New("cannot add or change rules whose names have the 'gittuf-' prefix")
 	ErrCannotMeetThreshold                             = errors.New("insufficient keys to meet threshold")
+	ErrInvalidThreshold                                = errors.New("threshold must be a positive integer")
 	ErrUnknownGlobalRuleType                           = errors.New("unknown global rule type")
 	ErrGlobalRuleBlockForcePushesOnlyAppliesToGitPaths = errors.New("all patterns for block force pushes global rule must be for Git references")
 	ErrGlobalRuleNotFound                              = errors.New("global rule not found")

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -361,6 +361,12 @@ func (r *RootMetadata) GetGitHubAppPrincipals(appName string) ([]tuf.Principal, 
 
 // AddGlobalRule adds a new global rule to RootMetadata.
 func (r *RootMetadata) AddGlobalRule(globalRule tuf.GlobalRule) error {
+	if thresholdRule, ok := globalRule.(tuf.GlobalRuleThreshold); ok {
+		if thresholdRule.GetThreshold() <= 0 {
+			return tuf.ErrInvalidThreshold
+		}
+	}
+
 	allGlobalRules := r.GlobalRules
 	if allGlobalRules == nil {
 		allGlobalRules = []tuf.GlobalRule{}
@@ -402,6 +408,12 @@ func (r *RootMetadata) GetGlobalRules() []tuf.GlobalRule {
 
 // UpdateGlobalRule updates the specified global rule from the RootMetadata.
 func (r *RootMetadata) UpdateGlobalRule(globalRule tuf.GlobalRule) error {
+	if thresholdRule, ok := globalRule.(tuf.GlobalRuleThreshold); ok {
+		if thresholdRule.GetThreshold() <= 0 {
+			return tuf.ErrInvalidThreshold
+		}
+	}
+
 	allGlobalRules := r.GlobalRules
 	updatedGlobalRules := []tuf.GlobalRule{}
 	found := false

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -568,7 +568,11 @@ func TestGlobalRules(t *testing.T) {
 
 	assert.Nil(t, rootMetadata.GlobalRules) // no global rule yet
 
-	err := rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
+	err := rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("invalid-threshold", []string{"git:refs/heads/main"}, 0))
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+	assert.Nil(t, rootMetadata.GlobalRules)
+
+	err = rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
 	assert.Nil(t, err)
 	err = rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
 	assert.ErrorIs(t, err, tuf.ErrGlobalRuleAlreadyExists)
@@ -598,6 +602,14 @@ func TestGlobalRules(t *testing.T) {
 	assert.Equal(t, 2, len(rootMetadata.GlobalRules))
 	assert.Equal(t, "threshold-2-main", rootMetadata.GlobalRules[0].GetName())
 	assert.Equal(t, "block-force-pushes", rootMetadata.GlobalRules[1].GetName())
+
+	invalidThresholdGlobalRule := &GlobalRuleThreshold{
+		Name:      "threshold-2-main",
+		Paths:     []string{"git:refs/heads/main"},
+		Threshold: 0,
+	}
+	err = rootMetadata.UpdateGlobalRule(invalidThresholdGlobalRule)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
 
 	updatedThresholdGlobalRule := &GlobalRuleThreshold{
 		Name:      "threshold-2-main",

--- a/internal/tuf/v01/targets.go
+++ b/internal/tuf/v01/targets.go
@@ -64,6 +64,10 @@ func (t *TargetsMetadata) AddRule(ruleName string, authorizedPrincipalIDs, ruleP
 		}
 	}
 
+	if threshold <= 0 {
+		return tuf.ErrInvalidThreshold
+	}
+
 	if len(authorizedPrincipalIDs) < threshold {
 		return tuf.ErrCannotMeetThreshold
 	}
@@ -97,6 +101,10 @@ func (t *TargetsMetadata) UpdateRule(ruleName string, authorizedPrincipalIDs, ru
 		if _, has := t.Delegations.Keys[principalID]; !has {
 			return tuf.ErrPrincipalNotFound
 		}
+	}
+
+	if threshold <= 0 {
+		return tuf.ErrInvalidThreshold
 	}
 
 	if len(authorizedPrincipalIDs) < threshold {

--- a/internal/tuf/v01/targets_test.go
+++ b/internal/tuf/v01/targets_test.go
@@ -233,7 +233,10 @@ func TestAddRuleAndGetRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := targetsMetadata.AddRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 1)
+	err := targetsMetadata.AddRule("invalid-threshold-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 0)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+
+	err = targetsMetadata.AddRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Keys[key1.KeyID])
@@ -280,6 +283,9 @@ func TestUpdateDelegation(t *testing.T) {
 	if err := targetsMetadata.AddPrincipal(key2); err != nil {
 		t.Fatal(err)
 	}
+	err = targetsMetadata.UpdateRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 0)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+
 	err = targetsMetadata.UpdateRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key1.KeyID)

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -449,6 +449,12 @@ func (r *RootMetadata) UnmarshalJSON(data []byte) error {
 
 // AddGlobalRule adds a new global rule to RootMetadata.
 func (r *RootMetadata) AddGlobalRule(globalRule tuf.GlobalRule) error {
+	if thresholdRule, ok := globalRule.(tuf.GlobalRuleThreshold); ok {
+		if thresholdRule.GetThreshold() <= 0 {
+			return tuf.ErrInvalidThreshold
+		}
+	}
+
 	allGlobalRules := r.GlobalRules
 	if allGlobalRules == nil {
 		allGlobalRules = []tuf.GlobalRule{}
@@ -486,6 +492,12 @@ func (r *RootMetadata) DeleteGlobalRule(ruleName string) error {
 
 // UpdateGlobalRule updates the specified global rule from the RootMetadata.
 func (r *RootMetadata) UpdateGlobalRule(globalRule tuf.GlobalRule) error {
+	if thresholdRule, ok := globalRule.(tuf.GlobalRuleThreshold); ok {
+		if thresholdRule.GetThreshold() <= 0 {
+			return tuf.ErrInvalidThreshold
+		}
+	}
+
 	allGlobalRules := r.GlobalRules
 	updatedGlobalRules := []tuf.GlobalRule{}
 	found := false

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -659,7 +659,11 @@ func TestGlobalRules(t *testing.T) {
 
 	assert.Nil(t, rootMetadata.GlobalRules) // no global rule yet
 
-	err := rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
+	err := rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("invalid-threshold", []string{"git:refs/heads/main"}, 0))
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+	assert.Nil(t, rootMetadata.GlobalRules)
+
+	err = rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
 	assert.Nil(t, err)
 	err = rootMetadata.AddGlobalRule(NewGlobalRuleThreshold("threshold-2-main", []string{"git:refs/heads/main"}, 2))
 	assert.ErrorIs(t, err, tuf.ErrGlobalRuleAlreadyExists)
@@ -689,6 +693,14 @@ func TestGlobalRules(t *testing.T) {
 	assert.Equal(t, 2, len(rootMetadata.GlobalRules))
 	assert.Equal(t, "threshold-2-main", rootMetadata.GlobalRules[0].GetName())
 	assert.Equal(t, "block-force-pushes", rootMetadata.GlobalRules[1].GetName())
+
+	invalidThresholdGlobalRule := &GlobalRuleThreshold{
+		Name:      "threshold-2-main",
+		Paths:     []string{"git:refs/heads/main"},
+		Threshold: 0,
+	}
+	err = rootMetadata.UpdateGlobalRule(invalidThresholdGlobalRule)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
 
 	updatedThresholdGlobalRule := &GlobalRuleThreshold{
 		Name:      "threshold-2-main",

--- a/internal/tuf/v02/targets.go
+++ b/internal/tuf/v02/targets.go
@@ -69,6 +69,10 @@ func (t *TargetsMetadata) AddRule(ruleName string, authorizedPrincipalIDs, ruleP
 		}
 	}
 
+	if threshold <= 0 {
+		return tuf.ErrInvalidThreshold
+	}
+
 	if len(authorizedPrincipalIDs) < threshold {
 		return tuf.ErrCannotMeetThreshold
 	}
@@ -102,6 +106,10 @@ func (t *TargetsMetadata) UpdateRule(ruleName string, authorizedPrincipalIDs, ru
 		if _, has := t.Delegations.Principals[principalID]; !has {
 			return tuf.ErrPrincipalNotFound
 		}
+	}
+
+	if threshold <= 0 {
+		return tuf.ErrInvalidThreshold
 	}
 
 	if len(authorizedPrincipalIDs) < threshold {

--- a/internal/tuf/v02/targets_test.go
+++ b/internal/tuf/v02/targets_test.go
@@ -262,7 +262,10 @@ func TestAddRuleAndGetRules(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := targetsMetadata.AddRule("test-rule", []string{key1.KeyID, key2.KeyID, person.PersonID}, []string{"test/"}, 1)
+	err := targetsMetadata.AddRule("invalid-threshold-rule", []string{key1.KeyID, key2.KeyID, person.PersonID}, []string{"test/"}, 0)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+
+	err = targetsMetadata.AddRule("test-rule", []string{key1.KeyID, key2.KeyID, person.PersonID}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)
 	assert.Equal(t, key1, targetsMetadata.Delegations.Principals[key1.KeyID])
@@ -311,6 +314,9 @@ func TestUpdateDelegation(t *testing.T) {
 	if err := targetsMetadata.AddPrincipal(key2); err != nil {
 		t.Fatal(err)
 	}
+	err = targetsMetadata.UpdateRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 0)
+	assert.ErrorIs(t, err, tuf.ErrInvalidThreshold)
+
 	err = targetsMetadata.UpdateRule("test-rule", []string{key1.KeyID, key2.KeyID}, []string{"test/"}, 1)
 	assert.Nil(t, err)
 	assert.Contains(t, targetsMetadata.Delegations.Principals, key1.KeyID)


### PR DESCRIPTION
Refers #1289 
## Description

This pull request introduces stricter validation for threshold values in both the TUI forms and the TUF metadata logic, ensuring that thresholds must be positive integers. It improves user feedback in the TUI and adds error handling to prevent invalid thresholds from being set at both the UI and data model levels.

**Threshold validation improvements:**

* Added checks in the TUI form submission handlers (`handlePolicyFormSubmit` and `handleGlobalFormSubmit` in `internal/cmd/tui/update.go`) to ensure that the threshold input is a valid number, displaying a user-friendly error message if not.
* Introduced a new error constant `ErrInvalidThreshold` in `internal/tuf/tuf.go` to represent invalid threshold values.

**TUF metadata enforcement:**

* Updated the `AddRule` and `UpdateRule` methods in both `internal/tuf/v01/targets.go` and `internal/tuf/v02/targets.go` to return an error if the threshold is not a positive integer. 
* Enhanced the `AddGlobalRule` and `UpdateGlobalRule` methods in both `internal/tuf/v01/root.go` and `internal/tuf/v02/root.go` to enforce that global rule thresholds must be positive integers, returning `ErrInvalidThreshold` otherwise.
<!-- Enter a description of what your pull request does. -->

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.
  
I used Copilot to **write description** for this Pull request :)

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
