### PR TITLE
Add reference authorization version coverage

### DIFF
--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -4,8 +4,11 @@
 package attestations
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/gittuf/gittuf/internal/attestations/authorizations"
+	authorizationsv01 "github.com/gittuf/gittuf/internal/attestations/authorizations/v01"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
@@ -52,6 +55,35 @@ func TestSetReferenceAuthorization(t *testing.T) {
 		err := attestations.SetReferenceAuthorization(repo, tagApproval, tagRef, testID, testID)
 		assert.Nil(t, err)
 		assert.Contains(t, attestations.referenceAuthorizations, ReferenceAuthorizationPath(tagRef, testID, testID))
+	})
+
+	t.Run("v01", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+		env := createReferenceAuthorizationAttestationEnvelopeV01(t, testRef, testID, testID)
+
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		attestations := &Attestations{}
+
+		err := attestations.SetReferenceAuthorization(repo, env, testRef, testID, testID)
+		assert.Nil(t, err)
+		assert.Contains(t, attestations.referenceAuthorizations, ReferenceAuthorizationPath(testRef, testID, testID))
+	})
+
+	t.Run("unknown version", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+		env := createReferenceAuthorizationAttestationEnvelopeWithPredicateType(t, testRef, testID, testID, "https://gittuf.dev/reference-authorization/unknown")
+
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		attestations := &Attestations{}
+
+		err := attestations.SetReferenceAuthorization(repo, env, testRef, testID, testID)
+		assert.ErrorIs(t, err, authorizations.ErrUnknownAuthorizationVersion)
 	})
 }
 
@@ -166,6 +198,50 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, tagApproval, tagApprovalFetched)
 	})
+
+	t.Run("v01", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+		env := createReferenceAuthorizationAttestationEnvelopeV01(t, testRef, testID, testID)
+
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		attestations := &Attestations{}
+
+		err := attestations.SetReferenceAuthorization(repo, env, testRef, testID, testID)
+		assert.Nil(t, err)
+
+		fetchedEnv, err := attestations.GetReferenceAuthorizationFor(repo, testRef, testID, testID)
+		assert.Nil(t, err)
+		assert.Equal(t, env, fetchedEnv)
+	})
+
+	t.Run("unknown version", func(t *testing.T) {
+		testRef := "refs/heads/main"
+		testID := gitinterface.ZeroHash.String()
+		env := createReferenceAuthorizationAttestationEnvelopeWithPredicateType(t, testRef, testID, testID, "https://gittuf.dev/reference-authorization/unknown")
+
+		tempDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+		attestations := &Attestations{}
+
+		envBytes, err := json.Marshal(env)
+		if err != nil {
+			t.Fatal(err)
+		}
+		blobID, err := repo.WriteBlob(envBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		attestations.referenceAuthorizations = map[string]gitinterface.Hash{
+			ReferenceAuthorizationPath(testRef, testID, testID): blobID,
+		}
+
+		_, err = attestations.GetReferenceAuthorizationFor(repo, testRef, testID, testID)
+		assert.ErrorIs(t, err, authorizations.ErrUnknownAuthorizationVersion)
+	})
 }
 
 func createReferenceAuthorizationAttestationEnvelopes(t *testing.T, refName, fromID, toID string, tag bool) *sslibdsse.Envelope {
@@ -183,6 +259,39 @@ func createReferenceAuthorizationAttestationEnvelopes(t *testing.T, refName, fro
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}
+
+func createReferenceAuthorizationAttestationEnvelopeV01(t *testing.T, refName, fromID, toID string) *sslibdsse.Envelope {
+	t.Helper()
+
+	authorization, err := authorizationsv01.NewReferenceAuthorization(refName, fromID, toID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	env, err := dsse.CreateEnvelope(authorization)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return env
+}
+
+func createReferenceAuthorizationAttestationEnvelopeWithPredicateType(t *testing.T, refName, fromID, toID, predicateType string) *sslibdsse.Envelope {
+	t.Helper()
+
+	authorization, err := NewReferenceAuthorizationForCommit(refName, fromID, toID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authorization.PredicateType = predicateType
 
 	env, err := dsse.CreateEnvelope(authorization)
 	if err != nil {


### PR DESCRIPTION
## Description

Adds test coverage for reference authorization version handling.

The tests check that v0.1 reference authorizations can be stored and fetched, and that unknown predicate versions are rejected when storing or fetching an authorization.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
