### PR TITLE
Add targets RemovePrincipal coverage

### DIFF
--- a/internal/tuf/v01/targets_test.go
+++ b/internal/tuf/v01/targets_test.go
@@ -400,6 +400,32 @@ func TestRemoveRule(t *testing.T) {
 	assert.Contains(t, targetsMetadata.Delegations.Keys, key.KeyID)
 }
 
+func TestRemovePrincipal(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+
+	err := targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalNotFound)
+
+	err = targetsMetadata.AddPrincipal(key)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Keys, key.KeyID)
+
+	err = targetsMetadata.AddRule("test-rule", []string{key.KeyID}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+
+	err = targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalStillInUse)
+
+	err = targetsMetadata.RemoveRule("test-rule")
+	assert.Nil(t, err)
+
+	err = targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.Nil(t, err)
+	assert.NotContains(t, targetsMetadata.Delegations.Keys, key.KeyID)
+}
+
 func TestUpdatePrincipal(t *testing.T) {
 	targetsMetadata := initialTestTargetsMetadata(t)
 

--- a/internal/tuf/v02/targets_test.go
+++ b/internal/tuf/v02/targets_test.go
@@ -474,6 +474,49 @@ func TestRemoveRule(t *testing.T) {
 	assert.Contains(t, targetsMetadata.Delegations.Principals, key.KeyID)
 }
 
+func TestRemovePrincipal(t *testing.T) {
+	targetsMetadata := initialTestTargetsMetadata(t)
+
+	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
+	person := &Person{
+		PersonID: "jane.doe",
+		PublicKeys: map[string]*Key{
+			key.KeyID: key,
+		},
+	}
+
+	err := targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalNotFound)
+
+	err = targetsMetadata.AddPrincipal(key)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, key.KeyID)
+
+	err = targetsMetadata.AddPrincipal(person)
+	assert.Nil(t, err)
+	assert.Contains(t, targetsMetadata.Delegations.Principals, person.PersonID)
+
+	err = targetsMetadata.RemovePrincipal("")
+	assert.ErrorIs(t, err, tuf.ErrInvalidPrincipalID)
+
+	err = targetsMetadata.AddRule("test-rule", []string{key.KeyID}, []string{"test/"}, 1)
+	assert.Nil(t, err)
+
+	err = targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.ErrorIs(t, err, tuf.ErrPrincipalStillInUse)
+
+	err = targetsMetadata.RemovePrincipal(person.PersonID)
+	assert.Nil(t, err)
+	assert.NotContains(t, targetsMetadata.Delegations.Principals, person.PersonID)
+
+	err = targetsMetadata.RemoveRule("test-rule")
+	assert.Nil(t, err)
+
+	err = targetsMetadata.RemovePrincipal(key.KeyID)
+	assert.Nil(t, err)
+	assert.NotContains(t, targetsMetadata.Delegations.Principals, key.KeyID)
+}
+
 func TestUpdatePrincipal(t *testing.T) {
 	targetsMetadata := initialTestTargetsMetadata(t)
 


### PR DESCRIPTION
## Description

Adds coverage for `RemovePrincipal` in TUF targets metadata.

The tests cover removing principals from both v01 and v02 targets metadata, including the case where the principal is still referenced by a rule.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
