### PR TITLE
refactor(tui) :- split main landing choice screen into modular component

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -53,7 +53,7 @@ type model struct {
 	ctx               context.Context
 	screen            screen
 	spinner           spinner.Model
-	choiceList        list.Model
+	homeScreen        homeScreen
 	policyScreen      policyScreen
 	trustScreenList   list.Model
 	policyRulesScreen policyRulesScreen
@@ -157,10 +157,12 @@ func initialModel(ctx context.Context, o *options) model {
 		policyName: o.policyName,
 		options:    o,
 
-		choiceList: newMenuList("gittuf TUI", []list.Item{
-			item{title: "Policy", desc: "View and manage gittuf Policy"},
-			item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
-		}, delegate),
+		homeScreen: homeScreen{
+			choiceList: newMenuList("gittuf TUI", []list.Item{
+				item{title: "Policy", desc: "View and manage gittuf Policy"},
+				item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
+			}, delegate),
+		},
 		policyScreen: policyScreen{
 			policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
 				item{title: "View Rules", desc: "View and manage policy rules"},
@@ -213,7 +215,7 @@ func (m *model) resizeLists() {
 		innerHeight = 0
 	}
 
-	m.choiceList.SetSize(innerWidth, innerHeight)
+	m.homeScreen.choiceList.SetSize(innerWidth, innerHeight)
 	m.policyScreen.policyScreenList.SetSize(innerWidth, innerHeight)
 	m.trustScreenList.SetSize(innerWidth, innerHeight)
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)

--- a/internal/cmd/tui/screen_home.go
+++ b/internal/cmd/tui/screen_home.go
@@ -1,0 +1,38 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type homeScreen struct {
+	choiceList list.Model
+}
+
+func (s *homeScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if keyMsg.String() == "enter" {
+			if sel, ok := s.choiceList.SelectedItem().(item); ok {
+				switch sel.title {
+				case "Policy":
+					m.screen = screenPolicy
+				case "Trust":
+					m.screen = screenTrust
+				}
+			}
+			return *m, nil
+		}
+	}
+
+	s.choiceList, cmd = s.choiceList.Update(msg)
+	return *m, cmd
+}
+
+func (s *homeScreen) View(m *model) string {
+	return m.renderScreen("Home", s.choiceList.View(), renderActionHints(m.readOnly))
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -106,7 +106,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Screen-specific input handling
 		switch m.screen {
-		case screenChoice, screenTrust:
+		case screenChoice:
+			return m.homeScreen.Update(msg, &m)
+		case screenTrust:
 			if msg.String() == "enter" {
 				return m.handleEnter()
 			}
@@ -128,7 +130,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Delegate to active bubbles component per screen
 	switch m.screen {
 	case screenChoice:
-		m.choiceList, cmd = m.choiceList.Update(msg)
+		return m.homeScreen.Update(msg, &m)
 	case screenPolicy:
 		return m.policyScreen.Update(msg, &m)
 	case screenTrust:
@@ -146,17 +148,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // handleEnter handles the enter key press on selection menu screens.
 func (m model) handleEnter() (tea.Model, tea.Cmd) {
-	switch m.screen {
-	case screenChoice:
-		if i, ok := m.choiceList.SelectedItem().(item); ok {
-			switch i.title {
-			case "Policy":
-				m.screen = screenPolicy
-			case "Trust":
-				m.screen = screenTrust
-			}
-		}
-	case screenTrust:
+	if m.screen == screenTrust {
 		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
 			m.screen = screenTrustGlobalRules
 			m.refreshGlobalRules()

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -354,7 +354,7 @@ func (m model) View() string {
 		)
 
 	case screenChoice:
-		return m.renderScreen("Home", m.choiceList.View(), renderActionHints(m.readOnly))
+		return m.homeScreen.View(&m)
 
 	case screenPolicy:
 		return m.policyScreen.View(&m)


### PR DESCRIPTION
## Description

This pull request refactors the gittuf TUI by extracting the main landing choice screen (`screenChoice`) into a separate, self-contained component file (`screen_home.go`).

Additionally, this PR:
- Defines the `homeScreen` struct to encapsulate the main landing choice menu list.
- Delegates choice list update cycles and view rendering to the new component.
- Cleans up legacy choice list handlers and fields from `model.go`, `update.go`, and `view.go`.
- Fixes a single-case switch lint check in the event handlers of `update.go` by converting it into a clean `if` assertion.

This is the third PR in the TUI modularity series.

## AI Usage

- [x] I **did not** use generative AI at all in making the content of this pull request.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).