### PR TITLE
test :- add unit tests for make-controller command

### DIFF
--- a/internal/cmd/trust/makecontroller/makecontroller_test.go
+++ b/internal/cmd/trust/makecontroller/makecontroller_test.go
@@ -1,0 +1,157 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package makecontroller
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeController(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "dummy-key",
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("invalid signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "non-existent-key",
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize the repository first
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.NoError(t, err)
+	})
+
+	t.Run("success with RSL entry", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initialize the repository first
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey:   keyPath,
+			WithRSLEntry: true,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts))
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests for the `gittuf trust make-controller` command in `internal/cmd/trust/makecontroller`. It covers the following scenarios using the standard `cmd.ExecuteCommandC` helper pattern:
- Failing execution when there is no repository.
- Failing execution when an invalid signing key is provided.
- Successful execution.
- Successful execution with the `--create-rsl-entry` (`WithRSLEntry`) option.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used an AI assistant to generate the test cases based on the existing test patterns in the repository (such as the `ExecuteCommandC` pattern), followed by a thorough manual review to ensure correctness.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
