### PR TITLE
test: add focused coverage for attestations and signerverifier options

### DIFF
--- a/internal/signerverifier/common/common_test.go
+++ b/internal/signerverifier/common/common_test.go
@@ -1,0 +1,70 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCertsFromPath(t *testing.T) {
+	t.Run("file not found", func(t *testing.T) {
+		_, err := LoadCertsFromPath(filepath.Join(t.TempDir(), "missing.pem"))
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("invalid pem", func(t *testing.T) {
+		pemPath := filepath.Join(t.TempDir(), "invalid.pem")
+		err := os.WriteFile(pemPath, []byte("not a cert"), 0o600)
+		require.Nil(t, err)
+
+		_, err = LoadCertsFromPath(pemPath)
+		assert.ErrorContains(t, err, "PEM decoding")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		pemPath := filepath.Join(t.TempDir(), "cert.pem")
+		err := os.WriteFile(pemPath, createTestCertificatePEM(t), 0o600)
+		require.Nil(t, err)
+
+		certs, err := LoadCertsFromPath(pemPath)
+		assert.Nil(t, err)
+		assert.Len(t, certs, 1)
+	})
+}
+
+func createTestCertificatePEM(t *testing.T) []byte {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.Nil(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "gittuf-test-cert",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, privateKey.Public(), privateKey)
+	require.Nil(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+}

--- a/internal/signerverifier/gpg/gpg_test.go
+++ b/internal/signerverifier/gpg/gpg_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGPG(t *testing.T) {
@@ -74,11 +76,47 @@ func TestGPG(t *testing.T) {
 }
 
 func TestLoadGPGKeyFromBytes(t *testing.T) {
-	keyBytes := artifacts.GPGKey1Public
+	t.Run("valid", func(t *testing.T) {
+		key, err := LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+		assert.Nil(t, err)
+		assert.Equal(t, KeyType, key.KeyType)
+		assert.Equal(t, KeyType, key.Scheme)
+		assert.Equal(t, "157507bbe151e378ce8126c1dcfe043cdd2db96e", key.KeyID)
+	})
 
-	key, err := LoadGPGKeyFromBytes(keyBytes)
-	assert.Nil(t, err)
-	assert.Equal(t, KeyType, key.KeyType)
-	assert.Equal(t, KeyType, key.Scheme)
-	assert.Equal(t, "157507bbe151e378ce8126c1dcfe043cdd2db96e", key.KeyID)
+	t.Run("invalid", func(t *testing.T) {
+		_, err := LoadGPGKeyFromBytes([]byte("not a gpg key"))
+		assert.ErrorContains(t, err, "no armored data found")
+	})
+}
+
+func TestNewVerifierFromKey(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		pubKey, err := LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+		require.Nil(t, err)
+
+		verifier, err := NewVerifierFromKey(pubKey)
+		assert.Nil(t, err)
+		require.NotNil(t, verifier)
+
+		keyID, err := verifier.KeyID()
+		assert.Nil(t, err)
+		assert.Equal(t, pubKey.KeyID, keyID)
+
+		assert.Equal(t, verifier.entity.PrimaryKey.PublicKey, verifier.Public())
+		assert.Equal(t, "DCFE043CDD2DB96E", verifier.entity.PrimaryKey.KeyIdString())
+		assert.Equal(t, pubKey, verifier.MetadataKey())
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := NewVerifierFromKey(&signerverifier.SSLibKey{
+			KeyID:   "bad",
+			KeyType: KeyType,
+			Scheme:  KeyType,
+			KeyVal: signerverifier.KeyVal{
+				Public: "invalid",
+			},
+		})
+		assert.ErrorContains(t, err, "failed to parse gpg key")
+	})
 }


### PR DESCRIPTION
## Description

This PR improves test coverage across the `attestations` and `signerverifier` packages by adding targeted unit tests for certificate loading, predicate conversion, and sigstore options. It also extends GPG tests to include better coverage for negative paths and accessors, ensuring more robust error handling and verification across the signer/verifier components.
## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->



## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).