### PR TITLE
Add targets delegations unmarshal coverage

### DIFF
--- a/internal/tuf/v02/targets_test.go
+++ b/internal/tuf/v02/targets_test.go
@@ -4,6 +4,7 @@
 package v02
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -76,6 +77,48 @@ func TestTargetsMetadataAndDelegations(t *testing.T) {
 		assert.False(t, exists)
 
 		assert.Empty(t, delegations.Principals)
+	})
+}
+
+func TestDelegationsUnmarshalJSON(t *testing.T) {
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	person := &Person{
+		PersonID:   "jane.doe",
+		PublicKeys: map[string]*Key{key.KeyID: key},
+	}
+
+	t.Run("key and person principals", func(t *testing.T) {
+		delegations := &Delegations{
+			Principals: map[string]tuf.Principal{
+				key.KeyID:       key,
+				person.PersonID: person,
+			},
+			Roles: []*Delegation{AllowRule()},
+		}
+
+		data, err := json.Marshal(delegations)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		got := &Delegations{}
+		err = json.Unmarshal(data, got)
+		assert.Nil(t, err)
+		assert.Equal(t, delegations, got)
+	})
+
+	t.Run("invalid JSON", func(t *testing.T) {
+		delegations := &Delegations{}
+
+		err := json.Unmarshal([]byte(`{`), delegations)
+		assert.ErrorContains(t, err, "unexpected end of JSON input")
+	})
+
+	t.Run("unrecognized principal", func(t *testing.T) {
+		delegations := &Delegations{}
+
+		err := json.Unmarshal([]byte(`{"principals":{"unknown":{"name":"unknown"}}}`), delegations)
+		assert.ErrorContains(t, err, "unrecognized principal type")
 	})
 }
 


### PR DESCRIPTION
## Description

Adds test coverage for `Delegations.UnmarshalJSON` in the v0.2 targets metadata implementation.

The tests check that key and person principals can be unmarshaled correctly. They also cover invalid JSON and unrecognized principal types.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
