### PR TITLE
Add ApplyAttestations coverage

### DIFF
--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -17,11 +17,68 @@ import (
 	githubv01 "github.com/gittuf/gittuf/internal/attestations/github/v01"
 	"github.com/gittuf/gittuf/internal/common"
 	"github.com/gittuf/gittuf/internal/common/set"
+	"github.com/gittuf/gittuf/internal/rsl"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestApplyAttestations(t *testing.T) {
+	testDir := t.TempDir()
+	r := gitinterface.CreateTestGitRepository(t, testDir, false)
+	repo := &Repository{r: r}
+
+	fromRef := "refs/heads/main"
+	targetTagRef := "refs/tags/v1"
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialCommitID, err := repo.r.Commit(emptyTreeID, fromRef, "Initial commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.RecordRSLEntryForReference(testCtx, fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+		t.Fatal(err)
+	}
+
+	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+	if err := repo.AddReferenceAuthorization(testCtx, signer, targetTagRef, fromRef, false); err != nil {
+		t.Fatal(err)
+	}
+
+	attestationsCommitID, err := repo.r.GetReference(attestations.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = rsl.GetLatestReferenceUpdaterEntry(repo.r, rsl.ForReference(attestations.Ref))
+	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
+
+	err = repo.ApplyAttestations(testCtx, "", true, false)
+	assert.Nil(t, err)
+
+	entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo.r, rsl.ForReference(attestations.Ref))
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, attestations.Ref, entry.GetRefName())
+	assert.Equal(t, attestationsCommitID, entry.GetTargetID())
+
+	allAttestations, err := attestations.LoadCurrentAttestations(repo.r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, env.Signatures, 1)
+}
 
 func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {


### PR DESCRIPTION
## Description

Adds coverage for `ApplyAttestations`.

The test creates a reference authorization attestation, applies attestations locally, and checks that the RSL records the new `refs/gittuf/attestations` entry.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
