### PR TITLE
Fix/policy delete delegated rule files

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -31,6 +31,7 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
 * [gittuf policy add-person](gittuf_policy_add-person.md)	 - Add a trusted person to a policy file
 * [gittuf policy add-rule](gittuf_policy_add-rule.md)	 - Add a new rule to a policy file
 * [gittuf policy apply](gittuf_policy_apply.md)	 - Validate and apply changes from policy-staging to policy
+* [gittuf policy delete-file](gittuf_policy_delete-file.md)	 - Delete a delegated policy file
 * [gittuf policy discard](gittuf_policy_discard.md)	 - Discard the currently staged changes to policy
 * [gittuf policy increment-version](gittuf_policy_increment-version.md)	 - Increment the integer version of the specified rule file metadata
 * [gittuf policy init](gittuf_policy_init.md)	 - Initialize policy file
@@ -45,4 +46,3 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
 * [gittuf policy stage](gittuf_policy_stage.md)	 - Stage and push local policy-staging changes to remote repository
 * [gittuf policy update-person](gittuf_policy_update-person.md)	 - Update a person in a policy file
 * [gittuf policy update-rule](gittuf_policy_update-rule.md)	 - Update an existing rule in a policy file
-

--- a/docs/cli/gittuf_policy_delete-file.md
+++ b/docs/cli/gittuf_policy_delete-file.md
@@ -1,0 +1,35 @@
+## gittuf policy delete-file
+
+Delete a delegated policy file
+
+### Synopsis
+
+The 'delete-file' command removes a delegated gittuf policy file from policy metadata.
+
+```
+gittuf policy delete-file [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for delete-file
+      --policy-name string   name of delegated policy file to delete
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/experimental/gittuf/targets.go
+++ b/experimental/gittuf/targets.go
@@ -19,6 +19,8 @@ import (
 )
 
 var ErrInvalidPolicyName = errors.New("invalid rule or policy file name, cannot be 'root'")
+var ErrCannotDeletePrimaryPolicyFile = errors.New("cannot delete primary policy file")
+var ErrCannotDeleteReachablePolicyFile = errors.New("cannot delete reachable delegated policy file")
 
 // InitializeTargets is the interface for the user to create the specified
 // policy file.
@@ -273,6 +275,46 @@ func (r *Repository) RemoveDelegation(ctx context.Context, signer sslibdsse.Sign
 
 	commitMessage := fmt.Sprintf("Remove rule '%s' from policy '%s'", ruleName, targetsRoleName)
 	return r.updateTargetsMetadata(ctx, state, signer, targetsRoleName, targetsMetadata, commitMessage, options.CreateRSLEntry, signCommit)
+}
+
+func (r *Repository) DeletePolicyFile(ctx context.Context, targetsRoleName string, signCommit bool, opts ...trustpolicyopts.Option) error {
+	if targetsRoleName == policy.RootRoleName || targetsRoleName == policy.TargetsRoleName {
+		return ErrCannotDeletePrimaryPolicyFile
+	}
+
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		if err := r.r.CanSign(); err != nil {
+			return err
+		}
+	}
+
+	options := &trustpolicyopts.Options{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	slog.Debug("Loading current policy...")
+	state, err := policy.LoadCurrentState(ctx, r.r, policy.PolicyStagingRef, policyopts.BypassRSL())
+	if err != nil {
+		return err
+	}
+	if !state.HasTargetsRole(targetsRoleName) {
+		return policy.ErrMetadataNotFound
+	}
+
+	referenced, err := state.Metadata.HasRuleFileReference(targetsRoleName)
+	if err != nil {
+		return err
+	}
+	if referenced {
+		return ErrCannotDeleteReachablePolicyFile
+	}
+
+	delete(state.Metadata.DelegationEnvelopes, targetsRoleName)
+
+	commitMessage := fmt.Sprintf("Delete policy '%s'", targetsRoleName)
+	return state.Commit(r.r, commitMessage, options.CreateRSLEntry, signCommit)
 }
 
 // AddPrincipalToTargets is the interface for a user to add a trusted principal

--- a/experimental/gittuf/targets.go
+++ b/experimental/gittuf/targets.go
@@ -313,7 +313,7 @@ func (r *Repository) DeletePolicyFile(ctx context.Context, targetsRoleName strin
 
 	delete(state.Metadata.DelegationEnvelopes, targetsRoleName)
 
-	commitMessage := fmt.Sprintf("Delete policy '%s'", targetsRoleName)
+	commitMessage := fmt.Sprintf("Delete policy file '%s'", targetsRoleName)
 	return state.Commit(r.r, commitMessage, options.CreateRSLEntry, signCommit)
 }
 

--- a/internal/cmd/policy/deletefile/deletefile.go
+++ b/internal/cmd/policy/deletefile/deletefile.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
-	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +16,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.policyName,
 		"policy-name",
-		policy.TargetsRoleName,
+		"",
 		"name of delegated policy file to delete",
 	)
 }

--- a/internal/cmd/policy/deletefile/deletefile.go
+++ b/internal/cmd/policy/deletefile/deletefile.go
@@ -1,0 +1,51 @@
+package deletefile
+
+import (
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	p          *persistent.Options
+	policyName string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		policy.TargetsRoleName,
+		"name of delegated policy file to delete",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	opts := []trustpolicyopts.Option{}
+	if o.p.WithRSLEntry {
+		opts = append(opts, trustpolicyopts.WithRSLEntry())
+	}
+
+	return repo.DeletePolicyFile(cmd.Context(), o.policyName, true, opts...)
+}
+
+func New(persistent *persistent.Options) *cobra.Command {
+	o := &options{p: persistent}
+	cmd := &cobra.Command{
+		Use:               "delete-file",
+		Short:             "Delete a delegated policy file",
+		Long:              "The 'delete-file' command removes a delegated gittuf policy file from policy metadata.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/addkey"
 	"github.com/gittuf/gittuf/internal/cmd/policy/addperson"
 	"github.com/gittuf/gittuf/internal/cmd/policy/addrule"
+	"github.com/gittuf/gittuf/internal/cmd/policy/deletefile"
 	"github.com/gittuf/gittuf/internal/cmd/policy/incrementversion"
 	i "github.com/gittuf/gittuf/internal/cmd/policy/init"
 	"github.com/gittuf/gittuf/internal/cmd/policy/listprincipals"
@@ -40,6 +41,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(addperson.New(o))
 	cmd.AddCommand(addrule.New(o))
 	cmd.AddCommand(apply.New())
+	cmd.AddCommand(deletefile.New(o))
 	cmd.AddCommand(discard.New())
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(incrementversion.New(o))

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -186,6 +186,45 @@ func (s *StateMetadata) GetTargetsMetadata(roleName string, migrate bool) (tuf.T
 	}
 }
 
+func (s *StateMetadata) HasRuleFileReference(roleName string) (bool, error) {
+	targetsMetadata, err := s.GetTargetsMetadata(TargetsRoleName, true)
+	if err != nil {
+		if errors.Is(err, ErrMetadataNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	queue := targetsMetadata.GetRules()
+	seen := map[string]bool{TargetsRoleName: true}
+	for len(queue) > 1 {
+		rule := queue[0]
+		queue = queue[1:]
+
+		if rule.ID() == roleName {
+			return true, nil
+		}
+
+		if seen[rule.ID()] || s.DelegationEnvelopes == nil {
+			continue
+		}
+		if _, ok := s.DelegationEnvelopes[rule.ID()]; !ok {
+			continue
+		}
+
+		// If a rule has a corresponding delegation file, retrieve its metadata,
+		// then add the rules in that metadata to the queue
+		delegatedMetadata, err := s.GetTargetsMetadata(rule.ID(), true)
+		if err != nil {
+			return false, err
+		}
+		seen[rule.ID()] = true
+		queue = append(delegatedMetadata.GetRules(), queue...)
+	}
+
+	return false, nil
+}
+
 func (s *StateMetadata) WriteTree(repo *gitinterface.Repository) (gitinterface.Hash, error) {
 	metadata := map[string]*sslibdsse.Envelope{}
 	metadata[RootRoleName] = s.RootEnvelope

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -796,6 +796,14 @@ func (s *StateMetadata) VerifyNewStateMetadata(_ context.Context, newStateMetada
 			// file, so if the new state doesn't have it, it's a rollback.
 			// This will change once we support deleting rule files.
 			if errors.Is(err, ErrMetadataNotFound) {
+				referenced, refErr := newStateMetadata.HasRuleFileReference(name)
+				if refErr != nil {
+					return refErr
+				}
+				if !referenced {
+					continue
+				}
+
 				return fmt.Errorf("%w: new policy is missing delegated rule file '%s'", ErrMetadataRollbackDetected, name)
 			}
 

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -782,9 +782,10 @@ func (s *StateMetadata) VerifyNewStateMetadata(_ context.Context, newStateMetada
 	// Then compare all delegated rule files.
 	// We need to check that the rule files in the new state with the same name
 	// as a rule file in the current state have greater or equal version numbers.
-	// The new state may have a rule file added that doesn't exist in the
-	// current state, but it shouldn't have any removed rule files compared to
-	// the current state as we don't yet support deleting rule files.
+	// The new state may add delegated rule files that do not exist in the
+	// current state. It may also remove delegated rule files, but only when the
+	// new delegation graph no longer references the removed role. If the removed
+	// role is still referenced, treat the missing metadata as rollback.
 	for name := range s.DelegationEnvelopes {
 		currentDelegatedTargetsMetadata, err := s.GetTargetsMetadata(name, true)
 		if err != nil {
@@ -793,8 +794,9 @@ func (s *StateMetadata) VerifyNewStateMetadata(_ context.Context, newStateMetada
 		newDelegatedTargetsMetadata, err := newStateMetadata.GetTargetsMetadata(name, true)
 		if err != nil {
 			// At this point, we know the current state has this delegated rule
-			// file, so if the new state doesn't have it, it's a rollback.
-			// This will change once we support deleting rule files.
+			// file. Missing metadata in the new state is allowed only when the
+			// new delegation graph no longer references the role; otherwise,
+			// the missing file is a rollback signal.
 			if errors.Is(err, ErrMetadataNotFound) {
 				referenced, refErr := newStateMetadata.HasRuleFileReference(name)
 				if refErr != nil {


### PR DESCRIPTION
## Description

Fixes a rule deletion bug caused by gittuf not providing a way to delete delegated policy files.

Previously, when a user removed a delegation rule with `gittuf policy remove-rule`, the corresponding delegated policy file could remain in policy metadata. During `gittuf policy apply`, this stale, unreachable delegated metadata caused `ErrDanglingDelegationMetadata`.

This PR:

1. Adds a new `gittuf policy delete-file` CLI command.
2. Deletes the corresponding delegated policy file by removing its entry from the current state's `DelegationEnvelopes` and then committing a newly written policy tree.
3. Updates rollback verification so that a missing delegated rule file is treated as valid only when the new policy graph no longer references that delegated role. If the new `targets` metadata can still reach a rule with that delegated role name, the missing file is still treated as rollback/corruption.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->
I use AI to help analyze possible causes of the bug, think through potential solutions, and check whether my code covers all the cases it should consider.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [ ] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
