### PR TITLE
test :- add unit tests for update-hook command

### DIFF
--- a/internal/cmd/trust/updatehook/updatehook_test.go
+++ b/internal/cmd/trust/updatehook/updatehook_test.go
@@ -1,0 +1,366 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package updatehook
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/dev"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateHook(t *testing.T) {
+	t.Run("not in dev mode", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "0")
+
+		pOpts := &persistent.Options{}
+		c := New(pOpts)
+
+		_, _, _, err := cmd.ExecuteCommandC(c,
+			"--file-path", "test.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+		)
+		assert.ErrorIs(t, err, dev.ErrNotInDevMode)
+	})
+
+	t.Run("invalid environment", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+
+		pOpts := &persistent.Options{}
+		c := New(pOpts)
+
+		_, _, _, err := cmd.ExecuteCommandC(c,
+			"--file-path", "test.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+			"--env", "invalid",
+		)
+		assert.ErrorIs(t, err, tuf.ErrInvalidHookEnvironment)
+	})
+
+	t.Run("invalid timeout", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+
+		pOpts := &persistent.Options{}
+		c := New(pOpts)
+
+		_, _, _, err := cmd.ExecuteCommandC(c,
+			"--file-path", "test.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+			"--timeout", "0",
+		)
+		assert.ErrorIs(t, err, gittuf.ErrInvalidHookTimeout)
+	})
+
+	t.Run("no repository", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "dummy-key",
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", "test.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+		)
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("invalid signer", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "non-existent-key",
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", "test.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+		)
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("invalid file path", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", "non-existent-script.lua",
+			"--hook-name", "test-hook",
+			"--principal-ID", "test-principal",
+			"--is-pre-commit",
+		)
+		assert.ErrorContains(t, err, "no such file or directory")
+	})
+
+	t.Run("success pre-commit", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		scriptPath := filepath.Join(tmpDir, "script.lua")
+		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add the hook first so it exists to be updated
+		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", scriptPath,
+			"--hook-name", "test-hook",
+			"--principal-ID", "new-principal",
+			"--is-pre-commit",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("success pre-push", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		scriptPath := filepath.Join(tmpDir, "script.lua")
+		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add the hook first so it exists to be updated
+		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", scriptPath,
+			"--hook-name", "test-hook",
+			"--principal-ID", "new-principal",
+			"--is-pre-push",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("success with RSL entry", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		scriptPath := filepath.Join(tmpDir, "script.lua")
+		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Add the hook first so it exists to be updated
+		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey:   keyPath,
+			WithRSLEntry: true,
+		}
+		c := New(pOpts)
+
+		_, _, _, err = cmd.ExecuteCommandC(c,
+			"--file-path", scriptPath,
+			"--hook-name", "test-hook",
+			"--principal-ID", "new-principal",
+			"--is-pre-commit",
+		)
+		assert.NoError(t, err)
+	})
+}

--- a/internal/cmd/trust/updatehook/updatehook_test.go
+++ b/internal/cmd/trust/updatehook/updatehook_test.go
@@ -177,7 +177,7 @@ func TestUpdateHook(t *testing.T) {
 			"--principal-ID", "test-principal",
 			"--is-pre-commit",
 		)
-		assert.ErrorContains(t, err, "no such file or directory")
+		assert.ErrorIs(t, err, os.ErrNotExist)
 	})
 
 	t.Run("success pre-commit", func(t *testing.T) {


### PR DESCRIPTION
## Description

This pull request implements comprehensive unit tests for the `update-hook` CLI command in `internal/cmd/trust/updatehook/updatehook_test.go` using the `cmd.ExecuteCommandC` pattern. 

The tests cover:
- Checking that the command is disabled when not in developer mode (`GITTUF_DEV=0`).
- Validating that options like `--env` and `--timeout` are correctly checked for invalid values.
- Testing error handling when run outside a Git repository or when invalid/missing credentials (signers) are provided.
- Successfully updating existing hooks (in both `pre-commit` and `pre-push` stages) and validating both standard execution and RSL entry creation modes.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used  AI coding assistant to design and implement the unit tests in `updatehook_test.go` based on established patterns in the gittuf codebase.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
