### PR TITLE
test :- verify version CLI command developer mode warning

### DIFF
--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -11,13 +11,23 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	t.Run("run", func(t *testing.T) {
-		_, stdOut, _, err := cmd.ExecuteCommandC(New(), "version")
-		if err != nil {
-			t.Fatal(err)
-		}
+	t.Run("default (no dev mode env var)", func(t *testing.T) {
+		_, stdOut, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
 
-		expected := "gittuf version"
-		assert.Contains(t, stdOut.String(), expected)
+		output := stdOut.String()
+		assert.Contains(t, output, "gittuf version")
+		assert.NotContains(t, output, "gittuf is operating in developer mode")
+	})
+
+	t.Run("dev mode active", func(t *testing.T) {
+		t.Setenv("GITTUF_DEV", "1")
+
+		_, stdOut, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+
+		output := stdOut.String()
+		assert.Contains(t, output, "gittuf version")
+		assert.Contains(t, output, "gittuf is operating in developer mode")
 	})
 }


### PR DESCRIPTION
## Description

This pull request adds a new unit test to `internal/cmd/version/version_test.go` to verify developer mode warnings printed by the `gittuf version` command.

Specifically, it asserts that when the environment variable `GITTUF_DEV` is set to `1` (which activates dev mode), the output of the version command includes the warning: `"gittuf is operating in developer mode"`.

This ensures the version CLI tool handles environment variable checks correctly under developer mode.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to structure the test and construct the environment variable assertions (`t.Setenv`).

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).