### PR TITLE
Add ReconcileLocalRSLWithRemote transport prefix coverage

### DIFF
--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -334,6 +334,75 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		assert.NotEqual(t, originalRSLTip, currentRSLTip)
 	})
 
+	t.Run("remote uses gittuf transport prefix", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+		remoteRepo := &Repository{r: remoteR}
+
+		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate remote actions
+		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		// TODO: this should be handled by the Repository package
+		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := localR.RemoveRemote(remoteName); err != nil {
+			t.Fatal(err)
+		}
+		if err := localR.AddRemote(remoteName, gittufTransportPrefix+tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		localRepo := &Repository{r: localR}
+
+		// Simulate more remote actions
+		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		originalRSLTip, err := localRepo.r.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false)
+		assert.Nil(t, err)
+
+		currentRSLTip, err := localRepo.r.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
+		assert.NotEqual(t, originalRSLTip, currentRSLTip)
+
+		_, err = localR.GetRemoteURL(fmt.Sprintf("check-remote-%s", remoteName))
+		assert.ErrorContains(t, err, "No such remote")
+
+		remoteURL, err := localR.GetRemoteURL(remoteName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Equal(t, gittufTransportPrefix+tmpDir, remoteURL)
+	})
+
 	t.Run("remote has no updates for local", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)


### PR DESCRIPTION
## Description

Adds test coverage for `ReconcileLocalRSLWithRemote`.

The test configures `origin` with a `gittuf::` transport-prefixed URL, adds a newer remote RSL entry, reconciles the local RSL, and checks that the temporary remote is removed afterward.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).