### PR TITLE
Added Tests for internal/attestations/common/common.go

### DIFF
--- a/internal/attestations/common/common_test.go
+++ b/internal/attestations/common/common_test.go
@@ -1,0 +1,84 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPredicateToPBStruct(t *testing.T) {
+	t.Run("converts map predicate", func(t *testing.T) {
+		predicate := map[string]any{
+			"repo":      "gittuf",
+			"threshold": 2,
+			"active":    true,
+			"scopes":    []any{"push", "pull"},
+			"metadata": map[string]any{
+				"team": "security",
+			},
+		}
+
+		predicateStruct, err := PredicateToPBStruct(predicate)
+		require.Nil(t, err)
+
+		expected := map[string]any{
+			"repo":      "gittuf",
+			"threshold": float64(2),
+			"active":    true,
+			"scopes":    []any{"push", "pull"},
+			"metadata": map[string]any{
+				"team": "security",
+			},
+		}
+
+		assert.Equal(t, expected, predicateStruct.AsMap())
+	})
+
+	t.Run("converts struct predicate", func(t *testing.T) {
+		type testPredicate struct {
+			Name     string `json:"name"`
+			Attempts int    `json:"attempts"`
+			Approved bool   `json:"approved"`
+			Reviewer string `json:"reviewer"`
+		}
+
+		predicateStruct, err := PredicateToPBStruct(testPredicate{
+			Name:     "review",
+			Attempts: 3,
+			Approved: true,
+			Reviewer: "alice",
+		})
+		require.Nil(t, err)
+
+		expected := map[string]any{
+			"name":     "review",
+			"attempts": float64(3),
+			"approved": true,
+			"reviewer": "alice",
+		}
+
+		assert.Equal(t, expected, predicateStruct.AsMap())
+	})
+
+	t.Run("returns marshal error", func(t *testing.T) {
+		predicate := map[string]any{
+			"invalid": func() {},
+		}
+
+		predicateStruct, err := PredicateToPBStruct(predicate)
+		assert.ErrorContains(t, err, "unsupported type")
+		assert.Nil(t, predicateStruct)
+	})
+
+	t.Run("returns unmarshal error for non-object JSON", func(t *testing.T) {
+		predicate := []string{"not", "an", "object"}
+
+		predicateStruct, err := PredicateToPBStruct(predicate)
+		assert.ErrorContains(t, err, "cannot unmarshal array")
+		assert.Nil(t, predicateStruct)
+	})
+}


### PR DESCRIPTION
## Description
Refers #1292 
I added tests for common.go, covering 100% of the statements.


<img width="1673" height="59" alt="image" src="https://github.com/user-attachments/assets/63e5a340-52cf-4df6-9666-6cc676ef05af" />

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
