### PR TITLE
test :- add unit tests for rsl record command

### DIFF
--- a/internal/cmd/rsl/record/record_test.go
+++ b/internal/cmd/rsl/record/record_test.go
@@ -1,0 +1,125 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package record
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecord(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "main", "--local-only")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("missing arguments", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
+		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
+	})
+
+	t.Run("missing remote-name or local-only", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "main")
+		assert.ErrorContains(t, err, "at least one of the flags in the group [remote-name local-only] is required")
+	})
+
+	t.Run("both remote-name and local-only", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "main", "--local-only", "--remote-name", "origin")
+		assert.ErrorContains(t, err, "if any flags in the group [remote-name local-only] are set")
+	})
+
+	t.Run("no signing key configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		err = r.SetGitConfig("user.signingkey", "")
+		require.NoError(t, err)
+
+		treeBuilder := gitinterface.NewTreeBuilder(r)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+
+		_, err = r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+		require.NoError(t, err)
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "main", "--local-only")
+		assert.ErrorIs(t, err, gitinterface.ErrSigningKeyNotSpecified)
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces comprehensive unit tests for the `rsl record` subcommand. The tests cover both validation/error-handling conditions and execution scenarios:
- Repository identification error checking.
- Positional arguments validation (exactly 1 argument required).
- Mutual exclusivity and requirement checks for `--remote-name` and `--local-only` flags.
- Command execution verification (ensuring it properly triggers the signing checks in the RSL logic).

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used Ai to draft the unit test suite and verify standard Go syntax, formatting, and static analysis constraints.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
