### PR TITLE
rsl: Make entry parsing strict and ordered

### DIFF
--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -1144,167 +1144,287 @@ func PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo *gitint
 }
 
 func parseRSLEntryText(id gitinterface.Hash, text string) (Entry, error) {
+	// Each parser returns a concrete pointer type. Assign to a local and return
+	// an explicit nil interface on error: returning the typed nil pointer
+	// directly would yield a non-nil Entry wrapping a nil pointer.
 	switch {
 	case strings.HasPrefix(text, ReferenceEntryHeader):
-		return parseReferenceEntryText(id, text)
+		entry, err := parseReferenceEntryText(id, text)
+		if err != nil {
+			return nil, err
+		}
+		return entry, nil
 	case strings.HasPrefix(text, AnnotationEntryHeader):
-		return parseAnnotationEntryText(id, text)
+		entry, err := parseAnnotationEntryText(id, text)
+		if err != nil {
+			return nil, err
+		}
+		return entry, nil
 	case strings.HasPrefix(text, PropagationEntryHeader):
-		return parsePropagationEntryText(id, text)
+		entry, err := parsePropagationEntryText(id, text)
+		if err != nil {
+			return nil, err
+		}
+		return entry, nil
 	default:
 		return nil, ErrInvalidRSLEntry
 	}
 }
 
+// parseReferenceEntryText parses a reference entry as a state machine. The
+// fields must appear in the order ref, targetID, number, each at most once;
+// number is optional and trailing. Out-of-order fields and duplicates are
+// rejected. Unknown keys are ignored for forward compatibility.
 func parseReferenceEntryText(id gitinterface.Hash, text string) (*ReferenceEntry, error) {
-	lines := strings.Split(text, "\n")
-	if len(lines) < 4 {
-		return nil, ErrInvalidRSLEntry
+	body, err := entryBody(text, ReferenceEntryHeader)
+	if err != nil {
+		return nil, err
 	}
-	lines = lines[2:]
+
+	const (
+		expectRef = iota
+		expectTargetID
+		expectNumber
+		done
+	)
 
 	entry := &ReferenceEntry{ID: id}
-	for _, l := range lines {
-		l = strings.TrimSpace(l)
-
-		ls := strings.Split(l, ":")
-		if len(ls) < 2 {
+	state := expectRef
+	for _, line := range body {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
 			return nil, ErrInvalidRSLEntry
 		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
 
-		switch strings.TrimSpace(ls[0]) {
+		switch key {
 		case RefKey:
-			entry.RefName = strings.TrimSpace(ls[1])
+			if state != expectRef {
+				return nil, ErrInvalidRSLEntry
+			}
+			entry.RefName = value
+			state = expectTargetID
 
 		case TargetIDKey:
-			targetHash, err := gitinterface.NewHash(strings.TrimSpace(ls[1]))
-			if err != nil {
+			if state != expectTargetID {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setHash(&entry.TargetID, value); err != nil {
 				return nil, err
 			}
-
-			entry.TargetID = targetHash
+			state = expectNumber
 
 		case NumberKey:
-			number, err := strconv.ParseUint(strings.TrimSpace(ls[1]), 10, 64)
-			if err != nil {
+			if state != expectNumber {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setNumber(&entry.Number, value); err != nil {
 				return nil, err
 			}
-
-			entry.Number = number
+			state = done
 		}
 	}
 
+	if state < expectNumber {
+		// ref and/or targetID were not seen.
+		return nil, ErrInvalidRSLEntry
+	}
 	return entry, nil
 }
 
+// parseAnnotationEntryText parses an annotation entry as a state machine. One or
+// more entryID fields come first, followed by skip, then an optional number,
+// then an optional PEM message block. The message is decoded separately, so the
+// state machine stops at its begin marker.
 func parseAnnotationEntryText(id gitinterface.Hash, text string) (*AnnotationEntry, error) {
 	annotation := &AnnotationEntry{
 		ID:          id,
 		RSLEntryIDs: []gitinterface.Hash{},
 	}
 
-	messageBlock, _ := pem.Decode([]byte(text)) // rest doesn't seem to work when the PEM block is at the end of text, see: https://go.dev/play/p/oZysAfemA-v
-	if messageBlock != nil {
-		annotation.Message = string(messageBlock.Bytes)
+	body, err := entryBody(text, AnnotationEntryHeader)
+	if err != nil {
+		return nil, err
 	}
 
-	lines := strings.Split(text, "\n")
-	if len(lines) < 4 {
-		return nil, ErrInvalidRSLEntry
+	// Only attempt to decode a message when the begin marker is present; most
+	// annotations carry no message, so this avoids copying the text and running
+	// the PEM scanner for them.
+	if strings.Contains(text, BeginMessage) {
+		messageBlock, _ := pem.Decode([]byte(text)) // rest doesn't seem to work when the PEM block is at the end of text, see: https://go.dev/play/p/oZysAfemA-v
+		if messageBlock != nil {
+			annotation.Message = string(messageBlock.Bytes)
+		}
 	}
-	lines = lines[2:]
 
-	for _, l := range lines {
-		l = strings.TrimSpace(l)
-		if l == BeginMessage {
+	const (
+		expectEntryID = iota // one or more entryIDs, then skip
+		expectNumber         // entryIDs and skip seen; optional number
+		done
+	)
+
+	state := expectEntryID
+	for _, line := range body {
+		line = strings.TrimSpace(line)
+		if line == BeginMessage {
 			break
 		}
 
-		ls := strings.Split(l, ":")
-		if len(ls) < 2 {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
 			return nil, ErrInvalidRSLEntry
 		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
 
-		switch strings.TrimSpace(ls[0]) {
+		switch key {
 		case EntryIDKey:
-			hash, err := gitinterface.NewHash(strings.TrimSpace(ls[1]))
+			if state != expectEntryID {
+				return nil, ErrInvalidRSLEntry
+			}
+			hash, err := gitinterface.NewHash(value)
 			if err != nil {
 				return nil, err
 			}
-
 			annotation.RSLEntryIDs = append(annotation.RSLEntryIDs, hash)
 
 		case SkipKey:
-			if strings.TrimSpace(ls[1]) == "true" {
-				annotation.Skip = true
-			} else {
-				annotation.Skip = false
+			if state != expectEntryID || len(annotation.RSLEntryIDs) == 0 {
+				return nil, ErrInvalidRSLEntry
 			}
+			switch value {
+			case "true":
+				annotation.Skip = true
+			case "false":
+				annotation.Skip = false
+			default:
+				return nil, ErrInvalidRSLEntry
+			}
+			state = expectNumber
 
 		case NumberKey:
-			number, err := strconv.ParseUint(strings.TrimSpace(ls[1]), 10, 64)
-			if err != nil {
+			if state != expectNumber {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setNumber(&annotation.Number, value); err != nil {
 				return nil, err
 			}
-
-			annotation.Number = number
+			state = done
 		}
 	}
 
+	if state < expectNumber {
+		// entryID(s) and/or skip were not seen.
+		return nil, ErrInvalidRSLEntry
+	}
 	return annotation, nil
 }
 
+// parsePropagationEntryText parses a propagation entry as a state machine. The
+// fields must appear in the order ref, targetID, upstreamRepository,
+// upstreamEntryID, number, each at most once; number is optional and trailing.
 func parsePropagationEntryText(id gitinterface.Hash, text string) (*PropagationEntry, error) {
-	lines := strings.Split(text, "\n")
-	if len(lines) < 6 {
-		return nil, ErrInvalidRSLEntry
+	body, err := entryBody(text, PropagationEntryHeader)
+	if err != nil {
+		return nil, err
 	}
-	lines = lines[2:]
+
+	const (
+		expectRef = iota
+		expectTargetID
+		expectUpstreamRepository
+		expectUpstreamEntryID
+		expectNumber
+		done
+	)
 
 	entry := &PropagationEntry{ID: id}
-	for _, l := range lines {
-		l = strings.TrimSpace(l)
-
-		ls := strings.Split(l, ":")
-		if len(ls) < 2 {
+	state := expectRef
+	for _, line := range body {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), ":")
+		if !ok {
 			return nil, ErrInvalidRSLEntry
 		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
 
-		switch strings.TrimSpace(ls[0]) {
+		switch key {
 		case RefKey:
-			entry.RefName = strings.TrimSpace(ls[1])
+			if state != expectRef {
+				return nil, ErrInvalidRSLEntry
+			}
+			entry.RefName = value
+			state = expectTargetID
 
 		case TargetIDKey:
-			targetHash, err := gitinterface.NewHash(strings.TrimSpace(ls[1]))
-			if err != nil {
+			if state != expectTargetID {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setHash(&entry.TargetID, value); err != nil {
 				return nil, err
 			}
-
-			entry.TargetID = targetHash
+			state = expectUpstreamRepository
 
 		case UpstreamRepositoryKey:
-			// The location may also have `:`, so we need to handle all items in ls
-			entry.UpstreamRepository = strings.TrimSpace(strings.Join(ls[1:], ":"))
+			if state != expectUpstreamRepository {
+				return nil, ErrInvalidRSLEntry
+			}
+			// The location may also contain ':', so value retains everything
+			// after the first separator.
+			entry.UpstreamRepository = value
+			state = expectUpstreamEntryID
 
 		case UpstreamEntryIDKey:
-			upstreamEntryIDHash, err := gitinterface.NewHash(strings.TrimSpace(ls[1]))
-			if err != nil {
+			if state != expectUpstreamEntryID {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setHash(&entry.UpstreamEntryID, value); err != nil {
 				return nil, err
 			}
-
-			entry.UpstreamEntryID = upstreamEntryIDHash
+			state = expectNumber
 
 		case NumberKey:
-			number, err := strconv.ParseUint(strings.TrimSpace(ls[1]), 10, 64)
-			if err != nil {
+			if state != expectNumber {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := setNumber(&entry.Number, value); err != nil {
 				return nil, err
 			}
-
-			entry.Number = number
+			state = done
 		}
 	}
 
+	if state < expectNumber {
+		// A required field before number was not seen.
+		return nil, ErrInvalidRSLEntry
+	}
 	return entry, nil
+}
+
+// entryBody validates the entry's header line and the mandatory blank line that
+// follows it, returning the remaining body lines for the state machine.
+func entryBody(text, header string) ([]string, error) {
+	lines := strings.Split(text, "\n")
+	if len(lines) < 2 || lines[0] != header || strings.TrimSpace(lines[1]) != "" {
+		return nil, ErrInvalidRSLEntry
+	}
+	return lines[2:], nil
+}
+
+func setHash(dst *gitinterface.Hash, value string) error {
+	hash, err := gitinterface.NewHash(value)
+	if err != nil {
+		return err
+	}
+	*dst = hash
+	return nil
+}
+
+func setNumber(dst *uint64, value string) error {
+	number, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return err
+	}
+	*dst = number
+	return nil
 }
 
 func filterAnnotationsForRelevantAnnotations(allAnnotations []*AnnotationEntry, entryID gitinterface.Hash) []*AnnotationEntry {

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -2328,6 +2328,35 @@ func TestParseRSLEntryText(t *testing.T) {
 			expectedError: ErrInvalidRSLEntry,
 			message:       fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, "abcdef12345678900987654321fedcbaabcdef12", UpstreamRepositoryKey, upstreamRepository),
 		},
+		"entry, with number": {
+			expectedEntry: &ReferenceEntry{
+				ID:       gitinterface.ZeroHash,
+				RefName:  "refs/heads/main",
+				TargetID: nonZeroHash,
+				Number:   42,
+			},
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, "abcdef12345678900987654321fedcbaabcdef12", NumberKey, 42),
+		},
+		"annotation, with number": {
+			expectedEntry: &AnnotationEntry{
+				ID:          gitinterface.ZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				Skip:        true,
+				Number:      7,
+			},
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", NumberKey, 7),
+		},
+		"propagation entry, with number": {
+			expectedEntry: &PropagationEntry{
+				ID:                 gitinterface.ZeroHash,
+				RefName:            "refs/heads/main",
+				TargetID:           gitinterface.ZeroHash,
+				UpstreamRepository: upstreamRepository,
+				UpstreamEntryID:    gitinterface.ZeroHash,
+				Number:             3,
+			},
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String(), NumberKey, 3),
+		},
 	}
 
 	for name, test := range tests {
@@ -2339,6 +2368,212 @@ func TestParseRSLEntryText(t *testing.T) {
 				t.Errorf("expected\n%+v\n\ngot\n%+v", test.expectedEntry, entry)
 			}
 		})
+	}
+}
+
+func TestParseRSLEntryTextRejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	zero := gitinterface.ZeroHash.String()
+	upstream := "https://git.example.com/example/repository"
+
+	// Each message below is malformed in exactly one way and must be rejected
+	// with ErrInvalidRSLEntry. The previous loose parser accepted most of these
+	// (last-write-wins, any order, missing fields), so these are the adversarial
+	// cases that motivate the state machine.
+	tests := map[string]string{
+		"reference, duplicate ref": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", RefKey, "refs/heads/other", TargetIDKey, zero),
+		"reference, duplicate targetID": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, TargetIDKey, zero),
+		"reference, duplicate number": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d\n%s: %d",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, NumberKey, 1, NumberKey, 2),
+		"reference, targetID before ref": fmt.Sprintf("%s\n\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, TargetIDKey, zero, RefKey, "refs/heads/main"),
+		"reference, number before targetID": fmt.Sprintf("%s\n\n%s: %s\n%s: %d\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", NumberKey, 1, TargetIDKey, zero),
+		"reference, missing ref": fmt.Sprintf("%s\n\n%s: %s",
+			ReferenceEntryHeader, TargetIDKey, zero),
+		"reference, missing targetID": fmt.Sprintf("%s\n\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main"),
+		"reference, line without colon": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ngarbage",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"reference, header with trailing text": fmt.Sprintf("%s extra\n\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"reference, non-blank second line": fmt.Sprintf("%s\nnot blank\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"annotation, entryID after skip": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, "true", EntryIDKey, zero),
+		"annotation, duplicate skip": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, "true", SkipKey, "false"),
+		"annotation, skip before entryID": fmt.Sprintf("%s\n\n%s: %s\n%s: %s",
+			AnnotationEntryHeader, SkipKey, "true", EntryIDKey, zero),
+		"annotation, missing skip": fmt.Sprintf("%s\n\n%s: %s",
+			AnnotationEntryHeader, EntryIDKey, zero),
+		"annotation, missing entryID": fmt.Sprintf("%s\n\n%s: %s",
+			AnnotationEntryHeader, SkipKey, "true"),
+		"annotation, invalid skip value": fmt.Sprintf("%s\n\n%s: %s\n%s: %s",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, "maybe"),
+		"propagation, duplicate upstreamRepository": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, upstream, UpstreamRepositoryKey, upstream, UpstreamEntryIDKey, zero),
+		"propagation, upstreamEntryID before upstreamRepository": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamEntryIDKey, zero, UpstreamRepositoryKey, upstream),
+		"propagation, missing upstreamEntryID": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, upstream),
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			assert.True(t, entry == nil, "expected a true nil Entry, not a typed nil pointer")
+			assert.ErrorIs(t, err, ErrInvalidRSLEntry)
+		})
+	}
+}
+
+func TestParseRSLEntryTextForwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	zero := gitinterface.ZeroHash.String()
+	upstream := "https://git.example.com:8443/example/repository"
+
+	tests := map[string]struct {
+		message       string
+		expectedEntry Entry
+	}{
+		"reference, unknown trailing key ignored": {
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\nfutureField: someValue",
+				ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+			expectedEntry: &ReferenceEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		},
+		"reference, unknown leading key ignored": {
+			message: fmt.Sprintf("%s\n\nfutureField: someValue\n%s: %s\n%s: %s",
+				ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+			expectedEntry: &ReferenceEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		},
+		"annotation, unknown key ignored between fields": {
+			message: fmt.Sprintf("%s\n\n%s: %s\nfutureField: someValue\n%s: %s",
+				AnnotationEntryHeader, EntryIDKey, zero, SkipKey, "false"),
+			expectedEntry: &AnnotationEntry{ID: gitinterface.ZeroHash, RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash}, Skip: false},
+		},
+		"propagation, upstreamRepository with colons preserved": {
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s",
+				PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, upstream, UpstreamEntryIDKey, zero),
+			expectedEntry: &PropagationEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash, UpstreamRepository: upstream, UpstreamEntryID: gitinterface.ZeroHash},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, test.message)
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedEntry, entry)
+		})
+	}
+}
+
+const (
+	fuzzZeroHash    = "0000000000000000000000000000000000000000"
+	fuzzNonZeroHash = "abcdef12345678900987654321fedcbaabcdef12"
+)
+
+func FuzzParseRSLEntryText(f *testing.F) {
+	f.Add("")
+	f.Add("not an entry")
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, SkipKey, "true"))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com:8443/repo", UpstreamEntryIDKey, fuzzNonZeroHash))
+
+	f.Fuzz(func(_ *testing.T, text string) {
+		_, _ = parseRSLEntryText(gitinterface.ZeroHash, text)
+	})
+}
+
+func FuzzParseReferenceEntryText(f *testing.F) {
+	f.Add("")
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzNonZeroHash, NumberKey, 5))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, TargetIDKey, fuzzZeroHash, RefKey, "refs/heads/main"))
+
+	f.Fuzz(func(_ *testing.T, text string) {
+		_, _ = parseReferenceEntryText(gitinterface.ZeroHash, text)
+	})
+}
+
+func FuzzParseAnnotationEntryText(f *testing.F) {
+	f.Add("")
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, SkipKey, "true"))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, EntryIDKey, fuzzNonZeroHash, SkipKey, "false", BeginMessage, base64.StdEncoding.EncodeToString([]byte("note")), EndMessage))
+
+	f.Fuzz(func(_ *testing.T, text string) {
+		_, _ = parseAnnotationEntryText(gitinterface.ZeroHash, text)
+	})
+}
+
+func FuzzParsePropagationEntryText(f *testing.F) {
+	f.Add("")
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com:8443/repo", UpstreamEntryIDKey, fuzzNonZeroHash))
+	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com/repo", UpstreamEntryIDKey, fuzzNonZeroHash, NumberKey, 9))
+
+	f.Fuzz(func(_ *testing.T, text string) {
+		_, _ = parsePropagationEntryText(gitinterface.ZeroHash, text)
+	})
+}
+
+func BenchmarkParseReferenceEntryText(b *testing.B) {
+	text := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzNonZeroHash, NumberKey, 42)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parseReferenceEntryText(gitinterface.ZeroHash, text); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseAnnotationEntryText(b *testing.B) {
+	text := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %d\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, EntryIDKey, fuzzNonZeroHash, SkipKey, "true", NumberKey, 42, BeginMessage, base64.StdEncoding.EncodeToString([]byte("annotation message")), EndMessage)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parseAnnotationEntryText(gitinterface.ZeroHash, text); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseAnnotationEntryTextNoMessage(b *testing.B) {
+	text := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, SkipKey, "true", NumberKey, 42)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parseAnnotationEntryText(gitinterface.ZeroHash, text); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParsePropagationEntryText(b *testing.B) {
+	text := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzNonZeroHash, UpstreamRepositoryKey, "https://git.example.com:8443/example/repository", UpstreamEntryIDKey, fuzzZeroHash, NumberKey, 42)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parsePropagationEntryText(gitinterface.ZeroHash, text); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseRSLEntryText(b *testing.B) {
+	text := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzNonZeroHash, NumberKey, 42)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parseRSLEntryText(gitinterface.ZeroHash, text); err != nil {
+			b.Fatal(err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Change the RSL entry parsers so that they are stricter. Fields must appear in their canonical order, each at most once (`entryID` being the one repeatable field in annotations). Out-of-order fields, duplicates, and missing required fields are all rejected. Unknown keys are still ignored so we keep forward compatibility with future fields.

### Performance Impact (benchstat)

Both `sec/op` and `B/op` improved by `~30%`, while allocations dropped by `~45%`:

```
                             │   before    │              after                 │
                             │   sec/op    │   sec/op     vs base               │
ParseReferenceEntryText-24      235.2n        153.2n      -34.89%
ParseAnnotationEntryText-24     819.4n        694.0n      -15.29%
ParsePropagationEntryText-24    437.1n        254.9n      -41.68%
ParseRSLEntryText-24            234.1n        167.9n      -28.28%
geomean                         374.7n        259.7n      -30.69%

                             │    B/op     │    B/op      vs base               │
ParseReferenceEntryText-24      280.0         184.0       -34.29%
ParseAnnotationEntryText-24     848.0         720.0       -15.09%
ParsePropagationEntryText-24    512.0         272.0       -46.88%
ParseRSLEntryText-24            280.0         184.0       -34.29%

                             │  allocs/op  │ allocs/op    vs base               │
ParseReferenceEntryText-24      6.000         3.000       -50.00%
ParseAnnotationEntryText-24     16.00         12.00       -25.00%
ParsePropagationEntryText-24    10.000        4.000       -60.00%
ParseRSLEntryText-24            6.000         3.000       -50.00%
geomean                         8.712         4.559       -47.67%
```

The information above is based on the benchmarks introduced by these changes.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

AI was used to prototype and compare different parsing approaches, as well as to help expand test coverage. All AI-assisted output was iteratively reviewed, refined, and validated through continuous developer feedback before being included in the PR.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
