### PR TITLE
Attestations tests

### DIFF
--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -1007,21 +1006,7 @@ func TestGetGitHubPullRequestReviewDetails(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := exec.Command(
-			"git",
-			"-C", testDir,
-			"commit-tree",
-			"-m", "Merge feature into main\n",
-			"-p", targetHeadCommitID.String(),
-			"-p", featureHeadCommitID.String(),
-			mergeTreeID.String(),
-		)
-
-		out, err := cmd.Output()
-		assert.Nil(t, err)
-
-		mergeCommitID, err := gitinterface.NewHash(strings.TrimSpace(string(out)))
-		assert.Nil(t, err)
+		mergeCommitID := r.CommitWithParents(t, mergeTreeID, []gitinterface.Hash{targetHeadCommitID, featureHeadCommitID}, "Merge feature into main", false)
 
 		err = r.SetReference(absTargetRef, mergeCommitID)
 		assert.Nil(t, err)
@@ -1167,21 +1152,7 @@ func TestGetGitHubPullRequestReviewDetails(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		cmd := exec.Command(
-			"git",
-			"-C", testDir,
-			"commit-tree",
-			"-m", "Merge feature into main\n",
-			"-p", targetHeadCommitID.String(),
-			"-p", featureHeadCommitID.String(),
-			mergeTreeID.String(),
-		)
-
-		out, err := cmd.Output()
-		assert.Nil(t, err)
-
-		mergeCommitID, err := gitinterface.NewHash(strings.TrimSpace(string(out)))
-		assert.Nil(t, err)
+		mergeCommitID := r.CommitWithParents(t, mergeTreeID, []gitinterface.Hash{targetHeadCommitID, featureHeadCommitID}, "Merge feature into main", false)
 
 		err = r.SetReference(absTargetRef, mergeCommitID)
 		assert.Nil(t, err)

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -1072,7 +1072,7 @@ func TestGetGitHubPullRequestReviewDetails(t *testing.T) {
 					MergedAt: &gogithub.Timestamp{
 						Time: time.Now(),
 					},
-					MergeCommitSHA: gogithub.String(string(mergeCommitID.String())),
+					MergeCommitSHA: gogithub.String(mergeCommitID.String()),
 				},
 			),
 			gogithubmock.WithRequestMatch(
@@ -1204,7 +1204,7 @@ func TestGetGitHubPullRequestReviewDetails(t *testing.T) {
 					MergedAt: &gogithub.Timestamp{
 						Time: time.Now(),
 					},
-					MergeCommitSHA: gogithub.String(string(mergeCommitID.String())),
+					MergeCommitSHA: gogithub.String(mergeCommitID.String()),
 				},
 			),
 			gogithubmock.WithRequestMatch(

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -956,5 +957,411 @@ func TestGetGitHubClient(t *testing.T) {
 		client, err := getGitHubClient(githubopts.DefaultGitHubBaseURL, "")
 		assert.Nil(t, err)
 		assert.NotNil(t, client)
+	})
+}
+
+func TestGetGitHubPullRequestReviewDetails(t *testing.T) {
+	t.Run("Test the case where the review is already stored in the attestations state", func(t *testing.T) {
+		testDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, testDir, false)
+		repo := &Repository{r: r}
+
+		targetRef := "main"
+		absTargetRef := "refs/heads/main"
+		featureRef := "feature"
+		absFeatureRef := "refs/heads/feature"
+
+		// Create common base for main and feature branches
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		initialCommitID, err := repo.r.Commit(emptyTreeID, absTargetRef, "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.r.SetReference(absFeatureRef, initialCommitID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create main branch as the target branch with a Git commit
+		// Add a single commit
+		targetCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
+		targetHeadCommitID := targetCommitIDs[0]
+
+		if err := repo.RecordRSLEntryForReference(testCtx, targetRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create feature branch with two Git commits
+		// Add two commits
+		featureCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
+		featureHeadCommitID := featureCommitIDs[1]
+		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		mergeTreeID, err := r.GetMergeTree(targetHeadCommitID, featureHeadCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(
+			"git",
+			"-C", testDir,
+			"commit-tree",
+			"-m", "Merge feature into main\n",
+			"-p", targetHeadCommitID.String(),
+			"-p", featureHeadCommitID.String(),
+			mergeTreeID.String(),
+		)
+
+		out, err := cmd.Output()
+		assert.Nil(t, err)
+
+		mergeCommitID, err := gitinterface.NewHash(strings.TrimSpace(string(out)))
+		assert.Nil(t, err)
+
+		err = r.SetReference(absTargetRef, mergeCommitID)
+		assert.Nil(t, err)
+
+		t.Setenv("GITTUF_DEV", "1")
+
+		mockedHTTPClient := gogithubmock.NewMockedHTTPClient(
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsByOwnerByRepoByPullNumber,
+				gogithub.PullRequest{
+					ID: gogithub.Int64(1),
+					Base: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("main"),
+						SHA: gogithub.String(initialCommitID.String()),
+					},
+					Head: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("feature"),
+						SHA: gogithub.String(featureHeadCommitID.String()),
+					},
+					MergedAt: &gogithub.Timestamp{
+						Time: time.Now(),
+					},
+				},
+				gogithub.PullRequest{
+					ID: gogithub.Int64(1),
+					Base: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("main"),
+						SHA: gogithub.String(initialCommitID.String()),
+					},
+					Head: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("feature"),
+						SHA: gogithub.String(featureHeadCommitID.String()),
+					},
+					MergedAt: &gogithub.Timestamp{
+						Time: time.Now(),
+					},
+				},
+				gogithub.PullRequest{
+					ID: gogithub.Int64(1),
+					Base: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("main"),
+						SHA: gogithub.String(targetHeadCommitID.String()),
+					},
+					Head: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("feature"),
+						SHA: gogithub.String(featureHeadCommitID.String()),
+					},
+					MergedAt: &gogithub.Timestamp{
+						Time: time.Now(),
+					},
+					MergeCommitSHA: gogithub.String(string(mergeCommitID.String())),
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsReviewsByOwnerByRepoByPullNumberByReviewId,
+				gogithub.PullRequestReview{
+					ID: gogithub.Int64(123),
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposGitRefByOwnerByRepoByRef,
+				gogithub.Reference{
+					Ref: gogithub.String("refs/heads/main"),
+					Object: &gogithub.GitObject{
+						SHA: gogithub.String(targetHeadCommitID.String()),
+					},
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposGitCommitsByOwnerByRepoByCommitSha,
+				gogithub.Commit{
+					SHA: gogithub.String(mergeCommitID.String()),
+					Tree: &gogithub.Tree{
+						SHA: gogithub.String(mergeTreeID.String()),
+					},
+				},
+			),
+		)
+
+		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+		mockedGoGitHubClient := gogithub.NewClient(mockedHTTPClient)
+
+		err = repo.AddGitHubPullRequestAttestationForNumber(testCtx, signer, "owner", "repo", 1, false, githubopts.WithMockedGitHubAPIClient(mockedHTTPClient), githubopts.WithRSLEntry())
+		assert.Nil(t, err)
+		err = repo.AddGitHubPullRequestApprover(testCtx, signer, "owner", "repo", 1, 123, "bob", false, githubopts.WithMockedGitHubAPIClient(mockedHTTPClient), githubopts.WithRSLEntry())
+		assert.Nil(t, err)
+
+		attestations, err := attestations.LoadCurrentAttestations(repo.r)
+		assert.Nil(t, err)
+
+		baseRef, fromID, toID, err := repo.getGitHubPullRequestReviewDetails(testCtx, attestations, mockedGoGitHubClient, githubopts.DefaultGitHubBaseURL, "owner", "repo", 1, 123, true)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "refs/heads/main", baseRef)
+		assert.Equal(t, toID, mergeTreeID.String())
+		assert.Equal(t, fromID, targetHeadCommitID.String())
+	})
+
+	t.Run("Test the case where the review is not in attestations state and useGitHubAPI is true", func(t *testing.T) {
+		testDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, testDir, false)
+		repo := &Repository{r: r}
+
+		targetRef := "main"
+		absTargetRef := "refs/heads/main"
+		featureRef := "feature"
+		absFeatureRef := "refs/heads/feature"
+
+		// Create common base for main and feature branches
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		initialCommitID, err := repo.r.Commit(emptyTreeID, absTargetRef, "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.r.SetReference(absFeatureRef, initialCommitID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create main branch as the target branch with a Git commit
+		// Add a single commit
+		targetCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absTargetRef, 1, gpgKeyBytes)
+		targetHeadCommitID := targetCommitIDs[0]
+
+		if err := repo.RecordRSLEntryForReference(testCtx, targetRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create feature branch with two Git commits
+		// Add two commits
+		featureCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, r, absFeatureRef, 2, gpgKeyBytes)
+		featureHeadCommitID := featureCommitIDs[1]
+		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		mergeTreeID, err := r.GetMergeTree(targetHeadCommitID, featureHeadCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := exec.Command(
+			"git",
+			"-C", testDir,
+			"commit-tree",
+			"-m", "Merge feature into main\n",
+			"-p", targetHeadCommitID.String(),
+			"-p", featureHeadCommitID.String(),
+			mergeTreeID.String(),
+		)
+
+		out, err := cmd.Output()
+		assert.Nil(t, err)
+
+		mergeCommitID, err := gitinterface.NewHash(strings.TrimSpace(string(out)))
+		assert.Nil(t, err)
+
+		err = r.SetReference(absTargetRef, mergeCommitID)
+		assert.Nil(t, err)
+
+		t.Setenv("GITTUF_DEV", "1")
+
+		mockedHTTPClient := gogithubmock.NewMockedHTTPClient(
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsByOwnerByRepoByPullNumber,
+				gogithub.PullRequest{
+					ID: gogithub.Int64(1),
+					Base: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("main"),
+						SHA: gogithub.String(initialCommitID.String()),
+					},
+					Head: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("feature"),
+						SHA: gogithub.String(featureHeadCommitID.String()),
+					},
+					MergedAt: &gogithub.Timestamp{
+						Time: time.Now(),
+					},
+					MergeCommitSHA: gogithub.String(string(mergeCommitID.String())),
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsReviewsByOwnerByRepoByPullNumberByReviewId,
+				gogithub.PullRequestReview{
+					ID: gogithub.Int64(123),
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposGitRefByOwnerByRepoByRef,
+				gogithub.Reference{
+					Ref: gogithub.String("refs/heads/main"),
+					Object: &gogithub.GitObject{
+						SHA: gogithub.String(targetHeadCommitID.String()),
+					},
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposGitCommitsByOwnerByRepoByCommitSha,
+				gogithub.Commit{
+					SHA: gogithub.String(mergeCommitID.String()),
+					Tree: &gogithub.Tree{
+						SHA: gogithub.String(mergeTreeID.String()),
+					},
+				},
+			),
+		)
+
+		mockedGoGitHubClient := gogithub.NewClient(mockedHTTPClient)
+
+		attestations, err := attestations.LoadCurrentAttestations(repo.r)
+		assert.Nil(t, err)
+
+		baseRef, fromID, toID, err := repo.getGitHubPullRequestReviewDetails(testCtx, attestations, mockedGoGitHubClient, githubopts.DefaultGitHubBaseURL, "owner", "repo", 1, 123, true)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "refs/heads/main", baseRef)
+		assert.Equal(t, toID, mergeTreeID.String())
+		assert.Equal(t, fromID, targetHeadCommitID.String())
+	})
+
+	t.Run("Test the case where the review is not in attestations state and useGitHubAPI is false but head hash is not locally found", func(t *testing.T) {
+		remoteDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, remoteDir, false)
+		remoteRepo := &Repository{r: remoteR}
+
+		localDir := t.TempDir()
+		localR := gitinterface.CreateTestGitRepository(t, localDir, false)
+		localRepo := &Repository{r: localR}
+
+		targetRef := "main"
+		absTargetRef := "refs/heads/main"
+		featureRef := "feature"
+		absFeatureRef := "refs/heads/feature"
+
+		// Create common base for main and feature branches
+		// remoteTreeBuilder := gitinterface.NewTreeBuilder(remoteRepo.r)
+		// localTreeBuilder := gitinterface.NewTreeBuilder(localRepo.r)
+		remoteTreeBuilder := gitinterface.NewTreeBuilder(remoteRepo.r)
+
+		emptyRemoteTreeID, err := remoteTreeBuilder.WriteTreeFromEntries(nil)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		initialCommitID, err := remoteRepo.r.Commit(emptyRemoteTreeID, absTargetRef, "Initial commit\n", false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.r.SetReference(absFeatureRef, initialCommitID); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create main branch as the target branch with a Git commit
+		// Add a single commit
+		targetCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, remoteR, absTargetRef, 1, gpgKeyBytes)
+		targetHeadCommitID := targetCommitIDs[0]
+
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, targetRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.r.FetchObject(remoteDir, targetHeadCommitID)
+		assert.Nil(t, err)
+
+		err = localRepo.r.SetReference(absTargetRef, targetHeadCommitID)
+		assert.Nil(t, err)
+
+		err = localRepo.r.FetchObject(remoteDir, initialCommitID)
+		assert.Nil(t, err)
+
+		err = localRepo.r.SetReference(absFeatureRef, initialCommitID)
+		assert.Nil(t, err)
+
+		if err := localRepo.RecordRSLEntryForReference(testCtx, targetRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := localRepo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create feature branch with two Git commits
+		// Add two commits
+		featureCommitIDs := common.AddNTestCommitsToSpecifiedRef(t, remoteR, absFeatureRef, 1, gpgKeyBytes)
+		featureHeadCommitID := featureCommitIDs[0]
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		mergeTreeID, err := remoteR.GetMergeTree(targetHeadCommitID, featureHeadCommitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		t.Setenv("GITTUF_DEV", "1")
+
+		mockedHTTPClient := gogithubmock.NewMockedHTTPClient(
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsByOwnerByRepoByPullNumber,
+				gogithub.PullRequest{
+					ID: gogithub.Int64(1),
+					Base: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("main"),
+						SHA: gogithub.String(initialCommitID.String()),
+					},
+					Head: &gogithub.PullRequestBranch{
+						Ref: gogithub.String("feature"),
+						SHA: gogithub.String(featureHeadCommitID.String()),
+						Repo: &gogithub.Repository{
+							CloneURL: gogithub.String(remoteDir),
+							// ... other fields
+						},
+					},
+					MergedAt: &gogithub.Timestamp{
+						Time: time.Now(),
+					},
+				},
+			),
+			gogithubmock.WithRequestMatch(
+				gogithubmock.GetReposPullsReviewsByOwnerByRepoByPullNumberByReviewId,
+				gogithub.PullRequestReview{
+					ID: gogithub.Int64(123),
+				},
+			),
+		)
+
+		mockedGoGitHubClient := gogithub.NewClient(mockedHTTPClient)
+
+		attestations, err := attestations.LoadCurrentAttestations(localRepo.r)
+		assert.Nil(t, err)
+
+		baseRef, fromID, toID, err := localRepo.getGitHubPullRequestReviewDetails(testCtx, attestations, mockedGoGitHubClient, githubopts.DefaultGitHubBaseURL, "owner", "repo", 1, 123, false)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "refs/heads/main", baseRef)
+		assert.Equal(t, toID, mergeTreeID.String())
+		assert.Equal(t, fromID, targetHeadCommitID.String())
 	})
 }

--- a/pkg/gitinterface/changes_test.go
+++ b/pkg/gitinterface/changes_test.go
@@ -243,7 +243,7 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 		}
 
 		// Create a merge commit with two parents
-		cM := repo.commitWithParents(t, treeB, []Hash{cA, cB}, "Merge commit\n", false)
+		cM := repo.CommitWithParents(t, treeB, []Hash{cA, cB}, "Merge commit\n", false)
 
 		diffs, err := repo.GetFilePathsChangedByCommit(cM)
 		assert.Nil(t, err)
@@ -289,7 +289,7 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 		}
 
 		// Create a merge commit with two parents and a different tree
-		cM := repo.commitWithParents(t, treeC, []Hash{cA, cB}, "Merge commit\n", false)
+		cM := repo.CommitWithParents(t, treeC, []Hash{cA, cB}, "Merge commit\n", false)
 
 		diffs, err := repo.GetFilePathsChangedByCommit(cM)
 		assert.Nil(t, err)
@@ -335,7 +335,7 @@ func TestGetFilePathsChangedByCommitRepository(t *testing.T) {
 		}
 
 		// Create a merge commit with two parents and an overlapping tree
-		cM := repo.commitWithParents(t, treeC, []Hash{cA, cB}, "Merge commit\n", false)
+		cM := repo.CommitWithParents(t, treeC, []Hash{cA, cB}, "Merge commit\n", false)
 
 		diffs, err := repo.GetFilePathsChangedByCommit(cM)
 		assert.Nil(t, err)

--- a/pkg/gitinterface/commit.go
+++ b/pkg/gitinterface/commit.go
@@ -126,10 +126,10 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 	return commitIDHash, r.CheckAndSetReference(targetRef, commitIDHash, refTip)
 }
 
-// commitWithParents creates a new commit in the repo but does not update any
+// CommitWithParents creates a new commit in the repo but does not update any
 // references. It is only meant to be used for tests, and therefore accepts
 // specific parent commit IDs.
-func (r *Repository) commitWithParents(t *testing.T, treeID Hash, parentIDs []Hash, message string, sign bool) Hash { //nolint:unparam
+func (r *Repository) CommitWithParents(t *testing.T, treeID Hash, parentIDs []Hash, message string, sign bool) Hash { //nolint:unparam
 	args := []string{"commit-tree", "-m", message}
 
 	for _, commitID := range parentIDs {

--- a/pkg/gitinterface/commit_test.go
+++ b/pkg/gitinterface/commit_test.go
@@ -629,7 +629,7 @@ func TestGetCommonAncestor(t *testing.T) {
 	}
 
 	// Add child commit B
-	commitB := repo.commitWithParents(t, emptyTreeID, []Hash{initialCommitID}, "Second commit B\n", false)
+	commitB := repo.CommitWithParents(t, emptyTreeID, []Hash{initialCommitID}, "Second commit B\n", false)
 
 	// Test commits, ensure we get back initial commit
 	commonAncestor, err := repo.GetCommonAncestor(commitA, commitB)
@@ -637,7 +637,7 @@ func TestGetCommonAncestor(t *testing.T) {
 	assert.Equal(t, initialCommitID, commonAncestor)
 
 	// Test with disjoint commit histories
-	commitDisconnected := repo.commitWithParents(t, emptyTreeID, nil, "Disconnected initial commit\n", false)
+	commitDisconnected := repo.CommitWithParents(t, emptyTreeID, nil, "Disconnected initial commit\n", false)
 
 	_, err = repo.GetCommonAncestor(commitDisconnected, commitA)
 	assert.NotNil(t, err)

--- a/pkg/gitinterface/log_test.go
+++ b/pkg/gitinterface/log_test.go
@@ -95,7 +95,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 		}
 
 		// Add a common merge commit
-		mergeCommit := repo.commitWithParents(
+		mergeCommit := repo.CommitWithParents(
 			t,
 			emptyTreeID,
 			[]Hash{
@@ -158,7 +158,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 			featureBranchCommits = append(featureBranchCommits, commitHash)
 		}
 
-		newMergeCommit := repo.commitWithParents(
+		newMergeCommit := repo.CommitWithParents(
 			t,
 			emptyTreeID,
 			[]Hash{
@@ -221,7 +221,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 	treeHashes := createTestTrees(t, repo, emptyBlobHash, 6)
 
 	// creating the first commit
-	commitID := repo.commitWithParents(t, treeHashes[0], nil, fmt.Sprintf("Test commit %v", 1), false)
+	commitID := repo.CommitWithParents(t, treeHashes[0], nil, fmt.Sprintf("Test commit %v", 1), false)
 	commitIDs = append(commitIDs, commitID)
 
 	// creating two children from the first commit
@@ -230,15 +230,15 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 	commitIDs = append(commitIDs, children...)
 
 	// creating a child for commit 2, which in the visual will be commit 4
-	commitID = repo.commitWithParents(t, treeHashes[3], []Hash{children[0]}, fmt.Sprintf("Test commit %v", 4), false)
+	commitID = repo.CommitWithParents(t, treeHashes[3], []Hash{children[0]}, fmt.Sprintf("Test commit %v", 4), false)
 	commitIDs = append(commitIDs, commitID)
 
 	// creating a merge commit from the two children, which in the visual will be commit 5
-	commitID = repo.commitWithParents(t, treeHashes[4], children, fmt.Sprintf("Test commit %v", 5), false)
+	commitID = repo.CommitWithParents(t, treeHashes[4], children, fmt.Sprintf("Test commit %v", 5), false)
 	commitIDs = append(commitIDs, commitID)
 
 	// creating a child for commit 3, which in the visual will be commit 6
-	commitID = repo.commitWithParents(t, treeHashes[5], []Hash{children[1]}, fmt.Sprintf("Test commit %v", 6), false)
+	commitID = repo.CommitWithParents(t, treeHashes[5], []Hash{children[1]}, fmt.Sprintf("Test commit %v", 6), false)
 	commitIDs = append(commitIDs, commitID)
 
 	// Git tree with merge commit structure without its commit trees and its values:
@@ -349,7 +349,7 @@ func createChildrenCommits(t *testing.T, repo *Repository, treeHashes []Hash, pa
 	children := make([]Hash, 0, numChildren)
 
 	for i := 1; i <= numChildren; i++ {
-		commitID := repo.commitWithParents(t, treeHashes[i], []Hash{parentHash}, fmt.Sprintf("Test commit %v", i+1), false)
+		commitID := repo.CommitWithParents(t, treeHashes[i], []Hash{parentHash}, fmt.Sprintf("Test commit %v", i+1), false)
 		children = append(children, commitID)
 	}
 	return children


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

Adds test to ensure that the 'if has' condition of getGitHubPullRequestReviewDetails is covered. Added more tests to ensure coverage of more lines.

```
func (r *Repository) getGitHubPullRequestReviewDetails(ctx context.Context, currentAttestations *attestations.Attestations, client *gogithub.Client, githubBaseURL, owner, repository string, pullRequestNumber int, reviewID int64, useGitHubAPI bool) (string, string, string, error) {
        indexPath, has, err := currentAttestations.GetGitHubPullRequestApprovalIndexPathForReviewID(githubBaseURL, reviewID)
        if err != nil {
                return "", "", "", err
        }
        if has {
                base, from, to := indexPathToComponents(indexPath)
                return base, from, to, nil
        }
```

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [X] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
