### PR TITLE
pkg/gitinterface: Return error from createTestTrees helper

### DIFF
--- a/pkg/gitinterface/log_test.go
+++ b/pkg/gitinterface/log_test.go
@@ -219,9 +219,6 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 	}
 
 	treeHashes := createTestTrees(t, repo, emptyBlobHash, 6)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// creating the first commit
 	commitID := repo.commitWithParents(t, treeHashes[0], nil, fmt.Sprintf("Test commit %v", 1), false)


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

Fixes a nilness error in `createTestTrees` where the helper function's signature declared an `error` return value but never actually returned it, instead calling `t.Fatal(err)` internally.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [X] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
