### PR TITLE
test :- add unit tests for CLI disable-github-app-approvals command

### DIFF
--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
@@ -1,0 +1,232 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package disablegithubappapprovals
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDisableGitHubAppApprovals(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		pOpts := &persistent.Options{
+			SigningKey: "dummy-key",
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("invalid signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		pOpts := &persistent.Options{
+			SigningKey: "non-existent-key",
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("success already untrusted", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--app-name", "github-app")
+		assert.NoError(t, err)
+	})
+
+	t.Run("success disable trusted app", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		key, err := gittuf.LoadPublicKey(keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = repo.AddGitHubApp(t.Context(), signer, "github-app", key, false)
+		assert.NoError(t, err)
+
+		err = repo.TrustGitHubApp(t.Context(), signer, "github-app", false)
+		assert.NoError(t, err)
+
+		err = repo.StagePolicy(t.Context(), "", true, false)
+		assert.NoError(t, err)
+
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		assert.NoError(t, err)
+		rootMetadata, err := state.GetRootMetadata(false)
+		assert.NoError(t, err)
+		assert.True(t, rootMetadata.IsGitHubAppApprovalTrusted("github-app"))
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--app-name", "github-app")
+		assert.NoError(t, err)
+
+		err = repo.StagePolicy(t.Context(), "", true, false)
+		assert.NoError(t, err)
+
+		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		assert.NoError(t, err)
+		rootMetadata, err = state.GetRootMetadata(false)
+		assert.NoError(t, err)
+		assert.False(t, rootMetadata.IsGitHubAppApprovalTrusted("github-app"))
+	})
+
+	t.Run("success disable trusted app with RSL entry", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		key, err := gittuf.LoadPublicKey(keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = repo.AddGitHubApp(t.Context(), signer, "github-app", key, false)
+		assert.NoError(t, err)
+
+		err = repo.TrustGitHubApp(t.Context(), signer, "github-app", false)
+		assert.NoError(t, err)
+
+		err = repo.StagePolicy(t.Context(), "", true, false)
+		assert.NoError(t, err)
+
+		pOpts := &persistent.Options{
+			SigningKey:   keyPath,
+			WithRSLEntry: true,
+		}
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--app-name", "github-app")
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

This pull request implements comprehensive unit tests for the `disable-github-app-approvals` subcommand under `gittuf trust`, achieving 100% statement coverage. 

Following the project's established test patterns, the unit tests:
1. Are structured under a single main `TestDisableGitHubAppApprovals(t *testing.T)` function using subtests (`t.Run`).
2. Utilize `t.Context()` for proper context propagation instead of `context.Background()`.
3. Use `assert.ErrorContains` with locale-safe error substrings (e.g., checking `"unable to identify git directory"` when not in a Git repository).

The following test scenarios are covered:
- Running command in a directory that is not a Git repository.
- Running command with an invalid/non-existent signing key.
- Successfully disabling approvals for an app that is already untrusted (checks exit code 0).
- Successfully disabling approvals for an app that is currently trusted (and verifying that the status transitions to untrusted).
- Successfully disabling approvals for an app with RSL entry enabled.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

LLM was used to assist in generating the unit test structure and validating the command's logical flows. The code was manually reviewed, verified to achieve 100% statement coverage and passed all local tests and `golangci-lint` checks.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
