### PR TITLE
fix(sigstore): add coverage tests and public key extraction for Sigstore

### DIFF
--- a/internal/signerverifier/sigstore/helpers_test.go
+++ b/internal/signerverifier/sigstore/helpers_test.go
@@ -1,0 +1,102 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTokenForIdentityAndIssuer(t *testing.T) {
+	token := makeToken(t, &idToken{
+		Issuer:        "https://issuer.example",
+		Subject:       "octocat",
+		Email:         "octo@example.com",
+		EmailVerified: true,
+	})
+
+	identity, issuer, err := parseTokenForIdentityAndIssuer(token, "")
+	require.NoError(t, err)
+	assert.Equal(t, "octo@example.com", identity)
+	assert.Equal(t, "https://issuer.example", issuer)
+}
+
+func TestParseTokenForIdentityAndIssuer_FederatedClaims(t *testing.T) {
+	token := makeToken(t, &idToken{
+		Issuer:          "https://issuer.example",
+		Subject:         "octocat",
+		EmailVerified:   false,
+		FederatedClaims: &federatedClaims{ConnectorID: "https://connector.example"},
+	})
+
+	identity, issuer, err := parseTokenForIdentityAndIssuer(token, "")
+	require.NoError(t, err)
+	assert.Equal(t, "octocat", identity)
+	assert.Equal(t, "https://connector.example", issuer)
+}
+
+func TestParseTokenForIdentityAndIssuer_FulcioConfig(t *testing.T) {
+	issuerURL := "https://issuer.example"
+	token := makeToken(t, &idToken{
+		Issuer:  issuerURL,
+		Subject: "octocat",
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != fulcioConfigurationEndpoint {
+			t.Fatalf("unexpected fulcio path: %s", r.URL.Path)
+		}
+
+		response := map[string]any{
+			"issuers": []map[string]any{
+				{
+					"issuer_type":    "username",
+					"subject_domain": "example.com",
+				},
+			},
+		}
+
+		require.NoError(t, json.NewEncoder(w).Encode(response))
+	}))
+	defer server.Close()
+
+	identity, issuer, err := parseTokenForIdentityAndIssuer(token, server.URL)
+	require.NoError(t, err)
+	assert.Equal(t, "octocat", identity)
+	assert.Equal(t, issuerURL, issuer)
+}
+
+func TestParseTokenForIdentityAndIssuer_InvalidToken(t *testing.T) {
+	_, _, err := parseTokenForIdentityAndIssuer("invalid", "")
+	assert.ErrorContains(t, err, "invalid token")
+}
+
+func TestParseTokenForIdentityAndIssuer_InvalidBase64(t *testing.T) {
+	_, _, err := parseTokenForIdentityAndIssuer("header.@@@.sig", "")
+	assert.Error(t, err)
+}
+
+func TestStringAsBoolUnmarshal(t *testing.T) {
+	var value stringAsBool
+
+	assert.NoError(t, value.UnmarshalJSON([]byte("true")))
+	assert.Equal(t, stringAsBool(true), value)
+	assert.Error(t, value.UnmarshalJSON([]byte("nope")))
+}
+
+func makeToken(t *testing.T, tok *idToken) string {
+	t.Helper()
+
+	payloadBytes, err := json.Marshal(tok)
+	require.NoError(t, err)
+
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	return "header." + payload + ".sig"
+}

--- a/internal/signerverifier/sigstore/sigstore.go
+++ b/internal/signerverifier/sigstore/sigstore.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"log/slog"
@@ -44,10 +45,11 @@ const (
 )
 
 type Verifier struct {
-	rekorURL string
-	issuer   string
-	identity string
-	ext      *structpb.Struct
+	rekorURL  string
+	issuer    string
+	identity  string
+	ext       *structpb.Struct
+	publicKey crypto.PublicKey
 }
 
 func NewVerifierFromIdentityAndIssuer(identity, issuer string, opts ...verifieropts.Option) *Verifier {
@@ -119,6 +121,8 @@ func (v *Verifier) Verify(_ context.Context, data, sig []byte) error {
 		return err
 	}
 
+	v.publicKey, _ = publicKeyFromVerificationMaterial(verificationMaterial)
+
 	expectedIdentity, err := verify.NewShortCertificateIdentity(v.issuer, "", v.identity, "")
 	if err != nil {
 		slog.Debug(fmt.Sprintf("Unable to create expected identity constraint: %v", err))
@@ -146,12 +150,39 @@ func (v *Verifier) KeyID() (string, error) {
 }
 
 func (v *Verifier) Public() crypto.PublicKey {
-	// TODO
-	return nil
+	return v.publicKey
 }
 
 func (v *Verifier) SetExtension(ext *structpb.Struct) {
 	v.ext = ext
+}
+
+func publicKeyFromVerificationMaterial(verif *protobundle.VerificationMaterial) (crypto.PublicKey, error) {
+	if verif == nil {
+		return nil, nil
+	}
+
+	if cert := verif.GetCertificate(); cert != nil {
+		x509Cert, err := x509.ParseCertificate(cert.GetRawBytes())
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse Sigstore certificate: %w", err)
+		}
+		return x509Cert.PublicKey, nil
+	}
+
+	if chain := verif.GetX509CertificateChain(); chain != nil {
+		certs := chain.GetCertificates()
+		if len(certs) == 0 {
+			return nil, nil
+		}
+		x509Cert, err := x509.ParseCertificate(certs[0].GetRawBytes())
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse Sigstore certificate chain: %w", err)
+		}
+		return x509Cert.PublicKey, nil
+	}
+
+	return nil, nil
 }
 
 func (v *Verifier) ExpectedExtensionKind() string {

--- a/internal/signerverifier/sigstore/sigstore_test.go
+++ b/internal/signerverifier/sigstore/sigstore_test.go
@@ -1,0 +1,102 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicKeyFromVerificationMaterialCertificate(t *testing.T) {
+	certBytes, publicKey := createTestCertificate(t)
+
+	material := &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_Certificate{
+			Certificate: &protocommon.X509Certificate{RawBytes: certBytes},
+		},
+	}
+
+	key, err := publicKeyFromVerificationMaterial(material)
+	require.NoError(t, err)
+	assert.Equal(t, publicKey, key)
+}
+
+func TestPublicKeyFromVerificationMaterialChain(t *testing.T) {
+	certBytes, publicKey := createTestCertificate(t)
+
+	material := &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_X509CertificateChain{
+			X509CertificateChain: &protocommon.X509CertificateChain{
+				Certificates: []*protocommon.X509Certificate{{RawBytes: certBytes}},
+			},
+		},
+	}
+
+	key, err := publicKeyFromVerificationMaterial(material)
+	require.NoError(t, err)
+	assert.Equal(t, publicKey, key)
+}
+
+func TestPublicKeyFromVerificationMaterialNil(t *testing.T) {
+	key, err := publicKeyFromVerificationMaterial(nil)
+	require.NoError(t, err)
+	assert.Nil(t, key)
+}
+
+func TestPublicKeyFromVerificationMaterialEmptyChain(t *testing.T) {
+	material := &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_X509CertificateChain{
+			X509CertificateChain: &protocommon.X509CertificateChain{},
+		},
+	}
+
+	key, err := publicKeyFromVerificationMaterial(material)
+	require.NoError(t, err)
+	assert.Nil(t, key)
+}
+
+func TestPublicKeyFromVerificationMaterialInvalidCertificate(t *testing.T) {
+	material := &protobundle.VerificationMaterial{
+		Content: &protobundle.VerificationMaterial_Certificate{
+			Certificate: &protocommon.X509Certificate{RawBytes: []byte("not-a-cert")},
+		},
+	}
+
+	_, err := publicKeyFromVerificationMaterial(material)
+	assert.ErrorContains(t, err, "unable to parse Sigstore certificate")
+}
+
+func createTestCertificate(t *testing.T) ([]byte, any) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "gittuf-test-cert",
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(1 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		BasicConstraintsValid: true,
+	}
+
+	derBytes, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, privateKey.Public(), privateKey)
+	require.NoError(t, err)
+
+	return derBytes, privateKey.Public()
+}


### PR DESCRIPTION
## Description

This adds Sigstore verifier support by extracting the public key from Sigstore verification material, and it includes focused unit tests for sigstore token parsing and public-key extraction so the new verifier logic is covered.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
