### PR TITLE
feat: enable persistent cache by default on trust init and clone

### DIFF
--- a/experimental/gittuf/cache.go
+++ b/experimental/gittuf/cache.go
@@ -7,6 +7,13 @@ import (
 	"github.com/gittuf/gittuf/internal/cache"
 )
 
+const (
+	// CacheAutomaticEnablementGitKey is the git config key used to control
+	// whether gittuf automatically enables the persistent cache after clone and
+	// trust init. Users can set this to "false" to opt out.
+	CacheAutomaticEnablementGitKey = "gittuf.cache.automatic"
+)
+
 // PopulateCache scans the repository's RSL and generates a persistent
 // local-only cache of policy and attestation entries. This makes subsequent
 // verifications faster.
@@ -17,4 +24,21 @@ func (r *Repository) PopulateCache() error {
 // DeleteCache deletes the local persistent cache.
 func (r *Repository) DeleteCache() error {
 	return cache.DeletePersistentCache(r.r)
+}
+
+// GetAutomaticCacheEnablementStatus returns if the user has opted out of
+// automatic cache enablement. Returns false by default (meaning automatic
+// enablement is enabled) unless gittuf.cache.automatic=false is set.
+func (r *Repository) GetAutomaticCacheEnablementStatus() bool {
+	config, err := r.r.GetGitConfig()
+	if err != nil {
+		return false
+	}
+
+	val, exists := config[CacheAutomaticEnablementGitKey]
+	if !exists {
+		return false
+	}
+
+	return val == "false"
 }

--- a/experimental/gittuf/sync.go
+++ b/experimental/gittuf/sync.go
@@ -97,7 +97,18 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRo
 			return repository, ErrExpectedRootKeysDoNotMatch
 		}
 	}
-
 	slog.Debug("Verifying HEAD...")
-	return repository, repository.VerifyRef(ctx, head)
+	if err := repository.VerifyRef(ctx, head); err != nil {
+		return repository, err
+	}
+
+	// enable and populate the persistent cache by default after cloning
+	// this is a non-fatal operation - if it fails, we log and continue
+	if !repository.GetAutomaticCacheEnablementStatus() {
+		if err := repository.PopulateCache(); err != nil {
+			slog.Warn("could not populate cache", "error", err)
+		}
+	}
+
+	return repository, nil
 }

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -4,6 +4,8 @@
 package init
 
 import (
+	"log/slog"
+
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
 	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
@@ -39,7 +41,17 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	if o.p.WithRSLEntry {
 		opts = append(opts, rootopts.WithRSLEntry())
 	}
-	return repo.InitializeRoot(cmd.Context(), signer, true, opts...)
+	if err := repo.InitializeRoot(cmd.Context(), signer, true, opts...); err != nil {
+		return err
+	}
+
+	if !repo.GetAutomaticCacheEnablementStatus() {
+		if err := repo.PopulateCache(); err != nil {
+			slog.Warn("could not populate cache", "error", err)
+		}
+	}
+
+	return nil
 }
 
 func New(persistent *persistent.Options) *cobra.Command {


### PR DESCRIPTION
## Description

Auto-enable and populate the persistent cache after `gittuf trust init`
and `gittuf clone`, so users benefit from the cache without any manual
setup. Users can opt out by setting `gittuf.cache.automatic=false` in
their local git config.

Fixes #723

## Changes

- Add `CacheAutomaticEnablementGitKey` exported constant in
  `experimental/gittuf/cache.go` for the `gittuf.cache.automatic`
  git config key
- Add `IsCacheAutomaticEnablementDisabled()` helper to check if the
  user has opted out of automatic cache enablement
- Auto-populate cache after `gittuf clone` in `sync.go`
- Auto-populate cache after `gittuf trust init` in `init.go`
- Remove changes to `internal/policy/searcher.go` (not needed)

## Testing

- All existing tests pass (`go test ./...`)