### PR TITLE
Add policy state query coverage

### DIFF
--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -14,6 +14,7 @@ import (
 	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
+	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
@@ -968,6 +969,30 @@ func TestStateHasFileRule(t *testing.T) {
 		hasFileRule := state.hasFileRule
 		assert.False(t, hasFileRule)
 	})
+}
+
+func TestStateGetAllPrincipals(t *testing.T) {
+	t.Parallel()
+	state := createTestStateWithPolicy(t)
+
+	rootKey := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, rootPubKeyBytes))
+	gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+	require.Nil(t, err)
+	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
+
+	principals := state.GetAllPrincipals()
+	assert.Len(t, principals, 2)
+	assert.Contains(t, principals, rootKey.ID())
+	assert.Contains(t, principals, gpgKey.ID())
+}
+
+func TestStateHasRuleName(t *testing.T) {
+	t.Parallel()
+	state := createTestStateWithPolicy(t)
+
+	assert.True(t, state.HasRuleName("protect-main"))
+	assert.True(t, state.HasRuleName("protect-files-1-and-2"))
+	assert.False(t, state.HasRuleName("missing-rule"))
 }
 
 func TestApply(t *testing.T) {


### PR DESCRIPTION
## Description

Adds coverage for policy state query helpers.

The tests check that `GetAllPrincipals` returns principals collected during state preprocessing, and that `HasRuleName` recognizes existing policy rules while rejecting a missing rule.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
