### PR TITLE
Add Sync transport prefix coverage

### DIFF
--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -653,6 +653,55 @@ func TestSync(t *testing.T) {
 		assert.Empty(t, divergedRefs)
 	})
 
+	t.Run("remote uses gittuf transport prefix", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, true)
+		remoteRepo := &Repository{r: remoteR}
+
+		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
+		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
+		if err := localR.RemoveRemote(remoteName); err != nil {
+			t.Fatal(err)
+		}
+		if err := localR.AddRemote(remoteName, gittufTransportPrefix+tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
+		assert.Nil(t, err)
+		assert.Empty(t, divergedRefs)
+
+		_, err = localR.GetRemoteURL(fmt.Sprintf("check-remote-%s", remoteName))
+		assert.ErrorContains(t, err, "No such remote")
+
+		remoteURL, err := localR.GetRemoteURL(remoteName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, gittufTransportPrefix+tmpDir, remoteURL)
+		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
+	})
+
 	t.Run("local is strictly ahead of remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, true)


### PR DESCRIPTION
## Description

Adds test coverage for `Sync`.

The test configures `origin` with a `gittuf::` transport-prefixed URL, runs `Sync`, and checks that the temporary remote used for syncing is removed afterward.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).