### PR TITLE
test :- add unit tests for dev rsl-record command

### DIFF
--- a/internal/cmd/dev/rslrecordat/rslrecordat_test.go
+++ b/internal/cmd/dev/rslrecordat/rslrecordat_test.go
@@ -1,0 +1,98 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rslrecordat
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRSLRecordAt(t *testing.T) {
+	t.Setenv("GITTUF_DEV", "1")
+
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		keyPath := filepath.Join(tmpDir, "key")
+		if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-t", "some-target", "-k", keyPath, "refs/heads/main")
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("missing required flag target", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New(), "-k", "key-path", "refs/heads/main")
+		assert.ErrorContains(t, err, `required flag(s) "target" not set`)
+	})
+
+	t.Run("missing required flag signing-key", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New(), "-t", "some-target", "refs/heads/main")
+		assert.ErrorContains(t, err, `required flag(s) "signing-key" not set`)
+	})
+
+	t.Run("missing positional arguments", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New(), "-t", "some-target", "-k", "key-path")
+		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
+	})
+
+	t.Run("key file not found", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-t", "some-target", "-k", "non-existent-key-file", "refs/heads/main")
+		assert.ErrorIs(t, err, os.ErrNotExist)
+	})
+
+	t.Run("invalid target ID format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		currentDir, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			_ = os.Chdir(currentDir)
+		}()
+
+		keyPath := filepath.Join(tmpDir, "key")
+		if err := os.WriteFile(keyPath, []byte("key"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+
+		_, _, _, err = cmd.ExecuteCommandC(New(), "-t", "invalid-hash", "-k", keyPath, "refs/heads/main")
+		assert.ErrorContains(t, err, "wrong length")
+	})
+}


### PR DESCRIPTION
## Description

This pull request introduces unit tests for the `gittuf dev rsl-record` subcommand.

The new unit tests cover:
- Failure when run outside a Git repository.
- Validation for missing required flags (`--target` and `--signing-key`).
- Validation for missing positional arguments.
- Handling when the key file does not exist.
- Invalid format validation for the target ID.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

I used Ai to draft the unit test suite and verify the package compilation.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
