### PR TITLE
test: add coverage for VerifyEnvelope invalid threshold and threshold not met

### DIFF
--- a/internal/signerverifier/dsse/dsse_test.go
+++ b/internal/signerverifier/dsse/dsse_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/gittuf/gittuf/internal/signerverifier/common"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
@@ -64,9 +65,25 @@ func TestVerifyEnvelope(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	acceptedKeys, err := VerifyEnvelope(context.Background(), env, []sslibdsse.Verifier{signer.Verifier}, 1)
+	acceptedKeys, err := VerifyEnvelope(t.Context(), env, []sslibdsse.Verifier{signer.Verifier}, 1)
 	assert.Nil(t, err)
 	assert.Equal(t, keyID, acceptedKeys[0].KeyID)
+
+	t.Run("invalid threshold", func(t *testing.T) {
+		env := &sslibdsse.Envelope{}
+
+		acceptedKeys, err := VerifyEnvelope(t.Context(), env, nil, 0)
+
+		assert.Nil(t, acceptedKeys)
+		assert.ErrorIs(t, err, common.ErrInvalidThreshold)
+	})
+
+	t.Run("threshold not met", func(t *testing.T) {
+		acceptedKeys, err := VerifyEnvelope(t.Context(), env, []sslibdsse.Verifier{signer.Verifier}, 2)
+
+		assert.Len(t, acceptedKeys, 1)
+		assert.ErrorContains(t, err, "accepted signatures do not match threshold")
+	})
 }
 
 func loadSSHSigner(keyPath string) (*ssh.Signer, error) {


### PR DESCRIPTION
## Description
While looking through the coverage gaps for #463, I focused on the DSSE package since there were no open PRs covering it.

I found two error paths in `VerifyEnvelope` that weren't covered by the existing tests:
- when `threshold` is less than 1, it should return `common.ErrInvalidThreshold`
- when there aren't enough valid signatures to meet the required threshold

This PR adds a test for each of those cases and contributes toward #463.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I'm new to gittuf and Go, so I used generative AI to help me understand the codebase (RSL, policy verification, and the DSSE package) and learn how Go tests are structured. I read the implementation in `dsse.go` and the existing tests myself to identify the uncovered branches, then manually reviewed and verified the final tests before submitting this PR.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
