### PR TITLE
pkg/gitinterface: remove os.Chdir; set cmd.Dir on the executor instead

### DIFF
--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -64,18 +64,9 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 	}
 
 	repo := &Repository{clock: clockwork.NewRealClock()}
-	currentDir, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-
-	if err = os.Chdir(repositoryPath); err != nil {
-		return nil, err
-	}
-	defer os.Chdir(currentDir) //nolint:errcheck
 
 	slog.Debug("Identifying git directory for repository...")
-	stdOut, stdErr, err := repo.executor("rev-parse", "--git-dir").withoutGitDir().execute()
+	stdOut, stdErr, err := repo.executor("rev-parse", "--absolute-git-dir").withoutGitDir().withDir(repositoryPath).execute()
 	if err != nil {
 		errContents, newErr := io.ReadAll(stdErr)
 		if newErr != nil {
@@ -89,9 +80,7 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 		return nil, fmt.Errorf("unable to identify git directory for repository: %w", err)
 	}
 
-	// git rev-parse --git-dir returns a local path, so filepath.Abs gives us
-	// the final path _including_ symlink follows.
-	absPath, err := filepath.Abs(strings.TrimSpace(string(stdOutContents)))
+	absPath, err := filepath.EvalSymlinks(strings.TrimSpace(string(stdOutContents)))
 	if err != nil {
 		return nil, err
 	}
@@ -109,6 +98,7 @@ type executor struct {
 	args        []string
 	env         []string
 	stdIn       io.Reader
+	dir         string
 	unsetGitDir bool
 }
 
@@ -129,6 +119,14 @@ func (e *executor) withEnv(env ...string) *executor {
 // executed command.
 func (e *executor) withoutGitDir() *executor {
 	e.unsetGitDir = true
+	return e
+}
+
+// withDir runs the command with the given working directory instead of the
+// process's. Use this for worktree-relative commands (status, restore) so the
+// process-global os.Chdir is never touched.
+func (e *executor) withDir(dir string) *executor {
+	e.dir = dir
 	return e
 }
 
@@ -170,6 +168,9 @@ func (e *executor) execute() (io.Reader, io.Reader, error) {
 	cmd := exec.Command(binary, e.args...) //nolint:gosec
 	cmd.Env = e.env
 	cmd.Env = append(cmd.Env, "LC_ALL=C") // force git to the C (and thus english) locale
+	if e.dir != "" {
+		cmd.Dir = e.dir
+	}
 
 	var (
 		stdOut bytes.Buffer

--- a/pkg/gitinterface/repository_test.go
+++ b/pkg/gitinterface/repository_test.go
@@ -5,6 +5,7 @@ package gitinterface
 
 import (
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,4 +65,39 @@ func TestRepository(t *testing.T) {
 		_, err := LoadRepository(tmpDir)
 		assert.ErrorContains(t, err, "unable to identify git directory for repository")
 	})
+}
+
+func TestLoadRepositoryConcurrent(t *testing.T) {
+	// LoadRepository must not change the process working directory; concurrent
+	// callers for different paths must each resolve their own gitDirPath.
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	_ = CreateTestGitRepository(t, dirA, true)
+	_ = CreateTestGitRepository(t, dirB, false)
+
+	wantA, err := filepath.EvalSymlinks(dirA)
+	require.NoError(t, err)
+	wantB, err := filepath.EvalSymlinks(filepath.Join(dirB, ".git"))
+	require.NoError(t, err)
+
+	const iterations = 20
+	var wg sync.WaitGroup
+	for i := 0; i < iterations; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			r, err := LoadRepository(dirA)
+			if assert.NoError(t, err) {
+				assert.Equal(t, wantA, r.GetGitDir())
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			r, err := LoadRepository(dirB)
+			if assert.NoError(t, err) {
+				assert.Equal(t, wantB, r.GetGitDir())
+			}
+		}()
+	}
+	wg.Wait()
 }

--- a/pkg/gitinterface/status.go
+++ b/pkg/gitinterface/status.go
@@ -6,7 +6,6 @@ package gitinterface
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 )
 
@@ -100,16 +99,8 @@ func (r *Repository) Status() (map[string]FileStatus, error) {
 	if !r.IsBare() {
 		worktree = strings.TrimSuffix(worktree, ".git") // TODO: this doesn't support detached git dir
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, err
-	}
-	if err := os.Chdir(worktree); err != nil {
-		return nil, err
-	}
-	defer os.Chdir(cwd) //nolint:errcheck
 
-	output, err := r.executor("status", "--porcelain=1", "-z", "--untracked-files=all", "--ignored").executeString()
+	output, err := r.executor("status", "--porcelain=1", "-z", "--untracked-files=all", "--ignored").withDir(worktree).executeString()
 	if err != nil {
 		return nil, fmt.Errorf("unable to check status of repository: %w", err)
 	}

--- a/pkg/gitinterface/tree.go
+++ b/pkg/gitinterface/tree.go
@@ -303,19 +303,11 @@ func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, u
 		}
 		if head == localRef {
 			worktree := strings.TrimSuffix(r.gitDirPath, ".git") // TODO: this doesn't support detached git dir
-			cwd, err := os.Getwd()
-			if err != nil {
-				return nil, err
-			}
-			if err := os.Chdir(worktree); err != nil {
-				return nil, err
-			}
-			defer os.Chdir(cwd) //nolint:errcheck
 
-			if _, err := r.executor("restore", "--staged", localPath).executeString(); err != nil {
+			if _, err := r.executor("restore", "--staged", localPath).withDir(worktree).executeString(); err != nil {
 				return nil, err
 			}
-			if _, err := r.executor("restore", localPath).executeString(); err != nil {
+			if _, err := r.executor("restore", localPath).withDir(worktree).executeString(); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/gitinterface/utils.go
+++ b/pkg/gitinterface/utils.go
@@ -5,7 +5,6 @@ package gitinterface
 
 import (
 	"fmt"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -51,20 +50,12 @@ func (r *Repository) RestoreWorktree(t *testing.T) {
 	if !r.IsBare() {
 		worktree = strings.TrimSuffix(worktree, ".git") // TODO: this doesn't support detached git dir
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(worktree); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(cwd) //nolint:errcheck
 
-	if _, err := r.executor("restore", "--staged", ".").executeString(); err != nil {
+	if _, err := r.executor("restore", "--staged", ".").withDir(worktree).executeString(); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := r.executor("restore", ".").executeString(); err != nil {
+	if _, err := r.executor("restore", ".").withDir(worktree).executeString(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Description

`LoadRepository` did `os.Chdir(repositoryPath)` to run `git rev-parse --git-dir`, and `Status`/`RestoreWorktree`/tree-restore did the same to run worktree-relative commands. `os.Chdir` is process-global, so concurrent `LoadRepository` calls for distinct paths can each resolve the wrong `gitDirPath`.

This adds `executor.withDir(dir)` which sets `cmd.Dir` on the underlying `exec.Cmd` instead. `LoadRepository` now runs `git rev-parse --absolute-git-dir` with `cmd.Dir` set to the repository path and `EvalSymlinks` the result to match prior behaviour. The worktree commands use `withDir(worktree)`.

`TestLoadRepositoryConcurrent` runs 20 pairs of `LoadRepository` calls for two distinct repos in parallel under `-race` and asserts each gets its own `gitDirPath`.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Drafting assisted by an LLM; reviewed and tested by me before submission.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
