### PR TITLE
test: fix pager tests on Windows

### DIFF
--- a/internal/display/display_test.go
+++ b/internal/display/display_test.go
@@ -20,10 +20,16 @@ func getPagerTestCat() pager {
 }
 
 func (p *pagerTestCat) getBinary() string {
+	if runtime.GOOS == "windows" {
+		return "findstr"
+	}
 	return "cat"
 }
 
 func (p *pagerTestCat) getFlags() []string {
+	if runtime.GOOS == "windows" {
+		return []string{"/R", "^"}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Description

As discussed with maintainers, I am splitting my previous Windows compatibility work into smaller and isolated PRs. This PR specifically focuses on fixing the pager/display tests on Windows.

While testing Gittuf on Windows, I noticed that the tests in internal/display were failing because the test pager implementation relied on the cat command. Since cat is not available natively on Windows, the tests failed with a command-not-found error even though the underlying display logic itself was working correctly.

How I Resolved This :-

Updated the pagerTestCat helper to be platform-aware.

On Windows, the tests now use findstr /R "^" as a lightweight equivalent for cat
On Linux/macOS, the existing cat behavior remains unchanged

This change is limited to the test helper in internal/display/display_test.go and does not modify production code.

Impact :-

Ensures display and pager tests pass correctly on Windows
Improves cross-platform test reliability for contributors using Windows environments
Keeps the change isolated and atomic without affecting existing Linux/macOS behavior

I verified the changes on both Windows 11 and Ubuntu (WSL).

AI Usage :-

I did use generative AI in some form while preparing this pull request.

AI assistance was mainly used to:

help identify a Windows-compatible alternative for the pager test helper
review the test flow for cross-platform compatibility

Contributor Checklist :- 

- [x] I have manually reviewed all content submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a DCO Signoff.
- [x] By submitting this pull request, I agree to follow the gittuf Code of Conduct.
