### PR TITLE
docs: audit and fix CLI command docstrings across all commands

### DIFF
--- a/docs/cli/gittuf_add-hooks.md
+++ b/docs/cli/gittuf_add-hooks.md
@@ -4,7 +4,7 @@ Add git hooks that automatically create and sync RSL
 
 ### Synopsis
 
-The 'add-hooks' command installs Git hooks that automatically create and sync the RSL when certain Git actions occur, such as a push. By default, it prevents overwriting existing hooks unless the '--force' flag is specified.
+The 'add-hooks' command installs Git hooks that automatically create and sync the RSL when certain Git actions occur, such as a push. It is used to keep the RSL up to date without running gittuf commands manually.
 
 ```
 gittuf add-hooks [flags]

--- a/docs/cli/gittuf_attest.md
+++ b/docs/cli/gittuf_attest.md
@@ -11,7 +11,7 @@ The 'attest' command provides tools for attesting to code contributions. It incl
 ```
       --create-rsl-entry     create RSL entry for attestation change immediately (note: the new entry to the RSL will not be synced with the remote)
   -h, --help                 help for attest
-  -k, --signing-key string   signing key to use to sign attestation
+  -k, --signing-key string   signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_attest_apply.md
+++ b/docs/cli/gittuf_attest_apply.md
@@ -25,7 +25,7 @@ gittuf attest apply [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_authorize.md
+++ b/docs/cli/gittuf_attest_authorize.md
@@ -26,7 +26,7 @@ gittuf attest authorize [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github.md
+++ b/docs/cli/gittuf_attest_github.md
@@ -20,7 +20,7 @@ The 'github' command provides tools to create attestations for actions and entit
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_dismiss-approval.md
+++ b/docs/cli/gittuf_attest_github_dismiss-approval.md
@@ -27,7 +27,7 @@ gittuf attest github dismiss-approval [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_pull-request.md
+++ b/docs/cli/gittuf_attest_github_pull-request.md
@@ -29,7 +29,7 @@ gittuf attest github pull-request [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_record-approval.md
+++ b/docs/cli/gittuf_attest_github_record-approval.md
@@ -29,7 +29,7 @@ gittuf attest github record-approval [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign attestation
+  -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_cache.md
+++ b/docs/cli/gittuf_cache.md
@@ -4,7 +4,7 @@ Manage gittuf's caching functionality
 
 ### Synopsis
 
-The 'cache' command group contains subcommands to manage gittuf's local persistent cache. This cache helps improve performance by storing metadata locally. The cache is local-only and is not synchronized with remote repositories.
+The 'cache' command group contains subcommands to manage gittuf's local persistent cache. The cache is local-only and is not synchronized with remote repositories.
 
 ### Options
 

--- a/docs/cli/gittuf_cache_delete.md
+++ b/docs/cli/gittuf_cache_delete.md
@@ -4,7 +4,7 @@ Delete the local persistent cache
 
 ### Synopsis
 
-The 'delete' command deletes the local persistent cache used by gittuf.
+The 'delete' command deletes the local persistent cache used by gittuf. It is used to reclaim space or clear a stale cache. The cache must be reinitialized manually with 'gittuf cache init' before it can be used again.
 
 ```
 gittuf cache delete [flags]

--- a/docs/cli/gittuf_clone.md
+++ b/docs/cli/gittuf_clone.md
@@ -4,7 +4,7 @@ Clone repository and its gittuf references
 
 ### Synopsis
 
-The 'clone' command clones a gittuf-enabled Git repository along with its associated gittuf metadata. This command can also ensure the repository's trust root is established correctly by using specified root keys, optionally supplied using the --root-key flag. You may also specify a particular branch to check out with --branch and choose whether to create a bare repository using --bare.
+The 'clone' command clones a gittuf-enabled Git repository along with its associated gittuf metadata. It is used to obtain a repository and verify its RSL and policy against the provided root of trust keys.
 
 ```
 gittuf clone [flags]
@@ -16,7 +16,7 @@ gittuf clone [flags]
       --bare                   make a bare Git repository
   -b, --branch string          specify branch to check out
   -h, --help                   help for clone
-      --root-key public-keys   set of initial root of trust keys for the repository (supported values: paths to SSH keys, GPG key fingerprints, Sigstore/Fulcio identities)
+      --root-key public-keys   set of initial root of trust keys for the repository (each a path to an SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -11,7 +11,7 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
 ```
       --create-rsl-entry     create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
   -h, --help                 help for policy
-  -k, --signing-key string   signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string   signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -32,7 +32,7 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
 * [gittuf policy add-rule](gittuf_policy_add-rule.md)	 - Add a new rule to a policy file
 * [gittuf policy apply](gittuf_policy_apply.md)	 - Validate and apply changes from policy-staging to policy
 * [gittuf policy discard](gittuf_policy_discard.md)	 - Discard the currently staged changes to policy
-* [gittuf policy increment-version](gittuf_policy_increment-version.md)	 - Increment the integer version of the specified rule file metadata
+* [gittuf policy increment-version](gittuf_policy_increment-version.md)	 - Increment the integer version of the specified policy file metadata
 * [gittuf policy init](gittuf_policy_init.md)	 - Initialize policy file
 * [gittuf policy list-principals](gittuf_policy_list-principals.md)	 - List principals for the current policy in the specified rule file
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state

--- a/docs/cli/gittuf_policy_add-key.md
+++ b/docs/cli/gittuf_policy_add-key.md
@@ -4,7 +4,7 @@ Add a trusted key to a policy file
 
 ### Synopsis
 
-The 'add-key' command adds one or more trusted public keys to a gittuf policy file. This command is used to define which keys are authorized to sign commits or policy changes according to the repository's trust model. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'add-key' command adds one or more trusted public keys to a gittuf policy file. It is used to make keys available for use in policy rules. A key must be added to at least one rule before it can be used to authorize changes.
 
 ```
 gittuf policy add-key [flags]
@@ -15,7 +15,7 @@ gittuf policy add-key [flags]
 ```
   -h, --help                     help for add-key
       --policy-name string       name of policy file to add key to (default "targets")
-      --public-key stringArray   authorized public key
+      --public-key stringArray   authorized public key (path to SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -26,7 +26,7 @@ gittuf policy add-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_add-person.md
+++ b/docs/cli/gittuf_policy_add-person.md
@@ -4,7 +4,7 @@ Add a trusted person to a policy file
 
 ### Synopsis
 
-The 'add-person' command adds a trusted person to a gittuf policy file. In gittuf, a person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom') for tracking additional attributes. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'add-person' command adds a trusted person to a gittuf policy file. It is used to define a person, along with their authorized keys and platform identities, who can then be named in policy rules.
 
 ```
 gittuf policy add-person [flags]
@@ -17,8 +17,8 @@ gittuf policy add-person [flags]
       --custom stringArray                additional custom metadata in the form KEY=VALUE
   -h, --help                              help for add-person
       --person-ID string                  person ID
-      --policy-name string                name of policy file to add key to (default "targets")
-      --public-key stringArray            authorized public key for person
+      --policy-name string                name of policy file to add person to (default "targets")
+      --public-key stringArray            authorized public key for the person (path to SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -29,7 +29,7 @@ gittuf policy add-person [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_add-rule.md
+++ b/docs/cli/gittuf_policy_add-rule.md
@@ -4,7 +4,7 @@ Add a new rule to a policy file
 
 ### Synopsis
 
-The 'add-rule' command adds a new rule to a gittuf policy file. Each rule contains a name ('--rule-name') for the rule, one or more principals ('--authorize') who are allowed to sign within the scope of the rule, a set of rule patterns ('--rule-pattern') defining the namespaces or paths the rule governs, and a signature threshold ('--threshold'), which is the minimum number of valid signatures required to satisfy the rule. Principals can be specified by their principal IDs. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'add-rule' command adds a new rule to a gittuf policy file. It is used to authorize a set of principals to sign changes to the namespaces the rule protects, subject to a signature threshold.
 
 ```
 gittuf policy add-rule [flags]
@@ -29,7 +29,7 @@ gittuf policy add-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_apply.md
+++ b/docs/cli/gittuf_policy_apply.md
@@ -25,7 +25,7 @@ gittuf policy apply [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_discard.md
+++ b/docs/cli/gittuf_policy_discard.md
@@ -24,7 +24,7 @@ gittuf policy discard [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_increment-version.md
+++ b/docs/cli/gittuf_policy_increment-version.md
@@ -1,10 +1,10 @@
 ## gittuf policy increment-version
 
-Increment the integer version of the specified rule file metadata
+Increment the integer version of the specified policy file metadata
 
 ### Synopsis
 
-The 'increment-version' command increments the integer version of the specified rule file metadata without making any other changes.
+The 'increment-version' command increments the integer version of the specified policy file metadata without making any other changes. This is normally only needed when upgrading gittuf metadata created with versions older than v0.14.0.
 
 ```
 gittuf policy increment-version [flags]
@@ -25,7 +25,7 @@ gittuf policy increment-version [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_init.md
+++ b/docs/cli/gittuf_policy_init.md
@@ -4,7 +4,7 @@ Initialize policy file
 
 ### Synopsis
 
-This command initializes a new gittuf policy file with the specified policy name. The user must provide a valid signing key.
+The 'init' command initializes a new gittuf policy file in the repository. It is used to create a policy file that can then define the principals and rules governing changes to protected namespaces.
 
 ```
 gittuf policy init [flags]
@@ -25,7 +25,7 @@ gittuf policy init [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_list-principals.md
+++ b/docs/cli/gittuf_policy_list-principals.md
@@ -4,7 +4,7 @@ List principals for the current policy in the specified rule file
 
 ### Synopsis
 
-The 'list-principals' command lists all trusted principals defined in a gittuf policy rule file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'list-principals' command lists the trusted principals defined in a gittuf policy file. It is used to review which keys and persons are recognized before referencing them in rules.
 
 ```
 gittuf policy list-principals [flags]
@@ -26,7 +26,7 @@ gittuf policy list-principals [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_list-rules.md
+++ b/docs/cli/gittuf_policy_list-rules.md
@@ -4,7 +4,7 @@ List rules for the current state
 
 ### Synopsis
 
-The 'list-rules' command displays all policy rules defined in the current gittuf policy. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'list-rules' command lists the rules defined in a gittuf policy, shown as a tree in evaluation order. It is used to review which principals are authorized over which namespaces.
 
 ```
 gittuf policy list-rules [flags]
@@ -25,7 +25,7 @@ gittuf policy list-rules [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote.md
+++ b/docs/cli/gittuf_policy_remote.md
@@ -4,7 +4,7 @@ Tools for managing remote policies
 
 ### Synopsis
 
-The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.
+The 'remote' subcommand provides tools for pulling and pushing gittuf policy to and from remote repositories.
 
 ### Options
 
@@ -20,7 +20,7 @@ The 'remote' subcommand provides tools for managing gittuf interactions with rem
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote_pull.md
+++ b/docs/cli/gittuf_policy_remote_pull.md
@@ -4,7 +4,7 @@ Pull policy from the specified remote
 
 ### Synopsis
 
-The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.
+The 'pull' command fetches updates to the gittuf policy from the specified remote into the local repository.
 
 ```
 gittuf policy remote pull <remote> [flags]
@@ -24,7 +24,7 @@ gittuf policy remote pull <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote_push.md
+++ b/docs/cli/gittuf_policy_remote_push.md
@@ -24,7 +24,7 @@ gittuf policy remote push <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-key.md
+++ b/docs/cli/gittuf_policy_remove-key.md
@@ -4,7 +4,7 @@ Remove a key from a policy file
 
 ### Synopsis
 
-The 'remove-key' command removes the specified public key from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'remove-key' command removes a public key from a gittuf policy file. The key must first be removed from all rules that reference it before this command will succeed.
 
 ```
 gittuf policy remove-key [flags]
@@ -26,7 +26,7 @@ gittuf policy remove-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-person.md
+++ b/docs/cli/gittuf_policy_remove-person.md
@@ -4,7 +4,7 @@ Remove a person from a policy file
 
 ### Synopsis
 
-The 'remove-person' command removes the specified person from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'remove-person' command removes a trusted person from a gittuf policy file. The person must first be removed from all rules that reference them before this command will succeed.
 
 ```
 gittuf policy remove-person [flags]
@@ -26,7 +26,7 @@ gittuf policy remove-person [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-rule.md
+++ b/docs/cli/gittuf_policy_remove-rule.md
@@ -4,7 +4,7 @@ Remove rule from a policy file
 
 ### Synopsis
 
-The 'remove-rule' command deletes the specified rule from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'remove-rule' command removes a rule from a gittuf policy file. It is used to stop protecting a namespace or to remove an authorization that is no longer needed.
 
 ```
 gittuf policy remove-rule [flags]
@@ -26,7 +26,7 @@ gittuf policy remove-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_reorder-rules.md
+++ b/docs/cli/gittuf_policy_reorder-rules.md
@@ -4,7 +4,7 @@ Reorder rules in the specified policy file
 
 ### Synopsis
 
-The 'reorder-rules' command reorders rules in the specified policy file based on the order of rule names provided as arguments. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'reorder-rules' command reorders the rules in a gittuf policy file to match the sequence of rule names given as arguments. It is used to change the order in which rules are evaluated, since earlier rules take precedence.
 
 ```
 gittuf policy reorder-rules [flags]
@@ -25,7 +25,7 @@ gittuf policy reorder-rules [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_sign.md
+++ b/docs/cli/gittuf_policy_sign.md
@@ -4,7 +4,7 @@ Sign policy file
 
 ### Synopsis
 
-Sign the specified policy file with the provided signing key. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'sign' command adds a signature to a gittuf policy file using the supplied signing key. It is used to meet a policy file's signature threshold when multiple keys are required to approve it.
 
 ```
 gittuf policy sign [flags]
@@ -25,7 +25,7 @@ gittuf policy sign [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_stage.md
+++ b/docs/cli/gittuf_policy_stage.md
@@ -25,7 +25,7 @@ gittuf policy stage [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_update-person.md
+++ b/docs/cli/gittuf_policy_update-person.md
@@ -4,7 +4,7 @@ Update a person in a policy file
 
 ### Synopsis
 
-This command allows users to update a person's information in the specified policy file. By default, the main policy file is selected. The command replaces the person's existing information with the new values provided. If a field is not specified, its existing value is not preserved.
+The 'update-person' command updates a trusted person's definition in a gittuf policy file. It is used to change a person's keys, associated identities, or custom metadata. The update replaces the person entirely, so any field not provided is cleared rather than preserved.
 
 ```
 gittuf policy update-person [flags]
@@ -18,7 +18,7 @@ gittuf policy update-person [flags]
   -h, --help                              help for update-person
       --person-ID string                  person ID to update
       --policy-name string                name of policy file to update person in (default "targets")
-      --public-key stringArray            public keys for person
+      --public-key stringArray            public keys for the person (each a path to an SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -29,7 +29,7 @@ gittuf policy update-person [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_update-rule.md
+++ b/docs/cli/gittuf_policy_update-rule.md
@@ -4,7 +4,7 @@ Update an existing rule in a policy file
 
 ### Synopsis
 
-Update an existing rule in the specified policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.
+The 'update-rule' command updates an existing rule in a gittuf policy file. It is used to change the principals, patterns, or signature threshold that the rule enforces.
 
 ```
 gittuf policy update-rule [flags]
@@ -15,7 +15,7 @@ gittuf policy update-rule [flags]
 ```
       --authorize stringArray      authorize the principal IDs for the rule
   -h, --help                       help for update-rule
-      --policy-name string         name of policy file to add rule to (default "targets")
+      --policy-name string         name of policy file to update rule in (default "targets")
       --rule-name string           name of rule
       --rule-pattern stringArray   patterns used to identify namespaces rule applies to
       --threshold int              threshold of required valid signatures (default 1)
@@ -29,7 +29,7 @@ gittuf policy update-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_annotate.md
+++ b/docs/cli/gittuf_rsl_annotate.md
@@ -14,9 +14,9 @@ gittuf rsl annotate [flags]
 
 ```
   -h, --help                 help for annotate
-      --local-only           local only
+      --local-only           perform this operation locally without pushing to a remote repository
   -m, --message string       annotation message
-      --remote-name string   remote name
+      --remote-name string   name of the remote to push the annotation to
   -s, --skip                 mark annotated entries as to be skipped
 ```
 

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -4,7 +4,7 @@ Record latest state of a Git reference (e.g., 'main') in the RSL
 
 ### Synopsis
 
-The 'record' command records the latest state of a Git reference in the repository's RSL. The argument must be a valid Git reference (such as 'main', 'HEAD', or a tag name). For example: 'gittuf rsl record --local-only main'. This command is used to capture and track changes to references over time for auditing and consistency.
+The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time so they can be audited and verified. The argument must be a valid Git reference, such as 'main', 'HEAD', or a tag name.
 
 ```
 gittuf rsl record [flags]
@@ -15,8 +15,8 @@ gittuf rsl record [flags]
 ```
       --dst-ref string         name of destination reference, if it differs from source reference
   -h, --help                   help for record
-      --local-only             local only
-      --remote-name string     remote name
+      --local-only             perform this operation locally without pushing to a remote repository
+      --remote-name string     name of the remote to push the RSL entry to
       --skip-duplicate-check   skip check to see if latest entry for reference has same target
 ```
 

--- a/docs/cli/gittuf_rsl_remote_reconcile.md
+++ b/docs/cli/gittuf_rsl_remote_reconcile.md
@@ -4,7 +4,7 @@ Reconcile local RSL with remote RSL
 
 ### Synopsis
 
-This command checks the local RSL against the specified remote and reconciles the local RSL if needed. If the local RSL doesn't exist or is strictly behind the remote RSL, then the local RSL is updated to match the remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated. Finally, if the local and remote RSLs have diverged, then the local only RSL entries are reapplied over the latest entries in the remote if the local only RSL entries and remote only entries are for different Git references.
+The 'reconcile' command checks the local RSL against the specified remote and reconciles the local RSL if needed. It is used to bring the local RSL back in line with the remote after the two diverge. If the local RSL does not exist or is strictly behind the remote, it is updated to match the remote; if it is ahead, nothing is updated; and if the two have diverged, the local-only entries are reapplied over the latest remote entries when the local-only and remote-only entries are for different Git references.
 
 ```
 gittuf rsl remote reconcile <remote> [flags]

--- a/docs/cli/gittuf_rsl_skip-rewritten.md
+++ b/docs/cli/gittuf_rsl_skip-rewritten.md
@@ -4,7 +4,7 @@ Creates an RSL annotation to skip RSL reference entries that point to commits th
 
 ### Synopsis
 
-The 'skip-rewritten' command adds an RSL annotation to skip reference entries that point to commits no longer present in the given Git reference, useful when the history of a branch has been rewritten and some RSL entries refer to commits that no longer exist on the branch.
+The 'skip-rewritten' command adds an RSL annotation to skip reference entries that point to commits no longer present in the given Git reference. It is used after a branch's history has been rewritten, when some RSL entries refer to commits that no longer exist on the branch.
 
 ```
 gittuf rsl skip-rewritten [flags]

--- a/docs/cli/gittuf_sync.md
+++ b/docs/cli/gittuf_sync.md
@@ -4,7 +4,7 @@ Synchronize local references with remote references based on RSL
 
 ### Synopsis
 
-The 'sync' command synchronizes local references with the remote references based on the RSL (Reference State Log). By default, it uses the 'origin' remote unless a different remote name is provided. If references have diverged, it prints the list of affected refs and suggests rerunning the command with --overwrite to apply remote changes. Use with caution: --overwrite may discard local changes.
+The 'sync' command synchronizes the local repository with the remote by fetching and applying the latest gittuf metadata. It is used to ensure the local state is up to date with what has been pushed to the remote.
 
 ```
 gittuf sync [remoteName] [flags]

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -11,7 +11,7 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
 ```
       --create-rsl-entry     create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
   -h, --help                 help for trust
-  -k, --signing-key string   signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string   signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
 ```
 
 ### Options inherited from parent commands

--- a/docs/cli/gittuf_trust_add-controller-repository.md
+++ b/docs/cli/gittuf_trust_add-controller-repository.md
@@ -4,7 +4,7 @@ Add a controller repository
 
 ### Synopsis
 
-The 'add-controller-repository' command registers a controller repository in the repository's root of trust. It is used to add and configure a controller repository, including its name, location, and initial root principals.
+The 'add-controller-repository' command adds a controller repository to the repository's root of trust. It is used to designate a repository whose global rules this repository inherits.
 
 ```
 gittuf trust add-controller-repository [flags]
@@ -14,7 +14,7 @@ gittuf trust add-controller-repository [flags]
 
 ```
   -h, --help                                 help for add-controller-repository
-      --initial-root-principal stringArray   initial root principals of controller repository
+      --initial-root-principal stringArray   initial root principals of the controller repository (each a path to an SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
       --location string                      location of controller repository
       --name string                          name of controller repository
 ```
@@ -27,7 +27,7 @@ gittuf trust add-controller-repository [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-github-app.md
+++ b/docs/cli/gittuf_trust_add-github-app.md
@@ -4,7 +4,7 @@ Add GitHub app to gittuf root of trust
 
 ### Synopsis
 
-This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+The 'add-github-app' command adds a trusted key for the special GitHub app role to the repository's root of trust. It is used to verify signatures on GitHub pull request approval attestations.
 
 ```
 gittuf trust add-github-app [flags]
@@ -26,7 +26,7 @@ gittuf trust add-github-app [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-global-rule.md
+++ b/docs/cli/gittuf_trust_add-global-rule.md
@@ -4,7 +4,7 @@ Add a new global rule to root of trust
 
 ### Synopsis
 
-This command allows a user to add a new global rule to the root of trust. The user must specify the name, type, and rule pattern for the rule.
+The 'add-global-rule' command adds a new global rule to the repository's root of trust. It is used to enforce repository-wide constraints, such as requiring a signature threshold or blocking force pushes on matching namespaces.
 
 ```
 gittuf trust add-global-rule [flags]
@@ -28,7 +28,7 @@ gittuf trust add-global-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-hook.md
+++ b/docs/cli/gittuf_trust_add-hook.md
@@ -4,7 +4,7 @@ Add a script to be run as a gittuf hook, specify when and where to run it (devel
 
 ### Synopsis
 
-Add a script to be run as a gittuf hook, specify when and which environment to run it in. The only currently supported environment is 'lua' (developer mode only, set GITTUF_DEV=1)
+The 'add-hook' command adds a script to be run as a gittuf hook, recording which stage and environment it runs in. It is used to enforce automated checks during Git operations such as commit and push. The only currently supported environment is 'lua' (developer mode only, set GITTUF_DEV=1)
 
 ```
 gittuf trust add-hook [flags]
@@ -16,7 +16,7 @@ gittuf trust add-hook [flags]
   -e, --env string                 environment which the hook must run in (default "lua")
   -f, --file-path string           path of the script to be run as a hook
   -h, --help                       help for add-hook
-  -n, --hook-name string           Name of the hook
+  -n, --hook-name string           name of the hook
       --is-pre-commit              add the hook to the pre-commit stage
       --is-pre-push                add the hook to the pre-push stage
       --principal-ID stringArray   principal IDs which must run this hook
@@ -31,7 +31,7 @@ gittuf trust add-hook [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-network-repository.md
+++ b/docs/cli/gittuf_trust_add-network-repository.md
@@ -4,7 +4,7 @@ Add a network repository
 
 ### Synopsis
 
-The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to add and configure a network repository, including its name, location, and initial root principals.
+The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to declare another repository that participates in this repository's network so its state can be tracked and verified.
 
 ```
 gittuf trust add-network-repository [flags]
@@ -14,7 +14,7 @@ gittuf trust add-network-repository [flags]
 
 ```
   -h, --help                                 help for add-network-repository
-      --initial-root-principal stringArray   initial root principals of network repository
+      --initial-root-principal stringArray   initial root principals of the network repository (each a path to an SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
       --location string                      location of network repository
       --name string                          name of network repository
 ```
@@ -27,7 +27,7 @@ gittuf trust add-network-repository [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-policy-key.md
+++ b/docs/cli/gittuf_trust_add-policy-key.md
@@ -4,7 +4,7 @@ Add Policy key to gittuf root of trust
 
 ### Synopsis
 
-This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".
+The 'add-policy-key' command adds a new trusted key for the primary policy file to the repository's root of trust. It is used to authorize additional keys to sign the main policy metadata.
 
 ```
 gittuf trust add-policy-key [flags]
@@ -14,7 +14,7 @@ gittuf trust add-policy-key [flags]
 
 ```
   -h, --help                help for add-policy-key
-      --policy-key string   policy key to add to root of trust
+      --policy-key string   policy key to add (path to SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +25,7 @@ gittuf trust add-policy-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-propagation-directive.md
+++ b/docs/cli/gittuf_trust_add-propagation-directive.md
@@ -4,7 +4,7 @@ Add propagation directive into gittuf root of trust
 
 ### Synopsis
 
-The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are propagated into a downstream repository by specifying source and destination references and paths.
+The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are automatically propagated into a downstream repository.
 
 ```
 gittuf trust add-propagation-directive [flags]
@@ -30,7 +30,7 @@ gittuf trust add-propagation-directive [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-root-key.md
+++ b/docs/cli/gittuf_trust_add-root-key.md
@@ -4,7 +4,7 @@ Add Root key to gittuf root of trust
 
 ### Synopsis
 
-The 'add-root-key' command allows users to add a new root key to the repository's root of trust. This command facilitates the addition of an extra root key to the existing trusted root keys, enabling multiple root keys or key rotation. It requires a public key file or Sigstore identity via --root-key and a signing key via --signing-key. Optionally, the change can be recorded in the RSL.
+The 'add-root-key' command adds a new root key to the repository's root of trust. It is used to add additional trusted root keys or to facilitate key rotation.
 
 ```
 gittuf trust add-root-key [flags]
@@ -14,7 +14,7 @@ gittuf trust add-root-key [flags]
 
 ```
   -h, --help              help for add-root-key
-      --root-key string   root key to add to root of trust
+      --root-key string   root key to add (path to SSH public key, "gpg:<fingerprint>" for GPG, or "fulcio:<identity>::<issuer>" for Sigstore)
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +25,7 @@ gittuf trust add-root-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_apply.md
+++ b/docs/cli/gittuf_trust_apply.md
@@ -25,7 +25,7 @@ gittuf trust apply [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_disable-github-app-approvals.md
+++ b/docs/cli/gittuf_trust_disable-github-app-approvals.md
@@ -4,7 +4,7 @@ Mark GitHub app approvals as untrusted henceforth
 
 ### Synopsis
 
-The 'disable-github-app-approvals' command revokes a GitHub App's ability to approve changes by marking it untrusted in the trust policy.
+The 'disable-github-app-approvals' command marks a GitHub app's approvals as untrusted in the repository's root of trust. It is used to stop honoring new pull request approval attestations from the app. Previously issued attestations remain valid.
 
 ```
 gittuf trust disable-github-app-approvals [flags]
@@ -13,7 +13,7 @@ gittuf trust disable-github-app-approvals [flags]
 ### Options
 
 ```
-      --app-name string   name of app to add to root of trust (default "https://gittuf.dev/github-app")
+      --app-name string   name of the app whose approvals to mark untrusted (default "https://gittuf.dev/github-app")
   -h, --help              help for disable-github-app-approvals
 ```
 
@@ -25,7 +25,7 @@ gittuf trust disable-github-app-approvals [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_enable-github-app-approvals.md
+++ b/docs/cli/gittuf_trust_enable-github-app-approvals.md
@@ -4,7 +4,7 @@ Mark GitHub app approvals as trusted henceforth
 
 ### Synopsis
 
-The 'enable-github-app-approvals' command marks a GitHub App as trusted, allowing it to approve protected operations under the repository's trust policy.
+The 'enable-github-app-approvals' command marks a GitHub app's approvals as trusted in the repository's root of trust. It is used to honor new pull request approval attestations issued by the app.
 
 ```
 gittuf trust enable-github-app-approvals [flags]
@@ -13,7 +13,7 @@ gittuf trust enable-github-app-approvals [flags]
 ### Options
 
 ```
-      --app-name string   name of app to add to root of trust (default "https://gittuf.dev/github-app")
+      --app-name string   name of the app whose approvals to mark trusted (default "https://gittuf.dev/github-app")
   -h, --help              help for enable-github-app-approvals
 ```
 
@@ -25,7 +25,7 @@ gittuf trust enable-github-app-approvals [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_increment-version.md
+++ b/docs/cli/gittuf_trust_increment-version.md
@@ -4,7 +4,7 @@ Increment the integer version of the root metadata
 
 ### Synopsis
 
-The 'increment-version' command increments the integer version of the root metadata without making any other changes.
+The 'increment-version' command increments the integer version of the root of trust metadata without making any other changes. This is normally only needed when upgrading gittuf metadata created with versions older than v0.14.0.
 
 ```
 gittuf trust increment-version [flags]
@@ -24,7 +24,7 @@ gittuf trust increment-version [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_init.md
+++ b/docs/cli/gittuf_trust_init.md
@@ -14,7 +14,7 @@ gittuf trust init [flags]
 
 ```
   -h, --help              help for init
-      --location string   location of repository
+      --location string   canonical location of the repository to record in the root of trust
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +25,7 @@ gittuf trust init [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-global-rules.md
+++ b/docs/cli/gittuf_trust_list-global-rules.md
@@ -4,7 +4,7 @@ List global rules for the current state
 
 ### Synopsis
 
-This command allows users to list the currently defined global rules for the root of trust. The output is sorted by global rule type.
+The 'list-global-rules' command lists the global rules currently defined in the repository's root of trust. It is used to review the repository-wide constraints in effect, with output grouped by rule type.
 
 ```
 gittuf trust list-global-rules [flags]
@@ -25,7 +25,7 @@ gittuf trust list-global-rules [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-hooks.md
+++ b/docs/cli/gittuf_trust_list-hooks.md
@@ -25,7 +25,7 @@ gittuf trust list-hooks [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-propagation-directives.md
+++ b/docs/cli/gittuf_trust_list-propagation-directives.md
@@ -25,7 +25,7 @@ gittuf trust list-propagation-directives [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_make-controller.md
+++ b/docs/cli/gittuf_trust_make-controller.md
@@ -24,7 +24,7 @@ gittuf trust make-controller [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote.md
+++ b/docs/cli/gittuf_trust_remote.md
@@ -4,7 +4,7 @@ Tools for managing remote policies
 
 ### Synopsis
 
-The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.
+The 'remote' subcommand provides tools for pulling and pushing gittuf policy to and from remote repositories.
 
 ### Options
 
@@ -20,7 +20,7 @@ The 'remote' subcommand provides tools for managing gittuf interactions with rem
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote_pull.md
+++ b/docs/cli/gittuf_trust_remote_pull.md
@@ -4,7 +4,7 @@ Pull policy from the specified remote
 
 ### Synopsis
 
-The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.
+The 'pull' command fetches updates to the gittuf policy from the specified remote into the local repository.
 
 ```
 gittuf trust remote pull <remote> [flags]
@@ -24,7 +24,7 @@ gittuf trust remote pull <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote_push.md
+++ b/docs/cli/gittuf_trust_remote_push.md
@@ -24,7 +24,7 @@ gittuf trust remote push <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-github-app.md
+++ b/docs/cli/gittuf_trust_remove-github-app.md
@@ -13,7 +13,7 @@ gittuf trust remove-github-app [flags]
 ### Options
 
 ```
-      --app-name string   name of app to add to root of trust (default "https://gittuf.dev/github-app")
+      --app-name string   name of the app to remove from the root of trust (default "https://gittuf.dev/github-app")
   -h, --help              help for remove-github-app
 ```
 
@@ -25,7 +25,7 @@ gittuf trust remove-github-app [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-global-rule.md
+++ b/docs/cli/gittuf_trust_remove-global-rule.md
@@ -4,7 +4,7 @@ Remove a global rule from root of trust
 
 ### Synopsis
 
-This command allows users to remove an existing global rule from the root of trust. The name of the global rule must be specified.
+The 'remove-global-rule' command removes an existing global rule from the repository's root of trust. It is used to lift a repository-wide constraint that is no longer needed.
 
 ```
 gittuf trust remove-global-rule [flags]
@@ -25,7 +25,7 @@ gittuf trust remove-global-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-hook.md
+++ b/docs/cli/gittuf_trust_remove-hook.md
@@ -27,7 +27,7 @@ gittuf trust remove-hook [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-policy-key.md
+++ b/docs/cli/gittuf_trust_remove-policy-key.md
@@ -4,7 +4,7 @@ Remove Policy key from gittuf root of trust
 
 ### Synopsis
 
-This command allows users to remove a policy key from the gittuf root of trust. The policy key ID must be specified.
+The 'remove-policy-key' command removes a trusted key for the primary policy file from the repository's root of trust. It is used to revoke a key's authorization to sign policy metadata.
 
 ```
 gittuf trust remove-policy-key [flags]
@@ -14,7 +14,7 @@ gittuf trust remove-policy-key [flags]
 
 ```
   -h, --help                   help for remove-policy-key
-      --policy-key-ID string   ID of Policy key to be removed from root of trust
+      --policy-key-ID string   ID of the policy key to remove from the root of trust
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +25,7 @@ gittuf trust remove-policy-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-propagation-directive.md
+++ b/docs/cli/gittuf_trust_remove-propagation-directive.md
@@ -25,7 +25,7 @@ gittuf trust remove-propagation-directive [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-root-key.md
+++ b/docs/cli/gittuf_trust_remove-root-key.md
@@ -25,7 +25,7 @@ gittuf trust remove-root-key [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_set-repository-location.md
+++ b/docs/cli/gittuf_trust_set-repository-location.md
@@ -4,7 +4,7 @@ Set repository location
 
 ### Synopsis
 
-The 'set-repository-location' command updates the canonical location of a repository in the repository's root of trust. It is used to encode the canonical location of the repository inside gittuf metadata.
+The 'set-repository-location' command records the canonical location of the repository in its root of trust. It is used to tell other repositories in a gittuf network where to fetch this repository from.
 
 ```
 gittuf trust set-repository-location [flags]
@@ -14,7 +14,7 @@ gittuf trust set-repository-location [flags]
 
 ```
   -h, --help              help for set-repository-location
-      --location string   location of repository
+      --location string   canonical location of the repository to record in the root of trust
 ```
 
 ### Options inherited from parent commands
@@ -25,7 +25,7 @@ gittuf trust set-repository-location [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_sign.md
+++ b/docs/cli/gittuf_trust_sign.md
@@ -4,7 +4,7 @@ Sign root of trust
 
 ### Synopsis
 
-This command allows users to add their signature to the root of trust file.
+The 'sign' command adds a signature to the repository's root of trust using the supplied signing key. It is used to meet the root of trust's signature threshold when multiple root keys are required.
 
 ```
 gittuf trust sign [flags]
@@ -24,7 +24,7 @@ gittuf trust sign [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_stage.md
+++ b/docs/cli/gittuf_trust_stage.md
@@ -25,7 +25,7 @@ gittuf trust stage [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-global-rule.md
+++ b/docs/cli/gittuf_trust_update-global-rule.md
@@ -4,7 +4,7 @@ Update an existing global rule in the root of trust
 
 ### Synopsis
 
-This command allows users to update an existing global rule in the root of trust. The name of the global rule must be specified. Note that a global rule may only be updated with the same type of global rule, and changes to the type require removing and adding it again.
+The 'update-global-rule' command updates an existing global rule in the repository's root of trust. It is used to adjust a repository-wide constraint, such as its patterns or signature threshold. A global rule can only be updated with the same rule type; changing the type requires removing and adding the rule again.
 
 ```
 gittuf trust update-global-rule [flags]
@@ -28,7 +28,7 @@ gittuf trust update-global-rule [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-hook.md
+++ b/docs/cli/gittuf_trust_update-hook.md
@@ -4,7 +4,7 @@ Modify the parameters of an existing gittuf hook (developer mode only, set GITTU
 
 ### Synopsis
 
-Modify the parameters of an existing gittuf hook. Specify the name of the hook to update and provide all parameters with their updated values. You can specify multiple stages where the hook is defined. Note that all parameters required to add the hook must also be provided. If a hook exists in multiple stages, only the specified stage(s) will be updated. If a hook does not exist in the specified stage, it won't be updated; you should add a new hook to that stage instead. Currently, only the 'lua' environment is supported (developer mode only, set GITTUF_DEV=1)
+The 'update-hook' command modifies the parameters of an existing gittuf hook in the repository's root of trust. It is used to change a hook's script, environment, principals, or timeout. All parameters must be provided as when adding the hook, and only the stages given are updated; a stage where the hook does not already exist is left unchanged. The only currently supported environment is 'lua' (developer mode only, set GITTUF_DEV=1)
 
 ```
 gittuf trust update-hook [flags]
@@ -16,9 +16,9 @@ gittuf trust update-hook [flags]
   -e, --env string                 environment which the hook must run in (default "lua")
   -f, --file-path string           path of the script to be run as a hook
   -h, --help                       help for update-hook
-  -n, --hook-name string           Name of the hook
-      --is-pre-commit              update the hook to the pre-commit stage
-      --is-pre-push                update the hook to the pre-push stage
+  -n, --hook-name string           name of the hook
+      --is-pre-commit              update the hook in the pre-commit stage
+      --is-pre-push                update the hook in the pre-push stage
       --principal-ID stringArray   principal IDs which must run this hook
       --timeout int                timeout for hook execution (default 100)
 ```
@@ -31,7 +31,7 @@ gittuf trust update-hook [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-policy-threshold.md
+++ b/docs/cli/gittuf_trust_update-policy-threshold.md
@@ -4,7 +4,7 @@ Update Policy threshold in the gittuf root of trust
 
 ### Synopsis
 
-This command allows users to update the threshold of valid signatures required for the policy.
+The 'update-policy-threshold' command updates the number of signatures required to sign the primary policy file.
 
 ```
 gittuf trust update-policy-threshold [flags]
@@ -25,7 +25,7 @@ gittuf trust update-policy-threshold [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-propagation-directive.md
+++ b/docs/cli/gittuf_trust_update-propagation-directive.md
@@ -4,7 +4,7 @@ Update propagation directive in the root of trust (developer mode only, set GITT
 
 ### Synopsis
 
-The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to update how content is propagated between repositories by changing the source, destination, or associated parameters of a directive.
+The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to change how content is propagated between repositories. It requires developer mode to be enabled by setting the environment variable GITTUF_DEV=1.
 
 ```
 gittuf trust update-propagation-directive [flags]
@@ -30,7 +30,7 @@ gittuf trust update-propagation-directive [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-root-threshold.md
+++ b/docs/cli/gittuf_trust_update-root-threshold.md
@@ -4,7 +4,7 @@ Update Root threshold in the gittuf root of trust
 
 ### Synopsis
 
-This command allows users to update the threshold of valid signatures required for the root of trust.
+The 'update-root-threshold' command updates the number of signatures required to sign the repository's root of trust.
 
 ```
 gittuf trust update-root-threshold [flags]
@@ -25,7 +25,7 @@ gittuf trust update-root-threshold [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
-  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_tui.md
+++ b/docs/cli/gittuf_tui.md
@@ -4,7 +4,7 @@ Start the TUI for gittuf
 
 ### Synopsis
 
-This command starts a terminal-based interface to view and/or manage gittuf metadata. If a signing key is provided, mutating operations are enabled and signed. Without a signing key, the TUI runs in read-only mode. Changes to the policy files in the TUI are staged immediately without further confirmation and users are required to run `gittuf policy apply` to commit the changes.
+The 'tui' command starts a terminal-based interface to view and manage gittuf policy metadata. It is used to inspect or modify policy files interactively. A signing key must be provided to enable write operations; without one the TUI runs in read-only mode. Changes made in the TUI are staged immediately and require running 'gittuf policy apply' to take effect.
 
 ```
 gittuf tui [flags]
@@ -17,7 +17,7 @@ gittuf tui [flags]
   -h, --help                 help for tui
       --policy-name string   name of policy file to make changes to (default "targets")
       --read-only            interact with the TUI in read-only mode
-  -k, --signing-key string   signing key to use to sign root of trust (path to SSH key, "fulcio:" for Sigstore)
+  -k, --signing-key string   signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
       --target-ref string    specify which policy ref should be inspected (default "policy")
 ```
 

--- a/docs/cli/gittuf_verify-mergeable.md
+++ b/docs/cli/gittuf_verify-mergeable.md
@@ -4,7 +4,7 @@ Tools for verifying mergeability using gittuf policies
 
 ### Synopsis
 
-The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check policy compliance for a proposed merge by comparing the specified base and feature branches, optionally bypassing the RSL when determining the current state.
+The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check, before performing a merge, that the proposed merge would satisfy policy such as required approval thresholds.
 
 ```
 gittuf verify-mergeable [flags]

--- a/internal/cmd/addhooks/addhooks.go
+++ b/internal/cmd/addhooks/addhooks.go
@@ -49,7 +49,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-hooks",
 		Short:             "Add git hooks that automatically create and sync RSL",
-		Long:              `The 'add-hooks' command installs Git hooks that automatically create and sync the RSL when certain Git actions occur, such as a push. By default, it prevents overwriting existing hooks unless the '--force' flag is specified.`,
+		Long:              "The 'add-hooks' command installs Git hooks that automatically create and sync the RSL when certain Git actions occur, such as a push. It is used to keep the RSL up to date without running gittuf commands manually.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/attest/persistent/persistent.go
+++ b/internal/cmd/attest/persistent/persistent.go
@@ -3,7 +3,12 @@
 
 package persistent
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/spf13/cobra"
+)
 
 type Options struct {
 	SigningKey   string
@@ -16,7 +21,7 @@ func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
 		"signing-key",
 		"k",
 		"",
-		"signing key to use to sign attestation",
+		fmt.Sprintf("signing key to use to sign attestations (path to SSH key, \"%s<fingerprint>\" for GPG, \"%s\" for Sigstore)", gittuf.GPGKeyPrefix, gittuf.FulcioPrefix),
 	)
 
 	cmd.PersistentFlags().BoolVar(

--- a/internal/cmd/cache/cache.go
+++ b/internal/cmd/cache/cache.go
@@ -13,7 +13,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "cache",
 		Short:             "Manage gittuf's caching functionality",
-		Long:              `The 'cache' command group contains subcommands to manage gittuf's local persistent cache. This cache helps improve performance by storing metadata locally. The cache is local-only and is not synchronized with remote repositories.`,
+		Long:              "The 'cache' command group contains subcommands to manage gittuf's local persistent cache. The cache is local-only and is not synchronized with remote repositories.",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/cache/delete/delete.go
+++ b/internal/cmd/cache/delete/delete.go
@@ -24,10 +24,11 @@ func New() *cobra.Command {
 	o := &options{}
 
 	cmd := &cobra.Command{
-		Use:   "delete",
-		Short: "Delete the local persistent cache",
-		Long:  `The 'delete' command deletes the local persistent cache used by gittuf.`,
-		RunE:  o.Run,
+		Use:               "delete",
+		Short:             "Delete the local persistent cache",
+		Long:              "The 'delete' command deletes the local persistent cache used by gittuf. It is used to reclaim space or clear a stale cache. The cache must be reinitialized manually with 'gittuf cache init' before it can be used again.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/cache/init/init.go
+++ b/internal/cmd/cache/init/init.go
@@ -24,10 +24,11 @@ func (o *options) Run(_ *cobra.Command, _ []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Initialize persistent cache",
-		Long:  `The 'init' command initializes the local persistent cache for a gittuf repository, intended to improve performance of gittuf operations. This cache is local-only and is not synchronized with the remote.`,
-		RunE:  o.Run,
+		Use:               "init",
+		Short:             "Initialize persistent cache",
+		Long:              `The 'init' command initializes the local persistent cache for a gittuf repository, intended to improve performance of gittuf operations. This cache is local-only and is not synchronized with the remote.`,
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/clone/clone.go
+++ b/internal/cmd/clone/clone.go
@@ -28,7 +28,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(
 		&o.expectedRootKeys,
 		"root-key",
-		"set of initial root of trust keys for the repository (supported values: paths to SSH keys, GPG key fingerprints, Sigstore/Fulcio identities)",
+		"set of initial root of trust keys for the repository (each a path to an SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 
 	cmd.Flags().BoolVar(
@@ -65,7 +65,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "clone",
 		Short:             "Clone repository and its gittuf references",
-		Long:              `The 'clone' command clones a gittuf-enabled Git repository along with its associated gittuf metadata. This command can also ensure the repository's trust root is established correctly by using specified root keys, optionally supplied using the --root-key flag. You may also specify a particular branch to check out with --branch and choose whether to create a bare repository using --bare.`,
+		Long:              "The 'clone' command clones a gittuf-enabled Git repository along with its associated gittuf metadata. It is used to obtain a repository and verify its RSL and policy against the provided root of trust keys.",
 		Args:              cobra.RangeArgs(1, 2),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/policy/addkey/addkey.go
+++ b/internal/cmd/policy/addkey/addkey.go
@@ -30,7 +30,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.authorizedKeys,
 		"public-key",
 		[]string{},
-		"authorized public key",
+		"authorized public key (path to SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 	cmd.MarkFlagRequired("public-key") //nolint:errcheck
 }
@@ -68,7 +68,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-key",
 		Short:             "Add a trusted key to a policy file",
-		Long:              `The 'add-key' command adds one or more trusted public keys to a gittuf policy file. This command is used to define which keys are authorized to sign commits or policy changes according to the repository's trust model. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'add-key' command adds one or more trusted public keys to a gittuf policy file. It is used to make keys available for use in policy rules. A key must be added to at least one rule before it can be used to authorize changes.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addperson/addperson.go
+++ b/internal/cmd/policy/addperson/addperson.go
@@ -30,7 +30,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.policyName,
 		"policy-name",
 		policy.TargetsRoleName,
-		"name of policy file to add key to",
+		"name of policy file to add person to",
 	)
 
 	cmd.Flags().StringVar(
@@ -45,9 +45,9 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.publicKeys,
 		"public-key",
 		[]string{},
-		"authorized public key for person",
+		"authorized public key for the person (path to SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
-	cmd.MarkFlagRequired("authorize-key") //nolint:errcheck
+	cmd.MarkFlagRequired("public-key") //nolint:errcheck
 
 	cmd.Flags().StringArrayVar(
 		&o.associatedIdentities,
@@ -122,7 +122,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-person",
 		Short:             "Add a trusted person to a policy file",
-		Long:              `The 'add-person' command adds a trusted person to a gittuf policy file. In gittuf, a person definition consists of a unique identifier ('--person-ID'), one or more authorized public keys ('--public-key'), optional associated identities ('--associated-identity') on external platforms (e.g., GitHub, GitLab), and optional custom metadata ('--custom') for tracking additional attributes. Note that the keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'add-person' command adds a trusted person to a gittuf policy file. It is used to define a person, along with their authorized keys and platform identities, who can then be named in policy rules.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/addrule/addrule.go
+++ b/internal/cmd/policy/addrule/addrule.go
@@ -103,7 +103,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-rule",
 		Short:             "Add a new rule to a policy file",
-		Long:              `The 'add-rule' command adds a new rule to a gittuf policy file. Each rule contains a name ('--rule-name') for the rule, one or more principals ('--authorize') who are allowed to sign within the scope of the rule, a set of rule patterns ('--rule-pattern') defining the namespaces or paths the rule governs, and a signature threshold ('--threshold'), which is the minimum number of valid signatures required to satisfy the rule. Principals can be specified by their principal IDs. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'add-rule' command adds a new rule to a gittuf policy file. It is used to authorize a set of principals to sign changes to the namespaces the rule protects, subject to a signature threshold.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/incrementversion/incrementversion.go
+++ b/internal/cmd/policy/incrementversion/incrementversion.go
@@ -47,8 +47,8 @@ func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
 		Use:               "increment-version",
-		Short:             "Increment the integer version of the specified rule file metadata",
-		Long:              `The 'increment-version' command increments the integer version of the specified rule file metadata without making any other changes.`,
+		Short:             "Increment the integer version of the specified policy file metadata",
+		Long:              `The 'increment-version' command increments the integer version of the specified policy file metadata without making any other changes. This is normally only needed when upgrading gittuf metadata created with versions older than v0.14.0.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/init/init.go
+++ b/internal/cmd/policy/init/init.go
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "init",
 		Short:             "Initialize policy file",
-		Long:              "This command initializes a new gittuf policy file with the specified policy name. The user must provide a valid signing key.",
+		Long:              "The 'init' command initializes a new gittuf policy file in the repository. It is used to create a policy file that can then define the principals and rules governing changes to protected namespaces.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/listprincipals/listprincipals.go
+++ b/internal/cmd/policy/listprincipals/listprincipals.go
@@ -77,7 +77,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list-principals",
 		Short:             "List principals for the current policy in the specified rule file",
-		Long:              `The 'list-principals' command lists all trusted principals defined in a gittuf policy rule file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'list-principals' command lists the trusted principals defined in a gittuf policy file. It is used to review which keys and persons are recognized before referencing them in rules.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/listrules/listrules.go
+++ b/internal/cmd/policy/listrules/listrules.go
@@ -81,7 +81,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list-rules",
 		Short:             "List rules for the current state",
-		Long:              `The 'list-rules' command displays all policy rules defined in the current gittuf policy. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'list-rules' command lists the rules defined in a gittuf policy, shown as a tree in evaluation order. It is used to review which principals are authorized over which namespaces.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/persistent/persistent.go
+++ b/internal/cmd/policy/persistent/persistent.go
@@ -21,7 +21,7 @@ func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
 		"signing-key",
 		"k",
 		"",
-		fmt.Sprintf("signing key to use to sign root of trust (path to SSH key, \"%s\" for Sigstore)", gittuf.FulcioPrefix),
+		fmt.Sprintf("signing key to use to sign policy metadata (path to SSH key, \"%s<fingerprint>\" for GPG, \"%s\" for Sigstore)", gittuf.GPGKeyPrefix, gittuf.FulcioPrefix),
 	)
 
 	cmd.PersistentFlags().BoolVar(

--- a/internal/cmd/policy/removekey/removekey.go
+++ b/internal/cmd/policy/removekey/removekey.go
@@ -57,7 +57,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-key",
 		Short:             "Remove a key from a policy file",
-		Long:              `The 'remove-key' command removes the specified public key from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'remove-key' command removes a public key from a gittuf policy file. The key must first be removed from all rules that reference it before this command will succeed.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/removeperson/removeperson.go
+++ b/internal/cmd/policy/removeperson/removeperson.go
@@ -57,7 +57,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-person",
 		Short:             "Remove a person from a policy file",
-		Long:              `The 'remove-person' command removes the specified person from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'remove-person' command removes a trusted person from a gittuf policy file. The person must first be removed from all rules that reference them before this command will succeed.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/removerule/removerule.go
+++ b/internal/cmd/policy/removerule/removerule.go
@@ -57,7 +57,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-rule",
 		Short:             "Remove rule from a policy file",
-		Long:              `The 'remove-rule' command deletes the specified rule from the specified gittuf policy file. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'remove-rule' command removes a rule from a gittuf policy file. It is used to stop protecting a namespace or to remove an authorization that is no longer needed.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/reorderrules/reorderrules.go
+++ b/internal/cmd/policy/reorderrules/reorderrules.go
@@ -51,7 +51,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "reorder-rules",
 		Short:             "Reorder rules in the specified policy file",
-		Long:              `The 'reorder-rules' command reorders rules in the specified policy file based on the order of rule names provided as arguments. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'reorder-rules' command reorders the rules in a gittuf policy file to match the sequence of rule names given as arguments. It is used to change the order in which rules are evaluated, since earlier rules take precedence.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/sign/sign.go
+++ b/internal/cmd/policy/sign/sign.go
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "sign",
 		Short:             "Sign policy file",
-		Long:              `Sign the specified policy file with the provided signing key. By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'sign' command adds a signature to a gittuf policy file using the supplied signing key. It is used to meet a policy file's signature threshold when multiple keys are required to approve it.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/updateperson/updateperson.go
+++ b/internal/cmd/policy/updateperson/updateperson.go
@@ -45,7 +45,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.publicKeys,
 		"public-key",
 		[]string{},
-		"public keys for person",
+		"public keys for the person (each a path to an SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 
 	cmd.Flags().StringArrayVar(
@@ -127,7 +127,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-person",
 		Short:             "Update a person in a policy file",
-		Long:              `This command allows users to update a person's information in the specified policy file. By default, the main policy file is selected. The command replaces the person's existing information with the new values provided. If a field is not specified, its existing value is not preserved.`,
+		Long:              "The 'update-person' command updates a trusted person's definition in a gittuf policy file. It is used to change a person's keys, associated identities, or custom metadata. The update replaces the person entirely, so any field not provided is cleared rather than preserved.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/policy/updaterule/updaterule.go
+++ b/internal/cmd/policy/updaterule/updaterule.go
@@ -26,7 +26,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.policyName,
 		"policy-name",
 		policy.TargetsRoleName,
-		"name of policy file to add rule to",
+		"name of policy file to update rule in",
 	)
 
 	cmd.Flags().StringVar(
@@ -103,7 +103,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-rule",
 		Short:             "Update an existing rule in a policy file",
-		Long:              `Update an existing rule in the specified policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>". By default, the main policy file (targets) is used, which can be overridden with the '--policy-name' flag.`,
+		Long:              "The 'update-rule' command updates an existing rule in a gittuf policy file. It is used to change the principals, patterns, or signature threshold that the rule enforces.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/rsl/annotate/annotate.go
+++ b/internal/cmd/rsl/annotate/annotate.go
@@ -38,14 +38,14 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.remoteName,
 		"remote-name",
 		"",
-		"remote name",
+		"name of the remote to push the annotation to",
 	)
 
 	cmd.Flags().BoolVar(
 		&o.localOnly,
 		"local-only",
 		false,
-		"local only",
+		"perform this operation locally without pushing to a remote repository",
 	)
 
 	cmd.MarkFlagsOneRequired("remote-name", "local-only")

--- a/internal/cmd/rsl/record/record.go
+++ b/internal/cmd/rsl/record/record.go
@@ -35,14 +35,14 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.remoteName,
 		"remote-name",
 		"",
-		"remote name",
+		"name of the remote to push the RSL entry to",
 	)
 
 	cmd.Flags().BoolVar(
 		&o.localOnly,
 		"local-only",
 		false,
-		"local only",
+		"perform this operation locally without pushing to a remote repository",
 	)
 
 	cmd.MarkFlagsOneRequired("remote-name", "local-only")
@@ -74,7 +74,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "record",
 		Short:             "Record latest state of a Git reference (e.g., 'main') in the RSL",
-		Long:              `The 'record' command records the latest state of a Git reference in the repository's RSL. The argument must be a valid Git reference (such as 'main', 'HEAD', or a tag name). For example: 'gittuf rsl record --local-only main'. This command is used to capture and track changes to references over time for auditing and consistency.`,
+		Long:              "The 'record' command records the latest state of a Git reference in the repository's RSL. It is used to capture and track changes to references over time so they can be audited and verified. The argument must be a valid Git reference, such as 'main', 'HEAD', or a tag name.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/remote/reconcile/reconcile.go
+++ b/internal/cmd/rsl/remote/reconcile/reconcile.go
@@ -24,7 +24,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "reconcile <remote>",
 		Short:             "Reconcile local RSL with remote RSL",
-		Long:              `This command checks the local RSL against the specified remote and reconciles the local RSL if needed. If the local RSL doesn't exist or is strictly behind the remote RSL, then the local RSL is updated to match the remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated. Finally, if the local and remote RSLs have diverged, then the local only RSL entries are reapplied over the latest entries in the remote if the local only RSL entries and remote only entries are for different Git references.`,
+		Long:              "The 'reconcile' command checks the local RSL against the specified remote and reconciles the local RSL if needed. It is used to bring the local RSL back in line with the remote after the two diverge. If the local RSL does not exist or is strictly behind the remote, it is updated to match the remote; if it is ahead, nothing is updated; and if the two have diverged, the local-only entries are reapplied over the latest remote entries when the local-only and remote-only entries are for different Git references.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/rsl/skiprewritten/skiprewritten.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten.go
@@ -26,7 +26,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "skip-rewritten",
 		Short:             "Creates an RSL annotation to skip RSL reference entries that point to commits that do not exist in the specified ref",
-		Long:              `The 'skip-rewritten' command adds an RSL annotation to skip reference entries that point to commits no longer present in the given Git reference, useful when the history of a branch has been rewritten and some RSL entries refer to commits that no longer exist on the branch.`,
+		Long:              "The 'skip-rewritten' command adds an RSL annotation to skip reference entries that point to commits no longer present in the given Git reference. It is used after a branch's history has been rewritten, when some RSL entries refer to commits that no longer exist on the branch.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/sync/sync.go
+++ b/internal/cmd/sync/sync.go
@@ -55,11 +55,12 @@ func (o *options) Run(cmd *cobra.Command, args []string) error {
 func New() *cobra.Command {
 	o := &options{}
 	cmd := &cobra.Command{
-		Use:   "sync [remoteName]",
-		Short: "Synchronize local references with remote references based on RSL",
-		Long:  `The 'sync' command synchronizes local references with the remote references based on the RSL (Reference State Log). By default, it uses the 'origin' remote unless a different remote name is provided. If references have diverged, it prints the list of affected refs and suggests rerunning the command with --overwrite to apply remote changes. Use with caution: --overwrite may discard local changes.`,
-		Args:  cobra.MaximumNArgs(1),
-		RunE:  o.Run,
+		Use:               "sync [remoteName]",
+		Short:             "Synchronize local references with remote references based on RSL",
+		Long:              "The 'sync' command synchronizes the local repository with the remote by fetching and applying the latest gittuf metadata. It is used to ensure the local state is up to date with what has been pushed to the remote.",
+		Args:              cobra.MaximumNArgs(1),
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository.go
@@ -39,7 +39,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.initialRootPrincipals,
 		"initial-root-principal",
 		[]string{},
-		"initial root principals of controller repository",
+		"initial root principals of the controller repository (each a path to an SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 	cmd.MarkFlagRequired("initial-root-principal") //nolint:errcheck
 }
@@ -77,7 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-controller-repository",
 		Short:             `Add a controller repository`,
-		Long:              "The 'add-controller-repository' command registers a controller repository in the repository's root of trust. It is used to add and configure a controller repository, including its name, location, and initial root principals.",
+		Long:              "The 'add-controller-repository' command adds a controller repository to the repository's root of trust. It is used to designate a repository whose global rules this repository inherits.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addgithubapp/addgithubapp.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp.go
@@ -64,7 +64,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-github-app",
 		Short:             "Add GitHub app to gittuf root of trust",
-		Long:              `This command allows users to add a trusted key for the special GitHub app role. This key is used to verify signatures on GitHub pull request approval attestations. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Long:              "The 'add-github-app' command adds a trusted key for the special GitHub app role to the repository's root of trust. It is used to verify signatures on GitHub pull request approval attestations.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addglobalrule/addglobalrule.go
+++ b/internal/cmd/trust/addglobalrule/addglobalrule.go
@@ -96,7 +96,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-global-rule",
 		Short:             `Add a new global rule to root of trust`,
-		Long:              "This command allows a user to add a new global rule to the root of trust. The user must specify the name, type, and rule pattern for the rule.",
+		Long:              "The 'add-global-rule' command adds a new global rule to the repository's root of trust. It is used to enforce repository-wide constraints, such as requiring a signature threshold or blocking force pushes on matching namespaces.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addhook/addhook.go
+++ b/internal/cmd/trust/addhook/addhook.go
@@ -60,7 +60,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"hook-name",
 		"n",
 		"",
-		"Name of the hook",
+		"name of the hook",
 	)
 	cmd.MarkFlagRequired("hook-name") //nolint:errcheck
 
@@ -141,7 +141,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-hook",
 		Short:             fmt.Sprintf("Add a script to be run as a gittuf hook, specify when and where to run it (developer mode only, set %s=1)", dev.DevModeKey),
-		Long:              fmt.Sprintf("Add a script to be run as a gittuf hook, specify when and which environment to run it in. The only currently supported environment is 'lua' (developer mode only, set %s=1)", dev.DevModeKey),
+		Long:              fmt.Sprintf("The 'add-hook' command adds a script to be run as a gittuf hook, recording which stage and environment it runs in. It is used to enforce automated checks during Git operations such as commit and push. The only currently supported environment is 'lua' (developer mode only, set %s=1)", dev.DevModeKey),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository.go
@@ -39,7 +39,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.initialRootPrincipals,
 		"initial-root-principal",
 		[]string{},
-		"initial root principals of network repository",
+		"initial root principals of the network repository (each a path to an SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 	cmd.MarkFlagRequired("initial-root-principal") //nolint:errcheck
 }
@@ -77,7 +77,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-network-repository",
 		Short:             `Add a network repository`,
-		Long:              "The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to add and configure a network repository, including its name, location, and initial root principals.",
+		Long:              "The 'add-network-repository' command registers a network repository in the repository's root of trust. It is used to declare another repository that participates in this repository's network so its state can be tracked and verified.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addpolicykey/addpolicykey.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey.go
@@ -20,7 +20,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.targetsKey,
 		"policy-key",
 		"",
-		"policy key to add to root of trust",
+		"policy key to add (path to SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 	cmd.MarkFlagRequired("policy-key") //nolint:errcheck
 }
@@ -53,7 +53,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-policy-key",
 		Short:             "Add Policy key to gittuf root of trust",
-		Long:              `This command allows users to add a new trusted key for the main policy file. Note that authorized keys can be specified from disk, from the GPG keyring using the "gpg:<fingerprint>" format, or as a Sigstore identity as "fulcio:<identity>::<issuer>".`,
+		Long:              "The 'add-policy-key' command adds a new trusted key for the primary policy file to the repository's root of trust. It is used to authorize additional keys to sign the main policy metadata.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective.go
@@ -92,7 +92,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-propagation-directive",
 		Short:             `Add propagation directive into gittuf root of trust`,
-		Long:              "The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are propagated into a downstream repository by specifying source and destination references and paths.",
+		Long:              "The 'add-propagation-directive' command registers a propagation directive in the repository's root of trust. It is used to define how contents from an upstream repository are automatically propagated into a downstream repository.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/addrootkey/addrootkey.go
+++ b/internal/cmd/trust/addrootkey/addrootkey.go
@@ -20,7 +20,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.newRootKey,
 		"root-key",
 		"",
-		"root key to add to root of trust",
+		"root key to add (path to SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
 	cmd.MarkFlagRequired("root-key") //nolint:errcheck
 }
@@ -53,7 +53,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "add-root-key",
 		Short:             "Add Root key to gittuf root of trust",
-		Long:              `The 'add-root-key' command allows users to add a new root key to the repository's root of trust. This command facilitates the addition of an extra root key to the existing trusted root keys, enabling multiple root keys or key rotation. It requires a public key file or Sigstore identity via --root-key and a signing key via --signing-key. Optionally, the change can be recorded in the RSL.`,
+		Long:              "The 'add-root-key' command adds a new root key to the repository's root of trust. It is used to add additional trusted root keys or to facilitate key rotation.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals.go
@@ -21,7 +21,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.appName,
 		"app-name",
 		tuf.GitHubAppRoleName,
-		"name of app to add to root of trust",
+		"name of the app whose approvals to mark untrusted",
 	)
 }
 
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "disable-github-app-approvals",
 		Short:             "Mark GitHub app approvals as untrusted henceforth",
-		Long:              `The 'disable-github-app-approvals' command revokes a GitHub App's ability to approve changes by marking it untrusted in the trust policy.`,
+		Long:              "The 'disable-github-app-approvals' command marks a GitHub app's approvals as untrusted in the repository's root of trust. It is used to stop honoring new pull request approval attestations from the app. Previously issued attestations remain valid.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals.go
@@ -21,7 +21,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.appName,
 		"app-name",
 		tuf.GitHubAppRoleName,
-		"name of app to add to root of trust",
+		"name of the app whose approvals to mark trusted",
 	)
 }
 
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "enable-github-app-approvals",
 		Short:             "Mark GitHub app approvals as trusted henceforth",
-		Long:              `The 'enable-github-app-approvals' command marks a GitHub App as trusted, allowing it to approve protected operations under the repository's trust policy.`,
+		Long:              "The 'enable-github-app-approvals' command marks a GitHub app's approvals as trusted in the repository's root of trust. It is used to honor new pull request approval attestations issued by the app.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/incrementversion/incrementversion.go
+++ b/internal/cmd/trust/incrementversion/incrementversion.go
@@ -37,7 +37,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "increment-version",
 		Short:             "Increment the integer version of the root metadata",
-		Long:              `The 'increment-version' command increments the integer version of the root metadata without making any other changes.`,
+		Long:              `The 'increment-version' command increments the integer version of the root of trust metadata without making any other changes. This is normally only needed when upgrading gittuf metadata created with versions older than v0.14.0.`,
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/init/init.go
+++ b/internal/cmd/trust/init/init.go
@@ -20,7 +20,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.location,
 		"location",
 		"",
-		"location of repository",
+		"canonical location of the repository to record in the root of trust",
 	)
 }
 

--- a/internal/cmd/trust/listglobalrules/listglobalrules.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules.go
@@ -76,7 +76,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "list-global-rules",
 		Short:             "List global rules for the current state",
-		Long:              "This command allows users to list the currently defined global rules for the root of trust. The output is sorted by global rule type.",
+		Long:              "The 'list-global-rules' command lists the global rules currently defined in the repository's root of trust. It is used to review the repository-wide constraints in effect, with output grouped by rule type.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/persistent/persistent.go
+++ b/internal/cmd/trust/persistent/persistent.go
@@ -21,7 +21,7 @@ func (o *Options) AddPersistentFlags(cmd *cobra.Command) {
 		"signing-key",
 		"k",
 		"",
-		fmt.Sprintf("signing key to use to sign root of trust (path to SSH key, \"%s\" for Sigstore)", gittuf.FulcioPrefix),
+		fmt.Sprintf("signing key to use to sign root of trust (path to SSH key, \"%s<fingerprint>\" for GPG, \"%s\" for Sigstore)", gittuf.GPGKeyPrefix, gittuf.FulcioPrefix),
 	)
 
 	cmd.PersistentFlags().BoolVar(

--- a/internal/cmd/trust/removegithubapp/removegithubapp.go
+++ b/internal/cmd/trust/removegithubapp/removegithubapp.go
@@ -21,7 +21,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.appName,
 		"app-name",
 		tuf.GitHubAppRoleName,
-		"name of app to add to root of trust",
+		"name of the app to remove from the root of trust",
 	)
 }
 

--- a/internal/cmd/trust/removeglobalrule/removeglobalrule.go
+++ b/internal/cmd/trust/removeglobalrule/removeglobalrule.go
@@ -49,7 +49,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-global-rule",
 		Short:             `Remove a global rule from root of trust`,
-		Long:              "This command allows users to remove an existing global rule from the root of trust. The name of the global rule must be specified.",
+		Long:              "The 'remove-global-rule' command removes an existing global rule from the repository's root of trust. It is used to lift a repository-wide constraint that is no longer needed.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/removepolicykey/removepolicykey.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey.go
@@ -22,7 +22,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.targetsKeyID,
 		"policy-key-ID",
 		"",
-		"ID of Policy key to be removed from root of trust",
+		"ID of the policy key to remove from the root of trust",
 	)
 	cmd.MarkFlagRequired("policy-key-ID") //nolint:errcheck
 }
@@ -50,7 +50,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove-policy-key",
 		Short:             "Remove Policy key from gittuf root of trust",
-		Long:              "This command allows users to remove a policy key from the gittuf root of trust. The policy key ID must be specified.",
+		Long:              "The 'remove-policy-key' command removes a trusted key for the primary policy file from the repository's root of trust. It is used to revoke a key's authorization to sign policy metadata.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/setrepositorylocation/setrepositorylocation.go
+++ b/internal/cmd/trust/setrepositorylocation/setrepositorylocation.go
@@ -20,7 +20,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		&o.location,
 		"location",
 		"",
-		"location of repository",
+		"canonical location of the repository to record in the root of trust",
 	)
 	cmd.MarkFlagRequired("location") //nolint:errcheck
 }
@@ -48,7 +48,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "set-repository-location",
 		Short:             "Set repository location",
-		Long:              "The 'set-repository-location' command updates the canonical location of a repository in the repository's root of trust. It is used to encode the canonical location of the repository inside gittuf metadata.",
+		Long:              "The 'set-repository-location' command records the canonical location of the repository in its root of trust. It is used to tell other repositories in a gittuf network where to fetch this repository from.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/sign/sign.go
+++ b/internal/cmd/trust/sign/sign.go
@@ -39,7 +39,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "sign",
 		Short:             "Sign root of trust",
-		Long:              "This command allows users to add their signature to the root of trust file.",
+		Long:              "The 'sign' command adds a signature to the repository's root of trust using the supplied signing key. It is used to meet the root of trust's signature threshold when multiple root keys are required.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updateglobalrule/updateglobalrule.go
+++ b/internal/cmd/trust/updateglobalrule/updateglobalrule.go
@@ -94,7 +94,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-global-rule",
 		Short:             `Update an existing global rule in the root of trust`,
-		Long:              "This command allows users to update an existing global rule in the root of trust. The name of the global rule must be specified. Note that a global rule may only be updated with the same type of global rule, and changes to the type require removing and adding it again.",
+		Long:              "The 'update-global-rule' command updates an existing global rule in the repository's root of trust. It is used to adjust a repository-wide constraint, such as its patterns or signature threshold. A global rule can only be updated with the same rule type; changing the type requires removing and adding the rule again.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updatehook/updatehook.go
+++ b/internal/cmd/trust/updatehook/updatehook.go
@@ -44,14 +44,14 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"is-pre-commit",
 		"",
 		false,
-		"update the hook to the pre-commit stage",
+		"update the hook in the pre-commit stage",
 	)
 	cmd.Flags().BoolVarP(
 		&o.isPrePush,
 		"is-pre-push",
 		"",
 		false,
-		"update the hook to the pre-push stage",
+		"update the hook in the pre-push stage",
 	)
 	cmd.MarkFlagsOneRequired("is-pre-commit", "is-pre-push")
 
@@ -60,7 +60,7 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"hook-name",
 		"n",
 		"",
-		"Name of the hook",
+		"name of the hook",
 	)
 	cmd.MarkFlagRequired("hook-name") //nolint:errcheck
 
@@ -141,7 +141,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-hook",
 		Short:             fmt.Sprintf("Modify the parameters of an existing gittuf hook (developer mode only, set %s=1)", dev.DevModeKey),
-		Long:              fmt.Sprintf("Modify the parameters of an existing gittuf hook. Specify the name of the hook to update and provide all parameters with their updated values. You can specify multiple stages where the hook is defined. Note that all parameters required to add the hook must also be provided. If a hook exists in multiple stages, only the specified stage(s) will be updated. If a hook does not exist in the specified stage, it won't be updated; you should add a new hook to that stage instead. Currently, only the 'lua' environment is supported (developer mode only, set %s=1)", dev.DevModeKey),
+		Long:              fmt.Sprintf("The 'update-hook' command modifies the parameters of an existing gittuf hook in the repository's root of trust. It is used to change a hook's script, environment, principals, or timeout. All parameters must be provided as when adding the hook, and only the stages given are updated; a stage where the hook does not already exist is left unchanged. The only currently supported environment is 'lua' (developer mode only, set %s=1)", dev.DevModeKey),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold.go
@@ -46,10 +46,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "update-policy-threshold",
-		Short: "Update Policy threshold in the gittuf root of trust",
-		Long:  "This command allows users to update the threshold of valid signatures required for the policy.",
-		RunE:  o.Run,
+		Use:               "update-policy-threshold",
+		Short:             "Update Policy threshold in the gittuf root of trust",
+		Long:              "The 'update-policy-threshold' command updates the number of signatures required to sign the primary policy file.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective.go
+++ b/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective.go
@@ -94,7 +94,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "update-propagation-directive",
 		Short:             fmt.Sprintf("Update propagation directive in the root of trust (developer mode only, set %s=1)", dev.DevModeKey),
-		Long:              "The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to update how content is propagated between repositories by changing the source, destination, or associated parameters of a directive.",
+		Long:              fmt.Sprintf("The 'update-propagation-directive' command modifies an existing propagation directive in the repository's root of trust. It is used to change how content is propagated between repositories. It requires developer mode to be enabled by setting the environment variable %s=1.", dev.DevModeKey),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold.go
@@ -46,10 +46,11 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 func New(persistent *persistent.Options) *cobra.Command {
 	o := &options{p: persistent}
 	cmd := &cobra.Command{
-		Use:   "update-root-threshold",
-		Short: "Update Root threshold in the gittuf root of trust",
-		Long:  "This command allows users to update the threshold of valid signatures required for the root of trust.",
-		RunE:  o.Run,
+		Use:               "update-root-threshold",
+		Short:             "Update Root threshold in the gittuf root of trust",
+		Long:              "The 'update-root-threshold' command updates the number of signatures required to sign the repository's root of trust.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
 	}
 	o.AddFlags(cmd)
 

--- a/internal/cmd/trustpolicy/remote/pull/pull.go
+++ b/internal/cmd/trustpolicy/remote/pull/pull.go
@@ -25,7 +25,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "pull <remote>",
 		Short:             "Pull policy from the specified remote",
-		Long:              "The 'pull' command retrieves policy updates from the specified remote and applies them to the local repository.",
+		Long:              "The 'pull' command fetches updates to the gittuf policy from the specified remote into the local repository.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,

--- a/internal/cmd/trustpolicy/remote/remote.go
+++ b/internal/cmd/trustpolicy/remote/remote.go
@@ -13,7 +13,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remote",
 		Short:             "Tools for managing remote policies",
-		Long:              "The 'remote' subcommand provides tools for managing gittuf interactions with remote repositories.",
+		Long:              "The 'remote' subcommand provides tools for pulling and pushing gittuf policy to and from remote repositories.",
 		DisableAutoGenTag: true,
 	}
 

--- a/internal/cmd/tui/tui.go
+++ b/internal/cmd/tui/tui.go
@@ -51,7 +51,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "tui",
 		Short:             "Start the TUI for gittuf",
-		Long:              "This command starts a terminal-based interface to view and/or manage gittuf metadata. If a signing key is provided, mutating operations are enabled and signed. Without a signing key, the TUI runs in read-only mode. Changes to the policy files in the TUI are staged immediately without further confirmation and users are required to run `gittuf policy apply` to commit the changes.",
+		Long:              "The 'tui' command starts a terminal-based interface to view and manage gittuf policy metadata. It is used to inspect or modify policy files interactively. A signing key must be provided to enable write operations; without one the TUI runs in read-only mode. Changes made in the TUI are staged immediately and require running 'gittuf policy apply' to take effect.",
 		RunE:              o.Run,
 		DisableAutoGenTag: true,
 	}
@@ -61,7 +61,7 @@ func New(persistent *persistent.Options) *cobra.Command {
 	return cmd
 }
 
-// startTUI intitializes a new model for the TUI
+// startTUI initializes a new model for the TUI
 func startTUI(ctx context.Context, o *options) error {
 	m := initialModel(ctx, o)
 

--- a/internal/cmd/verifymergeable/verifymergeable.go
+++ b/internal/cmd/verifymergeable/verifymergeable.go
@@ -60,7 +60,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "verify-mergeable",
 		Short:             "Tools for verifying mergeability using gittuf policies",
-		Long:              "The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check policy compliance for a proposed merge by comparing the specified base and feature branches, optionally bypassing the RSL when determining the current state.",
+		Long:              "The 'verify-mergeable' command evaluates whether a feature branch can be merged into a base branch under the repository's gittuf policies. It is used to check, before performing a merge, that the proposed merge would satisfy policy such as required approval thresholds.",
 		Args:              cobra.ExactArgs(0),
 		RunE:              o.Run,
 		DisableAutoGenTag: true,


### PR DESCRIPTION
## Description

Audited and fixed CLI command docstrings across all commands in `internal/cmd/`. Changes fall into these categories:

1. **Consistency and format:** Rewrote Long descriptions across ~55 command files to follow the uniform format "The '<command>' command <does what>. It is used to <when/why>." Removed "allows users to", "This command...", flag restatements in Long descriptions, and the repeated "By default, the main policy file (targets) is used" boilerplate.
2. **GPG support:** Added GPG key format (`gpg:<fingerprint>`) to `--signing-key` persistent flag descriptions across `trust/persistent`, `policy/persistent`, and `attest/persistent`, which previously only mentioned SSH and Sigstore.
3. **Key-accepting flags:** Updated `--root-key`, `--policy-key`, `--public-key`, `--initial-root-principal`, and `--root-key` on clone to document all three supported formats: path to SSH public key, `gpg:<fingerprint>` for GPG, and `fulcio:<identity>::<issuer>` for Sigstore.
4. **Flag description fixes:** Standardized `--local-only` and `--remote-name` descriptions across `rsl annotate` and `rsl record`. Fixed vague `--location` descriptions in `trust init` and `set-repository-location`.
5. **Real bugs caught:**
   - `policy/addperson`: `MarkFlagRequired("authorize-key")` referenced a nonexistent flag, silently not enforcing the required check. Fixed to `"public-key"`.
   - Copy-paste errors: `remove-github-app`, `disable-github-app-approvals`, and `enable-github-app-approvals` all described their `--app-name` flag as "name of app to add". Fixed to accurately describe each command's action.
   - `policy/updaterule`: `--policy-name` flag said "name of policy file to add rule to". Fixed to "update rule in".
6. **`DisableAutoGenTag`:** Added where missing (`update-policy-threshold`, `update-root-threshold`, `sync`, `cache/init`, `cache/delete`).

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [[DCO Signoff](https://wiki.linuxfoundation.org/dco)](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [[Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md)](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).