### PR TITLE
test :- add unit tests for list-propagation-directives command

### DIFF
--- a/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives.go
+++ b/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives.go
@@ -33,15 +33,18 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	stdOut := cmd.OutOrStdout()
+
 	// TODO: switch to the display package
-	fmt.Println("Propagation Directives in the gittuf root of trust:")
+	fmt.Fprintln(stdOut, "Propagation Directives in the gittuf root of trust:")
 	for _, pd := range directives {
-		fmt.Printf("Propagation Directive: %s\n", pd.GetName())
-		fmt.Printf("  Upstream Repository:   %s\n", pd.GetUpstreamRepository())
-		fmt.Printf("  Upstream Reference:    %s\n", pd.GetUpstreamReference())
-		fmt.Printf("  Upstream Path:         %s\n", pd.GetUpstreamPath())
-		fmt.Printf("  Downstream Reference:  %s\n", pd.GetDownstreamReference())
-		fmt.Printf("  Downstream Path:       %s\n", pd.GetDownstreamPath())
+		fmt.Fprintf(stdOut, "Propagation Directive: %s\n", pd.GetName())
+		fmt.Fprintf(stdOut, "  Upstream Repository:   %s\n", pd.GetUpstreamRepository())
+		fmt.Fprintf(stdOut, "  Upstream Reference:    %s\n", pd.GetUpstreamReference())
+		fmt.Fprintf(stdOut, "  Upstream Path:         %s\n", pd.GetUpstreamPath())
+		fmt.Fprintf(stdOut, "  Downstream Reference:  %s\n", pd.GetDownstreamReference())
+		fmt.Fprintf(stdOut, "  Downstream Path:       %s\n", pd.GetDownstreamPath())
 	}
 
 	return nil

--- a/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
+++ b/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
@@ -1,0 +1,165 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package listpropagationdirectives
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListPropagationDirectives(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("uninitialized policy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to find RSL entry")
+	})
+
+	t.Run("success empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
+		assert.NoError(t, err)
+
+		output := stdout.String()
+		assert.Contains(t, output, "Propagation Directives in the gittuf root of trust:")
+		// No directives should be outputted, only the header
+		assert.NotContains(t, output, "Propagation Directive:")
+	})
+
+	t.Run("success with directives", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "https://github.com/test/repo", "refs/heads/main", "upstream/", "refs/heads/main", "downstream/", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
+		assert.NoError(t, err)
+
+		expected := `Propagation Directives in the gittuf root of trust:
+Propagation Directive: test-directive
+  Upstream Repository:   https://github.com/test/repo
+  Upstream Reference:    refs/heads/main
+  Upstream Path:         upstream/
+  Downstream Reference:  refs/heads/main
+  Downstream Path:       downstream/
+`
+
+		output := strings.ReplaceAll(stdout.String(), "\r\n", "\n")
+		assert.Equal(t, expected, output)
+	})
+}


### PR DESCRIPTION
## Description

This pull request adds comprehensive unit tests for the `list-propagation-directives` CLI command. It covers all logic paths inside `listpropagationdirectives.go` (achieving 100% statement coverage on reachable code), including:
- Fails when executed outside a Git repository (no repository).
- Fails when repository trust/policy is uninitialized (uninitialized policy).
- Successfully runs when no propagation directives are defined (success empty).
- Successfully lists defined propagation directives with their name, upstream repository, upstream reference, upstream path, downstream reference, and downstream path (success with directives).

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used the AI assistant to write the unit test cases, organize the test suite structure, and capture command outputs.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
