### PR TITLE
experimental/gittuf: WithRecordSigningKeyBytes / WithAnnotateSigningKeyBytes

### DIFF
--- a/experimental/gittuf/options/rsl/rsl.go
+++ b/experimental/gittuf/options/rsl/rsl.go
@@ -8,6 +8,7 @@ type RecordOptions struct {
 	RemoteName            string
 	LocalOnly             bool
 	SkipCheckForDuplicate bool
+	SigningKeyBytes       []byte
 }
 
 type RecordOption func(o *RecordOptions)
@@ -38,9 +39,22 @@ func WithRecordLocalOnly() RecordOption {
 	}
 }
 
+// WithRecordSigningKeyBytes provides a PEM-encoded private key to sign the RSL
+// entry commit with directly, instead of reading user.signingKey from git
+// config. It is only consulted when RecordRSLEntryForReference is called with
+// signCommit=true; with signCommit=false the entry is unsigned regardless.
+// Intended for embedders (forges) that hold their own signing key and operate
+// on bare repositories with no per-repo git config.
+func WithRecordSigningKeyBytes(pem []byte) RecordOption {
+	return func(o *RecordOptions) {
+		o.SigningKeyBytes = pem
+	}
+}
+
 type AnnotateOptions struct {
-	RemoteName string
-	LocalOnly  bool
+	RemoteName      string
+	LocalOnly       bool
+	SigningKeyBytes []byte
 }
 
 type AnnotateOption func(o *AnnotateOptions)
@@ -54,5 +68,13 @@ func WithAnnotateRemote(remoteName string) AnnotateOption {
 func WithAnnotateLocalOnly() AnnotateOption {
 	return func(o *AnnotateOptions) {
 		o.LocalOnly = true
+	}
+}
+
+// WithAnnotateSigningKeyBytes provides a PEM-encoded private key to sign the
+// annotation commit with directly. See WithRecordSigningKeyBytes.
+func WithAnnotateSigningKeyBytes(pem []byte) AnnotateOption {
+	return func(o *AnnotateOptions) {
+		o.SigningKeyBytes = pem
 	}
 }

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -37,17 +37,17 @@ var (
 // RecordRSLEntryForReference is the interface for the user to add an RSL entry
 // for the specified Git reference.
 func (r *Repository) RecordRSLEntryForReference(ctx context.Context, refName string, signCommit bool, opts ...rslopts.RecordOption) error {
-	if signCommit {
+	options := &rslopts.RecordOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	if signCommit && options.SigningKeyBytes == nil {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
 		if err != nil {
 			return err
 		}
-	}
-
-	options := &rslopts.RecordOptions{}
-	for _, fn := range opts {
-		fn(options)
 	}
 
 	if options.RemoteName == "" && !options.LocalOnly {
@@ -109,7 +109,12 @@ func (r *Repository) RecordRSLEntryForReference(ctx context.Context, refName str
 	// signCommit must be verified for the refName in the delegation tree.
 
 	slog.Debug("Creating RSL reference entry...")
-	if err := rsl.NewReferenceEntry(refName, refTip).Commit(r.r, signCommit); err != nil {
+	entry := rsl.NewReferenceEntry(refName, refTip)
+	if signCommit && options.SigningKeyBytes != nil {
+		if err := entry.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
+			return err
+		}
+	} else if err := entry.Commit(r.r, signCommit); err != nil {
 		return err
 	}
 
@@ -176,18 +181,17 @@ func (r *Repository) SkipAllInvalidReferenceEntriesForRef(targetRef string, sign
 // RecordRSLAnnotation is the interface for the user to add an RSL annotation
 // for one or more prior RSL entries.
 func (r *Repository) RecordRSLAnnotation(ctx context.Context, rslEntryIDs []string, skip bool, message string, signCommit bool, opts ...rslopts.AnnotateOption) error {
-	// TODO: local only?
-	if signCommit {
+	options := &rslopts.AnnotateOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	if signCommit && options.SigningKeyBytes == nil {
 		slog.Debug("Checking if Git signing is configured...")
 		err := r.r.CanSign()
 		if err != nil {
 			return err
 		}
-	}
-
-	options := &rslopts.AnnotateOptions{}
-	for _, fn := range opts {
-		fn(options)
 	}
 
 	if options.RemoteName == "" && !options.LocalOnly {
@@ -216,7 +220,12 @@ func (r *Repository) RecordRSLAnnotation(ctx context.Context, rslEntryIDs []stri
 	// signCommit must be verified for the refNames of the rslEntryIDs.
 
 	slog.Debug("Creating RSL annotation entry...")
-	if err := rsl.NewAnnotationEntry(rslEntryHashes, skip, message).Commit(r.r, signCommit); err != nil {
+	annotation := rsl.NewAnnotationEntry(rslEntryHashes, skip, message)
+	if signCommit && options.SigningKeyBytes != nil {
+		if err := annotation.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
+			return err
+		}
+	} else if err := annotation.Commit(r.r, signCommit); err != nil {
 		return err
 	}
 

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/policy"
 	"github.com/gittuf/gittuf/internal/rsl"
+	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
@@ -2158,4 +2160,125 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 		}
 		assert.Equal(t, leafControllerMetadataTreeID, propagatedLeafControllerTreeID)
 	})
+}
+
+func TestRecordRSLEntryForReferenceWithSigningKeyBytes(t *testing.T) {
+	// signCommit=true with no per-repo signing config would normally fail in
+	// CanSign(). WithRecordSigningKeyBytes skips CanSign and signs the RSL
+	// entry commit with the supplied PEM key directly, the same path
+	// CommitUsingSpecificKey takes.
+	tempDir := t.TempDir()
+	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	repo := &Repository{r: r}
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+	require.NoError(t, err)
+
+	err = repo.RecordRSLEntryForReference(
+		testCtx,
+		"refs/heads/main",
+		true,
+		rslopts.WithRecordLocalOnly(),
+		rslopts.WithRecordSigningKeyBytes(artifacts.SSHED25519Private),
+	)
+	require.NoError(t, err)
+
+	entryT, err := rsl.GetLatestEntry(repo.r)
+	require.NoError(t, err)
+	entry, ok := entryT.(*rsl.ReferenceEntry)
+	require.True(t, ok)
+	assert.Equal(t, "refs/heads/main", entry.RefName)
+
+	keyPath := filepath.Join(tempDir, "ssh-key.pub")
+	require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+	publicKey, err := ssh.NewKeyFromFile(keyPath)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.r.VerifySignature(testCtx, entry.GetID(), publicKey))
+}
+
+func TestRecordRSLAnnotationWithSigningKeyBytes(t *testing.T) {
+	// Mirror the entry test for annotations.
+	tempDir := t.TempDir()
+	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	repo := &Repository{r: r}
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.RecordRSLEntryForReference(
+		testCtx,
+		"refs/heads/main",
+		false,
+		rslopts.WithRecordLocalOnly(),
+	))
+	entryT, err := rsl.GetLatestEntry(repo.r)
+	require.NoError(t, err)
+	entryID := entryT.GetID()
+
+	err = repo.RecordRSLAnnotation(
+		testCtx,
+		[]string{entryID.String()},
+		false,
+		"test annotation",
+		true,
+		rslopts.WithAnnotateLocalOnly(),
+		rslopts.WithAnnotateSigningKeyBytes(artifacts.SSHED25519Private),
+	)
+	require.NoError(t, err)
+
+	annT, err := rsl.GetLatestEntry(repo.r)
+	require.NoError(t, err)
+	ann, ok := annT.(*rsl.AnnotationEntry)
+	require.True(t, ok)
+	assert.Equal(t, "test annotation", ann.Message)
+
+	keyPath := filepath.Join(tempDir, "ssh-key.pub")
+	require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+	publicKey, err := ssh.NewKeyFromFile(keyPath)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.r.VerifySignature(testCtx, ann.GetID(), publicKey))
+}
+
+func TestRecordRSLEntryForReferenceSigningKeyBytesIgnoredWhenUnsigned(t *testing.T) {
+	// signCommit=false is the master switch: passing SigningKeyBytes alongside
+	// it leaves the entry unsigned. This keeps the API contract aligned with
+	// the existing flag rather than letting key presence silently override it.
+	tempDir := t.TempDir()
+	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	repo := &Repository{r: r}
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+	require.NoError(t, err)
+
+	require.NoError(t, repo.RecordRSLEntryForReference(
+		testCtx,
+		"refs/heads/main",
+		false,
+		rslopts.WithRecordLocalOnly(),
+		rslopts.WithRecordSigningKeyBytes(artifacts.SSHED25519Private),
+	))
+
+	entryT, err := rsl.GetLatestEntry(repo.r)
+	require.NoError(t, err)
+	entry, ok := entryT.(*rsl.ReferenceEntry)
+	require.True(t, ok)
+
+	keyPath := filepath.Join(tempDir, "ssh-key.pub")
+	require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+	publicKey, err := ssh.NewKeyFromFile(keyPath)
+	require.NoError(t, err)
+
+	err = repo.r.VerifySignature(testCtx, entry.GetID(), publicKey)
+	assert.Error(t, err, "entry must not be signed when signCommit=false")
 }


### PR DESCRIPTION
## Description

`RecordRSLEntryForReference` and `RecordRSLAnnotation` only consult `user.signingKey`/`gpg.format` via `CanSign()`. There is no parameter or option for passing a signing key directly, unlike `RecordRSLEntryForReferenceAtTarget` which already accepts `signingKeyBytes []byte`. A forge that holds its own witness key has to write that key into each bare repo's git config to record RSL entries.

Adds `WithRecordSigningKeyBytes(pem []byte)` and `WithAnnotateSigningKeyBytes(pem []byte)` to the existing option sets. When set, the entry/annotation skips `CanSign()` and signs via `CommitUsingSpecificKey`, the same path `RecordRSLEntryForReferenceAtTarget` uses. When unset, behaviour is unchanged.

Tests record a signed reference entry and a signed annotation entry using the option and verify the resulting commits with the matching public key.

PEM bytes match what `CommitUsingSpecificKey` already accepts. A `dsse.SignerVerifier` shape would be cleaner long-term, but the underlying `*.CommitUsingSpecificKey` chain takes raw key material; switching to an interface is a separate change.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Drafting assisted by an LLM; reviewed and tested by me before submission.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
