### PR TITLE
test :- add tests for policy updaterule command

### DIFF
--- a/internal/cmd/policy/updaterule/updaterule_test.go
+++ b/internal/cmd/policy/updaterule/updaterule_test.go
@@ -1,0 +1,588 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package updaterule
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rootopts "github.com/gittuf/gittuf/experimental/gittuf/options/root"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateRule(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Initial check
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
+		assert.Nil(t, err)
+		rules := targetsMetadata.GetRules()
+		assert.Equal(t, "rule-1", rules[0].ID())
+		assert.Equal(t, []string{"git:refs/heads/main"}, rules[0].GetProtectedNamespaces())
+		assert.Equal(t, 1, rules[0].GetThreshold())
+
+		// Update rule
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize-key", keyPath+".pub", "--rule-pattern", "git:refs/heads/feature", "--threshold", "1")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
+		assert.Nil(t, err)
+		rules = targetsMetadata.GetRules()
+		assert.Equal(t, "rule-1", rules[0].ID())
+		assert.Equal(t, []string{"git:refs/heads/feature"}, rules[0].GetProtectedNamespaces())
+		assert.Equal(t, 1, rules[0].GetThreshold())
+	})
+
+	t.Run("success with custom policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Update rule in custom-policy
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "--rule-name", "rule-1", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/feature")
+		assert.NoError(t, err)
+
+		// Verification
+		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
+		assert.Nil(t, err)
+		rules := targetsMetadata.GetRules()
+		assert.Equal(t, "rule-1", rules[0].ID())
+		assert.Equal(t, []string{"git:refs/heads/feature"}, rules[0].GetProtectedNamespaces())
+	})
+
+	t.Run("failing signer", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: "invalid-key"})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "failed to run command")
+	})
+
+	t.Run("policy metadata not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy", "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorIs(t, err, policy.ErrMetadataNotFound)
+	})
+
+	t.Run("cannot manipulate rule with gittuf prefix", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Run updaterule for rule with gittuf prefix
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "gittuf-some-rule", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "cannot add or change rules whose names have the 'gittuf-' prefix")
+	})
+
+	t.Run("principal not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", "non-existent-principal", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "principal not found")
+	})
+
+	t.Run("invalid threshold", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/main", "--threshold", "0")
+		assert.ErrorContains(t, err, "threshold must be a positive integer")
+	})
+
+	t.Run("cannot meet threshold", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/main", "--threshold", "2")
+		assert.ErrorContains(t, err, "insufficient keys to meet threshold")
+	})
+
+	t.Run("invalid policy name (root)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "root", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorIs(t, err, gittuf.ErrInvalidPolicyName)
+	})
+
+	t.Run("missing required rule-name flag", func(t *testing.T) {
+		command := New(&persistent.Options{SigningKey: "key"})
+		_, _, _, err := cmd.ExecuteCommandC(command, "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "required flag(s) \"rule-name\" not set")
+	})
+
+	t.Run("missing required rule-pattern flag", func(t *testing.T) {
+		command := New(&persistent.Options{SigningKey: "key"})
+		_, _, _, err := cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", "principal-1")
+		assert.ErrorContains(t, err, "required flag(s) \"rule-pattern\" not set")
+	})
+
+	t.Run("missing required authorize / authorize-key flags", func(t *testing.T) {
+		command := New(&persistent.Options{SigningKey: "key"})
+		_, _, _, err := cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "at least one of the flags in the group [authorize authorize-key] is required")
+	})
+
+	t.Run("missing authorize-key file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		command := New(&persistent.Options{SigningKey: keyPath})
+		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize-key", "non-existent-key.pub", "--rule-pattern", "git:refs/heads/main")
+		assert.ErrorContains(t, err, "No such file or directory")
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `gittuf policy update-rule` CLI command. The tests achieve 100% statement/logic coverage for `internal/cmd/policy/updaterule/updaterule.go`.

The following scenarios are covered :- 
- **No Repository**: Validates that running the command outside of a git repository fails gracefully.
- **Success**: Verifies that a rule can be successfully updated in the main targets policy file.
- **Success with Custom Policy Name**: Assures that a rule can be updated within a delegated target policy (custom policy) file.
- **Failing Signer**: Verifies that using an invalid/missing signing key returns an error.
- **Policy Metadata Not Found**: Verifies that specifying a non-existent policy name correctly returns a metadata-not-found error.
- **Cannot Manipulate Rule with Gittuf Prefix**: Verifies that trying to update rules starting with the reserved `gittuf-` prefix fails.
- **Principal Not Found**: Verifies that updating a rule to authorize a principal ID that is not registered returns a principal-not-found error.
- **Invalid Threshold**: Verifies that specifying a threshold <= 0 returns a validation error.
- **Cannot Meet Threshold**: Verifies that specifying a threshold greater than the number of authorized principals returns an error.
- **Invalid Policy Name (root)**: Verifies that attempting to update a rule named `root` fails.
- **Missing Required Flags**: Validates command constraints for missing required flags (`--rule-name`, `--rule-pattern`, and `--authorize`/`--authorize-key` group).
- **Missing Authorize Key File**: Verifies that a non-existent public key file path correctly returns a file-not-found error.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used AI to draft the unit tests for the `update-rule` command, validating correct parsing of authorize-key files, and verify rules, thresholds, and policy states.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
