### PR TITLE
fix(policy): State.Commit returns err instead of nil on WriteTree fai…

### DIFF
--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -724,14 +724,14 @@ func (s *State) Commit(repo *gitinterface.Repository, commitMessage string, crea
 
 	stateMetadataTreeID, err := s.Metadata.WriteTree(repo)
 	if err != nil {
-		return nil
+		return err
 	}
 	allTreeEntries = append(allTreeEntries, gitinterface.NewEntryTree(metadataTreeEntryName, stateMetadataTreeID))
 
 	for absoluteControllerPath, metadata := range s.ControllerMetadata {
 		stateMetadataTreeID, err := metadata.WriteTree(repo)
 		if err != nil {
-			return nil
+			return err
 		}
 		allTreeEntries = append(allTreeEntries, gitinterface.NewEntryTree(fmt.Sprintf("%s/%s", tuf.GittufControllerPrefix, absoluteControllerPath), stateMetadataTreeID))
 	}


### PR DESCRIPTION
## Description

`State.Commit` contained two error handling blocks that returned `nil` instead of `err` when `WriteTree` failed, silently swallowing the error and indicating success to the caller when the policy tree was never actually written.

Before (incorrect):
```go
stateMetadataTreeID, err := s.Metadata.WriteTree(repo)
if err != nil {
    return nil
}
```

After (correct):
```go
stateMetadataTreeID, err := s.Metadata.WriteTree(repo)
if err != nil {
    return err
}
```

The same incorrect pattern appeared twice, once for `s.Metadata.WriteTree` and once for `metadata.WriteTree` in the controller metadata loop.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).