### PR TITLE
test :- add unit tests for dev attest-github command

### DIFF
--- a/internal/cmd/dev/attestgithub/attestgithub.go
+++ b/internal/cmd/dev/attestgithub/attestgithub.go
@@ -9,25 +9,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-type options struct {
-	signingKey string
-}
-
-func (o *options) AddFlags(cmd *cobra.Command) {
+func New() *cobra.Command {
+	p := &persistent.Options{WithRSLEntry: true}
+	cmd := pullrequest.New(p)
 	cmd.Flags().StringVarP(
-		&o.signingKey,
+		&p.SigningKey,
 		"signing-key",
 		"k",
 		"",
 		"specify key to sign attestation with",
 	)
 	cmd.MarkFlagRequired("signing-key") //nolint:errcheck
-}
-
-func New() *cobra.Command {
-	o := &options{}
-	cmd := pullrequest.New(&persistent.Options{SigningKey: o.signingKey, WithRSLEntry: true})
-	o.AddFlags(cmd)
 	cmd.Deprecated = "switch to \"gittuf attest github pull-request\""
 	return cmd
 }

--- a/internal/cmd/dev/attestgithub/attestgithub_test.go
+++ b/internal/cmd/dev/attestgithub/attestgithub_test.go
@@ -1,0 +1,80 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package attestgithub
+
+import (
+	"os"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttestGitHub(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-k", "test-key", "--repository", "owner/repo", "--pull-request-number", "1")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("missing required flag signing-key", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New(), "--repository", "owner/repo", "--pull-request-number", "1")
+		assert.ErrorContains(t, err, `required flag(s) "signing-key" not set`)
+	})
+
+	t.Run("missing required flag repository", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New(), "-k", "test-key", "--pull-request-number", "1")
+		assert.ErrorContains(t, err, `required flag(s) "repository" not set`)
+	})
+
+	t.Run("invalid repository format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-k", "test-key", "--repository", "invalid-format", "--pull-request-number", "1")
+		assert.ErrorContains(t, err, "invalid format for repository, must be {owner}/{repo}")
+	})
+
+	t.Run("loading signer error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-k", "non-existent-key", "--repository", "owner/repo", "--pull-request-number", "1")
+		assert.ErrorContains(t, err, "ssh-keygen")
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces unit tests for the `gittuf dev attest-github` subcommand. It also addresses a bug where the `--signing-key` flag was not correctly bound and propagated to the underlying execution options.

The new unit tests cover:
- Failure when run outside a Git repository.
- Validation for missing required flags (`--signing-key` and `--repository`).
- Format validation for the `--repository` flag.
- Loading errors when a non-existent or invalid signing key is specified.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used Ai to draft the unit test suite, locate the flag binding issue, and verify the package compilation.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
