### PR TITLE
fix: add missing 'R' case to NewStatusCodeFromByte

### DIFF
--- a/pkg/gitinterface/status.go
+++ b/pkg/gitinterface/status.go
@@ -71,6 +71,8 @@ func NewStatusCodeFromByte(s byte) (StatusCode, error) {
 		return StatusCodeAdded, nil
 	case 'D':
 		return StatusCodeDeleted, nil
+	case 'R':
+		return StatusCodeRenamed, nil
 	case 'C':
 		return StatusCodeCopied, nil
 	case 'U':

--- a/pkg/gitinterface/status_test.go
+++ b/pkg/gitinterface/status_test.go
@@ -163,6 +163,7 @@ func TestNewStatusCodeFromByte(t *testing.T) {
 			{'T', StatusCodeTypeChanged},
 			{'A', StatusCodeAdded},
 			{'D', StatusCodeDeleted},
+			{'R', StatusCodeRenamed},
 			{'C', StatusCodeCopied},
 			{'U', StatusCodeUpdatedUnmerged},
 			{'?', StatusCodeUntracked},


### PR DESCRIPTION
## Description

While improving test coverage for `pkg/gitinterface` (#1294 ), I discovered that `NewStatusCodeFromByte` is missing the `'R'` case for `StatusCodeRenamed`. The constant exists and `StatusCode.String()` returns `"R"`, but parsing `'R'` back to the enum fails with `ErrInvalidStatusCode`.

This causes `Status()` to incorrectly fail when encountering renamed files in the working tree.

**Fix:** Added `case 'R': return StatusCodeRenamed, nil` to the switch.
**Test:** Added `{'R', StatusCodeRenamed}` to the existing `TestNewStatusCodeFromByte` table test (introduced in coverage PR).

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

I used an AI coding assistant to help identify the missing case while analyzing the coverage report. I manually wrote the fix and verified the test assertion.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
