### PR TITLE
test :- add unit tests for update-propagation-directive command

### DIFF
--- a/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
+++ b/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
@@ -1,0 +1,216 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package updatepropagationdirective
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/trust/persistent"
+	"github.com/gittuf/gittuf/internal/dev"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdatePropagationDirective(t *testing.T) {
+	t.Run("not in dev mode", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "0")
+
+		pOpts := &persistent.Options{}
+		c := New(pOpts)
+
+		_, _, _, err := cmd.ExecuteCommandC(c,
+			"--name", "test-directive",
+			"--from-repository", "origin",
+			"--from-reference", "refs/heads/main",
+			"--into-reference", "refs/heads/main",
+			"--into-path", "bar",
+		)
+		assert.ErrorIs(t, err, dev.ErrNotInDevMode)
+	})
+
+	t.Run("no repository", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "dummy-key",
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--name", "test-directive",
+			"--from-repository", "origin",
+			"--from-reference", "refs/heads/main",
+			"--into-reference", "refs/heads/main",
+			"--into-path", "bar",
+		)
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("invalid signer", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: "non-existent-key",
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--name", "test-directive",
+			"--from-repository", "origin",
+			"--from-reference", "refs/heads/main",
+			"--into-reference", "refs/heads/main",
+			"--into-path", "bar",
+		)
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey: keyPath,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--name", "test-directive",
+			"--from-repository", "origin-new",
+			"--from-reference", "refs/heads/dev",
+			"--from-path", "new-foo",
+			"--into-reference", "refs/heads/dev",
+			"--into-path", "new-bar",
+		)
+		assert.NoError(t, err)
+	})
+
+	t.Run("success with RSL entry", func(t *testing.T) {
+		t.Setenv(dev.DevModeKey, "1")
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		pOpts := &persistent.Options{
+			SigningKey:   keyPath,
+			WithRSLEntry: true,
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts),
+			"--name", "test-directive",
+			"--from-repository", "origin-new",
+			"--from-reference", "refs/heads/dev",
+			"--from-path", "new-foo",
+			"--into-reference", "refs/heads/dev",
+			"--into-path", "new-bar",
+		)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

This pull request implements unit tests for the `update-propagation-directive` CLI command in `internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go` using the `cmd.ExecuteCommandC` pattern. 

The tests cover:
- Verification that the command is disabled when not in developer mode (`GITTUF_DEV=0`).
- Handling of standard failure scenarios like missing git repositories or invalid signer credentials.
- Successful modification of existing propagation directives and validating both standard execution and RSL entry creation modes.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used  AI coding assistant to design and implement the unit tests in `updatepropagationdirective_test.go` based on established patterns in the gittuf codebase.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
