### PR TITLE
test :- add tests for policy listprincipals command

### DIFF
--- a/internal/cmd/policy/listprincipals/listprincipals.go
+++ b/internal/cmd/policy/listprincipals/listprincipals.go
@@ -46,24 +46,26 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	stdOut := cmd.OutOrStdout()
+
 	count := 0
 	for _, principal := range principals {
-		fmt.Printf("Principal %s:\n", principal.ID())
+		fmt.Fprintf(stdOut, "Principal %s:\n", principal.ID())
 
-		fmt.Printf(indentString + "Keys:\n")
+		fmt.Fprintf(stdOut, indentString+"Keys:\n")
 		for _, key := range principal.Keys() {
-			fmt.Printf(strings.Repeat(indentString, 2)+"%s (%s)\n", key.KeyID, key.KeyType)
+			fmt.Fprintf(stdOut, strings.Repeat(indentString, 2)+"%s (%s)\n", key.KeyID, key.KeyType)
 		}
 
 		customMetadata := principal.CustomMetadata()
 		if len(customMetadata) > 0 {
-			fmt.Printf(indentString + "Custom Metadata:\n")
+			fmt.Fprintf(stdOut, indentString+"Custom Metadata:\n")
 			for key, value := range principal.CustomMetadata() {
-				fmt.Printf(strings.Repeat(indentString, 2)+"%s: %s\n", key, value)
+				fmt.Fprintf(stdOut, strings.Repeat(indentString, 2)+"%s: %s\n", key, value)
 			}
 		}
 		if count < len(principals)-1 {
-			fmt.Println()
+			fmt.Fprintln(stdOut)
 		}
 		count++
 	}

--- a/internal/cmd/policy/listprincipals/listprincipals_test.go
+++ b/internal/cmd/policy/listprincipals/listprincipals_test.go
@@ -1,0 +1,172 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package listprincipals
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListPrincipals(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+
+		expectedOutput := fmt.Sprintf(`Principal %s:
+    Keys:
+        %s (%s)
+`, newKey.ID(), newKey.Keys()[0].KeyID, newKey.Keys()[0].KeyType)
+
+		assert.Equal(t, expectedOutput, strings.ReplaceAll(stdout.String(), "\r\n", "\n"))
+	})
+
+	t.Run("success with custom policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--policy-name", "custom-policy")
+		assert.NoError(t, err)
+
+		expectedOutput := fmt.Sprintf(`Principal %s:
+    Keys:
+        %s (%s)
+`, newKey.ID(), newKey.Keys()[0].KeyID, newKey.Keys()[0].KeyType)
+
+		assert.Equal(t, expectedOutput, strings.ReplaceAll(stdout.String(), "\r\n", "\n"))
+	})
+}


### PR DESCRIPTION

## Description

This pull request adds comprehensive unit tests for the `gittuf policy list-principals` command, achieving 100% logic coverage. It verifies the proper initialization of policies, the addition of keys to targets, and the accurate execution and stdout of the command for both the default policy (`targets`) and custom policies.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used ai assistant to help draft the `listprincipals_test.go` file, correctly mock the Repository's Root and Targets states with RSL entries, and debug any test failures. I manually reviewed and verified all the generated code.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
