### PR TITLE
Fix verifyMergeable functionality

### DIFF
--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -1375,7 +1375,7 @@ func verifyGitObjectAndAttestationsUsingVerifiers(ctx context.Context, verifiers
 			if trustedUsedPrincipalIDs.Len() >= verifier.Threshold()-1 {
 				slog.Debug(fmt.Sprintf("Counted '%d' principals towards threshold '%d' for '%s', policies can be met if the merge is by authorized person!", trustedUsedPrincipalIDs.Len(), verifier.Threshold(), verifier.Name()))
 				verifiedUsing = verifier.Name()
-				acceptedPrincipalIDs = trustedPrincipalIDs
+				acceptedPrincipalIDs = trustedUsedPrincipalIDs
 				rslEntrySignatureNeededForThreshold = true
 				break
 			}


### PR DESCRIPTION
Refers #1315
## Description

This pull request makes a targeted update to the logic for verifying principals in the `verifyGitObjectAndAttestationsUsingVerifiers` function. The change ensures that only the principals actually counted toward the verification threshold are accepted, rather than all trusted principals.

- Verification logic update:
  * In `verifyGitObjectAndAttestationsUsingVerifiers` (`internal/policy/verify.go`), changed assignment so that only the principals used to meet the threshold (`trustedUsedPrincipalIDs`) are accepted, instead of all trusted principals (`trustedPrincipalIDs`). This tightens the logic to accurately reflect which principals contributed to verification.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
