### PR TITLE
test :- add tests for policy removeperson command

### DIFF
--- a/internal/cmd/policy/removeperson/removeperson_test.go
+++ b/internal/cmd/policy/removeperson/removeperson_test.go
@@ -1,0 +1,210 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package removeperson
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemovePerson(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--person-ID", "dummy-person")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		person := &tufv02.Person{
+			PersonID:   "jane.doe",
+			PublicKeys: map[string]*tufv02.Key{newKey.ID(): newKey.(*tufv02.Key)},
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "jane.doe")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
+		assert.Nil(t, err)
+
+		_, ok := targetsMetadata.GetPrincipals()["jane.doe"]
+		assert.False(t, ok)
+	})
+
+	t.Run("success with custom policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		person := &tufv02.Person{
+			PersonID:   "jane.doe",
+			PublicKeys: map[string]*tufv02.Key{newKey.ID(): newKey.(*tufv02.Key)},
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "--person-ID", "jane.doe")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
+		assert.Nil(t, err)
+
+		_, ok := targetsMetadata.GetPrincipals()["jane.doe"]
+		assert.False(t, ok)
+	})
+
+	t.Run("failing signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: "invalid-key"})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "dummy-person")
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+}


### PR DESCRIPTION
## Description

This pull request adds comprehensive unit tests for the `gittuf policy remove-person` command, achieving 100% logic coverage. The tests verify the proper removal of a person (principal) from both the default policy (`targets`) and custom policies, and include coverage for scenarios without a repository and with failing signers.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used ai assistant to write unit tests (`removeperson_test.go`), format the code, and ensure all logic branches were covered through appropriate test cases including handling of custom policies and invalid signers. I manually reviewed and verified all the generated code.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
