### PR TITLE
fix: record RSL entry in Discard to keep staging ref in sync`

### DIFF
--- a/experimental/gittuf/policy.go
+++ b/experimental/gittuf/policy.go
@@ -97,8 +97,15 @@ func (r *Repository) ApplyPolicy(ctx context.Context, remoteName string, localOn
 	return err
 }
 
-func (r *Repository) DiscardPolicy() error {
-	return policy.Discard(r.r)
+func (r *Repository) DiscardPolicy(signCommit bool) error {
+	if signCommit {
+		slog.Debug("Checking if Git signing is configured...")
+		if err := r.r.CanSign(); err != nil {
+			return err
+		}
+	}
+
+	return policy.Discard(r.r, signCommit)
 }
 
 type DelegationWithDepth struct {

--- a/experimental/gittuf/policy_test.go
+++ b/experimental/gittuf/policy_test.go
@@ -213,7 +213,7 @@ func TestDiscardPolicy(t *testing.T) {
 		initialPolicyRef, err := repo.r.GetReference(policy.PolicyRef)
 		assert.Nil(t, err)
 
-		err = repo.DiscardPolicy()
+		err = repo.DiscardPolicy(false)
 		assert.Nil(t, err)
 
 		stagingRef, err := repo.r.GetReference(policy.PolicyStagingRef)
@@ -226,7 +226,7 @@ func TestDiscardPolicy(t *testing.T) {
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo := &Repository{r: r}
 
-		err := repo.DiscardPolicy()
+		err := repo.DiscardPolicy(false)
 		assert.Nil(t, err)
 
 		_, err = repo.r.GetReference(policy.PolicyStagingRef)
@@ -243,12 +243,54 @@ func TestDiscardPolicy(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = repo.DiscardPolicy()
+		err = repo.DiscardPolicy(false)
 		assert.Nil(t, err)
 
 		stagingRef, err := repo.r.GetReference(policy.PolicyStagingRef)
 		assert.Nil(t, err)
 		assert.Equal(t, initialRef, stagingRef)
+	})
+	// Regression test for issue #1342: Discard moved PolicyStagingRef without
+	// recording an RSL entry, leaving the staging ref out of sync with its
+	// latest RSL entry and causing a subsequent Apply to fail with
+	// ErrInvalidPolicy. createTestRepositoryWithPolicy applies the policy, so we
+	// must advance the staging ref past the policy ref before discarding to
+	// exercise the bug path (otherwise Discard hits its no-op guard).
+	t.Run("discard after real stage flow then apply succeeds", func(t *testing.T) {
+		repo := createTestRepositoryWithPolicy(t, "")
+
+		targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
+		gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgKeyBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		gpgKey := tufv02.NewKeyFromSSLibKey(gpgKeyR)
+
+		// Make a real policy change so PolicyStagingRef advances past PolicyRef.
+		if err := repo.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-feature", []string{gpgKey.KeyID}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write a real RSL entry for the staging ref.
+		if err := repo.StagePolicy(testCtx, "", true, false); err != nil {
+			t.Fatal(err)
+		}
+
+		// Discard resets staging back to the policy tip; this must also record
+		// an RSL entry so staging and the RSL stay in sync.
+		if err := repo.DiscardPolicy(false); err != nil {
+			t.Fatal(err)
+		}
+
+		err = policy.Apply(testCtx, repo.r, false)
+		assert.Nil(t, err)
+
+		policyTip, err := repo.r.GetReference(policy.PolicyRef)
+		assert.Nil(t, err)
+
+		stagingEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo.r, rsl.ForReference(policy.PolicyStagingRef))
+		assert.Nil(t, err)
+		assert.Equal(t, policyTip, stagingEntry.GetTargetID())
 	})
 }
 

--- a/experimental/gittuf/policy_test.go
+++ b/experimental/gittuf/policy_test.go
@@ -250,6 +250,7 @@ func TestDiscardPolicy(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, initialRef, stagingRef)
 	})
+
 	// Regression test for issue #1342: Discard moved PolicyStagingRef without
 	// recording an RSL entry, leaving the staging ref out of sync with its
 	// latest RSL entry and causing a subsequent Apply to fail with

--- a/internal/cmd/trustpolicy/discard/discard.go
+++ b/internal/cmd/trustpolicy/discard/discard.go
@@ -18,7 +18,7 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	return repo.DiscardPolicy()
+	return repo.DiscardPolicy(true)
 }
 
 func New() *cobra.Command {

--- a/internal/cmd/tui/screen_policy_lifecycle.go
+++ b/internal/cmd/tui/screen_policy_lifecycle.go
@@ -279,7 +279,7 @@ func handlePolicyLifecycleCommand(m *model, action string, policyName string, re
 			return m.repo.ApplyPolicy(m.ctx, remote, localOnly, true)
 		case "Discard Changes":
 			successMsg = "Successfully discarded policy changes."
-			return m.repo.DiscardPolicy()
+			return m.repo.DiscardPolicy(true)
 		case "Pull Policy":
 			successMsg = fmt.Sprintf("Successfully pulled policy from remote %q.", remote)
 			return m.repo.PullPolicy(remote)

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -872,7 +872,7 @@ func Apply(ctx context.Context, repo *gitinterface.Repository, signRSLEntry bool
 }
 
 // Discard resets the policy staging ref, discarding any changes made to the policy staging ref.
-func Discard(repo *gitinterface.Repository) error {
+func Discard(repo *gitinterface.Repository, signCommit bool) error {
 	policyTip, err := repo.GetReference(PolicyRef)
 	if err != nil {
 		if errors.Is(err, gitinterface.ErrReferenceNotFound) {
@@ -884,9 +884,27 @@ func Discard(repo *gitinterface.Repository) error {
 		return fmt.Errorf("failed to get policy reference %s: %w", PolicyRef, err)
 	}
 
+	// If the staging ref already matches policy, there is nothing to discard,
+	// so avoid recording a redundant RSL entry.
+	policyStagingTip, err := repo.GetReference(PolicyStagingRef)
+	if err != nil && !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to get policy staging reference %s: %w", PolicyStagingRef, err)
+	}
+	if err == nil && policyStagingTip.Equal(policyTip) {
+		return nil
+	}
+
 	// Reset PolicyStagingRef to match the actual policy ref
 	if err := repo.SetReference(PolicyStagingRef, policyTip); err != nil {
 		return fmt.Errorf("failed to reset policy staging reference %s: %w", PolicyStagingRef, err)
+	}
+
+	// Record an RSL entry for the reset so the staging ref stays in sync with
+	// its latest RSL entry. Without this, the staging ref points at policyTip
+	// while the latest staging RSL entry still references the discarded commit,
+	// causing ReconcileStaging/Apply to fail with ErrInvalidPolicy.
+	if err := rsl.NewReferenceEntry(PolicyStagingRef, policyTip).Commit(repo, signCommit); err != nil {
+		return fmt.Errorf("failed to record RSL entry for discarded policy staging reference %s: %w", PolicyStagingRef, err)
 	}
 
 	return nil

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -874,7 +874,7 @@ func Apply(ctx context.Context, repo gitstore.Storer, signRSLEntry bool) error {
 }
 
 // Discard resets the policy staging ref, discarding any changes made to the policy staging ref.
-func Discard(repo gitstore.Storer) error {
+func Discard(repo gitstore.Storer, signCommit bool) error {
 	policyTip, err := repo.GetReference(PolicyRef)
 	if err != nil {
 		if errors.Is(err, gitinterface.ErrReferenceNotFound) {
@@ -886,9 +886,27 @@ func Discard(repo gitstore.Storer) error {
 		return fmt.Errorf("failed to get policy reference %s: %w", PolicyRef, err)
 	}
 
+	// If the staging ref already matches policy, there is nothing to discard,
+	// so avoid recording a redundant RSL entry.
+	policyStagingTip, err := repo.GetReference(PolicyStagingRef)
+	if err != nil && !errors.Is(err, gitinterface.ErrReferenceNotFound) {
+		return fmt.Errorf("failed to get policy staging reference %s: %w", PolicyStagingRef, err)
+	}
+	if err == nil && policyStagingTip.Equal(policyTip) {
+		return nil
+	}
+
 	// Reset PolicyStagingRef to match the actual policy ref
 	if err := repo.SetReference(PolicyStagingRef, policyTip); err != nil {
 		return fmt.Errorf("failed to reset policy staging reference %s: %w", PolicyStagingRef, err)
+	}
+
+	// Record an RSL entry for the reset so the staging ref stays in sync with
+	// its latest RSL entry. Without this, the staging ref points at policyTip
+	// while the latest staging RSL entry still references the discarded commit,
+	// causing ReconcileStaging/Apply to fail with ErrInvalidPolicy.
+	if err := rsl.NewReferenceEntry(PolicyStagingRef, policyTip).Commit(repo, signCommit); err != nil {
+		return fmt.Errorf("failed to record RSL entry for discarded policy staging reference %s: %w", PolicyStagingRef, err)
 	}
 
 	return nil

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1224,7 +1224,7 @@ func TestDiscard(t *testing.T) {
 
 		assert.NotEqual(t, policyTip, stagingTip)
 
-		err = Discard(repo)
+		err = Discard(repo, false)
 		assert.Nil(t, err)
 
 		policyTip, err = repo.GetReference(PolicyRef)
@@ -1262,7 +1262,7 @@ func TestDiscard(t *testing.T) {
 		}
 		assert.Equal(t, commitID, stagingTip)
 
-		err = Discard(repo)
+		err = Discard(repo, false)
 		assert.Nil(t, err)
 
 		_, err = repo.GetReference(PolicyStagingRef)

--- a/internal/policy/policy_test.go
+++ b/internal/policy/policy_test.go
@@ -1249,7 +1249,7 @@ func TestDiscard(t *testing.T) {
 
 		assert.NotEqual(t, policyTip, stagingTip)
 
-		err = Discard(repo)
+		err = Discard(repo, false)
 		assert.Nil(t, err)
 
 		policyTip, err = repo.GetReference(PolicyRef)
@@ -1287,7 +1287,7 @@ func TestDiscard(t *testing.T) {
 		}
 		assert.Equal(t, commitID, stagingTip)
 
-		err = Discard(repo)
+		err = Discard(repo, false)
 		assert.Nil(t, err)
 
 		_, err = repo.GetReference(PolicyStagingRef)


### PR DESCRIPTION
Fixes #1342

## Description

`policy.Discard` resets `PolicyStagingRef` to match `PolicyRef` but did not record a corresponding RSL entry after doing so. This broke the invariant that a ref's tip must equal its latest RSL entry target. When `policy apply` was subsequently called, `ReconcileStaging` compared the staging ref tip (now pointing at the policy commit) against the latest staging RSL entry target (still pointing at the discarded staged commit) and returned `ErrInvalidPolicy`.

This PR fixes the issue by appending an RSL reference entry for `PolicyStagingRef` after `SetReference` in `policy.Discard`. An early-return guard is also added to skip both the ref update and RSL write when staging already equals policy tip, avoiding redundant entries in the no-op case.

To thread signing behavior consistently with the rest of the policy workflow, `signCommit bool` is added to `Discard` and `DiscardPolicy`, with the CLI passing `true` to match `apply`.

A regression test is added to `experimental/gittuf/policy_test.go` that drives the real `StagePolicy → DiscardPolicy → Apply` flow. The existing `TestDiscard` did not cover this path because it creates the staging ref via a raw `repo.Commit` call, bypassing the RSL entirely, so no staging RSL entry existed to conflict with.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
