### PR TITLE
feat(tui) :- upgrade interactive UI with bubbletea, breadcrumbs and intelligent read-only mode

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -32,6 +32,7 @@ const (
 	screenTrustGlobalRules                  // Global rule management screen
 	screenTrustAddGlobalRule                // Form: add a new global rule
 	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
+	screenHelp                              // Generic Help screen displaying keybindings
 )
 
 type item struct {
@@ -69,8 +70,13 @@ type model struct {
 	footer           string
 	errorMsg         string
 	readOnly         bool
+	width            int
+	height           int
 	confirmDelete    bool
 	deleteTarget     string
+	showHelp         bool
+	signerError      string
+	previousScreen   screen
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -81,6 +87,7 @@ type initDoneMsg struct {
 	globalRules []globalRule
 	readOnly    bool
 	footer      string
+	signerError string
 	err         error
 }
 
@@ -168,6 +175,48 @@ func initialModel(ctx context.Context, o *options) model {
 	return m
 }
 
+// resizeLists updates all list sizes to match the available content area, accounting for
+// the status bar, renderWithMargin margins (v=2), borders, footer, and readOnly/signerError state.
+// This must be called both on WindowSizeMsg and after initDoneMsg updates readOnly/signerError.
+func (m *model) resizeLists() {
+	// Width: subtract horizontal margin frame (h=4) + box padding+border (2+2=4) = 8
+	innerWidth := m.width - 8
+	if innerWidth < 0 {
+		innerWidth = 0
+	}
+
+	// Height offsets must match view.go renderScreen's boxHeight formula:
+	// boxHeight = m.height - v(2) - heightOffset_view
+	// so innerHeight = m.height - (v + heightOffset_view) = m.height - heightOffset_here
+	//
+	// Height offsets must match view.go renderScreen's boxHeight formula:
+	// boxHeight = m.height - v(2) - heightOffset_view
+	// so innerHeight = m.height - (v + heightOffset_view) = m.height - heightOffset_here
+	//
+	// Normal:   heightOffset_view=7 → innerHeight = m.height - 9
+	// readOnly: heightOffset_view=9 → innerHeight = m.height - 11
+	// readOnly+signerError: heightOffset_view = 7 + signerNoticeLines (dynamic)
+	//   → innerHeight = m.height - (2 + 7 + noticeLines) = m.height - 9 - noticeLines
+	heightOffset := 9
+	if m.readOnly {
+		heightOffset = 11
+		if m.signerError != "" {
+			// Same formula as view.go: v(2) + fixed(7) + dynamic notice lines
+			heightOffset = 9 + signerNoticeLines(m.signerError, m.width)
+		}
+	}
+	innerHeight := m.height - heightOffset
+	if innerHeight < 0 {
+		innerHeight = 0
+	}
+
+	m.choiceList.SetSize(innerWidth, innerHeight)
+	m.policyScreenList.SetSize(innerWidth, innerHeight)
+	m.trustScreenList.SetSize(innerWidth, innerHeight)
+	m.ruleList.SetSize(innerWidth, innerHeight)
+	m.globalRuleList.SetSize(innerWidth, innerHeight)
+}
+
 // loadRepoCmd performs all heavy TUI initialization asynchronously and sends
 // an initDoneMsg back to the program when complete.
 func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
@@ -180,15 +229,19 @@ func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
 		readOnly := o.readOnly
 		var signer dsse.SignerVerifier
 		var footer string
+		var signerError string
 
 		if !readOnly {
 			signer, err = gittuf.LoadSigner(repo, o.p.SigningKey)
 			if err != nil {
-				if !errors.Is(err, gittuf.ErrSigningKeyNotSpecified) {
-					return initDoneMsg{err: fmt.Errorf("failed to load signing key from Git config: %w", err)}
-				}
 				readOnly = true
-				footer = "No signing key found in Git config, running in read-only mode."
+				if errors.Is(err, gittuf.ErrSigningKeyNotSpecified) {
+					footer = "Read-only mode. Press 'h' to view help."
+				} else {
+					mErr := strings.TrimPrefix(err.Error(), "failed to load signing key from Git config: ")
+					signerError = fmt.Sprintf("Signing key issue: %s", mErr)
+					footer = "Read-only mode. Press 'h' to view help."
+				}
 			}
 		}
 
@@ -199,6 +252,7 @@ func loadRepoCmd(ctx context.Context, o *options) tea.Cmd {
 			globalRules: getGlobalRules(ctx, o),
 			readOnly:    readOnly,
 			footer:      footer,
+			signerError: signerError,
 		}
 	}
 }

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -11,10 +11,16 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
 )
+
+func init() {
+	lipgloss.SetColorProfile(termenv.Ascii)
+}
 
 func TestTUI(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -67,7 +73,7 @@ func TestTUI(t *testing.T) {
 
 		// Now we should be on the Policy Operations screen.
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-			return strings.Contains(string(out), "gittuf Policy Operations")
+			return strings.Contains(string(out), "Home › Policy")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 
 		// Select "View Rules" (already selected by default)
@@ -77,7 +83,7 @@ func TestTUI(t *testing.T) {
 		// We check for the "Policy Rules" title OR the screen-specific empty-state message.
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
 			content := string(out)
-			return strings.Contains(content, "Policy Rules") || strings.Contains(content, "No rules configured. Press 'A' to add one.")
+			return strings.Contains(content, "Home › Policy › Rules") || strings.Contains(content, "No rules configured")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 
 		// Send "q" to quit

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/gittuf/gittuf/internal/tuf"
 )
 
@@ -22,17 +21,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case initDoneMsg:
 		if msg.err != nil {
 			m.errorMsg = fmt.Sprintf("Initialization failed: %v", msg.err)
-			// Stay on the loading screen so the error is visible; user can press q to quit.
 			return m, nil
 		}
 		m.repo = msg.repo
 		m.signer = msg.signer
+		m.signerError = msg.signerError
 		m.rules = msg.rules
 		m.globalRules = msg.globalRules
 		m.readOnly = msg.readOnly
 		m.footer = msg.footer
 		m.updateRuleList()
 		m.updateGlobalRuleList()
+		// Resize all lists now that readOnly/signerError are known — the earlier
+		// WindowSizeMsg fired before these flags were set, so sizes must be corrected.
+		m.resizeLists()
 		m.screen = screenChoice
 		return m, nil
 
@@ -43,12 +45,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.WindowSizeMsg:
-		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
-		m.choiceList.SetSize(msg.Width-h, msg.Height-v)
-		m.policyScreenList.SetSize(msg.Width-h, msg.Height-v)
-		m.trustScreenList.SetSize(msg.Width-h, msg.Height-v)
-		m.ruleList.SetSize(msg.Width-h, msg.Height-v)
-		m.globalRuleList.SetSize(msg.Width-h, msg.Height-v)
+		m.width = msg.Width
+		m.height = msg.Height
+		m.resizeLists()
+		return m, nil
 
 	case tea.KeyMsg:
 		// Delete confirmation overlay intercepts all keys
@@ -66,6 +66,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
 				return m, tea.Quit
 			}
+		case "h":
+			// Toggle help screen if not in form mode
+			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
+				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
+				if m.screen == screenHelp {
+					// Toggle back
+					m.screen = m.previousScreen
+					return m, nil
+				}
+				// Go to help screen
+				m.previousScreen = m.screen
+				m.screen = screenHelp
+				return m, nil
+			}
 		case "esc":
 			m.footer = ""
 			switch m.screen {
@@ -79,6 +93,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = screenTrust
 			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 				m.screen = screenTrustGlobalRules
+			case screenHelp:
+				m.screen = m.previousScreen
 			}
 			return m, nil
 		}
@@ -267,14 +283,7 @@ func (m model) handlePolicyFormSubmit() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	var err error
-
-	parsedThr, err := strconv.ParseInt(m.inputs[3].Value(), 10, 0)
-	thr := int(parsedThr)
-	if err != nil {
-		m.errorMsg = "Invalid value specified; threshold must be a positive integer."
-		return m, nil
-	}
+	thr, _ := strconv.Atoi(m.inputs[3].Value())
 	r := rule{
 		name:      m.inputs[0].Value(),
 		pattern:   m.inputs[1].Value(),
@@ -283,6 +292,7 @@ func (m model) handlePolicyFormSubmit() (tea.Model, tea.Cmd) {
 	}
 	authorizedKeys := splitAndTrim(m.inputs[2].Value())
 
+	var err error
 	switch m.screen {
 	case screenPolicyAddRule:
 		err = repoAddRule(m.ctx, m.options, r, authorizedKeys)
@@ -314,14 +324,8 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 
 	parts := splitAndTrim(m.inputs[2].Value())
 	thr := 0
-	var err error
 	if m.inputs[1].Value() == tuf.GlobalRuleThresholdType {
-		parsedThr, err := strconv.ParseInt(m.inputs[3].Value(), 10, 0)
-		thr = int(parsedThr)
-		if err != nil {
-			m.errorMsg = "Invalid value specified; threshold must be a positive integer."
-			return m, nil
-		}
+		thr, _ = strconv.Atoi(m.inputs[3].Value())
 	}
 	gr := globalRule{
 		ruleName:     m.inputs[0].Value(),
@@ -330,6 +334,7 @@ func (m model) handleGlobalFormSubmit() (tea.Model, tea.Cmd) {
 		threshold:    thr,
 	}
 
+	var err error
 	switch m.screen {
 	case screenTrustAddGlobalRule:
 		err = repoAddGlobalRule(m.ctx, m.options, gr)

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -14,15 +14,21 @@ import (
 const (
 	colorRegularText = "#FFFFFF"
 	colorFocus       = "#007AFF"
+	colorAccent      = "#007AFF"
+	colorBorder      = "#1E3A5F"
 	colorBlur        = "#A0A0A0"
-	colorFooter      = "#11ff00"
-	colorSubtext     = "#555555"
-	colorErrorMsg    = "#FF0000"
+	colorFooter      = "#007AFF"
+	colorSubtext     = "#A0A0A0"
+	colorErrorMsg    = "#FF5252"
+	colorStatusBg    = "#1A1A2E"
+	colorEditMode    = "#007AFF"
+	colorReadOnly    = "#FF6B6B"
+	colorHelpKeyBg   = "#2A2A3E"
 )
 
 var (
 	titleStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(colorRegularText)).
+			Foreground(lipgloss.Color(colorAccent)).
 			Padding(0, 2).
 			MarginTop(1).
 			Bold(true)
@@ -33,8 +39,9 @@ var (
 
 	selectedItemStyle = lipgloss.NewStyle().
 				PaddingLeft(4).
-				Foreground(lipgloss.Color(colorRegularText)).
-				Background(lipgloss.Color(colorFocus))
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Background(lipgloss.Color(colorFocus)).
+				Bold(true)
 
 	focusedStyle = lipgloss.NewStyle().
 			PaddingLeft(4)
@@ -43,7 +50,46 @@ var (
 			Foreground(lipgloss.Color(colorBlur))
 
 	cursorStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color(colorRegularText))
+			Foreground(lipgloss.Color(colorAccent))
+
+	statusTitleStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colorAccent)).
+				Background(lipgloss.Color(colorStatusBg)).
+				Bold(true).
+				Padding(0, 1)
+
+	statusScreenStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colorBlur)).
+				Background(lipgloss.Color(colorStatusBg)).
+				Padding(0, 1)
+
+	statusEditModeStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color(colorEditMode)).
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Padding(0, 1).
+				Bold(true)
+
+	statusReadOnlyStyle = lipgloss.NewStyle().
+				Background(lipgloss.Color(colorReadOnly)).
+				Foreground(lipgloss.Color("#FFFFFF")).
+				Padding(0, 1).
+				Bold(true)
+
+	// Screen box — border around the content
+	screenBoxStyle = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(colorBorder)).
+			Padding(0, 1)
+
+	// Help bar key and description styles
+	helpKeyStyle = lipgloss.NewStyle().
+			Background(lipgloss.Color(colorHelpKeyBg)).
+			Foreground(lipgloss.Color(colorAccent)).
+			Padding(0, 1)
+
+	helpDescStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(colorBlur)).
+			Padding(0, 1)
 )
 
 // renderWithMargin wraps content in the standard margin used by all screens.
@@ -56,62 +102,158 @@ func renderFooter(text string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(text)
 }
 
+// signerNoticeLines returns how many terminal rows the signer-error notice will
+// occupy when rendered at the given terminal width. This matches the exact same
+// Width() call used in renderFooterBox so both the layout reservation and the
+// rendered output always agree.
+func signerNoticeLines(signerError string, termWidth int) int {
+	if signerError == "" {
+		return 0
+	}
+	noticeWidth := termWidth - 6
+	if noticeWidth < 20 {
+		noticeWidth = 20
+	}
+	wrapped := lipgloss.NewStyle().Width(noticeWidth).Render("Notice: " + signerError)
+	return strings.Count(wrapped, "\n") + 1
+}
+
+// renderFooterBox wraps the footer in a rich info box if the user requests help in read-only mode.
+func renderFooterBox(m model) string {
+	baseFooter := renderFooter(m.footer)
+	var signerNotice string
+
+	if m.signerError != "" {
+		signerNoticeWidth := m.width - 6
+		if signerNoticeWidth < 20 {
+			signerNoticeWidth = 20
+		}
+		wrappedErr := lipgloss.NewStyle().Width(signerNoticeWidth).Render("Notice: " + m.signerError)
+		signerNotice = lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Italic(true).Render(wrappedErr)
+	}
+
+	if m.readOnly && m.showHelp {
+		box := lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(lipgloss.Color(colorReadOnly)).
+			Padding(1, 2).
+			MarginTop(1)
+
+		title := lipgloss.NewStyle().Foreground(lipgloss.Color(colorReadOnly)).Bold(true).Render("Read-only mode")
+		explainWidth := m.width - 10
+		if explainWidth < 20 {
+			explainWidth = 20
+		}
+		explain := lipgloss.NewStyle().Foreground(lipgloss.Color(colorRegularText)).Width(explainWidth).Render("You are currently in read-only mode.")
+		if m.signerError != "" {
+			explain = lipgloss.NewStyle().Foreground(lipgloss.Color(colorRegularText)).Width(explainWidth).Render(m.signerError)
+		}
+		tip := lipgloss.NewStyle().Foreground(lipgloss.Color(colorFocus)).Render("Tip: You can still use the TUI to navigate and view all rules.")
+		fix := lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render("Fix steps:\n  - Run: " + lipgloss.NewStyle().Foreground(lipgloss.Color(colorFocus)).Bold(true).Render("gittuf trust init") + "\n  - Ensure your GPG/SSH/Fulcio key is correctly configured in Git")
+
+		inner := lipgloss.JoinVertical(lipgloss.Left, title, "", explain, tip, "", fix, "", baseFooter)
+		return box.Render(inner)
+	}
+
+	if signerNotice != "" {
+		// The status bar already shows the "Read-only" badge, so the footer text
+		// is redundant here. Use a double newline so there is one clear blank line
+		// of breathing room between the help key bar and the notice.
+		return "\n\n" + signerNotice
+	}
+
+	return baseFooter
+}
+
 // renderErrorMsg returns error messages styled in the error color.
 func renderErrorMsg(text string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorErrorMsg)).Render(text)
 }
 
+// renderStatusBar renders the top status bar showing screen name and current mode.
+func renderStatusBar(screenName string, readOnly bool, width int) string {
+	if width == 0 {
+		width = 80
+	}
+	title := statusTitleStyle.Render("gittuf")
+	screen := statusScreenStyle.Render("› " + screenName)
+	left := lipgloss.JoinHorizontal(lipgloss.Top, title, screen)
+
+	var modeTag string
+	if readOnly {
+		modeTag = statusReadOnlyStyle.Render(" Read-only ")
+	} else {
+		modeTag = statusEditModeStyle.Render(" Edit Mode ")
+	}
+
+	// Calculate remaining space for the gap. bar has Padding(0, 1) = 2 chars total.
+	gapWidth := width - lipgloss.Width(left) - lipgloss.Width(modeTag) - 2
+	if gapWidth < 0 {
+		gapWidth = 0
+	}
+
+	gap := lipgloss.NewStyle().
+		Background(lipgloss.Color(colorStatusBg)).
+		Width(gapWidth).
+		Render("")
+
+	return lipgloss.NewStyle().
+		Background(lipgloss.Color(colorStatusBg)).
+		Foreground(lipgloss.Color(colorRegularText)).
+		Padding(0, 1).
+		Width(width).
+		Render(lipgloss.JoinHorizontal(lipgloss.Top, left, gap, modeTag))
+}
+
+// renderHelpKey renders a single styled key + description pair.
+func renderHelpKey(key, desc string) string {
+	k := helpKeyStyle.Render(key)
+	d := helpDescStyle.Render(desc)
+	return lipgloss.JoinHorizontal(lipgloss.Top, k, d)
+}
+
+// renderStyledHelp renders the full help bar from a list of key/desc pairs.
+func renderStyledHelp(pairs [][2]string) string {
+	parts := make([]string, 0, len(pairs))
+	for _, p := range pairs {
+		parts = append(parts, renderHelpKey(p[0], p[1]))
+	}
+	return lipgloss.JoinHorizontal(lipgloss.Top, parts...)
+}
+
 // renderFormScreen renders a form screen with a title, input fields, help text, and footer.
-func (m model) renderFormScreen(title string) string {
+func (m model) renderFormScreen(formTitle string, breadcrumb string) string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(title) + "\n\n")
+	b.WriteString(titleStyle.Render(formTitle) + "\n\n")
 	for _, input := range m.inputs {
 		b.WriteString(input.View() + "\n")
 	}
 	b.WriteString("\n" + "Press Tab to advance, Enter to advance/submit, and Esc to go back." + "\n")
-	b.WriteString(renderFooter(m.footer))
+	b.WriteString(renderFooterBox(m))
 	b.WriteString(renderErrorMsg(m.errorMsg))
-	return renderWithMargin(b.String())
-}
-
-// renderListScreen renders a list with help text and footer.
-func (m model) renderListScreen(l list.Model, helpText string, emptyMsg string, isEmpty bool) string {
-	listView := l.View()
-	if isEmpty {
-		emptyMsgStyled := lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(emptyMsg)
-		listView = l.Title + "\n\n" + emptyMsgStyled
-	}
-
-	return renderWithMargin(
-		listView + "\n\n" +
-			renderFooter(m.footer) +
-			renderErrorMsg(m.errorMsg) +
-			"\n" + helpText,
+	return lipgloss.JoinVertical(lipgloss.Left,
+		renderStatusBar(breadcrumb, m.readOnly, m.width),
+		renderWithMargin(b.String()),
 	)
 }
 
-// screenPolicyRulesHelp returns the help bar for the policy rules view screen.
-func screenPolicyRulesHelp(readOnly bool) string {
+// renderActionHints returns the consistent action hints requested for the bottom of screens.
+func renderActionHints(readOnly bool) string {
 	if readOnly {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
-			"esc: back  q: quit",
-		)
+		return "\n" + renderStyledHelp([][2]string{
+			{"h", "help"},
+			{"esc", "back"},
+			{"q", "quit"},
+		})
 	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
-		"a: add  e: edit  d: delete  k: move-up  j: move-down  esc: back  q: quit",
-	)
-}
-
-// screenTrustGlobalRulesHelp returns the help bar for the global rules view screen.
-func screenTrustGlobalRulesHelp(readOnly bool) string {
-	if readOnly {
-		return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
-			"esc: back  q: quit",
-		)
-	}
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render(
-		"a: add  e: edit  d: delete  esc: back  q: quit",
-	)
+	return "\n" + renderStyledHelp([][2]string{
+		{"a", "add"},
+		{"e", "edit"},
+		{"d", "delete"},
+		{"h", "help"},
+		{"esc", "back"},
+		{"q", "quit"},
+	})
 }
 
 // renderDeleteOverlay renders the delete confirmation prompt.
@@ -122,8 +264,81 @@ func renderDeleteOverlay(target string) string {
 		Render(fmt.Sprintf("Delete rule %q? [y/n]", target))
 }
 
+// renderScreen provides unified boilerplate layout containing the title, central visual box, and footers.
+func (m model) renderScreen(title string, listContent string, overlays string) string {
+	h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+
+	boxWidth := m.width - h - 2
+	if boxWidth < 0 {
+		boxWidth = 0
+	}
+
+	heightOffset := 7
+	if m.readOnly {
+		heightOffset = 9
+		if m.signerError != "" {
+			// Dynamic: fixed overhead (7) + actual notice lines so the box
+			// perfectly fills any terminal regardless of width or screen size.
+			// Fixed overhead accounts for: 2 blank rows (between box and helpkeys),
+			// 1 helpkeys row, 1 blank gap (between helpkeys and notice).
+			heightOffset = 7 + signerNoticeLines(m.signerError, m.width)
+		}
+	}
+	boxHeight := m.height - v - heightOffset
+	if boxHeight < 0 {
+		boxHeight = 0
+	}
+
+	content := screenBoxStyle.Width(boxWidth).Height(boxHeight).Render(listContent)
+
+	return lipgloss.JoinVertical(lipgloss.Left,
+		renderStatusBar(title, m.readOnly, m.width),
+		renderWithMargin(
+			content+"\n"+
+				overlays+
+				renderFooterBox(m)+
+				renderErrorMsg(m.errorMsg),
+		),
+	)
+}
+
+// renderListOrEmpty generates dynamic content evaluating array length against fallback empty states.
+func (m model) renderListOrEmpty(l list.Model, length int, emptyTitleText string) string {
+	if length > 0 {
+		return l.View()
+	}
+
+	h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+
+	emptyTitle := lipgloss.NewStyle().Foreground(lipgloss.Color(colorRegularText)).Bold(true).Render(emptyTitleText)
+	emptyDesc := lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render("Get started by adding your first rule.\n\nPress 'a' to add rule")
+	emptyState := lipgloss.JoinVertical(lipgloss.Center, emptyTitle, "\n", emptyDesc)
+
+	boxWidth := m.width - h - 2
+	heightOffset := 8
+	if m.readOnly {
+		heightOffset = 10
+		if m.signerError != "" {
+			heightOffset = 12
+		}
+	}
+	boxHeight := m.height - v - heightOffset
+	if boxWidth < 0 {
+		boxWidth = 0
+	}
+	if boxHeight < 0 {
+		boxHeight = 0
+	}
+
+	return lipgloss.Place(boxWidth, boxHeight, lipgloss.Center, lipgloss.Center, emptyState)
+}
+
 // View renders the TUI.
 func (m model) View() string {
+	if m.width == 0 || m.height == 0 {
+		return m.spinner.View() + " Loading TUI...\n"
+	}
+
 	switch m.screen {
 	case screenLoading:
 		if m.errorMsg != "" {
@@ -137,12 +352,16 @@ func (m model) View() string {
 			titleStyle.Render("gittuf TUI") + "\n\n" +
 				m.spinner.View() + " Loading, please wait...\n",
 		)
+
 	case screenChoice:
-		return renderWithMargin(m.choiceList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
+		return m.renderScreen("Home", m.choiceList.View(), renderActionHints(m.readOnly))
+
 	case screenPolicy:
-		return renderWithMargin(m.policyScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
+		return m.renderScreen("Home › Policy", m.policyScreenList.View(), renderActionHints(m.readOnly))
+
 	case screenTrust:
-		return renderWithMargin(m.trustScreenList.View() + "\n" + renderFooter(m.footer) + renderErrorMsg(m.errorMsg))
+		return m.renderScreen("Home › Trust", m.trustScreenList.View(), renderActionHints(m.readOnly))
+
 	case screenPolicyRules:
 		overlay := ""
 		if m.confirmDelete {
@@ -155,8 +374,11 @@ func (m model) View() string {
 			)
 		}
 
-		emptyMsg := "No rules configured. Press 'A' to add one."
-		return m.renderListScreen(m.ruleList, overlay+screenPolicyRulesHelp(m.readOnly)+hint, emptyMsg, len(m.rules) == 0)
+		listView := m.renderListOrEmpty(m.ruleList, len(m.rules), "No rules configured")
+		overlays := overlay + renderActionHints(m.readOnly) + hint
+
+		return m.renderScreen("Home › Policy › Rules", listView, overlays)
+
 	case screenTrustGlobalRules:
 		overlay := ""
 		if m.confirmDelete {
@@ -169,16 +391,47 @@ func (m model) View() string {
 			)
 		}
 
-		emptyMsg := "No rules configured. Press 'A' to add one."
-		return m.renderListScreen(m.globalRuleList, overlay+screenTrustGlobalRulesHelp(m.readOnly)+hint, emptyMsg, len(m.globalRules) == 0)
+		listView := m.renderListOrEmpty(m.globalRuleList, len(m.globalRules), "No global rules configured")
+		overlays := overlay + renderActionHints(m.readOnly) + hint
+
+		return m.renderScreen("Home › Trust › Global Rules", listView, overlays)
+
 	case screenPolicyAddRule:
-		return m.renderFormScreen("Add Rule")
+		return m.renderFormScreen("Add Rule", "Home › Policy › Rules › Add")
+
 	case screenPolicyEditRule:
-		return m.renderFormScreen("Edit Rule")
+		return m.renderFormScreen("Edit Rule", "Home › Policy › Rules › Edit")
+
 	case screenTrustAddGlobalRule:
-		return m.renderFormScreen("Add Global Rule")
+		return m.renderFormScreen("Add Global Rule", "Home › Trust › Global Rules › Add")
+
 	case screenTrustEditGlobalRule:
-		return m.renderFormScreen("Edit Global Rule")
+		return m.renderFormScreen("Edit Global Rule", "Home › Trust › Global Rules › Edit")
+
+	case screenHelp:
+		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+		boxWidth := m.width - h - 2
+		boxHeight := m.height - v - 8
+		if boxWidth < 0 {
+			boxWidth = 0
+		}
+		if boxHeight < 0 {
+			boxHeight = 0
+		}
+
+		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(colorFocus)).Render("Help")
+		helpContent := title + "\n\n" +
+			"- ↑ ↓ : Navigate\n" +
+			"- Enter : Select\n" +
+			"- a : Add rule\n" +
+			"- e : Edit\n" +
+			"- d : Delete\n" +
+			"- esc : Back\n" +
+			"- q : Quit\n"
+
+		centeredContent := lipgloss.Place(boxWidth, boxHeight, lipgloss.Center, lipgloss.Center, helpContent)
+		return m.renderScreen("Help", centeredContent, "")
+
 	default:
 		return "Unknown screen"
 	}


### PR DESCRIPTION
## Description

This pull request introduces a major upgrade to the interactive terminal user interface (`gittuf tui`) by porting the `bubbletea` and `lipgloss` based custom UI. 

Key improvements include:
- **Modern Interactive UI** :- Replaced the basic skeleton with a fully functional, styled interactive interface for managing Policy and Trust rules.
- **Dynamic Breadcrumb Navigation** :- Implemented a dynamic top status bar that displays the current screen path (e.g., `gittuf › Home › Policy › Rules`), giving users better context of their location.
- **Intelligent Read-Only Mode** :- Added logic where the UI automatically falls back to a safe "READ ONLY" mode (with visual warnings and red badges) if the repository lacks trust initialization or if signing keys are not found, even when the `--read-only` flag is omitted.
- **Enhanced Empty States & Overlays** :- Added helpful empty state banners ("Get started by adding your first rule"), inline help footers and delete confirmation overlays.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used generative AI as a pair programmer to help draft the `lipgloss` UI components (like the status bar and breadcrumb logic), structure the `bubbletea` model updates, and debug Go test failures across platforms. All generated code was thoroughly reviewed, tested locally, and manually refined before submission.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
