### PR TITLE
Fix the tests using mock github API and add TestGetGitHubClient

### DIFF
--- a/experimental/gittuf/attestations.go
+++ b/experimental/gittuf/attestations.go
@@ -727,8 +727,10 @@ func (r *Repository) getGitHubPullRequestReviewDetails(ctx context.Context, curr
 		if err != nil {
 			return "", "", "", err
 		}
-		if err := r.r.FetchObject(pullRequest.GetHead().GetRepo().GetCloneURL(), headHash); err != nil {
-			return "", "", "", err
+		if !r.r.HasObject(headHash) {
+			if err := r.r.FetchObject(pullRequest.GetHead().GetRepo().GetCloneURL(), headHash); err != nil {
+				return "", "", "", err
+			}
 		}
 
 		// Now compute the merge tree ID

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -916,8 +916,8 @@ func TestIndexPathToComponents(t *testing.T) {
 func TestGetGitHubClient(t *testing.T) {
 	t.Run("default baseURL keeps github.com endpoints", func(t *testing.T) {
 		client, err := getGitHubClient(githubopts.DefaultGitHubBaseURL, "test-token")
-		require.Nil(t, err)
-		require.NotNil(t, client)
+		assert.Nil(t, err)
+		assert.NotNil(t, client)
 
 		// Default go-github BaseURL is api.github.com
 		assert.Equal(t, "https://api.github.com/", client.BaseURL.String())
@@ -926,8 +926,8 @@ func TestGetGitHubClient(t *testing.T) {
 
 	t.Run("enterprise baseURL gets /api/v3 and /api/uploads paths", func(t *testing.T) {
 		client, err := getGitHubClient("https://github.acme.internal", "test-token")
-		require.Nil(t, err)
-		require.NotNil(t, client)
+		assert.Nil(t, err)
+		assert.NotNil(t, client)
 
 		assert.Equal(t, "https://github.acme.internal/api/v3/", client.BaseURL.String())
 		assert.Equal(t, "https://github.acme.internal/api/uploads/", client.UploadURL.String())
@@ -935,8 +935,8 @@ func TestGetGitHubClient(t *testing.T) {
 
 	t.Run("trailing slash in baseURL is normalized", func(t *testing.T) {
 		client, err := getGitHubClient("https://github.acme.internal/", "test-token")
-		require.Nil(t, err)
-		require.NotNil(t, client)
+		assert.Nil(t, err)
+		assert.NotNil(t, client)
 
 		// Should produce the same paths as the no-trailing-slash case
 		assert.Equal(t, "https://github.acme.internal/api/v3/", client.BaseURL.String())
@@ -952,7 +952,7 @@ func TestGetGitHubClient(t *testing.T) {
 		// getGitHubClient itself doesn't enforce non-empty token;
 		// callers do (via ErrNoGitHubToken). This documents that behavior.
 		client, err := getGitHubClient(githubopts.DefaultGitHubBaseURL, "")
-		require.Nil(t, err)
-		require.NotNil(t, client)
+		assert.Nil(t, err)
+		assert.NotNil(t, client)
 	})
 }

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -610,37 +610,28 @@ func TestAddGitHubPullRequestApprover(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		pr := gogithub.PullRequest{
+			ID: gogithub.Int64(1),
+			Base: &gogithub.PullRequestBranch{
+				Ref: gogithub.String("main"),
+				SHA: gogithub.String(initialCommitID.String()),
+			},
+			Head: &gogithub.PullRequestBranch{
+				Ref: gogithub.String("feature"),
+				SHA: gogithub.String(featureHeadCommitID.String()),
+				Repo: &gogithub.Repository{
+					CloneURL: gogithub.String(testDir),
+				},
+			},
+			MergedAt: &gogithub.Timestamp{
+				Time: time.Now(),
+			},
+		}
+
 		mockedHTTPClient := gogithubmock.NewMockedHTTPClient(
 			gogithubmock.WithRequestMatch(
 				gogithubmock.GetReposPullsByOwnerByRepoByPullNumber,
-				gogithub.PullRequest{
-					ID: gogithub.Int64(1),
-					Base: &gogithub.PullRequestBranch{
-						Ref: gogithub.String("main"),
-						SHA: gogithub.String(initialCommitID.String()),
-					},
-					Head: &gogithub.PullRequestBranch{
-						Ref: gogithub.String("feature"),
-						SHA: gogithub.String(featureHeadCommitID.String()),
-					},
-					MergedAt: &gogithub.Timestamp{
-						Time: time.Now(),
-					},
-				},
-				gogithub.PullRequest{
-					ID: gogithub.Int64(1),
-					Base: &gogithub.PullRequestBranch{
-						Ref: gogithub.String("main"),
-						SHA: gogithub.String(initialCommitID.String()),
-					},
-					Head: &gogithub.PullRequestBranch{
-						Ref: gogithub.String("feature"),
-						SHA: gogithub.String(featureHeadCommitID.String()),
-					},
-					MergedAt: &gogithub.Timestamp{
-						Time: time.Now(),
-					},
-				},
+				pr, pr,
 			),
 			gogithubmock.WithRequestMatch(
 				gogithubmock.GetReposPullsReviewsByOwnerByRepoByPullNumberByReviewId,

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -912,3 +912,47 @@ func TestIndexPathToComponents(t *testing.T) {
 		assert.Equal(t, test.to, to, fmt.Sprintf("unexpected 'to' in test '%s'", name))
 	}
 }
+
+func TestGetGitHubClient(t *testing.T) {
+	t.Run("default baseURL keeps github.com endpoints", func(t *testing.T) {
+		client, err := getGitHubClient(githubopts.DefaultGitHubBaseURL, "test-token")
+		require.Nil(t, err)
+		require.NotNil(t, client)
+
+		// Default go-github BaseURL is api.github.com
+		assert.Equal(t, "https://api.github.com/", client.BaseURL.String())
+		assert.Equal(t, "https://uploads.github.com/", client.UploadURL.String())
+	})
+
+	t.Run("enterprise baseURL gets /api/v3 and /api/uploads paths", func(t *testing.T) {
+		client, err := getGitHubClient("https://github.acme.internal", "test-token")
+		require.Nil(t, err)
+		require.NotNil(t, client)
+
+		assert.Equal(t, "https://github.acme.internal/api/v3/", client.BaseURL.String())
+		assert.Equal(t, "https://github.acme.internal/api/uploads/", client.UploadURL.String())
+	})
+
+	t.Run("trailing slash in baseURL is normalized", func(t *testing.T) {
+		client, err := getGitHubClient("https://github.acme.internal/", "test-token")
+		require.Nil(t, err)
+		require.NotNil(t, client)
+
+		// Should produce the same paths as the no-trailing-slash case
+		assert.Equal(t, "https://github.acme.internal/api/v3/", client.BaseURL.String())
+		assert.Equal(t, "https://github.acme.internal/api/uploads/", client.UploadURL.String())
+	})
+
+	t.Run("invalid baseURL returns error", func(t *testing.T) {
+		_, err := getGitHubClient("://no-scheme", "test-token")
+		require.NotNil(t, err)
+	})
+
+	t.Run("empty token still produces a usable client", func(t *testing.T) {
+		// getGitHubClient itself doesn't enforce non-empty token;
+		// callers do (via ErrNoGitHubToken). This documents that behavior.
+		client, err := getGitHubClient(githubopts.DefaultGitHubBaseURL, "")
+		require.Nil(t, err)
+		require.NotNil(t, client)
+	})
+}

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -6,6 +6,7 @@ package gittuf
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -945,7 +946,8 @@ func TestGetGitHubClient(t *testing.T) {
 
 	t.Run("invalid baseURL returns error", func(t *testing.T) {
 		_, err := getGitHubClient("://no-scheme", "test-token")
-		require.NotNil(t, err)
+		var urlErr *url.Error
+		assert.ErrorAs(t, err, &urlErr)
 	})
 
 	t.Run("empty token still produces a usable client", func(t *testing.T) {


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->
The changes made to allow testing of AddGitHubPullRequestApprover using a mock client, were causing the test to fail.

This is because the Repo field in the Head of the mock PR in the mock GitHub aAPI was empty, but AddGitHubPullRequestApprover calls getGitHubPullRequestReviewDetails to get baseRef, fromID and toID to check if the pull request has already been approved.

But getGitHubPullRequestReviewDetails needs to call FetchObject with the pull request's head's repo as an argument, before calling GetMergeTree to extract toID. This was giving an error earlier because the repo had not been specified, so the following command was run:

git --git-dir /tmp/TestDismissGitHubPullRequestApprovertest_mocked_API2876472590/001/.git fetch 94735a390ae5aa4035923c689b68546abc0e6f8b

It gives an error since we don't provide a repo or remote name to git fetch.

I've now set the repo in the sample data returned by the API to point to the same testDir and also made sure that the SHA in the PR corresponds to one already committed to feature branch in the test. So fetching from this folder will now work as expected.

The second commit is just a sanity check.

I have also added tests for GetGitHubClient as it had 0% coverage previously.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [X] I **did not** use generative AI at all in making the content of this pull
  request.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [ ] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).

