### PR TITLE
pkg/gitinterface: open go-git with DetectDotGit:false

### DIFF
--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -36,7 +36,11 @@ type Repository struct {
 // GetGoGitRepository returns the go-git representation of a repository. We use
 // this in certain signing and verifying workflows.
 func (r *Repository) GetGoGitRepository() (*git.Repository, error) {
-	return git.PlainOpenWithOptions(r.gitDirPath, &git.PlainOpenOptions{DetectDotGit: true})
+	// gitDirPath is already the resolved git directory (set via
+	// `git rev-parse --git-dir` in LoadRepository), so DetectDotGit must be
+	// false: with it true, go-git looks for a .git entry inside this path,
+	// which a bare repository does not have, and returns ErrRepositoryNotExists.
+	return git.PlainOpenWithOptions(r.gitDirPath, &git.PlainOpenOptions{DetectDotGit: false})
 }
 
 // GetGitDir returns the GIT_DIR path for the repository.

--- a/pkg/gitinterface/repository_test.go
+++ b/pkg/gitinterface/repository_test.go
@@ -64,4 +64,34 @@ func TestRepository(t *testing.T) {
 		_, err := LoadRepository(tmpDir)
 		assert.ErrorContains(t, err, "unable to identify git directory for repository")
 	})
+
+	t.Run("GetGoGitRepository", func(t *testing.T) {
+		for _, bare := range []bool{false, true} {
+			name := "worktree"
+			if bare {
+				name = "bare"
+			}
+			t.Run(name, func(t *testing.T) {
+				tmpDir := t.TempDir()
+				repo := CreateTestGitRepository(t, tmpDir, bare)
+				ggr, err := repo.GetGoGitRepository()
+				require.NoError(t, err, "GetGoGitRepository on %s repo", name)
+				_, err = ggr.Head()
+				// Empty repo: ErrReferenceNotFound is fine; what matters is the
+				// repo opened. Anything else (esp. ErrRepositoryNotExists) is a
+				// failure to open the storage.
+				if err != nil {
+					assert.ErrorContains(t, err, "reference not found")
+				}
+			})
+		}
+	})
+
+	t.Run("GetGoGitRepository on .git-suffixed bare repo", func(t *testing.T) {
+		// Forge-style bare repos are conventionally named <name>.git.
+		dir := filepath.Join(t.TempDir(), "demo.git")
+		repo := CreateTestGitRepository(t, dir, true)
+		_, err := repo.GetGoGitRepository()
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
## Description

`GetGoGitRepository` (`pkg/gitinterface/repository.go`) calls `git.PlainOpenWithOptions(r.gitDirPath, &git.PlainOpenOptions{DetectDotGit: true})` on a path that is already the resolved git directory (set from `git rev-parse --git-dir` in `LoadRepository`).

With detect on, go-git looks for a `.git` entry inside that path. A bare repository has none, so go-git returns `ErrRepositoryNotExists` and every caller of `GetGoGitRepository` (`verifyCommitSignature`, tag verification) fails on bare repos with the generic `verifying Git namespace policies failed`.

`DetectDotGit:false` treats the path as the git dir directly and opens both bare and working-tree layouts.

Adds `TestRepository/GetGoGitRepository` with worktree and bare subtests, plus `TestRepository/GetGoGitRepository on .git-suffixed bare repo` covering the forge-conventional `<name>.git` layout that surfaced this in the first place.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Drafting was assisted by an LLM. The change is one line and the tests are direct; every line was reviewed against the existing repository.go flow before submission.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
