### PR TITLE
test :- add unit tests for trust addgithubapp command

### DIFF
--- a/internal/cmd/trust/addgithubapp/addgithubapp_test.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp_test.go
@@ -1,0 +1,230 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package addgithubapp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddGitHubApp(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "dummy-key",
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--app-name", "test-app",
+			"--app-key", "dummy-key",
+		)
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("invalid signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "non-existent-key",
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--app-name", "test-app",
+			"--app-key", "dummy-key",
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid app key", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize the repository first
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--app-name", "test-app",
+			"--app-key", "non-existent-key",
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		appKeyPath := filepath.Join(tmpDir, "app-key")
+		if err := os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize the repository first
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--app-name", "test-app",
+			"--app-key", appKeyPath+".pub",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("success with RSL entry", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		appKeyPath := filepath.Join(tmpDir, "app-key")
+		if err := os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize the repository first
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey:   keyPath,
+			WithRSLEntry: true,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--app-name", "test-app",
+			"--app-key", appKeyPath+".pub",
+		)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the `trust add-github-app` command to achieve 100% logic coverage for the package. 

The following scenarios are covered:
- Command execution without a valid repository (`TestAddGitHubAppNoRepository`)
- Execution with an invalid signing key/signer (`TestAddGitHubAppInvalidSigner`)
- Execution with an invalid app key (`TestAddGitHubAppInvalidAppKey`)
- Successful command execution (`TestAddGitHubAppSuccess`)
- Successful command execution with RSL Entry flag (`TestAddGitHubAppSuccessWithRSLEntry`)

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used an AI coding assistant to help draft and format the unit test cases for the command. The generated tests were then manually reviewed, tested locally, and refined to ensure they meet the project's standards and coverage requirements.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
