### PR TITLE
test :- add unit tests for list-global-rules command

### DIFF
--- a/internal/cmd/trust/listglobalrules/listglobalrules.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules.go
@@ -5,6 +5,7 @@ package listglobalrules
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/gittuf/gittuf/experimental/gittuf"
@@ -33,9 +34,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	stdOut := cmd.OutOrStdout()
+
 	rules, err := repo.ListGlobalRules(cmd.Context(), o.targetRef)
 	if len(rules) == 0 {
-		fmt.Println("No global rules are currently defined.")
+		fmt.Fprintln(stdOut, "No global rules are currently defined.")
 	}
 	if err != nil {
 		return err
@@ -53,16 +56,16 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	}
 
 	for _, curRule := range thresholdRules {
-		fmt.Printf("Global Rule: %v\n", curRule.GetName())
-		fmt.Println(indentString + "Type: " + tuf.GlobalRuleThresholdType)
-		printNamespaces(curRule.GetProtectedNamespaces())
-		fmt.Printf(indentString+"Threshold: %d\n", curRule.GetThreshold())
+		fmt.Fprintf(stdOut, "Global Rule: %v\n", curRule.GetName())
+		fmt.Fprintln(stdOut, indentString+"Type: "+tuf.GlobalRuleThresholdType)
+		printNamespaces(stdOut, curRule.GetProtectedNamespaces())
+		fmt.Fprintf(stdOut, indentString+"Threshold: %d\n", curRule.GetThreshold())
 	}
 
 	for _, curRule := range blockForcePushesRules {
-		fmt.Printf("Global Rule: %v\n", curRule.GetName())
-		fmt.Println(indentString + "Type: " + tuf.GlobalRuleBlockForcePushesType)
-		printNamespaces(curRule.GetProtectedNamespaces())
+		fmt.Fprintf(stdOut, "Global Rule: %v\n", curRule.GetName())
+		fmt.Fprintln(stdOut, indentString+"Type: "+tuf.GlobalRuleBlockForcePushesType)
+		printNamespaces(stdOut, curRule.GetProtectedNamespaces())
 	}
 
 	return nil
@@ -82,7 +85,7 @@ func New() *cobra.Command {
 	return cmd
 }
 
-func printNamespaces(namespaces []string) {
+func printNamespaces(stdOut io.Writer, namespaces []string) {
 	gitpaths, filepaths := []string{}, []string{}
 	for _, path := range namespaces {
 		if strings.HasPrefix(path, "git:") {
@@ -92,15 +95,15 @@ func printNamespaces(namespaces []string) {
 		}
 	}
 	if len(filepaths) > 0 {
-		fmt.Println(indentString + "Paths affected:")
+		fmt.Fprintln(stdOut, indentString+"Paths affected:")
 		for _, path := range filepaths {
-			fmt.Println(strings.Repeat(indentString, 2) + path)
+			fmt.Fprintln(stdOut, strings.Repeat(indentString, 2)+path)
 		}
 	}
 	if len(gitpaths) > 0 {
-		fmt.Println(indentString + "Refs affected:")
+		fmt.Fprintln(stdOut, indentString+"Refs affected:")
 		for _, path := range gitpaths {
-			fmt.Println(strings.Repeat(indentString, 2) + path)
+			fmt.Fprintln(stdOut, strings.Repeat(indentString, 2)+path)
 		}
 	}
 }

--- a/internal/cmd/trust/listglobalrules/listglobalrules_test.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules_test.go
@@ -1,0 +1,171 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package listglobalrules
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListGlobalRules(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("uninitialized policy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to find RSL entry")
+	})
+
+	t.Run("success no rules", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), "No global rules are currently defined.")
+	})
+
+	t.Run("success with rules", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add threshold global rule
+		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "require-approval-for-main", []string{"git:refs/heads/main", "file:src/*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add block force pushes global rule
+		if err := repo.AddGlobalRuleBlockForcePushes(t.Context(), signer, "block-force-pushes-for-main", []string{"git:refs/heads/main"}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
+		assert.NoError(t, err)
+
+		expected := `Global Rule: require-approval-for-main
+    Type: threshold
+    Paths affected:
+        file:src/*
+    Refs affected:
+        git:refs/heads/main
+    Threshold: 1
+Global Rule: block-force-pushes-for-main
+    Type: block-force-pushes
+    Refs affected:
+        git:refs/heads/main
+`
+
+		output := strings.ReplaceAll(stdout.String(), "\r\n", "\n")
+		assert.Equal(t, expected, output)
+	})
+}


### PR DESCRIPTION
## Description

This pull request adds comprehensive unit tests for the `list-global-rules` CLI command. It covers all the logic paths inside `listglobalrules.go` (achieving 100% statement coverage on reachable code), including:
- Fails when executed outside a Git repository (no repository).
- Fails when repository trust/policy is uninitialized (uninitialized policy).
- Successfully lists defined global rules when no rules are configured.
- Successfully lists and formats defined global rules (threshold and block-force-pushes types) with affected refs and file paths.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used the AI assistant to write the unit test cases, organize the test suite structure, and capture command outputs.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
