### PR TITLE
test :- verify version CLI command developer mode inactive

### DIFF
--- a/internal/cmd/version/version_test.go
+++ b/internal/cmd/version/version_test.go
@@ -1,0 +1,76 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVersionRun(t *testing.T) {
+	oldStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	cmd := New()
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = oldStdout
+		t.Fatal(err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	expected := "gittuf version"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, output)
+	}
+}
+
+func TestVersionDevModeInactive(t *testing.T) {
+	t.Setenv("GITTUF_DEV", "0")
+
+	oldStdout := os.Stdout
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	cmd := New()
+	if err := cmd.Execute(); err != nil {
+		w.Close()
+		os.Stdout = oldStdout
+		t.Fatal(err)
+	}
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatal(err)
+	}
+	output := buf.String()
+
+	expectedWarning := "gittuf is operating in developer mode"
+	if strings.Contains(output, expectedWarning) {
+		t.Errorf("expected output NOT to contain %q, got %q", expectedWarning, output)
+	}
+}


### PR DESCRIPTION
## Description

This pull request adds a new unit test to `internal/cmd/version/version_test.go` to verify that no developer mode warnings are printed when the `gittuf version` command runs under normal production mode.

Specifically, it asserts that when the environment variable `GITTUF_DEV` is explicitly set to `0` (or unset), the warning message `"gittuf is operating in developer mode"` is NOT printed in the output.

This ensures the version CLI tool does not show developer warnings to standard users.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to analyze test parameters and verify negation assertions (`strings.Contains` negative checks).

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).