### PR TITLE
refactor(tui) :-  split policy sub-menu into modular screen component

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -50,33 +50,33 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type model struct {
-	ctx              context.Context
-	screen           screen
-	spinner          spinner.Model
-	choiceList       list.Model
-	policyScreenList list.Model
-	trustScreenList  list.Model
-	rules            []rule
-	ruleList         list.Model
-	globalRules      []globalRule
-	globalRuleList   list.Model
-	inputs           []textinput.Model
-	focusIndex       int
-	cursorMode       cursor.Mode
-	repo             *gittuf.Repository
-	signer           dsse.SignerVerifier
-	policyName       string
-	options          *options
-	footer           string
-	errorMsg         string
-	readOnly         bool
-	width            int
-	height           int
-	confirmDelete    bool
-	deleteTarget     string
-	showHelp         bool
-	signerError      string
-	previousScreen   screen
+	ctx             context.Context
+	screen          screen
+	spinner         spinner.Model
+	choiceList      list.Model
+	policyScreen    policyScreen
+	trustScreenList list.Model
+	rules           []rule
+	ruleList        list.Model
+	globalRules     []globalRule
+	globalRuleList  list.Model
+	inputs          []textinput.Model
+	focusIndex      int
+	cursorMode      cursor.Mode
+	repo            *gittuf.Repository
+	signer          dsse.SignerVerifier
+	policyName      string
+	options         *options
+	footer          string
+	errorMsg        string
+	readOnly        bool
+	width           int
+	height          int
+	confirmDelete   bool
+	deleteTarget    string
+	showHelp        bool
+	signerError     string
+	previousScreen  screen
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -162,9 +162,11 @@ func initialModel(ctx context.Context, o *options) model {
 			item{title: "Policy", desc: "View and manage gittuf Policy"},
 			item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
 		}, delegate),
-		policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
-			item{title: "View Rules", desc: "View and manage policy rules"},
-		}, delegate),
+		policyScreen: policyScreen{
+			policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
+				item{title: "View Rules", desc: "View and manage policy rules"},
+			}, delegate),
+		},
 		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
 			item{title: "View Global Rules", desc: "View and manage global rules"},
 		}, delegate),
@@ -211,7 +213,7 @@ func (m *model) resizeLists() {
 	}
 
 	m.choiceList.SetSize(innerWidth, innerHeight)
-	m.policyScreenList.SetSize(innerWidth, innerHeight)
+	m.policyScreen.policyScreenList.SetSize(innerWidth, innerHeight)
 	m.trustScreenList.SetSize(innerWidth, innerHeight)
 	m.ruleList.SetSize(innerWidth, innerHeight)
 	m.globalRuleList.SetSize(innerWidth, innerHeight)

--- a/internal/cmd/tui/screen_policy.go
+++ b/internal/cmd/tui/screen_policy.go
@@ -1,0 +1,32 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type policyScreen struct {
+	policyScreenList list.Model
+}
+
+func (s *policyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		if msg.String() == "enter" {
+			if _, ok := s.policyScreenList.SelectedItem().(item); ok {
+				m.screen = screenPolicyRules
+				m.refreshRules()
+			}
+			return *m, nil
+		}
+	}
+	s.policyScreenList, cmd = s.policyScreenList.Update(msg)
+	return *m, cmd
+}
+
+func (s *policyScreen) View(m *model) string {
+	return m.renderScreen("Home › Policy", s.policyScreenList.View(), renderActionHints(m.readOnly))
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -101,7 +101,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Screen-specific input handling
 		switch m.screen {
-		case screenChoice, screenPolicy, screenTrust:
+		case screenChoice, screenTrust:
 			if msg.String() == "enter" {
 				return m.handleEnter()
 			}
@@ -131,7 +131,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenChoice:
 		m.choiceList, cmd = m.choiceList.Update(msg)
 	case screenPolicy:
-		m.policyScreenList, cmd = m.policyScreenList.Update(msg)
+		return m.policyScreen.Update(msg, &m)
 	case screenTrust:
 		m.trustScreenList, cmd = m.trustScreenList.Update(msg)
 	case screenPolicyRules:
@@ -156,11 +156,6 @@ func (m model) handleEnter() (tea.Model, tea.Cmd) {
 			case "Trust":
 				m.screen = screenTrust
 			}
-		}
-	case screenPolicy:
-		if _, ok := m.policyScreenList.SelectedItem().(item); ok {
-			m.screen = screenPolicyRules
-			m.refreshRules()
 		}
 	case screenTrust:
 		if _, ok := m.trustScreenList.SelectedItem().(item); ok {

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -357,7 +357,7 @@ func (m model) View() string {
 		return m.renderScreen("Home", m.choiceList.View(), renderActionHints(m.readOnly))
 
 	case screenPolicy:
-		return m.renderScreen("Home › Policy", m.policyScreenList.View(), renderActionHints(m.readOnly))
+		return m.policyScreen.View(&m)
 
 	case screenTrust:
 		return m.renderScreen("Home › Trust", m.trustScreenList.View(), renderActionHints(m.readOnly))


### PR DESCRIPTION
## Description

This pull request refactors the gittuf interactive TUI by extracting the **Policy Sub-menu** (`screenPolicy`) out of the monolithic controller and view files (`model.go`, `update.go`, and `view.go`) into its own dedicated screen component file (`screen_policy.go`).

This is the first PR in a planned series of incremental refactoring PRs to modularize the TUI screen-by-screen. Other TUI screens remain in their current locations for now to keep the changes atomic and easy to review.

- Extracted the policy operations menu model and its styling.
- Delegated update message routing and view rendering of `screenPolicy` state to the new `policyScreen` component.
- All existing unit tests in `internal/cmd/tui/...` pass successfully.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Generative AI  was used to assist in identifying screen-specific variables, drafting the structure of `screen_policy.go`, and refactoring the delegation switch blocks in `model.go`, `update.go`, and `view.go`. Manual testing, review, and refactoring adjustments were made to ensure compilation compatibility and test success.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).