### PR TITLE
ci: Log ref tips during gittuf verification workflow

### DIFF
--- a/.github/workflows/gittuf-verify.yml
+++ b/.github/workflows/gittuf-verify.yml
@@ -15,4 +15,9 @@ jobs:
           sleep 10s
           gittuf clone https://github.com/${{ github.repository }}
           cd gittuf
+          echo "RSL:            $(git show --oneline refs/gittuf/reference-state-log)"
+          echo "Policy:         $(git show --oneline refs/gittuf/policy)"
+          echo "Policy staging: $(git show --oneline refs/gittuf/policy-staging)"
+          echo "Attestations:   $(git show --oneline refs/gittuf/attestations)"
+          echo "Main:           $(git show --oneline refs/heads/main)"
           gittuf verify-ref main --verbose


### PR DESCRIPTION
## Description

Logs out ref tips during gittuf verification workflow.

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
