### PR TITLE
test :- enable and resolve encrypted SSH key tests on Windows

### DIFF
--- a/internal/signerverifier/ssh/ssh_test.go
+++ b/internal/signerverifier/ssh/ssh_test.go
@@ -6,6 +6,7 @@ package ssh
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -45,8 +46,15 @@ func TestSSH(t *testing.T) {
 	// Write script to mock password prompt
 
 	scriptPath := filepath.Join(tmpDir, "askpass.sh")
-	if err := os.WriteFile(scriptPath, artifacts.AskpassScript, 0o500); err != nil { //nolint:gosec
-		t.Fatal(err)
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(tmpDir, "askpass.bat")
+		if err := os.WriteFile(scriptPath, []byte("@echo hunter2\r\n"), 0o500); err != nil { //nolint:gosec
+			t.Fatal(err)
+		}
+	} else {
+		if err := os.WriteFile(scriptPath, artifacts.AskpassScript, 0o500); err != nil { //nolint:gosec
+			t.Fatal(err)
+		}
 	}
 
 	// Write test key pairs to temp dir with permissions required by ssh-keygen
@@ -54,6 +62,17 @@ func TestSSH(t *testing.T) {
 		keyPath := filepath.Join(tmpDir, test.keyName)
 		if err := os.WriteFile(keyPath, test.keyBytes, 0o600); err != nil {
 			t.Fatal(err)
+		}
+		if runtime.GOOS == "windows" && strings.Contains(test.keyName, "_enc") {
+			if err := exec.Command("icacls", keyPath, "/inheritance:r").Run(); err != nil { //nolint:gosec
+				t.Fatal(err)
+			}
+			user := os.Getenv("USERNAME")
+			if user != "" {
+				if err := exec.Command("icacls", keyPath, "/grant:r", user+":F").Run(); err != nil { //nolint:gosec
+					t.Fatal(err)
+				}
+			}
 		}
 	}
 
@@ -64,9 +83,6 @@ func TestSSH(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.keyName, func(t *testing.T) {
 			if strings.Contains(test.keyName, "_enc") {
-				if runtime.GOOS == "windows" {
-					t.Skip("TODO: test encrypted keys on windows")
-				}
 				t.Setenv("SSH_ASKPASS", scriptPath)
 				t.Setenv("SSH_ASKPASS_REQUIRE", "force")
 			}


### PR DESCRIPTION

## Description

This pull request enables and resolves test cases for encrypted SSH keys (`rsa_enc`, `ecdsa_enc`, `ed25519_enc`) in `internal/signerverifier/ssh/ssh_test.go` on Windows.

Previously, these tests were skipped on Windows because `ssh-keygen` was unable to resolve key file permissions and passphrase injection via `SSH_ASKPASS`.

This PR fixes the issues by :- 
1. Creating a Windows-compatible batch script (`askpass.bat`) to output the correct test password (`hunter2`) for passphrase decryption.
2. Limiting file permissions for encrypted private key files using Windows `icacls` (disabling inheritance and granting full control only to the current user) so `ssh-keygen` accepts them.
3. Removing the `t.Skip` check for encrypted keys on Windows to run the tests successfully.

## AI Usage
- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to help diagnose `ssh-keygen` permission errors on Windows and draft the `icacls` permission helper code inside `ssh_test.go`.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).