### PR TITLE
test :- add tests for policy reorderrules command

### DIFF
--- a/internal/cmd/policy/reorderrules/reorderrules_test.go
+++ b/internal/cmd/policy/reorderrules/reorderrules_test.go
@@ -1,0 +1,446 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reorderrules
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReorderRules(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "rule-2", "rule-1")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initial check
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
+		assert.Nil(t, err)
+		rules := targetsMetadata.GetRules()
+		assert.Equal(t, "rule-1", rules[0].ID())
+		assert.Equal(t, "rule-2", rules[1].ID())
+
+		// Reorder rules
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "rule-2", "rule-1")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
+		assert.Nil(t, err)
+
+		rules = targetsMetadata.GetRules()
+		assert.Equal(t, "rule-2", rules[0].ID())
+		assert.Equal(t, "rule-1", rules[1].ID())
+	})
+
+	t.Run("success with custom policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Reorder rules in custom-policy
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "rule-2", "rule-1")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
+		assert.Nil(t, err)
+
+		rules := targetsMetadata.GetRules()
+		assert.Equal(t, "rule-2", rules[0].ID())
+		assert.Equal(t, "rule-1", rules[1].ID())
+	})
+
+	t.Run("failing signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: "invalid-key"})
+		_, _, _, err = cmd.ExecuteCommandC(command, "rule-2", "rule-1")
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("policy metadata not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy", "rule-2", "rule-1")
+		assert.ErrorIs(t, err, policy.ErrMetadataNotFound)
+	})
+
+	t.Run("duplicated rule name in args", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "rule-1", "rule-1")
+		assert.ErrorContains(t, err, "two rules with same name found in policy")
+	})
+
+	t.Run("rule does not exist", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "rule-not-found")
+		assert.ErrorContains(t, err, "rules 'rule-not-found' do not exist in current rule file")
+	})
+
+	t.Run("rule missing in args", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command) // rule-1 is missing from command arguments
+		assert.ErrorContains(t, err, "rules 'rule-1' not specified")
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `gittuf policy reorder-rules` CLI command. The tests achieve 100% statement/logic coverage for `internal/cmd/policy/reorderrules/reorderrules.go`.

The following scenarios are covered:
- **No Repository**: Validates that running the command outside of a git repository fails gracefully.
- **Success**: Verifies successful reordering of rules in the main targets policy file.
- **Success with Custom Policy Name**: Assures that rules can be successfully reordered in a delegated target policy (custom policy) file.
- **Failing Signer**: Verifies that using an invalid/missing signing key returns an error.
- **Policy Metadata Not Found**: Verifies that specifying a non-existent policy name correctly returns a metadata-not-found error.
- **Duplicated Rule Name in Args**: Verifies that specifying duplicate rule names in command arguments returns a duplication error.
- **Rule Does Not Exist**: Verifies that specifying a non-existent rule returns a rule-not-found error.
- **Rule Missing in Args**: Verifies that omitting any existing rule from command arguments returns a missing-rules error.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used AI to draft the unit tests for the `reorder-rules` command, verifying correct integration with the gittuf repository state, and configuring the required test cases for duplicate rules, missing rules, and custom policies.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
