### PR TITLE
Add tests for internal policy searcher functionality

### DIFF
--- a/internal/policy/searcher_test.go
+++ b/internal/policy/searcher_test.go
@@ -212,6 +212,62 @@ func TestRegularSearcher(t *testing.T) {
 		assert.ErrorIs(t, err, attestations.ErrAttestationsNotFound)
 		assert.Nil(t, attestationsEntry)
 	})
+
+	t.Run("latest policy", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithOnlyRoot)
+
+		expectedPolicyEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newRegularSearcher(repo)
+		policyEntry, err := searcher.FindLatestPolicyEntry()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
+	})
+
+	t.Run("latest policy, no policy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newRegularSearcher(repo)
+		_, err := searcher.FindLatestPolicyEntry()
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+	})
+
+	t.Run("latest attestations", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentAttestations := &attestations.Attestations{}
+		if err := currentAttestations.Commit(repo, "Initial attestations\n", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedAttestationsEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newRegularSearcher(repo)
+		attestationsEntry, err := searcher.FindLatestAttestationsEntry()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
+	})
+
+	t.Run("latest attestations, no attestations", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		searcher := newRegularSearcher(repo)
+		_, err := searcher.FindLatestAttestationsEntry()
+		assert.ErrorIs(t, err, attestations.ErrAttestationsNotFound)
+	})
 }
 
 func TestCacheSearcher(t *testing.T) {
@@ -374,6 +430,49 @@ func TestCacheSearcher(t *testing.T) {
 		assert.Equal(t, expectedPolicyEntries, policyEntries)
 	})
 
+	t.Run("latest policy", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithOnlyRoot)
+
+		if err := cache.PopulatePersistentCache(repo); err != nil {
+			t.Fatal(err)
+		}
+		persistentCache, err := cache.LoadPersistentCache(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expectedPolicyEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newCacheSearcher(repo, persistentCache)
+		policyEntry, err := searcher.FindLatestPolicyEntry()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
+	})
+
+	t.Run("latest policy, no policy entries", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cache.PopulatePersistentCache(repo); err != nil {
+			t.Fatal(err)
+		}
+		persistentCache, err := cache.LoadPersistentCache(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newCacheSearcher(repo, persistentCache)
+		_, err = searcher.FindLatestPolicyEntry()
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+	})
+
 	t.Run("attestations exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
@@ -463,5 +562,54 @@ func TestCacheSearcher(t *testing.T) {
 		attestationsEntry, err := searcher.FindAttestationsEntryFor(entry)
 		assert.ErrorIs(t, err, attestations.ErrAttestationsNotFound)
 		assert.Nil(t, attestationsEntry)
+	})
+
+	t.Run("latest attestations", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentAttestations := &attestations.Attestations{}
+		if err := currentAttestations.Commit(repo, "Initial attestations\n", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedAttestationsEntry, err := rsl.GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cache.PopulatePersistentCache(repo); err != nil {
+			t.Fatal(err)
+		}
+		persistentCache, err := cache.LoadPersistentCache(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newCacheSearcher(repo, persistentCache)
+		attestationsEntry, err := searcher.FindLatestAttestationsEntry()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
+	})
+
+	t.Run("latest attestations, no attestations", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cache.PopulatePersistentCache(repo); err != nil {
+			t.Fatal(err)
+		}
+		persistentCache, err := cache.LoadPersistentCache(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		searcher := newCacheSearcher(repo, persistentCache)
+		_, err = searcher.FindLatestAttestationsEntry()
+		assert.ErrorIs(t, err, attestations.ErrAttestationsNotFound)
 	})
 }


### PR DESCRIPTION
## Description
This pull request adds comprehensive unit tests for the cache-based and regular searchers responsible for finding the latest policy and attestations entries. These tests improve coverage and ensure correct error handling when entries are missing.

New test coverage for policy and attestations searchers:

* Added tests for `cacheSearcher` covering:
  - Finding the latest policy entry, including the case where no policy entries exist.
  - Finding the latest attestations entry, including the case where no attestations exist.

* Added tests for `regularSearcher` covering:
  - Finding the latest policy entry and handling the absence of policy entries.
  - Finding the latest attestations entry and handling the absence of attestations.
  
## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.
 
### I used copilot suggestions, to fast up and auto complete tests, But i manually, reviewed all Paths, and code, and have understanding of what i had pushed here.


## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
