### PR TITLE
fix: make PropagateChangesFromUpstreamRepository atomic

### DIFF
--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -1086,6 +1086,15 @@ func PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo *gitint
 	// FIXME: We assume here that downstreamRepo and upstreamRepo have their
 	// gittuf refs already synced.
 
+	type pendingEntry struct {
+		directive       tuf.PropagationDirective
+		commitID        gitinterface.Hash
+		upstreamEntryID gitinterface.Hash
+	}
+
+	// Phase 1: compute all subtrees without writing any RSL entries. If any
+	// directive fails here, the RSL is left untouched.
+	var pending []pendingEntry
 	for _, detail := range details {
 		latestUpstreamEntry, _, err := GetLatestReferenceUpdaterEntry(upstreamRepo, ForReference(detail.GetUpstreamReference()), IsUnskipped())
 		if err != nil {
@@ -1132,12 +1141,18 @@ func PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo *gitint
 			return err
 		}
 
-		if err := NewPropagationEntry(detail.GetDownstreamReference(), commitID, detail.GetUpstreamRepository(), latestUpstreamEntry.GetID()).Commit(downstreamRepo, sign); err != nil {
+		pending = append(pending, pendingEntry{
+			directive:       detail,
+			commitID:        commitID,
+			upstreamEntryID: latestUpstreamEntry.GetID(),
+		})
+	}
+
+	// Phase 2: all subtrees computed successfully; write RSL entries.
+	for _, p := range pending {
+		if err := NewPropagationEntry(p.directive.GetDownstreamReference(), p.commitID, p.directive.GetUpstreamRepository(), p.upstreamEntryID).Commit(downstreamRepo, sign); err != nil {
 			return err
 		}
-
-		// TODO: error management should revert propagation entries?
-		// atomicity?
 	}
 
 	return nil

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -1889,6 +1889,97 @@ func TestPropagateChangesFromUpstreamRepository(t *testing.T) {
 	assert.Equal(t, propagationEntry.GetID(), latestEntry.GetID())
 }
 
+func TestPropagateChangesFromUpstreamRepositoryAtomicity(t *testing.T) {
+	// Set up an upstream repo with two branches.
+	upstreamRepoDir := t.TempDir()
+	upstreamRepo := gitinterface.CreateTestGitRepository(t, upstreamRepoDir, true)
+
+	blobID, err := upstreamRepo.WriteBlob([]byte("content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo)
+	upstreamTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+		gitinterface.NewEntryBlob("file", blobID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstreamMainCommitID, err := upstreamRepo.Commit(upstreamTreeID, "refs/heads/main", "Initial commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewReferenceEntry("refs/heads/main", upstreamMainCommitID).Commit(upstreamRepo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	upstreamFeatureCommitID, err := upstreamRepo.Commit(upstreamTreeID, "refs/heads/feature", "Feature commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewReferenceEntry("refs/heads/feature", upstreamFeatureCommitID).Commit(upstreamRepo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set up a downstream repo with only refs/heads/main.
+	downstreamRepoDir := t.TempDir()
+	downstreamRepo := gitinterface.CreateTestGitRepository(t, downstreamRepoDir, true)
+
+	downstreamBlobID, err := downstreamRepo.WriteBlob([]byte("downstream"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo)
+	downstreamTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+		gitinterface.NewEntryBlob("file", downstreamBlobID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	downstreamMainCommitID, err := downstreamRepo.Commit(downstreamTreeID, "refs/heads/main", "Initial commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewReferenceEntry("refs/heads/main", downstreamMainCommitID).Commit(downstreamRepo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Record the RSL tip before propagation.
+	rslTipBefore, err := GetLatestEntry(downstreamRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Two directives: the first targets refs/heads/main (valid), the second
+	// targets refs/heads/feature which does not exist in the downstream repo
+	// and will fail during Phase 1.
+	directives := []tuf.PropagationDirective{
+		&tufv01.PropagationDirective{
+			UpstreamReference:   "refs/heads/main",
+			UpstreamRepository:  upstreamRepoDir,
+			DownstreamReference: "refs/heads/main",
+			DownstreamPath:      "upstream-main",
+		},
+		&tufv01.PropagationDirective{
+			UpstreamReference:   "refs/heads/feature",
+			UpstreamRepository:  upstreamRepoDir,
+			DownstreamReference: "refs/heads/feature",
+			DownstreamPath:      "upstream-feature",
+		},
+	}
+
+	err = PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo, directives, false)
+	assert.ErrorIs(t, err, gitinterface.ErrReferenceNotFound)
+
+	// The RSL must be unchanged — no partial entries must have been written.
+	rslTipAfter, err := GetLatestEntry(downstreamRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, rslTipBefore.GetID(), rslTipAfter.GetID())
+}
+
 func TestAnnotationEntryRefersTo(t *testing.T) {
 	// We use these as stand-ins for actual RSL IDs that have the same data type
 	tempDir := t.TempDir()


### PR DESCRIPTION
 ## Description

  `PropagateChangesFromUpstreamRepository` was committing RSL `PropagationEntry` records inside the directive loop. If  
  any directive failed mid-loop (network error, missing ref, etc.), the RSL already contained entries for the completed
  directives with no rollback — making the partial state permanent on subsequent runs due to the idempotency check.     
                       
  This PR splits the function into two phases:                                                                          
  - **Phase 1**: compute all subtrees without writing any RSL entries. A failure here returns early leaving the RSL
  untouched.                                                                                                            
  - **Phase 2**: only reached if all directives succeed — writes all RSL entries.
                                                                                                                        
  Adds `TestPropagateChangesFromUpstreamRepositoryAtomicity` to verify that no RSL entries are written when a directive 
  fails during Phase 1.                                                                                                 
                                                                                                                        
  Fixes #1309     

  ## AI Usage

  - [x] I **did** use generative AI in some form in making the content of this                                          
    pull request. I have described my use of AI below.
                                                                                                                        
  I used minimal AI assistance in this PR, mainly for initial bug identification and outlining a high-level approach. All implementation, testing, and validation were done manually.
                                                                                                                        
  ## Contributor Checklist

  - [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
  - [x] I fully understand the content I am submitting.
  - [x] The changes introduced are documented and have tests included if applicable.                                    
  - [x] My changes do not infringe on copyright/trademarks/etc.
  - [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).                 
  - [x] By submitting this pull request, I agree to follow the gittuf [Code of                                          
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).                                           
                                                                                    