### PR TITLE
test :- verify version CLI command prefix v handling

### DIFF
--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -1,0 +1,80 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	internalversion "github.com/gittuf/gittuf/internal/version"
+)
+
+func TestVersionRun(t *testing.T) {
+	oldStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	cmd := New()
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = oldStdout
+		t.Fatal(err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	expected := "gittuf version"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, output)
+	}
+}
+
+func TestVersionPrefixV(t *testing.T) {
+	internalversion.SetGitVersionForTest("v0.14.0")
+	defer internalversion.SetGitVersionForTest("devel")
+
+	oldStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	cmd := New()
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = oldStdout
+		t.Fatal(err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	// Verify that the prefix 'v' was successfully stripped
+	expected := "gittuf version 0.14.0"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, output)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -21,3 +21,8 @@ func GetVersion() string {
 
 	return buildInfo.Main.Version
 }
+
+// SetGitVersionForTest is used in tests to override the basic version information.
+func SetGitVersionForTest(v string) {
+	gitVersion = v
+}


### PR DESCRIPTION
## Description

This pull request adds a new unit test to `internal/cmd/version/version_test.go` to verify the handling of the 'v' prefix in version strings.

Specifically, it tests that if `version.GetVersion()` returns a version string starting with 'v' (e.g. `v0.14.0`), the prefix 'v' is correctly stripped and the printed output displays the version as expected (`gittuf version 0.14.0`).

To support this without modifying production release settings (like Makefiles or goreleaser configurations):
1. We exported a simple `SetGitVersionForTest` helper function in `internal/version/version.go`.
2. The unit test uses this helper to mock the version to `v0.14.0` during test execution.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to draft the test case structure and design the `SetGitVersionForTest` helper function to handle unexported package variables during testing.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).