### PR TITLE
test: add parent resolution test for merge commits

### DIFF
--- a/pkg/gitinterface/commit_test.go
+++ b/pkg/gitinterface/commit_test.go
@@ -563,8 +563,6 @@ func TestGetCommitTreeID(t *testing.T) {
 }
 
 func TestGetCommitParentIDs(t *testing.T) {
-	// TODO: test with merge commit
-
 	tempDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tempDir, false)
 
@@ -596,6 +594,13 @@ func TestGetCommitParentIDs(t *testing.T) {
 	secondCommitParentIDs, err := repo.GetCommitParentIDs(secondCommitID)
 	assert.Nil(t, err)
 	assert.Equal(t, []Hash{initialCommitID}, secondCommitParentIDs)
+
+	// Create merge commit
+	mergeCommitID := repo.commitWithParents(t, emptyTreeID, []Hash{initialCommitID, secondCommitID}, "Merge commit\n", false)
+
+	mergeCommitParentIDs, err := repo.GetCommitParentIDs(mergeCommitID)
+	assert.Nil(t, err)
+	assert.Equal(t, []Hash{initialCommitID, secondCommitID}, mergeCommitParentIDs)
 
 	blobID, err := repo.WriteBlob([]byte("test"))
 	require.Nil(t, err)


### PR DESCRIPTION
## Description

This pull request addresses a testing gap in `pkg/gitinterface/commit_test.go` by adding a test case to verify parent resolution for merge commits with multiple parents.

Previously, `TestGetCommitParentIDs` only asserted parent resolution for commits with 0 or 1 parents, leaving merge commits untested (as noted in the `// TODO: test with merge commit` comment).

This PR :- 
1. Adds a verification path where a merge commit is created with multiple parents (`initialCommitID` and `secondCommitID`).
2. Asserts that `repo.GetCommitParentIDs()` correctly returns both parent IDs.
3. Cleans up the outdated TODO comment.

This ensures that gittuf's graph walking logic correctly tracks all branches, preventing any unverified history bypasses during ref verification.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to analyze codebase gaps and draft the merge commit parent assertion test structure.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).