### PR TITLE
test :- add tests for policy sign command

### DIFF
--- a/internal/cmd/policy/sign/sign_test.go
+++ b/internal/cmd/policy/sign/sign_test.go
@@ -1,0 +1,271 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sign
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSign(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}))
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		keyPath2 := filepath.Join(tmpDir, "test-key-2")
+		if err := os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initially, the TargetsEnvelope has 1 signature (from initialization)
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, state.Metadata.TargetsEnvelope.Signatures, 1)
+
+		// Sign targets with key2
+		command := New(&persistent.Options{SigningKey: keyPath2, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command)
+		assert.NoError(t, err)
+
+		// Verification
+		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Now, the TargetsEnvelope should have 2 signatures (one from keyPath, one from keyPath2)
+		assert.Len(t, state.Metadata.TargetsEnvelope.Signatures, 2)
+	})
+
+	t.Run("success with custom policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		keyPath2 := filepath.Join(tmpDir, "test-key-2")
+		if err := os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify custom-policy envelope initial signatures
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, state.Metadata.DelegationEnvelopes["custom-policy"].Signatures, 1)
+
+		// Sign custom-policy with key2
+		command := New(&persistent.Options{SigningKey: keyPath2, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.Len(t, state.Metadata.DelegationEnvelopes["custom-policy"].Signatures, 2)
+	})
+
+	t.Run("failing signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: "invalid-key"})
+		_, _, _, err = cmd.ExecuteCommandC(command)
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("policy metadata not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy")
+		assert.ErrorIs(t, err, policy.ErrMetadataNotFound)
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `gittuf policy sign` CLI command. The tests achieve 100% statement/logic coverage for `internal/cmd/policy/sign/sign.go`.

The following scenarios are covered:
- **No Repository**: Validates that running the command outside of a git repository fails gracefully.
- **Success**: Verifies that signing the main target policy file correctly appends a signature to its envelope.
- **Success with Custom Policy Name**: Assures that a delegated target policy (custom policy) file can be successfully signed.
- **Failing Signer**: Verifies that using an invalid/missing signing key returns an error.
- **Policy Metadata Not Found**: Verifies that specifying a non-existent policy name correctly returns a metadata-not-found error.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used AI to draft the unit tests for the `sign` command, verifying correct integration with the gittuf repository state using different keys (ED25519 and RSA) to append and assert signatures.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
