### PR TITLE
docs: fix policy command docstrings for stage, discard, and apply

### DIFF
--- a/docs/cli/gittuf_policy_apply.md
+++ b/docs/cli/gittuf_policy_apply.md
@@ -4,7 +4,7 @@ Validate and apply changes from policy-staging to policy
 
 ### Synopsis
 
-The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.
+The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and records the change in the RSL. Pass '--local-only' to apply without pushing upstream. Otherwise, supply the remote name as the first positional argument.
 
 ```
 gittuf policy apply [flags]
@@ -14,7 +14,7 @@ gittuf policy apply [flags]
 
 ```
   -h, --help         help for apply
-      --local-only   indicate that the policy must be committed into the RSL locally
+      --local-only   apply policy changes locally without pushing to a remote repository
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_policy_discard.md
+++ b/docs/cli/gittuf_policy_discard.md
@@ -4,7 +4,7 @@ Discard the currently staged changes to policy
 
 ### Synopsis
 
-The 'discard' command removes any currently staged policy changes. It is used to revert pending policy updates before they are applied to the repository.
+The 'discard' command removes any currently staged policy changes and records the discard in the RSL. It is used to revert pending policy updates before they are applied to the repository.
 
 ```
 gittuf policy discard [flags]

--- a/docs/cli/gittuf_policy_stage.md
+++ b/docs/cli/gittuf_policy_stage.md
@@ -4,7 +4,7 @@ Stage and push local policy-staging changes to remote repository
 
 ### Synopsis
 
-The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.
+The 'stage' command stages local policy changes and records them in the RSL. It optionally pushes the staged changes to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Pass '--local-only' to stage without pushing upstream. Otherwise, supply the remote name as the first positional argument.
 
 ```
 gittuf policy stage [flags]
@@ -14,7 +14,7 @@ gittuf policy stage [flags]
 
 ```
   -h, --help         help for stage
-      --local-only   indicate that the policy must be committed into the RSL locally
+      --local-only   stage policy changes locally without pushing to a remote repository
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust_apply.md
+++ b/docs/cli/gittuf_trust_apply.md
@@ -4,7 +4,7 @@ Validate and apply changes from policy-staging to policy
 
 ### Synopsis
 
-The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.
+The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and records the change in the RSL. Pass '--local-only' to apply without pushing upstream. Otherwise, supply the remote name as the first positional argument.
 
 ```
 gittuf trust apply [flags]
@@ -14,7 +14,7 @@ gittuf trust apply [flags]
 
 ```
   -h, --help         help for apply
-      --local-only   indicate that the policy must be committed into the RSL locally
+      --local-only   apply policy changes locally without pushing to a remote repository
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust_stage.md
+++ b/docs/cli/gittuf_trust_stage.md
@@ -4,7 +4,7 @@ Stage and push local policy-staging changes to remote repository
 
 ### Synopsis
 
-The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.
+The 'stage' command stages local policy changes and records them in the RSL. It optionally pushes the staged changes to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Pass '--local-only' to stage without pushing upstream. Otherwise, supply the remote name as the first positional argument.
 
 ```
 gittuf trust stage [flags]
@@ -14,7 +14,7 @@ gittuf trust stage [flags]
 
 ```
   -h, --help         help for stage
-      --local-only   indicate that the policy must be committed into the RSL locally
+      --local-only   stage policy changes locally without pushing to a remote repository
 ```
 
 ### Options inherited from parent commands

--- a/internal/cmd/trustpolicy/apply/apply.go
+++ b/internal/cmd/trustpolicy/apply/apply.go
@@ -17,7 +17,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.localOnly,
 		"local-only",
 		false,
-		"indicate that the policy must be committed into the RSL locally",
+		"apply policy changes locally without pushing to a remote repository",
 	)
 }
 
@@ -40,7 +40,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Validate and apply changes from policy-staging to policy",
-		Long:  "The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and can optionally commit the policy change into the RSL locally.",
+		Long:  "The 'apply' command validates and applies changes from the policy-staging area to the repository's policy. It is used to make staged policy updates effective and records the change in the RSL. Pass '--local-only' to apply without pushing upstream. Otherwise, supply the remote name as the first positional argument.",
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)

--- a/internal/cmd/trustpolicy/discard/discard.go
+++ b/internal/cmd/trustpolicy/discard/discard.go
@@ -26,7 +26,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "discard",
 		Short:             "Discard the currently staged changes to policy",
-		Long:              "The 'discard' command removes any currently staged policy changes. It is used to revert pending policy updates before they are applied to the repository.",
+		Long:              "The 'discard' command removes any currently staged policy changes and records the discard in the RSL. It is used to revert pending policy updates before they are applied to the repository.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trustpolicy/stage/stage.go
+++ b/internal/cmd/trustpolicy/stage/stage.go
@@ -17,7 +17,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.localOnly,
 		"local-only",
 		false,
-		"indicate that the policy must be committed into the RSL locally",
+		"stage policy changes locally without pushing to a remote repository",
 	)
 }
 
@@ -40,7 +40,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stage",
 		Short: "Stage and push local policy-staging changes to remote repository",
-		Long:  "The 'stage' command stages local policy changes from the policy-staging reference and optionally pushes them to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Changes can optionally be committed the to the RSL locally.",
+		Long:  "The 'stage' command stages local policy changes and records them in the RSL. It optionally pushes the staged changes to a remote repository. It is used to prepare policy updates so they can be reviewed and signed by other users if needed. Pass '--local-only' to stage without pushing upstream. Otherwise, supply the remote name as the first positional argument.",
 		RunE:  o.Run,
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
## Description

Fix incorrect docstrings in the `stage`, `discard`, and `apply` policy commands. The previous descriptions incorrectly stated that RSL entry creation was optional and controlled by a flag. RSL entries are written automatically by all three commands. The `--local-only` flag controls only whether changes are pushed to a remote repository, not whether an RSL entry is created.

Specific changes:
- `stage`: fix Long description removing the claim that RSL entries are optionally committed, fix typo "committed the to the RSL", fix `--local-only` flag description
- `discard`: fix Long description to mention that the discard is recorded in the RSL automatically
- `apply`: fix Long description removing the claim that RSL entries are optionally committed, fix `--local-only` flag description

CLI docs regenerated via `make generate`, which also updated the `gittuf trust stage` and `gittuf trust apply` doc pages.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [[DCO Signoff](https://wiki.linuxfoundation.org/dco)](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [[Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md)](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).