### PR TITLE
test :- add unit tests for rsl propagate command

### DIFF
--- a/internal/cmd/rsl/propagate/propagate_test.go
+++ b/internal/cmd/rsl/propagate/propagate_test.go
@@ -1,0 +1,54 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package propagate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPropagate(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success with no policy (nothing to propagate)", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `rsl propagate` subcommand. The tests cover both validation/error-handling conditions and successful execution scenarios:
- Repository identification error checking.
- Successful check when there are no propagation directives defined in the repository (safely exits with no-op).

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used ai to draft the unit test suite and verify standard Go syntax, formatting, and static analysis constraints.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
