### PR TITLE
Add test for ApplyPolicy remote sync

### DIFF
--- a/experimental/gittuf/policy_test.go
+++ b/experimental/gittuf/policy_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
@@ -136,6 +137,53 @@ func TestHasPolicy(t *testing.T) {
 		hasPolicy, err := repo.HasPolicy()
 		assert.Nil(t, err)
 		assert.False(t, hasPolicy)
+	})
+}
+
+func TestApplyPolicy(t *testing.T) {
+	remoteName := "origin"
+
+	t.Run("successful apply with remote sync", func(t *testing.T) {
+		remoteTmpDir := t.TempDir()
+		remoteRepo := gitinterface.CreateTestGitRepository(t, remoteTmpDir, false)
+
+		localRepo := createTestRepositoryWithPolicy(t, "")
+		if err := localRepo.r.CreateRemote(remoteName, remoteTmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := localRepo.PushPolicy(remoteName); err != nil {
+			t.Fatal(err)
+		}
+
+		originalRemoteRSLTip, err := remoteRepo.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
+		gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gpgKey := tufv02.NewKeyFromSSLibKey(gpgKeyR)
+
+		if err := localRepo.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-feature", []string{gpgKey.KeyID}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.ApplyPolicy(testCtx, remoteName, false, false)
+		assert.Nil(t, err)
+
+		currentRemoteRSLTip, err := remoteRepo.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.NotEqual(t, originalRemoteRSLTip, currentRemoteRSLTip)
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, policy.PolicyRef)
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, policy.PolicyStagingRef)
+		assertLocalAndRemoteRefsMatch(t, localRepo.r, remoteRepo, rsl.Ref)
 	})
 }
 


### PR DESCRIPTION
## Description

Adds a test for `ApplyPolicy` when remote sync is enabled.

The test sets up a local gittuf repo and an on-disk remote, makes a policy change locally, applies it with remote sync enabled, and checks that the policy and RSL refs match on both sides.

Tested with:

`go test ./experimental/gittuf`

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
