### PR TITLE
test :- add tests for policy listrules command

### DIFF
--- a/internal/cmd/policy/listrules/listrules.go
+++ b/internal/cmd/policy/listrules/listrules.go
@@ -35,11 +35,13 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
+	stdOut := cmd.OutOrStdout()
+
 	// Iterate through the rules, they are already in order, and the depth tells us how to indent.
 	// The order is a pre-order traversal of the delegation tree, so that the parent is always before the children.
 
 	for i, curRule := range rules {
-		fmt.Printf(strings.Repeat("    ", curRule.Depth)+"Rule %s:\n", curRule.Delegation.ID())
+		fmt.Fprintf(stdOut, strings.Repeat("    ", curRule.Depth)+"Rule %s:\n", curRule.Delegation.ID())
 		gitpaths, filepaths := []string{}, []string{}
 		for _, path := range curRule.Delegation.GetProtectedNamespaces() {
 			if strings.HasPrefix(path, "git:") {
@@ -49,26 +51,26 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 			}
 		}
 		if len(filepaths) > 0 {
-			fmt.Println(strings.Repeat("    ", curRule.Depth+1) + "Paths affected:")
+			fmt.Fprintln(stdOut, strings.Repeat("    ", curRule.Depth+1)+"Paths affected:")
 			for _, v := range filepaths {
-				fmt.Printf(strings.Repeat("    ", curRule.Depth+2)+"%s\n", v)
+				fmt.Fprintf(stdOut, strings.Repeat("    ", curRule.Depth+2)+"%s\n", v)
 			}
 		}
 		if len(gitpaths) > 0 {
-			fmt.Println(strings.Repeat("    ", curRule.Depth+1) + "Refs affected:")
+			fmt.Fprintln(stdOut, strings.Repeat("    ", curRule.Depth+1)+"Refs affected:")
 			for _, v := range gitpaths {
-				fmt.Printf(strings.Repeat("    ", curRule.Depth+2)+"%s\n", v)
+				fmt.Fprintf(stdOut, strings.Repeat("    ", curRule.Depth+2)+"%s\n", v)
 			}
 		}
 
-		fmt.Println(strings.Repeat("    ", curRule.Depth+1) + "Authorized keys:")
+		fmt.Fprintln(stdOut, strings.Repeat("    ", curRule.Depth+1)+"Authorized keys:")
 		for _, key := range curRule.Delegation.GetPrincipalIDs().Contents() {
-			fmt.Printf(strings.Repeat("    ", curRule.Depth+2)+"%s\n", key)
+			fmt.Fprintf(stdOut, strings.Repeat("    ", curRule.Depth+2)+"%s\n", key)
 		}
 
-		fmt.Println(strings.Repeat("    ", curRule.Depth+1) + fmt.Sprintf("Required valid signatures: %d", curRule.Delegation.GetThreshold()))
+		fmt.Fprintln(stdOut, strings.Repeat("    ", curRule.Depth+1)+fmt.Sprintf("Required valid signatures: %d", curRule.Delegation.GetThreshold()))
 		if i < len(rules)-1 {
-			fmt.Println()
+			fmt.Fprintln(stdOut)
 		}
 	}
 	return nil

--- a/internal/cmd/policy/listrules/listrules_test.go
+++ b/internal/cmd/policy/listrules/listrules_test.go
@@ -1,0 +1,146 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package listrules
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListRules(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main", "file:path/to/file"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-tags", []string{newKey.ID()}, []string{"git:refs/tags/"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+
+		out := strings.ReplaceAll(stdout.String(), "\r\n", "\n")
+		expectedProtectMain := fmt.Sprintf(
+			"Rule protect-main:\n    Paths affected:\n        file:path/to/file\n    Refs affected:\n        git:refs/heads/main\n    Authorized keys:\n        %s\n    Required valid signatures: 1",
+			newKey.ID(),
+		)
+		expectedProtectTags := fmt.Sprintf(
+			"Rule protect-tags:\n    Refs affected:\n        git:refs/tags/\n    Authorized keys:\n        %s\n    Required valid signatures: 1",
+			newKey.ID(),
+		)
+		assert.Contains(t, out, expectedProtectMain)
+		assert.Contains(t, out, expectedProtectTags)
+	})
+
+	t.Run("invalid target ref", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New()
+		command.SetArgs([]string{"--target-ref", "refs/gittuf/invalid"})
+		_, _, _, err = cmd.ExecuteCommandC(command)
+		assert.ErrorContains(t, err, "unable to find RSL entry")
+	})
+}


### PR DESCRIPTION
## Description

This pull request adds comprehensive unit tests for the `gittuf policy list-rules` command, achieving 100% logic coverage. It refactors the `listrules.go` command to use `cmd.OutOrStdout()` for deterministic and testable output. The tests verify the correct execution and formatting of the command's output for delegations involving both git references and file paths, as well as handling of invalid target references.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used ai assistant to write unit tests (`listrules_test.go`), format the code, and ensure all logic branches were covered through appropriate test cases including multiple namespaces (`git:`, `file:`) and invalid policy refs. I manually reviewed and verified all the generated code.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
