### PR TITLE
test(cli): add unit tests for rsl skip-rewritten command

### DIFF
--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -164,6 +164,12 @@ func (r *Repository) RecordRSLEntryForReferenceAtTarget(refName, targetID string
 }
 
 func (r *Repository) SkipAllInvalidReferenceEntriesForRef(targetRef string, signCommit bool) error {
+	if signCommit {
+		if err := r.r.CanSign(); err != nil {
+			return err
+		}
+	}
+
 	return rsl.SkipAllInvalidReferenceEntriesForRef(r.r, targetRef, signCommit)
 }
 

--- a/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
@@ -1,0 +1,105 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package skiprewritten
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipRewritten(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "refs/heads/main")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("missing arguments", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
+	})
+
+	t.Run("no signing key configured", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(cwd)
+		}()
+
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		err = r.SetGitConfig("gpg.format", "ssh")
+		require.NoError(t, err)
+
+		err = r.SetGitConfig("user.signingkey", "")
+		require.NoError(t, err)
+
+		libRepo, err := gittuf.LoadRepository(".")
+		require.NoError(t, err)
+
+		treeBuilder := gitinterface.NewTreeBuilder(r)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+
+		_, err = r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+		require.NoError(t, err)
+
+		err = libRepo.RecordRSLEntryForReference(t.Context(), "refs/heads/main", false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		err = r.SetReference("refs/heads/main", gitinterface.ZeroHash)
+		require.NoError(t, err)
+
+		_, err = r.Commit(emptyTreeHash, "refs/heads/main", "Real initial commit\n", false)
+		require.NoError(t, err)
+
+		err = libRepo.RecordRSLEntryForReference(t.Context(), "refs/heads/main", false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "refs/heads/main")
+		assert.ErrorIs(t, err, gitinterface.ErrSigningKeyNotSpecified)
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces unit tests for the `rsl skip-rewritten` subcommand. The tests verify:
- Behavior when no Git repository is identified.
- Proper argument length validation (requiring exactly 1 argument).
- Handling when no signing key is configured (by simulating a history rewrite and ensuring `ErrSigningKeyNotSpecified` is correctly returned).

Additionally, it adds a `CanSign()` verification check to `SkipAllInvalidReferenceEntriesForRef` in `experimental/gittuf/rsl.go` to ensure missing signing key configurations are properly surfaced at the API level prior to trying to commit.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used Ai to draft the unit test suite and verify standard Go syntax, formatting, and static analysis constraints.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
