### PR TITLE
Readd gittuf trust inspect-root, add gittuf policy inspect

### DIFF
--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -34,6 +34,7 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
 * [gittuf policy discard](gittuf_policy_discard.md)	 - Discard the currently staged changes to policy
 * [gittuf policy increment-version](gittuf_policy_increment-version.md)	 - Increment the integer version of the specified policy file metadata
 * [gittuf policy init](gittuf_policy_init.md)	 - Initialize policy file
+* [gittuf policy inspect](gittuf_policy_inspect.md)	 - Inspect policy metadata
 * [gittuf policy list-principals](gittuf_policy_list-principals.md)	 - List principals for the current policy in the specified rule file
 * [gittuf policy list-rules](gittuf_policy_list-rules.md)	 - List rules for the current state
 * [gittuf policy remote](gittuf_policy_remote.md)	 - Tools for managing remote policies

--- a/docs/cli/gittuf_policy_inspect.md
+++ b/docs/cli/gittuf_policy_inspect.md
@@ -1,0 +1,36 @@
+## gittuf policy inspect
+
+Inspect policy metadata
+
+### Synopsis
+
+This command displays a gittuf policy (rule) file's metadata in a human-readable format. Use --policy-name to select which policy file to display (defaults to the primary 'targets' file), and --revision to inspect the metadata as it was recorded in a specific policy commit.
+
+```
+gittuf policy inspect [flags]
+```
+
+### Options
+
+```
+  -h, --help                 help for inspect
+      --policy-name string   name of policy file to inspect (default "targets")
+      --revision string      commit ID of the gittuf policy-staging ref to inspect (defaults to the current state)
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf policy](gittuf_policy.md)	 - Tools to manage gittuf policies
+

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -40,6 +40,7 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
 * [gittuf trust enable-github-app-approvals](gittuf_trust_enable-github-app-approvals.md)	 - Mark GitHub app approvals as trusted henceforth
 * [gittuf trust increment-version](gittuf_trust_increment-version.md)	 - Increment the integer version of the root metadata
 * [gittuf trust init](gittuf_trust_init.md)	 - Initialize gittuf root of trust for repository
+* [gittuf trust inspect-root](gittuf_trust_inspect-root.md)	 - Inspect root metadata
 * [gittuf trust list-global-rules](gittuf_trust_list-global-rules.md)	 - List global rules for the current state
 * [gittuf trust list-hooks](gittuf_trust_list-hooks.md)	 - List gittuf hooks for the current policy state
 * [gittuf trust list-propagation-directives](gittuf_trust_list-propagation-directives.md)	 - Lists propagation directives in the gittuf root of trust

--- a/docs/cli/gittuf_trust_inspect-root.md
+++ b/docs/cli/gittuf_trust_inspect-root.md
@@ -1,0 +1,35 @@
+## gittuf trust inspect-root
+
+Inspect root metadata
+
+### Synopsis
+
+This command displays the root metadata in a human-readable format. By default, the current state is shown; use --revision to inspect the metadata as it was recorded in a specific policy commit.
+
+```
+gittuf trust inspect-root [flags]
+```
+
+### Options
+
+```
+  -h, --help              help for inspect-root
+      --revision string   commit ID of the gittuf policy-staging ref to inspect (defaults to the current state)
+```
+
+### Options inherited from parent commands
+
+```
+      --create-rsl-entry             create RSL entry for policy change immediately (note: the RSL will not be synced with the remote)
+      --no-color                     turn off colored output
+      --profile                      enable CPU and memory profiling
+      --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
+      --profile-memory-file string   file to store memory profile (default "memory.prof")
+  -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --verbose                      enable verbose logging
+```
+
+### SEE ALSO
+
+* [gittuf trust](gittuf_trust.md)	 - Tools for gittuf's root of trust
+

--- a/internal/cmd/policy/inspect/inspect.go
+++ b/internal/cmd/policy/inspect/inspect.go
@@ -1,0 +1,86 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	policyName string
+	revision   string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.policyName,
+		"policy-name",
+		policy.TargetsRoleName,
+		"name of policy file to inspect",
+	)
+
+	cmd.Flags().StringVar(
+		&o.revision,
+		"revision",
+		"",
+		"commit ID of the gittuf policy-staging ref to inspect (defaults to the current state)",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	var state *policy.State
+	if o.revision != "" {
+		var commitID gitinterface.Hash
+		commitID, err = gitinterface.NewHash(o.revision)
+		if err != nil {
+			return err
+		}
+
+		state, err = policy.LoadStateFromCommit(repo.GetGitRepository(), commitID)
+	} else {
+		state, err = policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	}
+	if err != nil {
+		return err
+	}
+
+	targetsMetadata, err := state.GetTargetsMetadata(o.policyName, false)
+	if err != nil {
+		return err
+	}
+
+	prettyJSON, err := json.MarshalIndent(targetsMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect",
+		Short:             "Inspect policy metadata",
+		Long:              "This command displays a gittuf policy (rule) file's metadata in a human-readable format. Use --policy-name to select which policy file to display (defaults to the primary 'targets' file), and --revision to inspect the metadata as it was recorded in a specific policy commit.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/policy/inspect/inspect_test.go
+++ b/internal/cmd/policy/inspect/inspect_test.go
@@ -1,0 +1,111 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspect(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+
+		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false))
+
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), `"type": "targets"`)
+	})
+
+	t.Run("invalid policy name", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+
+		command := New()
+		command.SetArgs([]string{"--policy-name", "does-not-exist"})
+		_, _, _, err = cmd.ExecuteCommandC(command)
+		assert.ErrorContains(t, err, "unable to find requested metadata file")
+	})
+}

--- a/internal/cmd/policy/policy.go
+++ b/internal/cmd/policy/policy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/policy/addrule"
 	"github.com/gittuf/gittuf/internal/cmd/policy/incrementversion"
 	i "github.com/gittuf/gittuf/internal/cmd/policy/init"
+	"github.com/gittuf/gittuf/internal/cmd/policy/inspect"
 	"github.com/gittuf/gittuf/internal/cmd/policy/listprincipals"
 	"github.com/gittuf/gittuf/internal/cmd/policy/listrules"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
@@ -43,6 +44,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(discard.New())
 	cmd.AddCommand(i.New(o))
 	cmd.AddCommand(incrementversion.New(o))
+	cmd.AddCommand(inspect.New())
 	cmd.AddCommand(listprincipals.New())
 	cmd.AddCommand(listrules.New())
 	cmd.AddCommand(remote.New())

--- a/internal/cmd/trust/inspectroot/inspectroot.go
+++ b/internal/cmd/trust/inspectroot/inspectroot.go
@@ -1,0 +1,78 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectroot
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/policy"
+	policyopts "github.com/gittuf/gittuf/internal/policy/options/policy"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	revision string
+}
+
+func (o *options) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(
+		&o.revision,
+		"revision",
+		"",
+		"commit ID of the gittuf policy-staging ref to inspect (defaults to the current state)",
+	)
+}
+
+func (o *options) Run(cmd *cobra.Command, _ []string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+
+	var state *policy.State
+	if o.revision != "" {
+		var commitID gitinterface.Hash
+		commitID, err = gitinterface.NewHash(o.revision)
+		if err != nil {
+			return err
+		}
+
+		state, err = policy.LoadStateFromCommit(repo.GetGitRepository(), commitID)
+	} else {
+		state, err = policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+	}
+	if err != nil {
+		return err
+	}
+
+	rootMetadata, err := state.GetRootMetadata(false)
+	if err != nil {
+		return err
+	}
+
+	prettyJSON, err := json.MarshalIndent(rootMetadata, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), string(prettyJSON))
+	return nil
+}
+
+func New() *cobra.Command {
+	o := &options{}
+	cmd := &cobra.Command{
+		Use:               "inspect-root",
+		Short:             "Inspect root metadata",
+		Long:              "This command displays the root metadata in a human-readable format. By default, the current state is shown; use --revision to inspect the metadata as it was recorded in a specific policy commit.",
+		RunE:              o.Run,
+		DisableAutoGenTag: true,
+	}
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/internal/cmd/trust/inspectroot/inspectroot_test.go
+++ b/internal/cmd/trust/inspectroot/inspectroot_test.go
@@ -1,0 +1,95 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package inspectroot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/internal/policy"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInspectRoot(t *testing.T) {
+	t.Run("no repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to identify git directory")
+	})
+
+	t.Run("uninitialized policy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		_, _, _, err = cmd.ExecuteCommandC(New())
+		assert.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		keyPath := filepath.Join(tmpDir, "test-key")
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chdir(cwd) //nolint:errcheck
+
+		require.NoError(t, os.Chdir(tmpDir))
+
+		repo, err := gittuf.LoadRepository(".")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		signer, err := gittuf.LoadSigner(repo, keyPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+
+		_, stdout, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), `"type": "root"`)
+
+		commitID, err := repo.GetGitRepository().GetReference(policy.PolicyStagingRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		command := New()
+		command.SetArgs([]string{"--revision", commitID.String()})
+		_, stdout, _, err = cmd.ExecuteCommandC(command)
+		assert.NoError(t, err)
+		assert.Contains(t, stdout.String(), `"type": "root"`)
+	})
+}

--- a/internal/cmd/trust/trust.go
+++ b/internal/cmd/trust/trust.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd/trust/enablegithubappapprovals"
 	"github.com/gittuf/gittuf/internal/cmd/trust/incrementversion"
 	i "github.com/gittuf/gittuf/internal/cmd/trust/init"
+	"github.com/gittuf/gittuf/internal/cmd/trust/inspectroot"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listglobalrules"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listhooks"
 	"github.com/gittuf/gittuf/internal/cmd/trust/listpropagationdirectives"
@@ -63,6 +64,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(disablegithubappapprovals.New(o))
 	cmd.AddCommand(enablegithubappapprovals.New(o))
 	cmd.AddCommand(incrementversion.New(o))
+	cmd.AddCommand(inspectroot.New())
 	cmd.AddCommand(listglobalrules.New())
 	cmd.AddCommand(listhooks.New())
 	cmd.AddCommand(listpropagationdirectives.New())

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -384,7 +384,7 @@ func LoadCurrentState(ctx context.Context, repo *gitinterface.Repository, ref st
 		}
 
 		// Note: this will not set the loadedEntry field in the policy state
-		return loadStateFromCommit(repo, commitID)
+		return LoadStateFromCommit(repo, commitID)
 	}
 
 	entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo, rsl.ForReference(ref))
@@ -1321,7 +1321,7 @@ func loadStateForEntry(repo *gitinterface.Repository, entry rsl.ReferenceUpdater
 		return nil, rsl.ErrRSLEntryDoesNotMatchRef
 	}
 
-	state, err := loadStateFromCommit(repo, entry.GetTargetID())
+	state, err := LoadStateFromCommit(repo, entry.GetTargetID())
 	if err != nil {
 		return nil, err
 	}
@@ -1329,7 +1329,10 @@ func loadStateForEntry(repo *gitinterface.Repository, entry rsl.ReferenceUpdater
 	return state, nil
 }
 
-func loadStateFromCommit(repo *gitinterface.Repository, commitID gitinterface.Hash) (*State, error) {
+// LoadStateFromCommit returns the policy state as recorded in the tree of the
+// specified commit. This allows a specific revision of the policy metadata to
+// be inspected directly, bypassing the RSL.
+func LoadStateFromCommit(repo *gitinterface.Repository, commitID gitinterface.Hash) (*State, error) {
 	commitTreeID, err := repo.GetCommitTreeID(commitID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Restores the previously removed 'gittuf trust inspect-root' command and adds an equivalent 'gittuf policy inspect' command for viewing raw policy (rule file) metadata. Both commands support an optional --revision flag to inspect a specific historical commit instead of the current state, and 'gittuf policy inspect' additionally supports --policy-name to select which rule file to display.

Closes #1459

## Description

Restores the previously removed 'gittuf trust inspect-root' command and adds an equivalent 'gittuf policy inspect' command for viewing raw policy (rule file) metadata. Both commands support an optional --revision flag to inspect a specific historical commit instead of the current state, and 'gittuf policy inspect' additionally supports --policy-name to select which rule file to display.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used an AI coding assistant to clarify the task steps, help fix code errors, and assist with testing. All changes were reviewed, tested, and verified by me before submission.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
