### PR TITLE
*: Increase attestations and options coverage

### DIFF
--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	ita "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetReferenceAuthorization(t *testing.T) {
@@ -84,6 +85,26 @@ func TestSetReferenceAuthorization(t *testing.T) {
 
 		err := attestations.SetReferenceAuthorization(repo, env, testRef, testID, testID)
 		assert.ErrorIs(t, err, authorizations.ErrUnknownAuthorizationVersion)
+	})
+
+	t.Run("miscellaneous error checking", func(t *testing.T) {
+		attestations := &Attestations{}
+
+		// Test invalid base64
+		garbageEnv := &sslibdsse.Envelope{
+			PayloadType: "invalid",
+			Payload:     "invalid",
+			Signatures:  nil,
+		}
+		err := attestations.SetReferenceAuthorization(nil, garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "unable to base64 decode payload (is payload in the right format?)")
+
+		// Test invalid JSON data
+		garbageEnv, err = dsse.CreateEnvelope("invalid")
+		require.Nil(t, err)
+
+		err = attestations.SetReferenceAuthorization(nil, garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "json: cannot unmarshal string into Go value of type map[string]interface {}")
 	})
 }
 

--- a/internal/attestations/authorizations/v01/v01_test.go
+++ b/internal/attestations/authorizations/v01/v01_test.go
@@ -12,7 +12,23 @@ import (
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	ita "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetters(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := gitinterface.ZeroHash.String()
+
+	authorization := ReferenceAuthorization{
+		TargetRef:      testRef,
+		FromRevisionID: testID,
+		TargetTreeID:   testID,
+	}
+
+	assert.Equal(t, testRef, authorization.GetRef())
+	assert.Equal(t, testID, authorization.GetFromID())
+	assert.Equal(t, testID, authorization.GetTargetID())
+}
 
 func TestNewReferenceAuthorization(t *testing.T) {
 	testRef := "refs/heads/main"
@@ -54,6 +70,24 @@ func TestValidate(t *testing.T) {
 
 	err = Validate(mainZeroZero, testAnotherRef, testID, testID)
 	assert.ErrorIs(t, err, authorizations.ErrInvalidAuthorization)
+
+	t.Run("miscellaneous error checking", func(t *testing.T) {
+		// Test invalid base64
+		garbageEnv := &sslibdsse.Envelope{
+			PayloadType: "invalid",
+			Payload:     "invalid",
+			Signatures:  nil,
+		}
+		err = Validate(garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "unable to base64 decode payload (is payload in the right format?)")
+
+		// Test invalid JSON data
+		garbageEnv, err = dsse.CreateEnvelope("invalid")
+		require.Nil(t, err)
+
+		err = Validate(garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "json: cannot unmarshal string into Go value of type v1.Statement")
+	})
 }
 
 func createTestEnvelope(t *testing.T, refName, fromID, toID string) *sslibdsse.Envelope {

--- a/internal/attestations/authorizations/v02/v02_test.go
+++ b/internal/attestations/authorizations/v02/v02_test.go
@@ -12,7 +12,23 @@ import (
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	ita "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetters(t *testing.T) {
+	testRef := "refs/heads/main"
+	testID := gitinterface.ZeroHash.String()
+
+	authorization := ReferenceAuthorization{
+		TargetRef: testRef,
+		FromID:    testID,
+		TargetID:  testID,
+	}
+
+	assert.Equal(t, testRef, authorization.GetRef())
+	assert.Equal(t, testID, authorization.GetFromID())
+	assert.Equal(t, testID, authorization.GetTargetID())
+}
 
 func TestNewReferenceAuthorization(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
@@ -120,6 +136,24 @@ func TestValidate(t *testing.T) {
 
 		err := Validate(authorization, testRef, testID, testID)
 		assert.ErrorIs(t, err, authorizations.ErrInvalidAuthorization)
+	})
+
+	t.Run("miscellaneous error checking", func(t *testing.T) {
+		// Test invalid base64
+		garbageEnv := &sslibdsse.Envelope{
+			PayloadType: "invalid",
+			Payload:     "invalid",
+			Signatures:  nil,
+		}
+		err := Validate(garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "unable to base64 decode payload (is payload in the right format?)")
+
+		// Test invalid JSON data
+		garbageEnv, err = dsse.CreateEnvelope("invalid")
+		require.Nil(t, err)
+
+		err = Validate(garbageEnv, "", "", "")
+		assert.ErrorContains(t, err, "json: cannot unmarshal string into Go value of type v1.Statement")
 	})
 }
 

--- a/internal/attestations/github/v01/approval_test.go
+++ b/internal/attestations/github/v01/approval_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/attestations/authorizations"
 	"github.com/gittuf/gittuf/internal/attestations/github"
+	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
@@ -20,6 +21,18 @@ const (
 	fromRevisionIDKey = "fromRevisionID"
 	targetTreeIDKey   = "targetTreeID"
 )
+
+func TestGetters(t *testing.T) {
+	approvers := set.NewSetFromItems("jane.doe@example.com")
+
+	authorization := PullRequestApprovalAttestation{
+		Approvers:          approvers,
+		DismissedApprovers: approvers,
+	}
+
+	assert.Equal(t, approvers.Contents(), authorization.GetApprovers())
+	assert.Equal(t, approvers.Contents(), authorization.GetDismissedApprovers())
+}
 
 func TestNewGitHubPullRequestApprovalAttestation(t *testing.T) {
 	testRef := "refs/heads/main"

--- a/internal/luasandbox/options/luasandbox/luasandbox_test.go
+++ b/internal/luasandbox/options/luasandbox/luasandbox_test.go
@@ -1,0 +1,20 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package luasandbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithLuaTimeout(t *testing.T) {
+	options := &EnvironmentOptions{}
+
+	option := WithLuaTimeout(10)
+
+	option(options)
+
+	assert.Equal(t, 10, options.LuaTimeout)
+}

--- a/internal/signerverifier/sigstore/options/signer/signer_test.go
+++ b/internal/signerverifier/sigstore/options/signer/signer_test.go
@@ -1,0 +1,67 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package signer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultOptions(t *testing.T) {
+	assert.Equal(t, defaultIssuerURL, DefaultOptions.IssuerURL)
+	assert.Equal(t, defaultClientID, DefaultOptions.ClientID)
+	assert.Equal(t, defaultFulcioURL, DefaultOptions.FulcioURL)
+	assert.Equal(t, defaultRekorURL, DefaultOptions.RekorURL)
+}
+
+func TestWithIssuerURL(t *testing.T) {
+	options := &Options{}
+
+	option := WithIssuerURL("example.com")
+
+	option(options)
+
+	assert.Equal(t, "example.com", options.IssuerURL)
+}
+
+func TestWithClientID(t *testing.T) {
+	options := &Options{}
+
+	option := WithClientID("abc123xyz")
+
+	option(options)
+
+	assert.Equal(t, "abc123xyz", options.ClientID)
+}
+
+func TestWithRedirectURL(t *testing.T) {
+	options := &Options{}
+
+	option := WithRedirectURL("example.com")
+
+	option(options)
+
+	assert.Equal(t, "example.com", options.RedirectURL)
+}
+
+func TestWithFulcioURL(t *testing.T) {
+	options := &Options{}
+
+	option := WithFulcioURL("example.com")
+
+	option(options)
+
+	assert.Equal(t, "example.com", options.FulcioURL)
+}
+
+func TestWithRekorURL(t *testing.T) {
+	options := &Options{}
+
+	option := WithRekorURL("example.com")
+
+	option(options)
+
+	assert.Equal(t, "example.com", options.RekorURL)
+}

--- a/internal/signerverifier/sigstore/options/verifier/verifier_test.go
+++ b/internal/signerverifier/sigstore/options/verifier/verifier_test.go
@@ -1,0 +1,20 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package verifier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithRekorURL(t *testing.T) {
+	options := &Options{}
+
+	option := WithRekorURL("example.com")
+
+	option(options)
+
+	assert.Equal(t, "example.com", options.RekorURL)
+}


### PR DESCRIPTION
## Description

Portion of https://github.com/gittuf/gittuf/pull/1346, split off to lighten review load. Increases internal/attestations testing coverage, and some options coverage as well.

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
