### PR TITLE
feat(sha256): support SHA-256 object format

### DIFF
--- a/experimental/gittuf/attestations.go
+++ b/experimental/gittuf/attestations.go
@@ -104,7 +104,7 @@ func (r *Repository) AddReferenceAuthorization(ctx context.Context, signer sslib
 		if !errors.Is(err, rsl.ErrRSLEntryNotFound) {
 			return err
 		}
-		fromID = gitinterface.ZeroHash
+		fromID = r.r.ZeroHash()
 	}
 
 	slog.Debug("Identifying current status of feature Git reference...")

--- a/experimental/gittuf/helpers_test.go
+++ b/experimental/gittuf/helpers_test.go
@@ -32,9 +32,13 @@ var (
 	ecdsaKeyBytes           = artifacts.SSHECDSAPrivate
 
 	testCtx = context.Background()
+
+	// testObjectFormats enumerates the Git object formats that behavioral test
+	// suites are run against.
+	testObjectFormats = []gitinterface.ObjectFormat{gitinterface.ObjectFormatSHA1, gitinterface.ObjectFormatSHA256}
 )
 
-func createTestRepositoryWithRoot(t *testing.T, location string) *Repository {
+func createTestRepositoryWithRoot(t *testing.T, location string, opts ...gitinterface.TestRepositoryOption) *Repository {
 	t.Helper()
 
 	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
@@ -42,9 +46,9 @@ func createTestRepositoryWithRoot(t *testing.T, location string) *Repository {
 	var repo *gitinterface.Repository
 	if location == "" {
 		tempDir := t.TempDir()
-		repo = gitinterface.CreateTestGitRepository(t, tempDir, false)
+		repo = gitinterface.CreateTestGitRepository(t, tempDir, false, opts...)
 	} else {
-		repo = gitinterface.CreateTestGitRepository(t, location, false)
+		repo = gitinterface.CreateTestGitRepository(t, location, false, opts...)
 	}
 
 	r := &Repository{r: repo}
@@ -63,10 +67,10 @@ func createTestRepositoryWithRoot(t *testing.T, location string) *Repository {
 	return r
 }
 
-func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
+func createTestRepositoryWithPolicy(t *testing.T, location string, opts ...gitinterface.TestRepositoryOption) *Repository {
 	t.Helper()
 
-	r := createTestRepositoryWithRoot(t, location)
+	r := createTestRepositoryWithRoot(t, location, opts...)
 
 	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
@@ -92,6 +96,48 @@ func createTestRepositoryWithPolicy(t *testing.T, location string) *Repository {
 	}
 
 	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []string{gpgKey.KeyID}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := policy.Apply(testCtx, r.r, false); err != nil {
+		t.Fatalf("failed to apply policy staging changes into policy, err = %s", err)
+	}
+
+	return r
+}
+
+// createTestRepositoryWithPolicyAuthorizingGitSigningKey sets up a repository
+// whose policy authorizes the SSH key configured as the repository's Git
+// signing key (see setupSigningKeys). This allows RSL entries created through
+// gittuf's standard, Git-signed workflow (RecordRSLEntryForReference) to be
+// verified.
+func createTestRepositoryWithPolicyAuthorizingGitSigningKey(t *testing.T, opts ...gitinterface.TestRepositoryOption) *Repository {
+	t.Helper()
+
+	r := createTestRepositoryWithRoot(t, "", opts...)
+
+	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+
+	targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
+	targetsPubKey := tufv01.NewKeyFromSSLibKey(targetsSigner.MetadataKey())
+
+	if err := r.AddTopLevelTargetsKey(testCtx, rootSigner, targetsPubKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.InitializeTargets(testCtx, targetsSigner, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The repository signs commits and RSL entries with the RSA SSH key (see
+	// setupSigningKeys), so authorize that key for the protected reference.
+	gitSigningKey := tufv01.NewKeyFromSSLibKey(rootSigner.MetadataKey())
+
+	if err := r.AddPrincipalToTargets(testCtx, targetsSigner, policy.TargetsRoleName, []tuf.Principal{gitSigningKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.AddDelegation(testCtx, targetsSigner, policy.TargetsRoleName, "protect-main", []string{gitSigningKey.KeyID}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
 		t.Fatal(err)
 	}
 

--- a/experimental/gittuf/hook.go
+++ b/experimental/gittuf/hook.go
@@ -151,7 +151,7 @@ func (r *Repository) InvokeHooksForStage(ctx context.Context, signer sslibdsse.S
 				// This likely means the remote doesn't have the specified ref.
 				// In this case, provide a zero hash as per original Git
 				// behavior.
-				remoteHash = gitinterface.ZeroHash
+				remoteHash = r.r.ZeroHash()
 			} else {
 				remoteHash, err = r.r.GetReference(remoteTrackerRef)
 				if err != nil {

--- a/experimental/gittuf/hook_test.go
+++ b/experimental/gittuf/hook_test.go
@@ -152,48 +152,54 @@ func TestInvokeHooksForStage(t *testing.T) {
 	})
 
 	t.Run("pre-push hook", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+		for _, objectFormat := range testObjectFormats {
+			t.Run(string(objectFormat), func(t *testing.T) {
+				tmpDir := t.TempDir()
+				repo := gitinterface.CreateTestGitRepository(t, tmpDir, false, gitinterface.WithObjectFormat(objectFormat))
 
-		treeBuilder := gitinterface.NewTreeBuilder(repo)
-		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
+				treeBuilder := gitinterface.NewTreeBuilder(repo)
+				emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// The remote does not have refs/heads/main, so the hook
+				// receives the repository's zero hash as the remote tip.
+				remoteTmpDir := t.TempDir()
+				_ = gitinterface.CreateTestGitRepository(t, remoteTmpDir, false, gitinterface.WithObjectFormat(objectFormat))
+
+				if err := repo.CreateRemote("origin", remoteTmpDir); err != nil {
+					t.Fatal(err)
+				}
+
+				r := &Repository{r: repo}
+
+				hookStage := tuf.HookStagePrePush
+				hookName := "test-hook"
+				environment := tuf.HookEnvironmentLua
+				timeout := 100
+				principals := []string{rootKey.KeyID}
+
+				if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
+					t.Fatal(err)
+				}
+				if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, false); err != nil {
+					t.Fatal(err)
+				}
+
+				err = r.StagePolicy(testCtx, "", true, false)
+				assert.Nil(t, err)
+				err = r.ApplyPolicy(testCtx, "", true, false)
+				assert.Nil(t, err)
+
+				codes, err := r.InvokeHooksForStage(testCtx, rootSigner, hookStage, hookopts.WithPrePush("origin", remoteTmpDir, []string{"refs/heads/main:refs/heads/main"}))
+				assert.Nil(t, err)
+				assert.Len(t, codes, 1)
+			})
 		}
-		_, err = repo.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		remoteTmpDir := t.TempDir()
-		_ = gitinterface.CreateTestGitRepository(t, remoteTmpDir, false)
-
-		if err := repo.CreateRemote("origin", remoteTmpDir); err != nil {
-			t.Fatal(err)
-		}
-
-		r := &Repository{r: repo}
-
-		hookStage := tuf.HookStagePrePush
-		hookName := "test-hook"
-		environment := tuf.HookEnvironmentLua
-		timeout := 100
-		principals := []string{rootKey.KeyID}
-
-		if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := r.AddHook(testCtx, rootSigner, []tuf.HookStage{hookStage}, hookName, hookBytes, environment, principals, timeout, false); err != nil {
-			t.Fatal(err)
-		}
-
-		err = r.StagePolicy(testCtx, "", true, false)
-		assert.Nil(t, err)
-		err = r.ApplyPolicy(testCtx, "", true, false)
-		assert.Nil(t, err)
-
-		codes, err := r.InvokeHooksForStage(testCtx, rootSigner, hookStage, hookopts.WithPrePush("origin", remoteTmpDir, []string{"refs/heads/main:refs/heads/main"}))
-		assert.Nil(t, err)
-		assert.Len(t, codes, 1)
 	})
 }

--- a/experimental/gittuf/verify_test.go
+++ b/experimental/gittuf/verify_test.go
@@ -21,7 +21,46 @@ import (
 )
 
 func TestVerifyRef(t *testing.T) {
-	repo := createTestRepositoryWithPolicy(t, "")
+	for _, objectFormat := range testObjectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			testVerifyRef(t, objectFormat)
+		})
+	}
+}
+
+// TestVerifyRefRecordedWithGitSigning exercises gittuf's standard workflow end
+// to end: commits and the RSL entry are created and signed via the Git binary
+// (RecordRSLEntryForReference), then verified. In SHA-256 repositories Git
+// stores the signature under the `gpgsig-sha256` header, so this guards against
+// regressions where signing and verification disagree on the header.
+func TestVerifyRefRecordedWithGitSigning(t *testing.T) {
+	for _, objectFormat := range testObjectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			repo := createTestRepositoryWithPolicyAuthorizingGitSigningKey(t, gitinterface.WithObjectFormat(objectFormat))
+
+			refName := "refs/heads/main"
+
+			// Commits are signed with the repository's Git signing key.
+			common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, rsaKeyBytes)
+
+			// Record the RSL entry through the Git-signed workflow.
+			if err := repo.RecordRSLEntryForReference(testCtx, refName, true, rslopts.WithRecordLocalOnly()); err != nil {
+				t.Fatal(err)
+			}
+
+			err := repo.VerifyRef(testCtx, refName, verifyopts.WithLatestOnly())
+			assert.Nil(t, err)
+
+			err = repo.VerifyRef(testCtx, refName)
+			assert.Nil(t, err)
+		})
+	}
+}
+
+func testVerifyRef(t *testing.T, objectFormat gitinterface.ObjectFormat) {
+	t.Helper()
+
+	repo := createTestRepositoryWithPolicy(t, "", gitinterface.WithObjectFormat(objectFormat))
 
 	refName := "refs/heads/main"
 	remoteRefName := "refs/heads/not-main"
@@ -104,9 +143,18 @@ func TestVerifyRef(t *testing.T) {
 }
 
 func TestVerifyRefFromEntry(t *testing.T) {
+	for _, objectFormat := range testObjectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			testVerifyRefFromEntry(t, objectFormat)
+		})
+	}
+}
+
+func testVerifyRefFromEntry(t *testing.T, objectFormat gitinterface.ObjectFormat) {
+	t.Helper()
 	t.Setenv(dev.DevModeKey, "1")
 
-	repo := createTestRepositoryWithPolicy(t, "")
+	repo := createTestRepositoryWithPolicy(t, "", gitinterface.WithObjectFormat(objectFormat))
 
 	refName := "refs/heads/main"
 	remoteRefName := "refs/heads/not-main"
@@ -163,7 +211,7 @@ func TestVerifyRefFromEntry(t *testing.T) {
 		},
 		"unknown ref": {
 			localRefName: "refs/heads/unknown",
-			fromEntryID:  gitinterface.ZeroHash,
+			fromEntryID:  repo.r.ZeroHash(),
 			err:          rsl.ErrRSLEntryNotFound,
 		},
 		"different local and remote ref names, from non-violating": {
@@ -269,6 +317,45 @@ func TestVerifyMergeable(t *testing.T) {
 		needsSignature, err := repo.VerifyMergeable(testCtx, targetRef, featureRef)
 		assert.Nil(t, err)
 		assert.False(t, needsSignature)
+	})
+
+	t.Run("mergeable with approval, unborn target ref", func(t *testing.T) {
+		// When the target ref has no RSL entry yet, both the attestation
+		// writer and the verifier must use the same zero hash for the from
+		// revision. In SHA-256 repositories a SHA-1 zero on either side makes
+		// the authorization unfindable.
+		for _, objectFormat := range testObjectFormats {
+			t.Run(string(objectFormat), func(t *testing.T) {
+				repo := createTestRepositoryWithPolicy(t, "", gitinterface.WithObjectFormat(objectFormat))
+
+				treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+				emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := repo.r.Commit(emptyTreeID, featureRef, "Initial commit\n", false); err != nil {
+					t.Fatal(err)
+				}
+				common.AddNTestCommitsToSpecifiedRef(t, repo.r, featureRef, 1, gpgUnauthorizedKeyBytes)
+				if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
+					t.Fatal(err)
+				}
+
+				gpg.SetupTestGPGHomeDir(t, gpgKeyBytes)
+				approverSigner, err := gpg.NewSignerFromKeyID("157507bbe151e378ce8126c1dcfe043cdd2db96e")
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := repo.AddReferenceAuthorization(testCtx, approverSigner, targetRef, featureRef, false, attestopts.WithRSLEntry()); err != nil {
+					t.Fatal(err)
+				}
+
+				needsSignature, err := repo.VerifyMergeable(testCtx, targetRef, featureRef)
+				assert.Nil(t, err)
+				assert.False(t, needsSignature)
+			})
+		}
 	})
 
 	t.Run("mergeable with approval and feature RSL bypass", func(t *testing.T) {

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -17,7 +17,6 @@ import (
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/rsl"
-	"github.com/gittuf/gittuf/pkg/gitinterface"
 )
 
 // handleSSH implements the helper for remotes configured to use SSH. For this
@@ -535,6 +534,8 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 			}
 
 			log("adding gittuf RSL entries")
+			zeroHash := repo.GetGitRepository().ZeroHash().String()
+			objectFormat := repo.GetGitRepository().GetObjectFormat()
 			pushObjects := set.NewSet[string]()
 			dstRefs := set.NewSet[string]()
 			for i, refSpec := range pushRefSpecs {
@@ -566,7 +567,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 
 				oldTip := remoteRefTips[dstRef]
 				if oldTip == "" {
-					oldTip = gitinterface.ZeroHash.String()
+					oldTip = zeroHash
 				}
 
 				newTipHash, err := repo.GetGitRepository().GetReference(srcRef)
@@ -585,7 +586,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					// because of inconsistencies between receive-pack
 					// implementations in sending status messages.
 					// TODO: check that server advertises all of these
-					pushCmd = fmt.Sprintf("%s%s report-status-v2 atomic object-format=sha1 agent=git/%s", pushCmd, string('\x00'), gitVersion)
+					pushCmd = fmt.Sprintf("%s%s report-status-v2 atomic object-format=%s agent=git/%s", pushCmd, string('\x00'), objectFormat, gitVersion)
 				}
 				pushCmd += "\n"
 
@@ -593,10 +594,10 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 					return nil, false, err
 				}
 
-				if newTip != gitinterface.ZeroHash.String() {
+				if newTip != zeroHash {
 					pushObjects.Add(newTip)
 				}
-				if oldTip != gitinterface.ZeroHash.String() {
+				if oldTip != zeroHash {
 					pushObjects.Add(fmt.Sprintf("^%s", oldTip)) // this is passed on to git rev-list to enumerate objects, and we're saying don't send the old objects
 				}
 			}
@@ -609,7 +610,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 			if len(gittufRefsTips) != 0 {
 				oldTip, has := remoteRefTips[rsl.Ref]
 				if !has {
-					oldTip = gitinterface.ZeroHash.String()
+					oldTip = zeroHash
 				}
 
 				newTipHash, err := repo.GetGitRepository().GetReference(rsl.Ref)
@@ -623,10 +624,10 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 				if _, err := helperStdIn.Write(packetEncode(pushCmd)); err != nil {
 					return nil, false, err
 				}
-				if newTip != gitinterface.ZeroHash.String() {
+				if newTip != zeroHash {
 					pushObjects.Add(newTip)
 				}
-				if oldTip != gitinterface.ZeroHash.String() {
+				if oldTip != zeroHash {
 					pushObjects.Add(fmt.Sprintf("^%s", oldTip)) // this is passed on to git rev-list to enumerate objects, and we're saying don't send the old objects
 				}
 			}

--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -35,13 +35,13 @@ var (
 	gpgUnauthorizedPubKeyBytes = artifacts.GPGKey2Public
 )
 
-func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State) (*gitinterface.Repository, *State) {
+func createTestRepository(t *testing.T, stateCreator func(*testing.T) *State, opts ...gitinterface.TestRepositoryOption) (*gitinterface.Repository, *State) {
 	t.Helper()
 
 	state := stateCreator(t)
 
 	tempDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false, opts...)
 	state.repository = repo
 
 	if err := state.Commit(repo, "Create test state", true, false); err != nil {

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -179,7 +179,7 @@ func (v *PolicyVerifier) VerifyMergeable(ctx context.Context, targetRef, feature
 	case err == nil:
 		fromID = targetEntry.GetTargetID()
 	case errors.Is(err, rsl.ErrRSLEntryNotFound):
-		fromID = gitinterface.ZeroHash
+		fromID = v.repo.ZeroHash()
 	default:
 		return false, err
 	}
@@ -219,7 +219,7 @@ func (v *PolicyVerifier) VerifyMergeableForCommit(ctx context.Context, targetRef
 	case err == nil:
 		fromID = targetEntry.GetTargetID()
 	case errors.Is(err, rsl.ErrRSLEntryNotFound):
-		fromID = gitinterface.ZeroHash
+		fromID = v.repo.ZeroHash()
 	default:
 		return false, err
 	}
@@ -951,7 +951,7 @@ func getApproverAttestationAndKeyIDs(ctx context.Context, repo *gitinterface.Rep
 		firstEntry = true
 	}
 
-	fromID := gitinterface.ZeroHash
+	fromID := repo.ZeroHash()
 	if !firstEntry {
 		fromID = priorRefEntry.GetTargetID()
 	}

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -2917,15 +2917,19 @@ func TestVerifyEntry(t *testing.T) {
 	refName := "refs/heads/main"
 
 	t.Run("successful verification", func(t *testing.T) {
-		repo, state := createTestRepository(t, createTestStateWithPolicy)
+		for _, objectFormat := range []gitinterface.ObjectFormat{gitinterface.ObjectFormatSHA1, gitinterface.ObjectFormatSHA256} {
+			t.Run(string(objectFormat), func(t *testing.T) {
+				repo, state := createTestRepository(t, createTestStateWithPolicy, gitinterface.WithObjectFormat(objectFormat))
 
-		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
+				commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+				entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+				entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+				entry.ID = entryID
 
-		err := verifyEntry(testCtx, repo, state, nil, entry)
-		assert.Nil(t, err)
+				err := verifyEntry(testCtx, repo, state, nil, entry)
+				assert.Nil(t, err)
+			})
+		}
 	})
 
 	t.Run("successful verification using persons", func(t *testing.T) {
@@ -2997,56 +3001,63 @@ func TestVerifyEntry(t *testing.T) {
 	})
 
 	t.Run("successful verification with higher threshold using latest reference authorization", func(t *testing.T) {
-		repo, state := createTestRepository(t, createTestStateWithThresholdPolicy)
+		for _, objectFormat := range []gitinterface.ObjectFormat{gitinterface.ObjectFormatSHA1, gitinterface.ObjectFormatSHA256} {
+			t.Run(string(objectFormat), func(t *testing.T) {
+				repo, state := createTestRepository(t, createTestStateWithThresholdPolicy, gitinterface.WithObjectFormat(objectFormat))
 
-		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
-		if err != nil {
-			t.Fatal(err)
+				currentAttestations, err := attestations.LoadCurrentAttestations(repo)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+
+				commitTreeID, err := repo.GetCommitTreeID(commitIDs[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Create authorization for this change
+				// This uses the latest reference authorization version. The
+				// from revision is the repository's zero hash, matching what
+				// gittuf writes when attesting a reference's first entry.
+				fromID := repo.ZeroHash().String()
+				authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, fromID, commitTreeID.String())
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				signer := setupSSHKeysForSigning(t, targets1KeyBytes, targets1PubKeyBytes)
+
+				env, err := dsse.CreateEnvelope(authorization)
+				if err != nil {
+					t.Fatal(err)
+				}
+				env, err = dsse.SignEnvelope(testCtx, env, signer)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, fromID, commitTreeID.String()); err != nil {
+					t.Fatal(err)
+				}
+				if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
+					t.Fatal(err)
+				}
+
+				currentAttestations, err = attestations.LoadCurrentAttestations(repo)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+				entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+				entry.ID = entryID
+
+				err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
+				assert.Nil(t, err)
+			})
 		}
-
-		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
-
-		commitTreeID, err := repo.GetCommitTreeID(commitIDs[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Create authorization for this change
-		// This uses the latest reference authorization version
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		signer := setupSSHKeysForSigning(t, targets1KeyBytes, targets1PubKeyBytes)
-
-		env, err := dsse.CreateEnvelope(authorization)
-		if err != nil {
-			t.Fatal(err)
-		}
-		env, err = dsse.SignEnvelope(testCtx, env, signer)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
-			t.Fatal(err)
-		}
-		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
-			t.Fatal(err)
-		}
-
-		currentAttestations, err = attestations.LoadCurrentAttestations(repo)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
-		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
-		entry.ID = entryID
-
-		err = verifyEntry(testCtx, repo, state, currentAttestations, entry)
-		assert.Nil(t, err)
 	})
 
 	t.Run("successful verification with higher threshold but using GitHub approval", func(t *testing.T) {

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -106,13 +106,24 @@ func TestNewReferenceEntry(t *testing.T) {
 }
 
 func TestCommitUsingSpecificKey(t *testing.T) {
+	for _, objectFormat := range []gitinterface.ObjectFormat{gitinterface.ObjectFormatSHA1, gitinterface.ObjectFormatSHA256} {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			testCommitUsingSpecificKey(t, objectFormat)
+		})
+	}
+}
+
+func testCommitUsingSpecificKey(t *testing.T, objectFormat gitinterface.ObjectFormat) {
+	t.Helper()
+
 	tempDir := t.TempDir()
-	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false, gitinterface.WithObjectFormat(objectFormat))
 	signingKeyBytes := artifacts.SSHED25519Private
 	refName := "refs/heads/main"
 	upstreamRepository := "http://git.example.com/repository"
+	zeroHash := repo.ZeroHash()
 
-	referenceEntry := NewReferenceEntry(refName, gitinterface.ZeroHash)
+	referenceEntry := NewReferenceEntry(refName, zeroHash)
 	err := referenceEntry.CommitUsingSpecificKey(repo, signingKeyBytes)
 	assert.Nil(t, err)
 
@@ -122,7 +133,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	assert.Nil(t, err)
 	referenceEntry = entry.(*ReferenceEntry)
 	assert.Equal(t, refName, referenceEntry.RefName)
-	assert.Equal(t, gitinterface.ZeroHash, referenceEntry.TargetID)
+	assert.Equal(t, zeroHash, referenceEntry.TargetID)
 	assert.Equal(t, uint64(1), referenceEntry.Number)
 
 	annotationEntry := NewAnnotationEntry([]gitinterface.Hash{referenceEntryID}, true, annotationMessage)
@@ -139,7 +150,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	assert.Equal(t, annotationMessage, annotationEntry.Message)
 	assert.Equal(t, uint64(2), annotationEntry.Number)
 
-	propagationEntry := NewPropagationEntry(refName, gitinterface.ZeroHash, upstreamRepository, referenceEntryID)
+	propagationEntry := NewPropagationEntry(refName, zeroHash, upstreamRepository, referenceEntryID)
 	err = propagationEntry.CommitUsingSpecificKey(repo, signingKeyBytes)
 	assert.Nil(t, err)
 
@@ -149,7 +160,7 @@ func TestCommitUsingSpecificKey(t *testing.T) {
 	assert.Nil(t, err)
 	propagationEntry = entry.(*PropagationEntry)
 	assert.Equal(t, refName, propagationEntry.RefName)
-	assert.Equal(t, gitinterface.ZeroHash, propagationEntry.TargetID)
+	assert.Equal(t, zeroHash, propagationEntry.TargetID)
 	assert.Equal(t, upstreamRepository, propagationEntry.UpstreamRepository)
 	assert.Equal(t, referenceEntryID, propagationEntry.UpstreamEntryID)
 	assert.Equal(t, uint64(3), propagationEntry.Number)

--- a/pkg/gitinterface/commit.go
+++ b/pkg/gitinterface/commit.go
@@ -102,7 +102,14 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 	if err != nil {
 		return ZeroHash, err
 	}
-	commit.Signature = signature
+	// SHA-256 repositories store the signature under the `gpgsig-sha256`
+	// header (go-git's SignatureSHA256), matching Git's own behavior, so it
+	// can be read back during verification.
+	if r.GetObjectFormat() == ObjectFormatSHA256 {
+		commit.SignatureSHA256 = signature
+	} else {
+		commit.Signature = signature
+	}
 
 	goGitRepo, err := r.GetGoGitRepository()
 	if err != nil {
@@ -170,33 +177,36 @@ func (r *Repository) verifyCommitSignature(ctx context.Context, commitID Hash, k
 		return fmt.Errorf("unable to load commit object: %w", err)
 	}
 
+	commitContents, err := getCommitBytesWithoutSignature(commit)
+	if err != nil {
+		return fmt.Errorf("unable to encode commit contents for verification: %w", err)
+	}
+
+	commitSignature := signatureForObjectID(commitID, commit.Signature, commit.SignatureSHA256)
+
+	if signatureBlockCount(commitSignature) > 1 {
+		return errors.Join(ErrIncorrectVerificationKey, ErrMultipleSignatures)
+	}
+
 	switch key.KeyType {
 	case gpg.KeyType:
-		if _, err := commit.Verify(key.KeyVal.Public); err != nil {
+		verifier, err := gpg.NewVerifierFromKey(key)
+		if err != nil {
+			return errors.Join(ErrIncorrectVerificationKey, err)
+		}
+		if err := verifier.Verify(ctx, commitContents, []byte(commitSignature)); err != nil {
 			return ErrIncorrectVerificationKey
 		}
 
 		return nil
 	case ssh.KeyType:
-		commitContents, err := getCommitBytesWithoutSignature(commit)
-		if err != nil {
-			return errors.Join(ErrVerifyingSSHSignature, err)
-		}
-		commitSignature := []byte(commit.Signature)
-
-		if err := verifySSHKeySignature(ctx, key, commitContents, commitSignature); err != nil {
+		if err := verifySSHKeySignature(ctx, key, commitContents, []byte(commitSignature)); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 
 		return nil
 	case sigstore.KeyType:
-		commitContents, err := getCommitBytesWithoutSignature(commit)
-		if err != nil {
-			return errors.Join(ErrVerifyingSigstoreSignature, err)
-		}
-		commitSignature := []byte(commit.Signature)
-
-		if err := verifyGitsignSignature(ctx, r, key, commitContents, commitSignature); err != nil {
+		if err := verifyGitsignSignature(ctx, r, key, commitContents, []byte(commitSignature)); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 

--- a/pkg/gitinterface/commit_test.go
+++ b/pkg/gitinterface/commit_test.go
@@ -6,6 +6,7 @@ package gitinterface
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,6 +23,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRepositoryCommitSHA256(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false, WithSHA256Format())
+
+	refName := "refs/heads/main"
+	treeBuilder := NewTreeBuilder(repo)
+
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit to a ref that does not yet exist: the "current" tip is the zero
+	// hash, which must match the repository's SHA-256 object format.
+	commitID, err := repo.Commit(emptyTreeID, refName, "Initial commit\n", false)
+	assert.Nil(t, err)
+	assert.Len(t, commitID.String(), 64)
+
+	refHead, err := repo.GetReference(refName)
+	require.Nil(t, err)
+	assert.Equal(t, commitID, refHead)
+}
 
 func TestRepositoryCommit(t *testing.T) {
 	tempDir := t.TempDir()
@@ -274,6 +298,184 @@ func TestRepositoryVerifyCommit(t *testing.T) {
 		err = repo.verifyCommitSignature(t.Context(), sshSignedCommitID, unknownKey)
 		assert.ErrorIs(t, err, ErrUnknownSigningMethod)
 	})
+}
+
+func TestRepositoryVerifyCommitSHA256(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false, WithSHA256Format())
+
+	treeBuilder := NewTreeBuilder(repo)
+
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sshSignedCommitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyDir := t.TempDir()
+	keyPath := filepath.Join(keyDir, "ssh-key")
+	if err := os.WriteFile(keyPath, artifacts.SSHRSAPublicSSH, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sshKey, err := ssh.NewKeyFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gpgKey, err := gpg.LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// gitsign/sigstore signed commits are not exercised here: that test relies
+	// on a precomputed signature over a fixed SHA-1 commit object, which cannot
+	// be reproduced for a SHA-256 repository.
+
+	t.Run("ssh signed commit, verify with ssh key", func(t *testing.T) {
+		err = repo.verifyCommitSignature(context.Background(), sshSignedCommitID, sshKey)
+		assert.Nil(t, err)
+	})
+
+	t.Run("ssh signed commit, verify with gpg key", func(t *testing.T) {
+		err = repo.verifyCommitSignature(context.Background(), sshSignedCommitID, gpgKey)
+		assert.ErrorIs(t, err, ErrIncorrectVerificationKey)
+	})
+
+	t.Run("unknown signing method", func(t *testing.T) {
+		unknownKey := &signerverifier.SSLibKey{KeyType: "unknown"}
+		err = repo.verifyCommitSignature(t.Context(), sshSignedCommitID, unknownKey)
+		assert.ErrorIs(t, err, ErrUnknownSigningMethod)
+	})
+}
+
+func TestCommitUsingSpecificKeySignatureHeader(t *testing.T) {
+	for _, objectFormat := range []ObjectFormat{ObjectFormatSHA1, ObjectFormatSHA256} {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := CreateTestGitRepository(t, tmpDir, false, WithObjectFormat(objectFormat))
+
+			emptyTreeID, err := NewTreeBuilder(repo).WriteTreeFromEntries(nil)
+			require.Nil(t, err)
+
+			commitID, err := repo.CommitUsingSpecificKey(emptyTreeID, "refs/heads/main", "Initial commit\n", artifacts.SSHRSAPrivate)
+			require.Nil(t, err)
+
+			raw, err := repo.executor("cat-file", "commit", commitID.String()).executeString()
+			require.Nil(t, err)
+
+			// The signature must be stored under the header matching the
+			// object's hash algorithm.
+			if objectFormat == ObjectFormatSHA256 {
+				assert.Contains(t, raw, "\ngpgsig-sha256 ")
+				assert.NotContains(t, raw, "\ngpgsig -")
+			} else {
+				assert.Contains(t, raw, "\ngpgsig -")
+				assert.NotContains(t, raw, "gpgsig-sha256")
+			}
+
+			keyDir := t.TempDir()
+			keyPath := filepath.Join(keyDir, "ssh-key")
+			require.Nil(t, os.WriteFile(keyPath, artifacts.SSHRSAPublicSSH, 0o600))
+			sshKey, err := ssh.NewKeyFromFile(keyPath)
+			require.Nil(t, err)
+
+			assert.Nil(t, repo.verifyCommitSignature(context.Background(), commitID, sshKey))
+		})
+	}
+}
+
+func TestSignatureBlockCount(t *testing.T) {
+	tests := map[string]struct {
+		signature string
+		expected  int
+	}{
+		"empty":             {"", 0},
+		"single pgp":        {"-----BEGIN PGP SIGNATURE-----\nabc\n-----END PGP SIGNATURE-----\n", 1},
+		"single ssh":        {"-----BEGIN SSH SIGNATURE-----\nabc\n-----END SSH SIGNATURE-----\n", 1},
+		"two pgp blocks":    {"-----BEGIN PGP SIGNATURE-----\na\n-----END PGP SIGNATURE-----\n-----BEGIN PGP SIGNATURE-----\nb\n-----END PGP SIGNATURE-----\n", 2},
+		"nested ssh blocks": {"-----BEGIN SSH SIGNATURE-----\n-----BEGIN SSH SIGNATURE-----\nabc\n-----END SSH SIGNATURE-----\n-----END SSH SIGNATURE-----\n", 2},
+		"no signature":      {"not a signature", 0},
+	}
+
+	for name, test := range tests {
+		assert.Equal(t, test.expected, signatureBlockCount(test.signature), name)
+	}
+}
+
+func TestVerifyCommitSignatureRejectsMultipleSignatures(t *testing.T) {
+	tests := map[string]struct {
+		signingKey      []byte
+		verificationKey func(t *testing.T) *signerverifier.SSLibKey
+	}{
+		"gpg": {
+			signingKey: artifacts.GPGKey1Private,
+			verificationKey: func(t *testing.T) *signerverifier.SSLibKey {
+				t.Helper()
+				key, err := gpg.LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+				require.Nil(t, err)
+				return key
+			},
+		},
+		"ssh": {
+			signingKey: artifacts.SSHED25519Private,
+			verificationKey: func(t *testing.T) *signerverifier.SSLibKey {
+				t.Helper()
+				keyPath := filepath.Join(t.TempDir(), "ssh-key.pub")
+				require.Nil(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+				key, err := ssh.NewKeyFromFile(keyPath)
+				require.Nil(t, err)
+				return key
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := CreateTestGitRepository(t, tmpDir, false)
+
+			goGitRepo, err := repo.GetGoGitRepository()
+			require.Nil(t, err)
+
+			testCommit := &object.Commit{
+				Author:    object.Signature{Name: testName, Email: testEmail, When: testClock.Now()},
+				Committer: object.Signature{Name: testName, Email: testEmail, When: testClock.Now()},
+				Message:   "Test commit\n",
+				TreeHash:  plumbing.ZeroHash,
+			}
+
+			commitEncoded := goGitRepo.Storer.NewEncodedObject()
+			require.Nil(t, testCommit.EncodeWithoutSignature(commitEncoded))
+			reader, err := commitEncoded.Reader()
+			require.Nil(t, err)
+			contents, err := io.ReadAll(reader)
+			require.Nil(t, err)
+
+			sig, err := signGitObjectUsingKey(contents, test.signingKey)
+			require.Nil(t, err)
+
+			// Two (individually valid) signature blocks, each on their own
+			// lines, must be rejected as ambiguous rather than verified
+			// against the first.
+			block := strings.TrimRight(sig, "\n") + "\n"
+			testCommit.Signature = block + block
+
+			commitEncoded = goGitRepo.Storer.NewEncodedObject()
+			require.Nil(t, testCommit.Encode(commitEncoded))
+			commitID, err := goGitRepo.Storer.SetEncodedObject(commitEncoded)
+			require.Nil(t, err)
+			commitHash, err := NewHash(commitID.String())
+			require.Nil(t, err)
+
+			err = repo.verifyCommitSignature(context.Background(), commitHash, test.verificationKey(t))
+			assert.ErrorIs(t, err, ErrMultipleSignatures)
+			assert.ErrorIs(t, err, ErrIncorrectVerificationKey)
+		})
+	}
 }
 
 func TestKnowsCommit(t *testing.T) {

--- a/pkg/gitinterface/common.go
+++ b/pkg/gitinterface/common.go
@@ -14,6 +14,15 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
+// ObjectFormat identifies the hash algorithm a Git repository uses for its
+// object IDs.
+type ObjectFormat string
+
+const (
+	ObjectFormatSHA1   ObjectFormat = "sha1"
+	ObjectFormatSHA256 ObjectFormat = "sha256"
+)
+
 const (
 	testName  = "Jane Doe"
 	testEmail = "jane.doe@example.com"
@@ -23,40 +32,87 @@ var (
 	testClock = clockwork.NewFakeClockAt(time.Date(1995, time.October, 26, 9, 0, 0, 0, time.UTC))
 )
 
-// CreateTestGitRepository creates a Git repository in the specified directory.
-// This is meant to be used by tests across gittuf packages. This helper also
-// sets up an ED25519 signing key that can be used to create reproducible
-// commits.
-func CreateTestGitRepository(t *testing.T, dir string, bare bool) *Repository {
+type testRepositoryOptions struct {
+	objectFormat ObjectFormat
+}
+
+// TestRepositoryOption configures the repository created by
+// CreateTestGitRepository.
+type TestRepositoryOption func(o *testRepositoryOptions)
+
+// WithObjectFormat creates the test repository using the specified object
+// format (hash algorithm).
+func WithObjectFormat(objectFormat ObjectFormat) TestRepositoryOption {
+	return func(o *testRepositoryOptions) {
+		o.objectFormat = objectFormat
+	}
+}
+
+// WithSHA256Format creates the test repository using the SHA-256 object
+// format.
+func WithSHA256Format() TestRepositoryOption {
+	return WithObjectFormat(ObjectFormatSHA256)
+}
+
+// CreateTestGitRepository creates a Git repository in the specified directory,
+// using the SHA-1 object format unless overridden via options. This is meant
+// to be used by tests across gittuf packages. This helper also sets up an
+// SSH RSA signing key that can be used to create reproducible commits.
+func CreateTestGitRepository(t *testing.T, dir string, bare bool, opts ...TestRepositoryOption) *Repository {
 	t.Helper()
 
-	repo := setupRepository(t, dir, bare)
-
-	// Set up author / committer identity
-	if err := repo.SetGitConfig("user.name", testName); err != nil {
+	repo, err := createTestGitRepository(dir, t.TempDir(), bare, opts...)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := repo.SetGitConfig("user.email", testEmail); err != nil {
-		t.Fatal(err)
-	}
-
-	// Set up signing via SSH key
-	keysDir := t.TempDir()
-	setupSigningKeys(t, keysDir)
-
-	if err := repo.SetGitConfig("user.signingkey", filepath.Join(keysDir, "key.pub")); err != nil {
-		t.Fatal(err)
-	}
-	if err := repo.SetGitConfig("gpg.format", "ssh"); err != nil {
-		t.Fatal(err)
-	}
-
 	return repo
 }
 
-func setupRepository(t *testing.T, dir string, bare bool) *Repository {
+func createTestGitRepository(dir, signingKeysDir string, bare bool, opts ...TestRepositoryOption) (*Repository, error) {
+	options := &testRepositoryOptions{objectFormat: ObjectFormatSHA1}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	repo, err := newTestRepository(dir, bare, options.objectFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set up author / committer identity
+	if err := repo.SetGitConfig("user.name", testName); err != nil {
+		return nil, err
+	}
+	if err := repo.SetGitConfig("user.email", testEmail); err != nil {
+		return nil, err
+	}
+
+	// Set up signing via SSH key
+	if err := writeSigningKeys(signingKeysDir); err != nil {
+		return nil, err
+	}
+
+	if err := repo.SetGitConfig("user.signingkey", filepath.Join(signingKeysDir, "key.pub")); err != nil {
+		return nil, err
+	}
+	if err := repo.SetGitConfig("gpg.format", "ssh"); err != nil {
+		return nil, err
+	}
+
+	return repo, nil
+}
+
+func setupRepository(t *testing.T, dir string, bare bool, objectFormat ObjectFormat) *Repository {
 	t.Helper()
 
+	repo, err := newTestRepository(dir, bare, objectFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return repo
+}
+
+func newTestRepository(dir string, bare bool, objectFormat ObjectFormat) (*Repository, error) {
 	var gitDirPath string
 	args := []string{"init"}
 	if bare {
@@ -65,20 +121,27 @@ func setupRepository(t *testing.T, dir string, bare bool) *Repository {
 	} else {
 		gitDirPath = filepath.Join(dir, ".git")
 	}
+	args = append(args, "--object-format", string(objectFormat))
 	args = append(args, "-b", "main")
 	args = append(args, dir)
 
 	cmd := exec.Command(binary, args...)
 	if err := cmd.Run(); err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 
-	return &Repository{gitDirPath: gitDirPath, clock: testClock}
+	repo := &Repository{gitDirPath: gitDirPath, clock: testClock}
+
+	format, err := repo.readObjectFormat()
+	if err != nil {
+		return nil, err
+	}
+	repo.objectFormat = format
+
+	return repo, nil
 }
 
-func setupSigningKeys(t *testing.T, dir string) {
-	t.Helper()
-
+func writeSigningKeys(dir string) error {
 	sshPrivateKey := artifacts.SSHRSAPrivate
 	sshPublicKey := artifacts.SSHRSAPublicSSH
 
@@ -86,10 +149,12 @@ func setupSigningKeys(t *testing.T, dir string) {
 	publicKeyPath := filepath.Join(dir, "key.pub")
 
 	if err := os.WriteFile(privateKeyPath, sshPrivateKey, 0o600); err != nil {
-		t.Fatal(err)
+		return err
 	}
 
 	if err := os.WriteFile(publicKeyPath, sshPublicKey, 0o600); err != nil {
-		t.Fatal(err)
+		return err
 	}
+
+	return nil
 }

--- a/pkg/gitinterface/common_test.go
+++ b/pkg/gitinterface/common_test.go
@@ -1,0 +1,74 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gitinterface
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTestGitRepository(t *testing.T) {
+	t.Run("configures test identity and signing key", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		signingKeysDir := t.TempDir()
+
+		repo, err := createTestGitRepository(tmpDir, signingKeysDir, false)
+		require.Nil(t, err)
+
+		config, err := repo.GetGitConfig()
+		require.Nil(t, err)
+		assert.Equal(t, testName, config["user.name"])
+		assert.Equal(t, testEmail, config["user.email"])
+		assert.Equal(t, filepath.Join(signingKeysDir, "key.pub"), config["user.signingkey"])
+		assert.Equal(t, "ssh", config["gpg.format"])
+	})
+
+	t.Run("invalid object format", func(t *testing.T) {
+		_, err := createTestGitRepository(t.TempDir(), t.TempDir(), false, WithObjectFormat("bogus"))
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid signing keys directory", func(t *testing.T) {
+		signingKeysDir := filepath.Join(t.TempDir(), "keys")
+		require.Nil(t, os.WriteFile(signingKeysDir, nil, 0o600))
+
+		_, err := createTestGitRepository(t.TempDir(), signingKeysDir, false)
+		assert.Error(t, err)
+	})
+}
+
+func TestWriteSigningKeys(t *testing.T) {
+	t.Run("writes rsa key pair", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		require.Nil(t, writeSigningKeys(tmpDir))
+
+		privateKey, err := os.ReadFile(filepath.Join(tmpDir, "key"))
+		require.Nil(t, err)
+		assert.Equal(t, artifacts.SSHRSAPrivate, privateKey)
+
+		publicKey, err := os.ReadFile(filepath.Join(tmpDir, "key.pub"))
+		require.Nil(t, err)
+		assert.Equal(t, artifacts.SSHRSAPublicSSH, publicKey)
+	})
+
+	t.Run("private key write error", func(t *testing.T) {
+		keysDir := filepath.Join(t.TempDir(), "keys")
+		require.Nil(t, os.WriteFile(keysDir, nil, 0o600))
+
+		assert.Error(t, writeSigningKeys(keysDir))
+	})
+
+	t.Run("public key write error", func(t *testing.T) {
+		keysDir := t.TempDir()
+		require.Nil(t, os.Mkdir(filepath.Join(keysDir, "key.pub"), 0o700))
+
+		assert.Error(t, writeSigningKeys(keysDir))
+	})
+}

--- a/pkg/gitinterface/hash.go
+++ b/pkg/gitinterface/hash.go
@@ -47,9 +47,28 @@ func (h Hash) Equal(other Hash) bool {
 	return bytes.Equal(h[:], other[:])
 }
 
-// ZeroHash represents an empty Hash.
-// TODO: use SHA-256 zero hash for repositories that have that as the default.
+// IsSHA256 returns true if the hash is a SHA-256 Git object ID, determined by
+// its length. SHA-1 object IDs are shorter.
+func (h Hash) IsSHA256() bool {
+	return len(h) == sha256.Size
+}
+
+// ZeroHash represents an empty SHA-1 Hash. It is safe to use as an
+// error-return sentinel and in comparisons via Hash.IsZero (which matches both
+// SHA-1 and SHA-256 zero hashes). When the value is passed to Git or compared
+// against a Git-produced ID, prefer Repository.ZeroHash, which returns the zero
+// hash matching the repository's object format.
 var ZeroHash = Hash(zeroSHA1HashBytes[:])
+
+// ZeroHash returns the all-zeroes Hash for the repository's object format. Git
+// uses this value to denote, for example, the absence of a previous value when
+// creating or deleting a reference.
+func (r *Repository) ZeroHash() Hash {
+	if r.objectFormat == ObjectFormatSHA256 {
+		return Hash(zeroSHA256HashBytes[:])
+	}
+	return Hash(zeroSHA1HashBytes[:])
+}
 
 // NewHash returns a Hash object after ensuring the input string is correctly
 // encoded.

--- a/pkg/gitinterface/references.go
+++ b/pkg/gitinterface/references.go
@@ -27,14 +27,14 @@ func (r *Repository) GetReference(refName string) (Hash, error) {
 	refTipID, err := r.executor("rev-parse", refName).executeString()
 	if err != nil {
 		if strings.Contains(err.Error(), "unknown revision or path not in the working tree") {
-			return ZeroHash, ErrReferenceNotFound
+			return r.ZeroHash(), ErrReferenceNotFound
 		}
-		return ZeroHash, fmt.Errorf("unable to read reference '%s': %w", refName, err)
+		return r.ZeroHash(), fmt.Errorf("unable to read reference '%s': %w", refName, err)
 	}
 
 	hash, err := NewHash(refTipID)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid Git ID for reference '%s': %w", refName, err)
+		return r.ZeroHash(), fmt.Errorf("invalid Git ID for reference '%s': %w", refName, err)
 	}
 
 	return hash, nil

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/go-git/go-git/v6"
+	gogitconfig "github.com/go-git/go-git/v6/config"
 	"github.com/jonboulle/clockwork"
 )
 
@@ -25,8 +26,9 @@ const (
 )
 
 var (
-	ErrRepositoryPathNotSpecified = errors.New("repository path not specified")
-	ErrUnknownObjectFormat        = errors.New("unknown object format")
+	ErrRepositoryPathNotSpecified    = errors.New("repository path not specified")
+	ErrUnknownObjectFormat           = errors.New("unknown object format")
+	ErrCompatObjectFormatUnsupported = errors.New("gittuf does not support repositories with extensions.compatObjectFormat enabled")
 )
 
 // Repository is a lightweight wrapper around a Git repository. It stores the
@@ -57,6 +59,95 @@ func (r *Repository) readObjectFormat() (ObjectFormat, error) {
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnknownObjectFormat, stdOut)
 	}
+}
+
+// ensureNoCompatObjectFormat returns an error if the repository is in dual
+// hash interop mode (extensions.compatObjectFormat). In that mode Git
+// maintains both SHA-1 and SHA-256 representations of every object and stores
+// additional compat signatures under headers gittuf does not process, so
+// signing and verification results would be unreliable. The config file is
+// read directly (without invoking Git) because Git builds without compat
+// support refuse to open such repositories at all.
+func (r *Repository) ensureNoCompatObjectFormat() error {
+	configPath := filepath.Join(r.gitDirPath, "config")
+	configFile, err := os.Open(configPath)
+	if err != nil {
+		return fmt.Errorf("unable to read repository config: %w", err)
+	}
+	defer configFile.Close() //nolint:errcheck
+
+	gitConfig, err := gogitconfig.ReadConfig(configFile)
+	if err != nil {
+		return fmt.Errorf("unable to parse repository config: %w", err)
+	}
+	compatFormat := gitConfig.Raw.Section("extensions").Options.Get("compatObjectFormat")
+	if compatFormat != "" {
+		return fmt.Errorf("%w: compat object format is set to '%s'", ErrCompatObjectFormatUnsupported, compatFormat)
+	}
+
+	return nil
+}
+
+func findGitDirPath(startPath string) (string, bool, error) {
+	currentPath, err := filepath.Abs(startPath)
+	if err != nil {
+		return "", false, err
+	}
+
+	for {
+		gitDirPath := filepath.Join(currentPath, ".git")
+		if fileInfo, err := os.Stat(gitDirPath); err == nil {
+			if fileInfo.IsDir() {
+				return gitDirPath, true, nil
+			}
+
+			resolvedGitDirPath, err := readGitDirFile(gitDirPath, currentPath)
+			if err != nil {
+				return "", false, err
+			}
+			return resolvedGitDirPath, true, nil
+		} else if !os.IsNotExist(err) {
+			return "", false, err
+		}
+
+		if isBareGitDir(currentPath) {
+			return currentPath, true, nil
+		}
+
+		parentPath := filepath.Dir(currentPath)
+		if parentPath == currentPath {
+			return "", false, nil
+		}
+		currentPath = parentPath
+	}
+}
+
+func readGitDirFile(gitDirFilePath, worktreePath string) (string, error) {
+	contents, err := os.ReadFile(gitDirFilePath)
+	if err != nil {
+		return "", err
+	}
+
+	gitDirPath, has := strings.CutPrefix(strings.TrimSpace(string(contents)), "gitdir:")
+	if !has {
+		return "", fmt.Errorf("invalid gitdir file: %s", gitDirFilePath)
+	}
+	gitDirPath = strings.TrimSpace(gitDirPath)
+	if !filepath.IsAbs(gitDirPath) {
+		gitDirPath = filepath.Join(worktreePath, gitDirPath)
+	}
+
+	return filepath.Abs(gitDirPath)
+}
+
+func isBareGitDir(path string) bool {
+	if fileInfo, err := os.Stat(filepath.Join(path, "config")); err != nil || fileInfo.IsDir() {
+		return false
+	}
+	if fileInfo, err := os.Stat(filepath.Join(path, "HEAD")); err != nil || fileInfo.IsDir() {
+		return false
+	}
+	return true
 }
 
 // GetGoGitRepository returns the go-git representation of a repository. We use
@@ -99,6 +190,17 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 		return nil, err
 	}
 	defer os.Chdir(currentDir) //nolint:errcheck
+
+	gitDirPath, has, err := findGitDirPath(".")
+	if err != nil {
+		return nil, err
+	}
+	if has {
+		repo.gitDirPath = gitDirPath
+		if err := repo.ensureNoCompatObjectFormat(); err != nil {
+			return nil, err
+		}
+	}
 
 	slog.Debug("Identifying git directory for repository...")
 	stdOut, stdErr, err := repo.executor("rev-parse", "--git-dir").withoutGitDir().execute()

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -24,13 +24,39 @@ const (
 	authorTimeKey    = "GIT_AUTHOR_DATE"
 )
 
-var ErrRepositoryPathNotSpecified = errors.New("repository path not specified")
+var (
+	ErrRepositoryPathNotSpecified = errors.New("repository path not specified")
+	ErrUnknownObjectFormat        = errors.New("unknown object format")
+)
 
 // Repository is a lightweight wrapper around a Git repository. It stores the
 // location of the repository's GIT_DIR.
 type Repository struct {
-	gitDirPath string
-	clock      clockwork.Clock
+	gitDirPath   string
+	objectFormat ObjectFormat
+	clock        clockwork.Clock
+}
+
+// GetObjectFormat returns the hash algorithm the repository uses for its object
+// IDs.
+func (r *Repository) GetObjectFormat() ObjectFormat {
+	return r.objectFormat
+}
+
+// readObjectFormat queries Git for the repository's object format (hash
+// algorithm).
+func (r *Repository) readObjectFormat() (ObjectFormat, error) {
+	stdOut, err := r.executor("rev-parse", "--show-object-format").executeString()
+	if err != nil {
+		return "", fmt.Errorf("unable to read object format: %w", err)
+	}
+
+	switch format := ObjectFormat(stdOut); format {
+	case ObjectFormatSHA1, ObjectFormatSHA256:
+		return format, nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnknownObjectFormat, stdOut)
+	}
 }
 
 // GetGoGitRepository returns the go-git representation of a repository. We use
@@ -97,6 +123,12 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 	}
 	slog.Debug(fmt.Sprintf("Setting git directory for repository to '%s'...", absPath))
 	repo.gitDirPath = absPath
+
+	objectFormat, err := repo.readObjectFormat()
+	if err != nil {
+		return nil, err
+	}
+	repo.objectFormat = objectFormat
 
 	return repo, nil
 }

--- a/pkg/gitinterface/repository_test.go
+++ b/pkg/gitinterface/repository_test.go
@@ -65,3 +65,27 @@ func TestRepository(t *testing.T) {
 		assert.ErrorContains(t, err, "unable to identify git directory for repository")
 	})
 }
+
+func TestRepositoryObjectFormat(t *testing.T) {
+	t.Run("sha1", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false, WithObjectFormat(ObjectFormatSHA1))
+		assert.Equal(t, ObjectFormatSHA1, repo.GetObjectFormat())
+		assert.Equal(t, "0000000000000000000000000000000000000000", repo.ZeroHash().String())
+
+		loaded, err := LoadRepository(tmpDir)
+		require.Nil(t, err)
+		assert.Equal(t, ObjectFormatSHA1, loaded.GetObjectFormat())
+	})
+
+	t.Run("sha256", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false, WithSHA256Format())
+		assert.Equal(t, ObjectFormatSHA256, repo.GetObjectFormat())
+		assert.Equal(t, "0000000000000000000000000000000000000000000000000000000000000000", repo.ZeroHash().String())
+
+		loaded, err := LoadRepository(tmpDir)
+		require.Nil(t, err)
+		assert.Equal(t, ObjectFormatSHA256, loaded.GetObjectFormat())
+	})
+}

--- a/pkg/gitinterface/repository_test.go
+++ b/pkg/gitinterface/repository_test.go
@@ -4,6 +4,7 @@
 package gitinterface
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -61,8 +62,148 @@ func TestRepository(t *testing.T) {
 
 	t.Run("invalid path", func(t *testing.T) {
 		tmpDir := t.TempDir()
+		if _, has, err := findGitDirPath(tmpDir); err == nil && has {
+			tmpDir = filepath.Join(tmpDir, "invalid-repository")
+			require.Nil(t, os.Mkdir(tmpDir, 0o700))
+			require.Nil(t, os.WriteFile(filepath.Join(tmpDir, ".git"), []byte("not a gitdir file"), 0o600))
+		}
+
 		_, err := LoadRepository(tmpDir)
-		assert.ErrorContains(t, err, "unable to identify git directory for repository")
+		assert.Error(t, err)
+	})
+}
+
+func TestEnsureNoCompatObjectFormat(t *testing.T) {
+	t.Run("no compat object format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false, WithSHA256Format())
+
+		assert.Nil(t, repo.ensureNoCompatObjectFormat())
+	})
+
+	t.Run("compat object format", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false, WithSHA256Format())
+
+		require.Nil(t, repo.SetGitConfig("extensions.compatObjectFormat", "sha1"))
+
+		assert.ErrorIs(t, repo.ensureNoCompatObjectFormat(), ErrCompatObjectFormatUnsupported)
+
+		_, err := LoadRepository(tmpDir)
+		assert.ErrorIs(t, err, ErrCompatObjectFormatUnsupported)
+	})
+
+	t.Run("missing config", func(t *testing.T) {
+		repo := &Repository{gitDirPath: t.TempDir()}
+
+		err := repo.ensureNoCompatObjectFormat()
+		assert.ErrorContains(t, err, "unable to read repository config")
+	})
+
+	t.Run("invalid config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.Nil(t, os.WriteFile(filepath.Join(tmpDir, "config"), []byte("[extensions\n"), 0o600))
+
+		repo := &Repository{gitDirPath: tmpDir}
+		err := repo.ensureNoCompatObjectFormat()
+		assert.ErrorContains(t, err, "unable to parse repository config")
+	})
+}
+
+func TestFindGitDirPath(t *testing.T) {
+	t.Run("worktree git directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_ = CreateTestGitRepository(t, tmpDir, false)
+
+		nestedDir := filepath.Join(tmpDir, "nested", "dir")
+		require.Nil(t, os.MkdirAll(nestedDir, 0o700))
+
+		gitDirPath, has, err := findGitDirPath(nestedDir)
+		require.Nil(t, err)
+		assert.True(t, has)
+		assert.Equal(t, filepath.Join(tmpDir, ".git"), gitDirPath)
+	})
+
+	t.Run("bare git directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		_ = CreateTestGitRepository(t, tmpDir, true)
+
+		gitDirPath, has, err := findGitDirPath(tmpDir)
+		require.Nil(t, err)
+		assert.True(t, has)
+		assert.Equal(t, tmpDir, gitDirPath)
+	})
+
+	t.Run("gitdir file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreePath := filepath.Join(tmpDir, "worktree")
+		require.Nil(t, os.MkdirAll(worktreePath, 0o700))
+
+		gitDirPath := filepath.Join(tmpDir, "actual.git")
+		require.Nil(t, os.WriteFile(filepath.Join(worktreePath, ".git"), []byte("gitdir: ../actual.git\n"), 0o600))
+
+		gotGitDirPath, has, err := findGitDirPath(worktreePath)
+		require.Nil(t, err)
+		assert.True(t, has)
+		assert.Equal(t, gitDirPath, gotGitDirPath)
+	})
+
+	t.Run("invalid gitdir file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.Nil(t, os.WriteFile(filepath.Join(tmpDir, ".git"), []byte("not a gitdir file"), 0o600))
+
+		_, has, err := findGitDirPath(tmpDir)
+		assert.False(t, has)
+		assert.ErrorContains(t, err, "invalid gitdir file")
+	})
+
+	t.Run("no git directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		if _, has, err := findGitDirPath(tmpDir); err == nil && has {
+			tmpDir = "/dev"
+			if _, has, err := findGitDirPath(tmpDir); err != nil || has {
+				t.Skip("unable to find a filesystem path outside a Git repository")
+			}
+		}
+
+		_, has, err := findGitDirPath(tmpDir)
+		require.Nil(t, err)
+		assert.False(t, has)
+	})
+}
+
+func TestReadGitDirFile(t *testing.T) {
+	t.Run("absolute gitdir path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitDirPath := filepath.Join(tmpDir, "actual.git")
+		gitDirFilePath := filepath.Join(tmpDir, ".git")
+		require.Nil(t, os.WriteFile(gitDirFilePath, []byte("gitdir: "+gitDirPath+"\n"), 0o600))
+
+		gotGitDirPath, err := readGitDirFile(gitDirFilePath, tmpDir)
+		require.Nil(t, err)
+		assert.Equal(t, gitDirPath, gotGitDirPath)
+	})
+
+	t.Run("missing gitdir file", func(t *testing.T) {
+		_, err := readGitDirFile(filepath.Join(t.TempDir(), ".git"), t.TempDir())
+		assert.Error(t, err)
+	})
+}
+
+func TestIsBareGitDir(t *testing.T) {
+	t.Run("config without head", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.Nil(t, os.WriteFile(filepath.Join(tmpDir, "config"), nil, 0o600))
+
+		assert.False(t, isBareGitDir(tmpDir))
+	})
+
+	t.Run("head as directory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		require.Nil(t, os.WriteFile(filepath.Join(tmpDir, "config"), nil, 0o600))
+		require.Nil(t, os.Mkdir(filepath.Join(tmpDir, "HEAD"), 0o700))
+
+		assert.False(t, isBareGitDir(tmpDir))
 	})
 }
 

--- a/pkg/gitinterface/signature.go
+++ b/pkg/gitinterface/signature.go
@@ -46,6 +46,7 @@ var (
 	ErrVerifyingSigstoreSignature = errors.New("unable to verify Sigstore signature")
 	ErrVerifyingSSHSignature      = errors.New("unable to verify SSH signature")
 	ErrInvalidSignature           = errors.New("unable to parse signature / signature has unexpected header")
+	ErrMultipleSignatures         = errors.New("object has multiple signatures")
 )
 
 // CanSign inspects the Git configuration to determine if commit / tag signing
@@ -259,4 +260,32 @@ func getSigningKeyInfo(gitConfig map[string]string) string {
 		return ""
 	}
 	return keyInfo
+}
+
+// signatureForObjectID selects the signature stored for a Git commit based on
+// its hash algorithm, identified by the OID length. SHA-256 commits store
+// their signature under the `gpgsig-sha256` header (go-git's SignatureSHA256),
+// SHA-1 commits under `gpgsig` (Signature). Tags are not covered here: Git
+// appends tag signatures to the tag payload regardless of the object format.
+func signatureForObjectID(objectID Hash, signature, signatureSHA256 string) string {
+	if objectID.IsSHA256() {
+		return signatureSHA256
+	}
+	return signature
+}
+
+// signatureBlockCount reports how many armored signature blocks appear in a
+// signature. Verification rejects values carrying more than one block, which
+// are ambiguous.
+func signatureBlockCount(signature string) int {
+	count := 0
+	for line := range strings.SplitSeq(signature, "\n") {
+		switch strings.TrimSpace(line) {
+		case "-----BEGIN PGP SIGNATURE-----",
+			"-----BEGIN PGP MESSAGE-----",
+			"-----BEGIN SSH SIGNATURE-----":
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/gitinterface/signature_test.go
+++ b/pkg/gitinterface/signature_test.go
@@ -69,7 +69,7 @@ func TestCanSign(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := setupRepository(t, tmpDir, false) // explicitly not using CreateTestGitRepository as that includes signing configurations
+			repo := setupRepository(t, tmpDir, false, ObjectFormatSHA1) // explicitly not using CreateTestGitRepository as that includes signing configurations
 
 			for key, value := range test.config {
 				if err := repo.SetGitConfig(key, value); err != nil {

--- a/pkg/gitinterface/sync.go
+++ b/pkg/gitinterface/sync.go
@@ -122,6 +122,10 @@ func CloneAndFetchRepository(remoteURL, dir, initialBranch string, refs []string
 		return nil, fmt.Errorf("unable to clone repository: %s", stdErr)
 	}
 
+	if err := repo.ensureNoCompatObjectFormat(); err != nil {
+		return nil, err
+	}
+
 	objectFormat, err := repo.readObjectFormat()
 	if err != nil {
 		return nil, err

--- a/pkg/gitinterface/sync.go
+++ b/pkg/gitinterface/sync.go
@@ -122,6 +122,12 @@ func CloneAndFetchRepository(remoteURL, dir, initialBranch string, refs []string
 		return nil, fmt.Errorf("unable to clone repository: %s", stdErr)
 	}
 
+	objectFormat, err := repo.readObjectFormat()
+	if err != nil {
+		return nil, err
+	}
+	repo.objectFormat = objectFormat
+
 	return repo, repo.Fetch(DefaultRemoteName, refs, true)
 }
 

--- a/pkg/gitinterface/sync_test.go
+++ b/pkg/gitinterface/sync_test.go
@@ -6,12 +6,20 @@ package gitinterface
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestWithFetchDepth(t *testing.T) {
+	options := &FetchOptions{}
+	WithFetchDepth(1)(options)
+
+	assert.Equal(t, 1, options.Depth)
+}
 
 func TestPushRefSpecRepository(t *testing.T) {
 	remoteName := "origin"
@@ -161,6 +169,43 @@ func TestPushRefSpecRepository(t *testing.T) {
 		err := localRepo.PushRefSpec("nonexistent", []string{refSpecs})
 		assert.ErrorContains(t, err, "unable to push")
 	})
+}
+
+func TestPushRepositorySHA256(t *testing.T) {
+	remoteName := "origin"
+	refName := "refs/heads/main"
+
+	localTmpDir := t.TempDir()
+	remoteTmpDir := t.TempDir()
+
+	localRepo := CreateTestGitRepository(t, localTmpDir, false, WithSHA256Format())
+	remoteRepo := CreateTestGitRepository(t, remoteTmpDir, true, WithSHA256Format())
+
+	if err := localRepo.CreateRemote(remoteName, remoteTmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	emptyBlobHash, err := localRepo.WriteBlob(nil)
+	require.Nil(t, err)
+	tree, err := NewTreeBuilder(localRepo).WriteTreeFromEntries([]TreeEntry{NewEntryBlob("foo", emptyBlobHash)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := localRepo.Commit(tree, refName, "Test commit\n", false); err != nil {
+		t.Fatal(err)
+	}
+
+	err = localRepo.Push(remoteName, []string{refName})
+	assert.Nil(t, err)
+
+	localRef, err := localRepo.GetReference(refName)
+	require.Nil(t, err)
+	remoteRef, err := remoteRepo.GetReference(refName)
+	require.Nil(t, err)
+
+	assert.Equal(t, localRef, remoteRef)
+	assert.Len(t, localRef.String(), 64)
 }
 
 func TestPushRepository(t *testing.T) {
@@ -475,6 +520,28 @@ func TestFetchRefSpecRepository(t *testing.T) {
 		err := localRepo.FetchRefSpec("nonexistent", []string{refSpecs})
 		assert.ErrorContains(t, err, "unable to fetch")
 	})
+
+	t.Run("fetch with depth", func(t *testing.T) {
+		localTmpDir := t.TempDir()
+		remoteTmpDir := t.TempDir()
+
+		localRepo := CreateTestGitRepository(t, localTmpDir, true)
+		remoteRepo := CreateTestGitRepository(t, remoteTmpDir, false)
+
+		require.Nil(t, localRepo.CreateRemote(remoteName, remoteTmpDir))
+
+		tree, err := NewTreeBuilder(remoteRepo).WriteTreeFromEntries(nil)
+		require.Nil(t, err)
+		remoteRef, err := remoteRepo.Commit(tree, refName, "Test commit\n", false)
+		require.Nil(t, err)
+
+		err = localRepo.FetchRefSpec(remoteName, []string{refSpecs}, WithFetchDepth(1))
+		require.Nil(t, err)
+
+		localRef, err := localRepo.GetReference(refName)
+		require.Nil(t, err)
+		assert.Equal(t, remoteRef, localRef)
+	})
 }
 
 func TestFetchRepository(t *testing.T) {
@@ -675,6 +742,32 @@ func TestFetchObject(t *testing.T) {
 		err := downstreamRepo.FetchObject("nonexistent", ZeroHash)
 		assert.ErrorContains(t, err, "unable to fetch object")
 	})
+}
+
+func TestCloneAndFetchRepositoryObjectFormat(t *testing.T) {
+	for _, objectFormat := range []ObjectFormat{ObjectFormatSHA1, ObjectFormatSHA256} {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			remoteTmpDir := t.TempDir()
+			localTmpDir := t.TempDir()
+
+			remoteRepo := CreateTestGitRepository(t, remoteTmpDir, false, WithObjectFormat(objectFormat))
+
+			emptyBlobHash, err := remoteRepo.WriteBlob(nil)
+			require.Nil(t, err)
+			tree, err := NewTreeBuilder(remoteRepo).WriteTreeFromEntries([]TreeEntry{NewEntryBlob("foo", emptyBlobHash)})
+			require.Nil(t, err)
+
+			if _, err := remoteRepo.Commit(tree, "refs/heads/main", "Commit to main\n", false); err != nil {
+				t.Fatal(err)
+			}
+
+			localRepo, err := CloneAndFetchRepository(remoteTmpDir, localTmpDir, "refs/heads/main", nil, false)
+			require.Nil(t, err)
+
+			assert.Equal(t, objectFormat, localRepo.GetObjectFormat())
+			assert.Equal(t, remoteRepo.ZeroHash(), localRepo.ZeroHash())
+		})
+	}
 }
 
 func TestCloneAndFetchRepository(t *testing.T) {
@@ -974,6 +1067,9 @@ func TestCloneAndFetchRepository(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		_, err := CloneAndFetchRepository("", "", "", nil, false)
 		assert.ErrorContains(t, err, "target directory must be specified")
+
+		_, err = CloneAndFetchRepository(filepath.Join(t.TempDir(), "missing"), t.TempDir(), "", nil, false)
+		assert.ErrorContains(t, err, "unable to clone repository")
 	})
 }
 

--- a/pkg/gitinterface/tag.go
+++ b/pkg/gitinterface/tag.go
@@ -19,9 +19,7 @@ import (
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 )
 
-var (
-	ErrTagAlreadyExists = errors.New("tag already exists")
-)
+var ErrTagAlreadyExists = errors.New("tag already exists")
 
 // TagUsingSpecificKey creates a Git tag signed using the specified, PEM encoded
 // SSH or GPG key. It is primarily intended for use with testing. As of now,
@@ -67,6 +65,9 @@ func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, sign
 	if err != nil {
 		return ZeroHash, err
 	}
+	// Git appends tag signatures to the tag payload regardless of the object
+	// format; only commits store the signature under a header named for the
+	// hash algorithm (`gpgsig` / `gpgsig-sha256`).
 	tag.Signature = signature
 
 	obj := goGitRepo.Storer.NewEncodedObject()
@@ -111,36 +112,42 @@ func (r *Repository) verifyTagSignature(ctx context.Context, tagID Hash, key *si
 
 	tag, err := goGitRepo.TagObject(plumbing.NewHash(tagID.String()))
 	if err != nil {
-		return fmt.Errorf("unable to load commit object: %w", err)
+		return fmt.Errorf("unable to load tag object: %w", err)
+	}
+
+	tagContents, err := getTagBytesWithoutSignature(tag)
+	if err != nil {
+		return fmt.Errorf("unable to encode tag contents for verification: %w", err)
+	}
+
+	// Git appends tag signatures to the tag payload regardless of the object
+	// format, so the signature is always in the Signature field (unlike
+	// commits, where the header depends on the hash algorithm).
+	tagSignature := tag.Signature
+
+	if signatureBlockCount(tagSignature) > 1 {
+		return errors.Join(ErrIncorrectVerificationKey, ErrMultipleSignatures)
 	}
 
 	switch key.KeyType {
 	case gpg.KeyType:
-		if _, err := tag.Verify(key.KeyVal.Public); err != nil {
+		verifier, err := gpg.NewVerifierFromKey(key)
+		if err != nil {
+			return errors.Join(ErrIncorrectVerificationKey, err)
+		}
+		if err := verifier.Verify(ctx, tagContents, []byte(tagSignature)); err != nil {
 			return ErrIncorrectVerificationKey
 		}
 
 		return nil
 	case ssh.KeyType:
-		tagContents, err := getTagBytesWithoutSignature(tag)
-		if err != nil {
-			return errors.Join(ErrVerifyingSSHSignature, err)
-		}
-		tagSignature := []byte(tag.Signature)
-
-		if err := verifySSHKeySignature(ctx, key, tagContents, tagSignature); err != nil {
+		if err := verifySSHKeySignature(ctx, key, tagContents, []byte(tagSignature)); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 
 		return nil
 	case sigstore.KeyType:
-		tagContents, err := getTagBytesWithoutSignature(tag)
-		if err != nil {
-			return errors.Join(ErrVerifyingSigstoreSignature, err)
-		}
-		tagSignature := []byte(tag.Signature)
-
-		if err := verifyGitsignSignature(ctx, r, key, tagContents, tagSignature); err != nil {
+		if err := verifyGitsignSignature(ctx, r, key, tagContents, []byte(tagSignature)); err != nil {
 			return errors.Join(ErrIncorrectVerificationKey, err)
 		}
 

--- a/pkg/gitinterface/tag_test.go
+++ b/pkg/gitinterface/tag_test.go
@@ -7,11 +7,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/signerverifier/gpg"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/secure-systems-lab/go-securesystemslib/signerverifier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -105,6 +108,213 @@ func TestRepositoryVerifyTag(t *testing.T) {
 		err = repo.verifyTagSignature(context.Background(), gpgSignedTag, unknownKey)
 		assert.ErrorIs(t, err, ErrUnknownSigningMethod)
 	})
+}
+
+// Git appends tag signatures to the tag payload, and go-git only ever
+// surfaces the trailing block as the tag's signature; the earlier blocks stay
+// in the message, so the signed payload no longer matches and verification
+// fails. The explicit multi-block check in verifyTagSignature is
+// defense-in-depth and is not reachable through go-git's tag decoding.
+func TestVerifyTagSignatureRejectsMultipleSignatures(t *testing.T) {
+	tests := map[string]struct {
+		signingKey      []byte
+		verificationKey func(t *testing.T) *signerverifier.SSLibKey
+	}{
+		"gpg": {
+			signingKey: artifacts.GPGKey1Private,
+			verificationKey: func(t *testing.T) *signerverifier.SSLibKey {
+				t.Helper()
+				key, err := gpg.LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+				require.Nil(t, err)
+				return key
+			},
+		},
+		"ssh": {
+			signingKey: artifacts.SSHED25519Private,
+			verificationKey: func(t *testing.T) *signerverifier.SSLibKey {
+				t.Helper()
+				keyPath := filepath.Join(t.TempDir(), "ssh-key.pub")
+				require.Nil(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+				key, err := ssh.NewKeyFromFile(keyPath)
+				require.Nil(t, err)
+				return key
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			repo := CreateTestGitRepository(t, tempDir, false)
+
+			emptyTreeID, err := NewTreeBuilder(repo).WriteTreeFromEntries(nil)
+			require.Nil(t, err)
+
+			commitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", false)
+			require.Nil(t, err)
+
+			goGitRepo, err := repo.GetGoGitRepository()
+			require.Nil(t, err)
+
+			gitConfig, err := repo.GetGitConfig()
+			require.Nil(t, err)
+
+			tag := &object.Tag{
+				Name: "test-tag",
+				Tagger: object.Signature{
+					Name:  gitConfig["user.name"],
+					Email: gitConfig["user.email"],
+					When:  repo.clock.Now(),
+				},
+				Message:    "test-tag\n",
+				TargetType: plumbing.CommitObject,
+				Target:     plumbing.NewHash(commitID.String()),
+			}
+
+			tagContents, err := getTagBytesWithoutSignature(tag)
+			require.Nil(t, err)
+
+			sig, err := signGitObjectUsingKey(tagContents, test.signingKey)
+			require.Nil(t, err)
+
+			// Two (individually valid) signature blocks, each on their own
+			// lines, must not verify against either block.
+			block := strings.TrimRight(sig, "\n") + "\n"
+			tag.Signature = block + block
+
+			tagEncoded := goGitRepo.Storer.NewEncodedObject()
+			require.Nil(t, tag.Encode(tagEncoded))
+			tagID, err := goGitRepo.Storer.SetEncodedObject(tagEncoded)
+			require.Nil(t, err)
+			tagHash, err := NewHash(tagID.String())
+			require.Nil(t, err)
+
+			err = repo.verifyTagSignature(context.Background(), tagHash, test.verificationKey(t))
+			assert.ErrorIs(t, err, ErrIncorrectVerificationKey)
+		})
+	}
+}
+
+func TestRepositoryVerifyTagSHA256(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false, WithSHA256Format())
+
+	treeBuilder := NewTreeBuilder(repo)
+
+	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	commitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sshSignedTag, err := repo.TagUsingSpecificKey(commitID, "test-tag-ssh", "test-tag-ssh\n", artifacts.SSHED25519Private)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyDir := t.TempDir()
+	keyPath := filepath.Join(keyDir, "ssh-key.pub")
+	if err := os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sshKey, err := ssh.NewKeyFromFile(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gpgSignedTag, err := repo.TagUsingSpecificKey(commitID, "test-tag-gpg", "test-tag-gpg\n", artifacts.GPGKey1Private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpgKey, err := gpg.LoadGPGKeyFromBytes(artifacts.GPGKey1Public)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("ssh signed tag, verify with ssh key", func(t *testing.T) {
+		err = repo.verifyTagSignature(context.Background(), sshSignedTag, sshKey)
+		assert.Nil(t, err)
+	})
+
+	t.Run("gpg signed tag, verify with gpg key", func(t *testing.T) {
+		err = repo.verifyTagSignature(context.Background(), gpgSignedTag, gpgKey)
+		assert.Nil(t, err)
+	})
+
+	t.Run("unknown signing method", func(t *testing.T) {
+		unknownKey := &signerverifier.SSLibKey{KeyType: "unknown"}
+		err = repo.verifyTagSignature(context.Background(), gpgSignedTag, unknownKey)
+		assert.ErrorIs(t, err, ErrUnknownSigningMethod)
+	})
+}
+
+func TestTagUsingSpecificKeySignatureHeader(t *testing.T) {
+	for _, objectFormat := range []ObjectFormat{ObjectFormatSHA1, ObjectFormatSHA256} {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := CreateTestGitRepository(t, tmpDir, false, WithObjectFormat(objectFormat))
+
+			emptyTreeID, err := NewTreeBuilder(repo).WriteTreeFromEntries(nil)
+			require.Nil(t, err)
+			commitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", false)
+			require.Nil(t, err)
+
+			tagID, err := repo.TagUsingSpecificKey(commitID, "v1", "v1\n", artifacts.SSHED25519Private)
+			require.Nil(t, err)
+
+			raw, err := repo.executor("cat-file", "tag", tagID.String()).executeString()
+			require.Nil(t, err)
+
+			// Git appends tag signatures to the tag payload regardless of
+			// the object format; the `gpgsig-sha256` header is only used for
+			// compat signatures in dual-hash interop repositories.
+			assert.NotContains(t, raw, "gpgsig-sha256")
+			assert.Contains(t, raw, "v1\n-----BEGIN SSH SIGNATURE-----")
+
+			keyDir := t.TempDir()
+			keyPath := filepath.Join(keyDir, "ssh-key.pub")
+			require.Nil(t, os.WriteFile(keyPath, artifacts.SSHED25519PublicSSH, 0o600))
+			sshKey, err := ssh.NewKeyFromFile(keyPath)
+			require.Nil(t, err)
+
+			assert.Nil(t, repo.verifyTagSignature(context.Background(), tagID, sshKey))
+		})
+	}
+}
+
+func TestVerifyTagSignatureGitCreatedTag(t *testing.T) {
+	for _, objectFormat := range []ObjectFormat{ObjectFormatSHA1, ObjectFormatSHA256} {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			tmpDir := t.TempDir()
+			repo := CreateTestGitRepository(t, tmpDir, false, WithObjectFormat(objectFormat))
+
+			emptyTreeID, err := NewTreeBuilder(repo).WriteTreeFromEntries(nil)
+			require.Nil(t, err)
+			commitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", false)
+			require.Nil(t, err)
+
+			// Sign the tag with Git itself, using the repository's configured
+			// SSH signing key, to ensure verification handles tags exactly as
+			// Git creates them.
+			_, err = repo.executor("tag", "-s", "-m", "v1", "v1", commitID.String()).executeString()
+			require.Nil(t, err)
+
+			tagID, err := repo.GetReference("refs/tags/v1")
+			require.Nil(t, err)
+
+			keyDir := t.TempDir()
+			keyPath := filepath.Join(keyDir, "ssh-key.pub")
+			require.Nil(t, os.WriteFile(keyPath, artifacts.SSHRSAPublicSSH, 0o600))
+			sshKey, err := ssh.NewKeyFromFile(keyPath)
+			require.Nil(t, err)
+
+			assert.Nil(t, repo.verifyTagSignature(context.Background(), tagID, sshKey))
+		})
+	}
 }
 
 func TestEnsureIsTag(t *testing.T) {

--- a/pkg/gitinterface/tag_test.go
+++ b/pkg/gitinterface/tag_test.go
@@ -317,6 +317,39 @@ func TestVerifyTagSignatureGitCreatedTag(t *testing.T) {
 	}
 }
 
+// A tag message may itself contain an armored signature block (e.g. quoted
+// release notes). Git treats only the trailing block as the tag's signature
+// (parse_signed_buffer in gpg-interface.c returns the last block start) and
+// everything before it as signed payload, so `git verify-tag` accepts such
+// tags. Verification must match and not reject them as multiple signatures.
+func TestVerifyTagSignatureArmorBlockInMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tmpDir, false)
+
+	emptyTreeID, err := NewTreeBuilder(repo).WriteTreeFromEntries(nil)
+	require.Nil(t, err)
+	commitID, err := repo.Commit(emptyTreeID, "refs/heads/main", "Initial commit\n", false)
+	require.Nil(t, err)
+
+	messageFile := filepath.Join(t.TempDir(), "message")
+	message := "release notes quoting a signature:\n-----BEGIN SSH SIGNATURE-----\nU1NIU0lHZHVtbXk=\n-----END SSH SIGNATURE-----\nend of notes\n"
+	require.Nil(t, os.WriteFile(messageFile, []byte(message), 0o600))
+
+	_, err = repo.executor("tag", "-s", "-F", messageFile, "v1", commitID.String()).executeString()
+	require.Nil(t, err)
+
+	tagID, err := repo.GetReference("refs/tags/v1")
+	require.Nil(t, err)
+
+	keyDir := t.TempDir()
+	keyPath := filepath.Join(keyDir, "ssh-key.pub")
+	require.Nil(t, os.WriteFile(keyPath, artifacts.SSHRSAPublicSSH, 0o600))
+	sshKey, err := ssh.NewKeyFromFile(keyPath)
+	require.Nil(t, err)
+
+	assert.Nil(t, repo.verifyTagSignature(context.Background(), tagID, sshKey))
+}
+
 func TestEnsureIsTag(t *testing.T) {
 	tmpDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tmpDir, false)

--- a/pkg/gitinterface/tree_test.go
+++ b/pkg/gitinterface/tree_test.go
@@ -23,6 +23,18 @@ func TestRepositoryEmptyTree(t *testing.T) {
 	assert.Equal(t, "4b825dc642cb6eb9a060e54bf8d69288fbee4904", hash.String())
 }
 
+func TestRepositoryEmptyTreeSHA256(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false, WithSHA256Format())
+
+	hash, err := repo.EmptyTree()
+	assert.Nil(t, err)
+
+	// SHA-256 ID used by Git to denote an empty tree
+	// $ git init --object-format=sha256 && git hash-object -t tree --stdin < /dev/null
+	assert.Equal(t, "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321", hash.String())
+}
+
 func TestGetPathIDInTree(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := CreateTestGitRepository(t, tempDir, false)


### PR DESCRIPTION
## Description

Make gittuf hash-algorithm aware so it operates on `SHA-256` repositories:

- gitinterface.Repository detects its object format (via `git rev-parse --show-object-format`) and exposes GetObjectFormat and a per-repo ZeroHash. GetReference returns the format-appropriate zero hash so ref updates to new refs succeed in SHA-256 repositories.
- Commit and tag signing/verification use the `gpgsig-sha256` header for SHA-256 objects (go-git's SignatureSHA256), matching Git's behavior. The verification field is chosen by the object's OID length. Fixes verify-ref failing on Git-signed SHA-256 RSL entries.
- git-remote-gittuf negotiates object-format from the repository instead of hardcoding sha1, and uses the repo-appropriate zero hash for ref tips.
- Test helpers can create SHA-256 repositories; gitinterface, rsl, policy, and experimental/gittuf suites now run under both formats, plus an end-to-end Git-signed record+verify test.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below:

AI was used to expand test coverage, to review/map gaps of SHA-256 support and to improve code documentation. All AI-assisted output was iteratively reviewed, refined, and validated through continuous developer feedback before being included in the PR.


## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
