### PR TITLE
Add tests for `/internal/signerverifier/sigstore/options/verifier`

### DIFF
--- a/internal/signerverifier/sigstore/options/verifier/verifier_test.go
+++ b/internal/signerverifier/sigstore/options/verifier/verifier_test.go
@@ -1,0 +1,36 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	assert.Equal(t, defaultRekorURL, DefaultOptions.RekorURL)
+}
+
+func TestWithRekorURL(t *testing.T) {
+	opts := &Options{}
+	customURL := "https://custom.rekor.example.com"
+
+	option := WithRekorURL(customURL)
+	option(opts)
+
+	assert.Equal(t, customURL, opts.RekorURL)
+}
+
+func TestWithRekorURL_DoesNotMutateDefaultOptions(t *testing.T) {
+	customURL := "https://custom.rekor.example.com"
+
+	option := WithRekorURL(customURL)
+	// Apply to a copy, not DefaultOptions
+	opts := &Options{RekorURL: DefaultOptions.RekorURL}
+	option(opts)
+
+	assert.Equal(t, customURL, opts.RekorURL)
+	assert.Equal(t, defaultRekorURL, DefaultOptions.RekorURL)
+}


### PR DESCRIPTION
## Description

This pull request adds unit tests for the `Options` configuration in the `verifier` package to ensure correct behavior when setting the `RekorURL` and to verify that the default options remain unchanged when modified.
<img width="1365" height="259" alt="image" src="https://github.com/user-attachments/assets/5c0ab6f3-6803-4c93-8a81-4ba1d71d6028" />

Testing improvements:

* Added `TestDefaultOptions` to confirm that `DefaultOptions.RekorURL` is set to the expected default value.
* Added `TestWithRekorURL` to verify that the `WithRekorURL` option correctly sets a custom `RekorURL` in an `Options` instance.
* Added `TestWithRekorURL_DoesNotMutateDefaultOptions` to ensure that applying the `WithRekorURL` option does not mutate the global `DefaultOptions`.
<!-- Enter a description of what your pull request does. -->

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

### _Copilot helped me to write this PR description :)_

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
