### PR TITLE
Add RSL helper coverage

### DIFF
--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -21,6 +21,39 @@ import (
 
 const annotationMessage = "test annotation"
 
+func TestRemoteTrackerRef(t *testing.T) {
+	assert.Equal(t, "refs/remotes/origin/gittuf/reference-state-log", RemoteTrackerRef("origin"))
+	assert.Equal(t, "refs/remotes/upstream/gittuf/reference-state-log", RemoteTrackerRef("upstream"))
+}
+
+func TestIsRelevantGittufRef(t *testing.T) {
+	tests := map[string]struct {
+		refName  string
+		expected bool
+	}{
+		"non gittuf ref": {
+			refName:  "refs/heads/main",
+			expected: false,
+		},
+		"policy staging ref": {
+			refName:  gittufPolicyStagingRef,
+			expected: false,
+		},
+		"policy ref": {
+			refName:  "refs/gittuf/policy",
+			expected: true,
+		},
+		"rsl ref": {
+			refName:  Ref,
+			expected: true,
+		},
+	}
+
+	for name, test := range tests {
+		assert.Equal(t, test.expected, isRelevantGittufRef(test.refName), fmt.Sprintf("unexpected result in test '%s'", name))
+	}
+}
+
 func TestNewReferenceEntry(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)


### PR DESCRIPTION
## Description

Adds coverage for small RSL helper behavior.

The tests check remote RSL tracking ref formatting and whether refs are treated as relevant gittuf refs, including non-gittuf refs and the policy staging ref.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
