### PR TITLE
fix(rsl): AnnotationEntry.setEntryNumber returns nil on empty RSL

### DIFF
--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -335,7 +335,7 @@ func (a *AnnotationEntry) setEntryNumber(repo *gitinterface.Repository) error {
 		}
 	}
 
-	return err
+	return nil
 }
 
 func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error) {


### PR DESCRIPTION
## Description

AnnotationEntry.setEntryNumber was returning err instead of nil when the RSL is empty. This caused AnnotationEntry.Commit and CommitUsingSpecificKey to fail with ErrRSLEntryNotFound even though the entry number was correctly set to 1.

ReferenceEntry and PropagationEntry both return nil in the same scenario. This fix makes AnnotationEntry consistent with them.

Fixes #1390

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [X] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
