### PR TITLE
test :- use standard direct os.Chdir defer calls in CLI tests

### DIFF
--- a/internal/cmd/addhooks/addhooks_test.go
+++ b/internal/cmd/addhooks/addhooks_test.go
@@ -11,18 +11,15 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddHooks(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
@@ -32,12 +29,8 @@ func TestAddHooks(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -54,25 +47,17 @@ func TestAddHooks(t *testing.T) {
 	t.Run("already exists", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Create a dummy hook file to simulate an existing hook
 		hookPath := filepath.Join(".git", "hooks")
-		if err := os.MkdirAll(hookPath, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(hookPath, 0755))
 		dummyHookPath := filepath.Join(hookPath, "pre-push")
-		if err := os.WriteFile(dummyHookPath, []byte("dummy hook content"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(dummyHookPath, []byte("dummy hook content"), 0o600))
 
 		_, _, stdErr, err := cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "already exists")
@@ -84,25 +69,17 @@ func TestAddHooks(t *testing.T) {
 	t.Run("force overwrite", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Create a dummy hook file to simulate an existing hook
 		hookPath := filepath.Join(".git", "hooks")
-		if err := os.MkdirAll(hookPath, 0755); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.MkdirAll(hookPath, 0755))
 		dummyHookPath := filepath.Join(hookPath, "pre-push")
-		if err := os.WriteFile(dummyHookPath, []byte("dummy hook content"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(dummyHookPath, []byte("dummy hook content"), 0o600))
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--force")
 		assert.NoError(t, err)
 

--- a/internal/cmd/addhooks/addhooks_test.go
+++ b/internal/cmd/addhooks/addhooks_test.go
@@ -23,9 +23,7 @@ func TestAddHooks(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -40,9 +38,7 @@ func TestAddHooks(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -64,9 +60,7 @@ func TestAddHooks(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -96,9 +90,7 @@ func TestAddHooks(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/attest/apply/apply_test.go
+++ b/internal/cmd/attest/apply/apply_test.go
@@ -24,9 +24,7 @@ func TestApply(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -81,9 +79,7 @@ func TestApply(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -138,9 +134,7 @@ func TestApply(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/attest/apply/apply_test.go
+++ b/internal/cmd/attest/apply/apply_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApply(t *testing.T) {
@@ -21,14 +22,10 @@ func TestApply(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -38,52 +35,32 @@ func TestApply(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo.GetGitRepository())
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = repo.GetGitRepository().Commit(emptyTreeID, fromRef, "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()))
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
 		assert.NoError(t, err)
@@ -93,52 +70,32 @@ func TestApply(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo.GetGitRepository())
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = repo.GetGitRepository().Commit(emptyTreeID, fromRef, "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()))
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "origin")
 		assert.Error(t, err)

--- a/internal/cmd/attest/authorize/authorize_test.go
+++ b/internal/cmd/attest/authorize/authorize_test.go
@@ -25,9 +25,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -130,9 +124,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -181,9 +173,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -242,9 +232,7 @@ func TestAuthorize(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/attest/authorize/authorize_test.go
+++ b/internal/cmd/attest/authorize/authorize_test.go
@@ -15,6 +15,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthorize(t *testing.T) {
@@ -22,14 +23,10 @@ func TestAuthorize(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestAuthorize(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -64,22 +57,14 @@ func TestAuthorize(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -92,43 +77,27 @@ func TestAuthorize(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo.GetGitRepository())
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = repo.GetGitRepository().Commit(emptyTreeID, fromRef, "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -141,43 +110,27 @@ func TestAuthorize(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo.GetGitRepository())
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = repo.GetGitRepository().Commit(emptyTreeID, fromRef, "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -191,52 +144,32 @@ func TestAuthorize(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		treeBuilder := gitinterface.NewTreeBuilder(repo.GetGitRepository())
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		initialCommitID, err := repo.GetGitRepository().Commit(emptyTreeID, fromRef, "Initial commit\n", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.RecordRSLEntryForReference(t.Context(), fromRef, false, rslopts.WithRecordLocalOnly()))
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddReferenceAuthorization(t.Context(), signer, targetTagRef, fromRef, false))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
+++ b/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDismissApproval(t *testing.T) {
@@ -24,14 +25,10 @@ func TestDismissApproval(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -45,14 +42,10 @@ func TestDismissApproval(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,17 +58,11 @@ func TestDismissApproval(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		testID := gitinterface.ZeroHash.String()
@@ -83,48 +70,30 @@ func TestDismissApproval(t *testing.T) {
 		approvers := []string{"jane.doe"}
 
 		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(fromRef, testID, testID, approvers, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		env, err := dsse.CreateEnvelope(githubAppApproval)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		env, err = dsse.SignEnvelope(t.Context(), env, signer)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		currentAttestations, err := attestations.LoadCurrentAttestations(repo.GetGitRepository())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = currentAttestations.SetGitHubPullRequestApprovalAttestation(repo.GetGitRepository(), env, "https://github.com", reviewID, tuf.GitHubAppRoleName, fromRef, testID, testID)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = currentAttestations.Commit(repo.GetGitRepository(), "Add GitHub pull request approval", true, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -137,17 +106,11 @@ func TestDismissApproval(t *testing.T) {
 		tmpDir := t.TempDir()
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 		repo, err := gittuf.LoadRepository(tmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		fromRef := "refs/heads/main"
 		testID := gitinterface.ZeroHash.String()
@@ -155,48 +118,30 @@ func TestDismissApproval(t *testing.T) {
 		approvers := []string{"jane.doe"}
 
 		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(fromRef, testID, testID, approvers, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		env, err := dsse.CreateEnvelope(githubAppApproval)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		env, err = dsse.SignEnvelope(t.Context(), env, signer)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		currentAttestations, err := attestations.LoadCurrentAttestations(repo.GetGitRepository())
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = currentAttestations.SetGitHubPullRequestApprovalAttestation(repo.GetGitRepository(), env, "https://github.com", reviewID, tuf.GitHubAppRoleName, fromRef, testID, testID)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = currentAttestations.Commit(repo.GetGitRepository(), "Add GitHub pull request approval", true, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
+++ b/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
@@ -27,9 +27,7 @@ func TestDismissApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -50,9 +48,7 @@ func TestDismissApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -124,9 +120,7 @@ func TestDismissApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -198,9 +192,7 @@ func TestDismissApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/attest/github/pullrequest/pullrequest_test.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest_test.go
@@ -24,9 +24,7 @@ func TestPullRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestPullRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -70,9 +66,7 @@ func TestPullRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -101,9 +95,7 @@ func TestPullRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -133,9 +125,7 @@ func TestPullRequest(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/attest/github/pullrequest/pullrequest_test.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPullRequest(t *testing.T) {
@@ -21,14 +22,10 @@ func TestPullRequest(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestPullRequest(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -63,14 +56,10 @@ func TestPullRequest(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -84,22 +73,14 @@ func TestPullRequest(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -114,22 +95,14 @@ func TestPullRequest(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/attest/github/recordapproval/recordapproval_test.go
+++ b/internal/cmd/attest/github/recordapproval/recordapproval_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecordApproval(t *testing.T) {
@@ -21,14 +22,10 @@ func TestRecordApproval(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestRecordApproval(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -63,14 +56,10 @@ func TestRecordApproval(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -84,22 +73,14 @@ func TestRecordApproval(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/attest/github/recordapproval/recordapproval_test.go
+++ b/internal/cmd/attest/github/recordapproval/recordapproval_test.go
@@ -24,9 +24,7 @@ func TestRecordApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestRecordApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -70,9 +66,7 @@ func TestRecordApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -101,9 +95,7 @@ func TestRecordApproval(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/cache/delete/delete_test.go
+++ b/internal/cmd/cache/delete/delete_test.go
@@ -26,9 +26,7 @@ func TestCacheDelete(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,9 +41,7 @@ func TestCacheDelete(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/cache/delete/delete_test.go
+++ b/internal/cmd/cache/delete/delete_test.go
@@ -14,18 +14,15 @@ import (
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCacheDelete(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
@@ -35,32 +32,22 @@ func TestCacheDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		gitRepo := repo.GetGitRepository()
 		err = rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(gitRepo, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Populate cache first so delete does not fail with cache-not-found
 		err = repo.PopulateCache()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.NoError(t, err)

--- a/internal/cmd/cache/init/init_test.go
+++ b/internal/cmd/cache/init/init_test.go
@@ -26,9 +26,7 @@ func TestCacheInit(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,9 +41,7 @@ func TestCacheInit(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/cache/init/init_test.go
+++ b/internal/cmd/cache/init/init_test.go
@@ -14,18 +14,15 @@ import (
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCacheInit(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
@@ -35,26 +32,18 @@ func TestCacheInit(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		gitRepo := repo.GetGitRepository()
 		err = rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(gitRepo, false)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.NoError(t, err)

--- a/internal/cmd/policy/addkey/addkey_test.go
+++ b/internal/cmd/policy/addkey/addkey_test.go
@@ -25,9 +25,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -118,9 +112,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -173,9 +165,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -229,9 +219,7 @@ func TestAddKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/addkey/addkey_test.go
+++ b/internal/cmd/policy/addkey/addkey_test.go
@@ -15,6 +15,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddKey(t *testing.T) {
@@ -22,14 +23,10 @@ func TestAddKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestAddKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -64,22 +57,14 @@ func TestAddKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -93,46 +78,26 @@ func TestAddKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -146,46 +111,26 @@ func TestAddKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -200,46 +145,26 @@ func TestAddKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/policy/addperson/addperson_test.go
+++ b/internal/cmd/policy/addperson/addperson_test.go
@@ -25,9 +25,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -110,9 +104,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -141,9 +133,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -180,9 +170,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -235,9 +223,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -291,9 +277,7 @@ func TestAddPerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/addperson/addperson_test.go
+++ b/internal/cmd/policy/addperson/addperson_test.go
@@ -15,6 +15,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddPerson(t *testing.T) {
@@ -22,14 +23,10 @@ func TestAddPerson(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -64,22 +57,14 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -93,22 +78,14 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -122,22 +99,14 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -151,46 +120,26 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -204,46 +153,26 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -258,46 +187,26 @@ func TestAddPerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/policy/addrule/addrule_test.go
+++ b/internal/cmd/policy/addrule/addrule_test.go
@@ -26,9 +26,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -49,9 +47,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -119,9 +113,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -181,9 +173,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -243,9 +233,7 @@ func TestAddRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/addrule/addrule_test.go
+++ b/internal/cmd/policy/addrule/addrule_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddRule(t *testing.T) {
@@ -23,14 +24,10 @@ func TestAddRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -44,14 +41,10 @@ func TestAddRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,22 +58,14 @@ func TestAddRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -94,53 +79,29 @@ func TestAddRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -154,53 +115,29 @@ func TestAddRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -214,53 +151,29 @@ func TestAddRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		newKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/policy/incrementversion/incrementversion_test.go
+++ b/internal/cmd/policy/incrementversion/incrementversion_test.go
@@ -25,9 +25,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -126,9 +120,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/incrementversion/incrementversion_test.go
+++ b/internal/cmd/policy/incrementversion/incrementversion_test.go
@@ -15,6 +15,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIncrementVersion(t *testing.T) {
@@ -22,14 +23,10 @@ func TestIncrementVersion(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -64,38 +57,22 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -109,38 +86,22 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/policy/init/init_test.go
+++ b/internal/cmd/policy/init/init_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInit(t *testing.T) {
@@ -21,14 +22,10 @@ func TestInit(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,35 +56,21 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the root first, as targets is typically initialized after root
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -105,35 +84,21 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the root first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -148,35 +113,21 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the root first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/policy/init/init_test.go
+++ b/internal/cmd/policy/init/init_test.go
@@ -24,9 +24,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +74,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -122,9 +116,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -167,9 +159,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/listprincipals/listprincipals_test.go
+++ b/internal/cmd/policy/listprincipals/listprincipals_test.go
@@ -29,9 +29,7 @@ func TestListPrincipals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -57,9 +55,7 @@ func TestListPrincipals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -124,9 +120,7 @@ func TestListPrincipals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/listprincipals/listprincipals_test.go
+++ b/internal/cmd/policy/listprincipals/listprincipals_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListPrincipals(t *testing.T) {
@@ -26,14 +27,10 @@ func TestListPrincipals(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -44,54 +41,30 @@ func TestListPrincipals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.ApplyPolicy(t.Context(), "", true, false))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New())
 		assert.NoError(t, err)
@@ -109,49 +82,27 @@ func TestListPrincipals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.ApplyPolicy(t.Context(), "", true, false))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--policy-name", "custom-policy")
 		assert.NoError(t, err)

--- a/internal/cmd/policy/listrules/listrules_test.go
+++ b/internal/cmd/policy/listrules/listrules_test.go
@@ -29,9 +29,7 @@ func TestListRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -57,9 +55,7 @@ func TestListRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -130,9 +126,7 @@ func TestListRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/listrules/listrules_test.go
+++ b/internal/cmd/policy/listrules/listrules_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListRules(t *testing.T) {
@@ -26,14 +27,10 @@ func TestListRules(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -44,63 +41,35 @@ func TestListRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main", "file:path/to/file"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main", "file:path/to/file"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-tags", []string{newKey.ID()}, []string{"git:refs/tags/"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-tags", []string{newKey.ID()}, []string{"git:refs/tags/"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.ApplyPolicy(t.Context(), "", true, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.ApplyPolicy(t.Context(), "", true, false))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New())
 		assert.NoError(t, err)
@@ -123,14 +92,10 @@ func TestListRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New()
 		command.SetArgs([]string{"--target-ref", "refs/gittuf/invalid"})

--- a/internal/cmd/policy/removekey/removekey_test.go
+++ b/internal/cmd/policy/removekey/removekey_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveKey(t *testing.T) {
@@ -25,14 +26,10 @@ func TestRemoveKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--public-key", "dummy-key")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,51 +40,29 @@ func TestRemoveKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--public-key", newKey.ID())
@@ -95,9 +70,7 @@ func TestRemoveKey(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
@@ -111,47 +84,27 @@ func TestRemoveKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "--public-key", newKey.ID())
@@ -159,9 +112,7 @@ func TestRemoveKey(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
@@ -175,14 +126,10 @@ func TestRemoveKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--public-key", "dummy-key")

--- a/internal/cmd/policy/removekey/removekey_test.go
+++ b/internal/cmd/policy/removekey/removekey_test.go
@@ -28,9 +28,7 @@ func TestRemoveKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -56,9 +54,7 @@ func TestRemoveKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -126,9 +122,7 @@ func TestRemoveKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -184,9 +178,7 @@ func TestRemoveKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/removeperson/removeperson_test.go
+++ b/internal/cmd/policy/removeperson/removeperson_test.go
@@ -19,6 +19,7 @@ import (
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemovePerson(t *testing.T) {
@@ -26,14 +27,10 @@ func TestRemovePerson(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--person-ID", "dummy-person")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -44,56 +41,34 @@ func TestRemovePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		person := &tufv02.Person{
 			PersonID:   "jane.doe",
 			PublicKeys: map[string]*tufv02.Key{newKey.ID(): newKey.(*tufv02.Key)},
 		}
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "jane.doe")
@@ -101,9 +76,7 @@ func TestRemovePerson(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
@@ -117,52 +90,32 @@ func TestRemovePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
 		person := &tufv02.Person{
 			PersonID:   "jane.doe",
 			PublicKeys: map[string]*tufv02.Key{newKey.ID(): newKey.(*tufv02.Key)},
 		}
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{person}, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "--person-ID", "jane.doe")
@@ -170,9 +123,7 @@ func TestRemovePerson(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
@@ -186,14 +137,10 @@ func TestRemovePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "dummy-person")

--- a/internal/cmd/policy/removeperson/removeperson_test.go
+++ b/internal/cmd/policy/removeperson/removeperson_test.go
@@ -29,9 +29,7 @@ func TestRemovePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -57,9 +55,7 @@ func TestRemovePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -132,9 +128,7 @@ func TestRemovePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -195,9 +189,7 @@ func TestRemovePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/removerule/removerule_test.go
+++ b/internal/cmd/policy/removerule/removerule_test.go
@@ -28,9 +28,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -56,9 +54,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -132,9 +128,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -212,9 +206,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -241,9 +233,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -283,9 +273,7 @@ func TestRemoveRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/removerule/removerule_test.go
+++ b/internal/cmd/policy/removerule/removerule_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveRule(t *testing.T) {
@@ -25,14 +26,10 @@ func TestRemoveRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--rule-name", "dummy-rule")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,55 +40,31 @@ func TestRemoveRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "protect-main")
@@ -99,9 +72,7 @@ func TestRemoveRule(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
@@ -117,67 +88,37 @@ func TestRemoveRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, "custom-policy", "protect-main", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "custom-policy", "--rule-name", "protect-main")
@@ -185,9 +126,7 @@ func TestRemoveRule(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
@@ -203,14 +142,10 @@ func TestRemoveRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "dummy-rule")
@@ -222,34 +157,20 @@ func TestRemoveRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Run removerule for policy that is not initialized
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -262,44 +183,24 @@ func TestRemoveRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		// Run removerule for rule with gittuf prefix
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})

--- a/internal/cmd/policy/reorderrules/reorderrules_test.go
+++ b/internal/cmd/policy/reorderrules/reorderrules_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReorderRules(t *testing.T) {
@@ -25,14 +26,10 @@ func TestReorderRules(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "rule-2", "rule-1")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,65 +40,37 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		// Initial check
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		rules := targetsMetadata.GetRules()
@@ -115,9 +84,7 @@ func TestReorderRules(t *testing.T) {
 
 		// Verification
 		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
@@ -132,71 +99,39 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-2", []string{newKey.ID()}, []string{"git:refs/heads/feature"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		// Reorder rules in custom-policy
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -205,9 +140,7 @@ func TestReorderRules(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
@@ -222,14 +155,10 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "rule-2", "rule-1")
@@ -241,34 +170,20 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy", "rule-2", "rule-1")
@@ -280,44 +195,24 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "rule-1", "rule-1")
@@ -329,44 +224,24 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "rule-not-found")
@@ -378,50 +253,26 @@ func TestReorderRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command) // rule-1 is missing from command arguments

--- a/internal/cmd/policy/reorderrules/reorderrules_test.go
+++ b/internal/cmd/policy/reorderrules/reorderrules_test.go
@@ -28,9 +28,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -56,9 +54,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -147,9 +143,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -231,9 +225,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -260,9 +252,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -301,9 +291,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -352,9 +340,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -403,9 +389,7 @@ func TestReorderRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/sign/sign_test.go
+++ b/internal/cmd/policy/sign/sign_test.go
@@ -28,9 +28,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -64,9 +62,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -142,9 +138,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -215,9 +209,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -244,9 +236,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/sign/sign_test.go
+++ b/internal/cmd/policy/sign/sign_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSign(t *testing.T) {
@@ -25,14 +26,10 @@ func TestSign(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}))
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,61 +40,35 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		keyPath2 := filepath.Join(tmpDir, "test-key-2")
-		if err := os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		// Initially, the TargetsEnvelope has 1 signature (from initialization)
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assert.Len(t, state.Metadata.TargetsEnvelope.Signatures, 1)
 
 		// Sign targets with key2
@@ -107,9 +78,7 @@ func TestSign(t *testing.T) {
 
 		// Verification
 		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		// Now, the TargetsEnvelope should have 2 signatures (one from keyPath, one from keyPath2)
 		assert.Len(t, state.Metadata.TargetsEnvelope.Signatures, 2)
 	})
@@ -119,73 +88,41 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		keyPath2 := filepath.Join(tmpDir, "test-key-2")
-		if err := os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath2, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(keyPath2+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
 		// Verify custom-policy envelope initial signatures
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assert.Len(t, state.Metadata.DelegationEnvelopes["custom-policy"].Signatures, 1)
 
 		// Sign custom-policy with key2
@@ -195,9 +132,7 @@ func TestSign(t *testing.T) {
 
 		// Verification
 		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		assert.Len(t, state.Metadata.DelegationEnvelopes["custom-policy"].Signatures, 2)
 	})
 
@@ -206,14 +141,10 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command)
@@ -225,34 +156,20 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy")

--- a/internal/cmd/policy/updateperson/updateperson_test.go
+++ b/internal/cmd/policy/updateperson/updateperson_test.go
@@ -30,9 +30,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -58,9 +56,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -143,9 +139,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -219,9 +213,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -248,9 +240,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -289,9 +279,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -318,9 +306,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -347,9 +333,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -376,9 +360,7 @@ func TestUpdatePerson(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/updateperson/updateperson_test.go
+++ b/internal/cmd/policy/updateperson/updateperson_test.go
@@ -20,6 +20,7 @@ import (
 	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdatePerson(t *testing.T) {
@@ -27,14 +28,10 @@ func TestUpdatePerson(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--person-ID", "person-1")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -45,47 +42,27 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		// First, add the person using add-person command
 		addPersonCmd := addpersoncmd.New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -94,9 +71,7 @@ func TestUpdatePerson(t *testing.T) {
 
 		// Verify it was added
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		principals := targetsMetadata.GetPrincipals()
@@ -112,9 +87,7 @@ func TestUpdatePerson(t *testing.T) {
 
 		// Verify updated fields
 		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		principals = targetsMetadata.GetPrincipals()
@@ -128,59 +101,33 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
 		// First, add the person using add-person command
 		addPersonCmd := addpersoncmd.New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -194,9 +141,7 @@ func TestUpdatePerson(t *testing.T) {
 
 		// Verify updated fields
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
 		principals := targetsMetadata.GetPrincipals()
@@ -210,14 +155,10 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "person-1")
@@ -229,34 +170,20 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy", "--person-ID", "person-1")
@@ -268,22 +195,14 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: keyPath})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "person-1", "--associated-identity", "invalididentity")
@@ -295,22 +214,14 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: keyPath})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "person-1", "--custom", "invalidcustom")
@@ -322,22 +233,14 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: keyPath})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "person-1", "--public-key", "non-existent-key.pub")
@@ -349,44 +252,24 @@ func TestUpdatePerson(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--person-ID", "non-existent-person")

--- a/internal/cmd/policy/updaterule/updaterule_test.go
+++ b/internal/cmd/policy/updaterule/updaterule_test.go
@@ -28,9 +28,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -56,9 +54,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -143,9 +139,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -221,9 +215,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -250,9 +242,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -291,9 +281,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -343,9 +331,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -400,9 +386,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -457,9 +441,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -511,9 +493,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -564,9 +544,7 @@ func TestUpdateRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/policy/updaterule/updaterule_test.go
+++ b/internal/cmd/policy/updaterule/updaterule_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateRule(t *testing.T) {
@@ -25,14 +26,10 @@ func TestUpdateRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(&persistent.Options{}), "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,61 +40,35 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		// Initial check
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err := state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		rules := targetsMetadata.GetRules()
@@ -112,9 +83,7 @@ func TestUpdateRule(t *testing.T) {
 
 		// Verification
 		state, err = policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err = state.GetTargetsMetadata(policy.TargetsRoleName, false)
 		assert.Nil(t, err)
 		rules = targetsMetadata.GetRules()
@@ -128,67 +97,37 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "custom-policy", []string{newKey.ID()}, []string{"*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, "custom-policy", false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, "custom-policy", []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
 
-		if err := repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, "custom-policy", "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		// Update rule in custom-policy
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -197,9 +136,7 @@ func TestUpdateRule(t *testing.T) {
 
 		// Verification
 		state, err := policy.LoadCurrentState(t.Context(), repo.GetGitRepository(), policy.PolicyStagingRef)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		targetsMetadata, err := state.GetTargetsMetadata("custom-policy", false)
 		assert.Nil(t, err)
 		rules := targetsMetadata.GetRules()
@@ -212,14 +149,10 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		command := New(&persistent.Options{SigningKey: "invalid-key"})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
@@ -231,34 +164,20 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--policy-name", "non-existent-policy", "--rule-name", "rule-1", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
@@ -270,44 +189,24 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
 
 		// Run updaterule for rule with gittuf prefix
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
@@ -320,50 +219,26 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", "non-existent-principal", "--rule-pattern", "git:refs/heads/main")
@@ -375,50 +250,26 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/main", "--threshold", "0")
@@ -430,50 +281,26 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 		newKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, newKey, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.InitializeTargets(t.Context(), signer, policy.TargetsRoleName, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddPrincipalToTargets(t.Context(), signer, policy.TargetsRoleName, []tuf.Principal{newKey}, false, trustpolicyopts.WithRSLEntry()))
+		require.NoError(t, repo.AddDelegation(t.Context(), signer, policy.TargetsRoleName, "rule-1", []string{newKey.ID()}, []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		command := New(&persistent.Options{SigningKey: keyPath, WithRSLEntry: true})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize", newKey.ID(), "--rule-pattern", "git:refs/heads/main", "--threshold", "2")
@@ -485,28 +312,18 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		command := New(&persistent.Options{SigningKey: keyPath})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "root", "--authorize", "principal-1", "--rule-pattern", "git:refs/heads/main")
@@ -536,28 +353,18 @@ func TestUpdateRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		_, err = gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		command := New(&persistent.Options{SigningKey: keyPath})
 		_, _, _, err = cmd.ExecuteCommandC(command, "--rule-name", "rule-1", "--authorize-key", "non-existent-key.pub", "--rule-pattern", "git:refs/heads/main")

--- a/internal/cmd/rsl/annotate/annotate_test.go
+++ b/internal/cmd/rsl/annotate/annotate_test.go
@@ -21,14 +21,10 @@ func TestAnnotate(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "some-entry-id", "-m", "annotation message", "--local-only")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -39,14 +35,10 @@ func TestAnnotate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "-m", "annotation message", "--local-only")
 		assert.ErrorContains(t, err, "requires at least 1 arg")
@@ -57,14 +49,10 @@ func TestAnnotate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "some-entry-id", "--local-only")
 		assert.ErrorContains(t, err, "required flag(s) \"message\" not set")
@@ -75,14 +63,10 @@ func TestAnnotate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "some-entry-id", "-m", "annotation message")
 		assert.ErrorContains(t, err, "at least one of the flags in the group [remote-name local-only] is required")
@@ -93,14 +77,10 @@ func TestAnnotate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "some-entry-id", "-m", "annotation message", "--local-only", "--remote-name", "origin")
 		assert.ErrorContains(t, err, "if any flags in the group [remote-name local-only] are set")
@@ -111,14 +91,10 @@ func TestAnnotate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), gitinterface.ZeroHash.String(), "-m", "annotation message", "--local-only")
 		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
@@ -129,14 +105,10 @@ func TestAnnotate(t *testing.T) {
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		libRepo, err := gittuf.LoadRepository(".")
 		require.NoError(t, err)
@@ -173,14 +145,10 @@ func TestAnnotate(t *testing.T) {
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		libRepo, err := gittuf.LoadRepository(".")
 		require.NoError(t, err)

--- a/internal/cmd/rsl/annotate/annotate_test.go
+++ b/internal/cmd/rsl/annotate/annotate_test.go
@@ -24,9 +24,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -44,9 +42,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -64,9 +60,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -84,9 +78,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -104,9 +96,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -124,9 +114,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -144,9 +132,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -190,9 +176,7 @@ func TestAnnotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/rsl/propagate/propagate_test.go
+++ b/internal/cmd/rsl/propagate/propagate_test.go
@@ -20,9 +20,7 @@ func TestPropagate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -40,9 +38,7 @@ func TestPropagate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/rsl/propagate/propagate_test.go
+++ b/internal/cmd/rsl/propagate/propagate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPropagate(t *testing.T) {
@@ -17,14 +18,10 @@ func TestPropagate(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -35,14 +32,10 @@ func TestPropagate(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.NoError(t, err)

--- a/internal/cmd/rsl/record/record_test.go
+++ b/internal/cmd/rsl/record/record_test.go
@@ -21,9 +21,7 @@ func TestRecord(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -41,9 +39,7 @@ func TestRecord(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -61,9 +57,7 @@ func TestRecord(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -81,9 +75,7 @@ func TestRecord(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -101,9 +93,7 @@ func TestRecord(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/rsl/record/record_test.go
+++ b/internal/cmd/rsl/record/record_test.go
@@ -18,14 +18,10 @@ func TestRecord(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "main", "--local-only")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -36,14 +32,10 @@ func TestRecord(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
 		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
@@ -54,14 +46,10 @@ func TestRecord(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "main")
 		assert.ErrorContains(t, err, "at least one of the flags in the group [remote-name local-only] is required")
@@ -72,14 +60,10 @@ func TestRecord(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "main", "--local-only", "--remote-name", "origin")
 		assert.ErrorContains(t, err, "if any flags in the group [remote-name local-only] are set")
@@ -90,14 +74,10 @@ func TestRecord(t *testing.T) {
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		err = r.SetGitConfig("user.signingkey", "")
 		require.NoError(t, err)

--- a/internal/cmd/rsl/remote/remote_test.go
+++ b/internal/cmd/rsl/remote/remote_test.go
@@ -20,9 +20,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -39,9 +37,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -58,9 +54,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +72,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -98,9 +90,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -118,9 +108,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -138,9 +126,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -158,9 +144,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -178,9 +162,7 @@ func TestRemoteCommands(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/rsl/remote/remote_test.go
+++ b/internal/cmd/rsl/remote/remote_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoteCommands(t *testing.T) {
@@ -17,14 +18,10 @@ func TestRemoteCommands(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "pull", "origin")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -34,14 +31,10 @@ func TestRemoteCommands(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "push", "origin")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -51,14 +44,10 @@ func TestRemoteCommands(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "reconcile", "origin")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -69,14 +58,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "pull")
 		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
@@ -87,14 +72,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "push")
 		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
@@ -105,14 +86,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "reconcile")
 		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
@@ -123,14 +100,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "pull", "non-existent")
 		assert.ErrorContains(t, err, "non-existent")
@@ -141,14 +114,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "push", "non-existent")
 		assert.ErrorContains(t, err, "non-existent")
@@ -159,14 +128,10 @@ func TestRemoteCommands(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "reconcile", "non-existent")
 		assert.ErrorContains(t, err, "No such remote")

--- a/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
@@ -20,14 +20,10 @@ func TestSkipRewritten(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "refs/heads/main")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -38,14 +34,10 @@ func TestSkipRewritten(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
@@ -56,14 +48,10 @@ func TestSkipRewritten(t *testing.T) {
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		err = r.SetGitConfig("gpg.format", "ssh")
 		require.NoError(t, err)

--- a/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
@@ -23,9 +23,7 @@ func TestSkipRewritten(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -43,9 +41,7 @@ func TestSkipRewritten(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -63,9 +59,7 @@ func TestSkipRewritten(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/sync/sync_test.go
+++ b/internal/cmd/sync/sync_test.go
@@ -26,9 +26,7 @@ func TestSync(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -43,9 +41,7 @@ func TestSync(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -99,9 +95,7 @@ func TestSync(t *testing.T) {
 		if err := os.Chdir(localTmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		// 3. Make Remote and Local Diverge
 		// Remote Action:

--- a/internal/cmd/sync/sync_test.go
+++ b/internal/cmd/sync/sync_test.go
@@ -14,18 +14,15 @@ import (
 	"github.com/gittuf/gittuf/internal/rsl"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSync(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
@@ -35,12 +32,8 @@ func TestSync(t *testing.T) {
 	t.Run("no remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -58,65 +51,40 @@ func TestSync(t *testing.T) {
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if _, err := remoteR.Commit(emptyTreeHash, refName, "Remote commit", false); err != nil {
-			t.Fatal(err)
-		}
+		_, err = remoteR.Commit(emptyTreeHash, refName, "Remote commit", false)
+		require.NoError(t, err)
 
 		// We need a dummy gittuf repo to record RSL
 		remoteRepo, err := gittuf.LoadRepository(remoteTmpDir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := remoteRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, remoteRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()))
 
 		// 2. Setup Local Repo (Clone remote)
 		localTmpDir := filepath.Join(t.TempDir(), "local-sync-test")
 		localR, err := gitinterface.CloneAndFetchRepository(remoteTmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := localR.SetGitConfig("user.name", "Jane Doe"); err != nil {
-			t.Fatal(err)
-		}
-		if err := localR.SetGitConfig("user.email", "jane.doe@example.com"); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, localR.SetGitConfig("user.name", "Jane Doe"))
+		require.NoError(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
 
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(localTmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(localTmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		// 3. Make Remote and Local Diverge
 		// Remote Action:
-		if _, err := remoteRepo.GetGitRepository().Commit(emptyTreeHash, refName, "Another remote commit", false); err != nil {
-			t.Fatal(err)
-		}
-		if err := remoteRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		_, err = remoteRepo.GetGitRepository().Commit(emptyTreeHash, refName, "Another remote commit", false)
+		require.NoError(t, err)
+		require.NoError(t, remoteRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()))
 
 		// Local Action:
 		localRepo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if _, err := localRepo.GetGitRepository().Commit(emptyTreeHash, refName, "Local commit", false); err != nil {
-			t.Fatal(err)
-		}
-		if err := localRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		_, err = localRepo.GetGitRepository().Commit(emptyTreeHash, refName, "Local commit", false)
+		require.NoError(t, err)
+		require.NoError(t, localRepo.RecordRSLEntryForReference(t.Context(), refName, false, rslopts.WithRecordLocalOnly()))
 
 		// 4. Test Sync without --overwrite (should catch divergence)
 		_, stdOut, _, err := cmd.ExecuteCommandC(New())

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository_test.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository_test.go
@@ -24,9 +24,7 @@ func TestAddControllerRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -51,9 +49,7 @@ func TestAddControllerRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -86,9 +82,7 @@ func TestAddControllerRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -142,9 +136,7 @@ func TestAddControllerRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -199,9 +191,7 @@ func TestAddControllerRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository_test.go
+++ b/internal/cmd/trust/addcontrollerrepository/addcontrollerrepository_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddControllerRepository(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddControllerRepository(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -46,14 +43,10 @@ func TestAddControllerRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -71,35 +64,21 @@ func TestAddControllerRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -117,43 +96,25 @@ func TestAddControllerRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		principalKeyPath := filepath.Join(tmpDir, "principal-key")
-		if err := os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -172,43 +133,25 @@ func TestAddControllerRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		principalKeyPath := filepath.Join(tmpDir, "principal-key")
-		if err := os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addgithubapp/addgithubapp_test.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddGitHubApp(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddGitHubApp(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -45,14 +42,10 @@ func TestAddGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -69,35 +62,21 @@ func TestAddGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -114,43 +93,25 @@ func TestAddGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		appKeyPath := filepath.Join(tmpDir, "app-key")
-		if err := os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -168,43 +129,25 @@ func TestAddGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		appKeyPath := filepath.Join(tmpDir, "app-key")
-		if err := os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(appKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(appKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addgithubapp/addgithubapp_test.go
+++ b/internal/cmd/trust/addgithubapp/addgithubapp_test.go
@@ -24,9 +24,7 @@ func TestAddGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -50,9 +48,7 @@ func TestAddGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -84,9 +80,7 @@ func TestAddGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -139,9 +133,7 @@ func TestAddGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -195,9 +187,7 @@ func TestAddGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addglobalrule/addglobalrule_test.go
+++ b/internal/cmd/trust/addglobalrule/addglobalrule_test.go
@@ -25,9 +25,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -52,9 +50,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -87,9 +83,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -137,9 +131,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -188,9 +180,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -236,9 +226,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -285,9 +273,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -335,9 +321,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -383,9 +367,7 @@ func TestAddGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addglobalrule/addglobalrule_test.go
+++ b/internal/cmd/trust/addglobalrule/addglobalrule_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddGlobalRule(t *testing.T) {
@@ -22,14 +23,10 @@ func TestAddGlobalRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -47,14 +44,10 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -72,35 +65,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -120,35 +99,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -169,35 +134,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -215,35 +166,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -262,35 +199,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -310,35 +233,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -356,35 +265,21 @@ func TestAddGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,

--- a/internal/cmd/trust/addhook/addhook_test.go
+++ b/internal/cmd/trust/addhook/addhook_test.go
@@ -68,9 +68,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -97,9 +95,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -134,9 +130,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -188,9 +182,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -242,9 +234,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -296,9 +286,7 @@ func TestAddHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addhook/addhook_test.go
+++ b/internal/cmd/trust/addhook/addhook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddHook(t *testing.T) {
@@ -65,14 +66,10 @@ func TestAddHook(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -92,14 +89,10 @@ func TestAddHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -119,34 +112,20 @@ func TestAddHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -166,39 +145,23 @@ func TestAddHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -218,39 +181,23 @@ func TestAddHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -270,39 +217,23 @@ func TestAddHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository_test.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository_test.go
@@ -24,9 +24,7 @@ func TestAddNetworkRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -51,9 +49,7 @@ func TestAddNetworkRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -86,9 +82,7 @@ func TestAddNetworkRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -145,9 +139,7 @@ func TestAddNetworkRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -204,9 +196,7 @@ func TestAddNetworkRepository(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addnetworkrepository/addnetworkrepository_test.go
+++ b/internal/cmd/trust/addnetworkrepository/addnetworkrepository_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddNetworkRepository(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddNetworkRepository(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -46,14 +43,10 @@ func TestAddNetworkRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -71,38 +64,22 @@ func TestAddNetworkRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.EnableController(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.EnableController(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -120,46 +97,26 @@ func TestAddNetworkRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		principalKeyPath := filepath.Join(tmpDir, "principal-key")
-		if err := os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.EnableController(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.EnableController(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -177,46 +134,26 @@ func TestAddNetworkRepository(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		principalKeyPath := filepath.Join(tmpDir, "principal-key")
-		if err := os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(principalKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(principalKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.EnableController(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
+		require.NoError(t, repo.EnableController(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addpolicykey/addpolicykey_test.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddPolicyKey(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddPolicyKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestAddPolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,22 +56,14 @@ func TestAddPolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -92,43 +77,25 @@ func TestAddPolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -143,43 +110,25 @@ func TestAddPolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addpolicykey/addpolicykey_test.go
+++ b/internal/cmd/trust/addpolicykey/addpolicykey_test.go
@@ -24,9 +24,7 @@ func TestAddPolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestAddPolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +74,7 @@ func TestAddPolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -117,9 +111,7 @@ func TestAddPolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -170,9 +162,7 @@ func TestAddPolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective_test.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective_test.go
@@ -24,9 +24,7 @@ func TestAddPropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -54,9 +52,7 @@ func TestAddPropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -92,9 +88,7 @@ func TestAddPropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -143,9 +137,7 @@ func TestAddPropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addpropagationdirective/addpropagationdirective_test.go
+++ b/internal/cmd/trust/addpropagationdirective/addpropagationdirective_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddPropagationDirective(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddPropagationDirective(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -49,14 +46,10 @@ func TestAddPropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -77,35 +70,21 @@ func TestAddPropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -126,35 +105,21 @@ func TestAddPropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/addrootkey/addrootkey_test.go
+++ b/internal/cmd/trust/addrootkey/addrootkey_test.go
@@ -24,9 +24,7 @@ func TestAddRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestAddRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +74,7 @@ func TestAddRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -117,9 +111,7 @@ func TestAddRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -169,9 +161,7 @@ func TestAddRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/addrootkey/addrootkey_test.go
+++ b/internal/cmd/trust/addrootkey/addrootkey_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAddRootKey(t *testing.T) {
@@ -21,14 +22,10 @@ func TestAddRootKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestAddRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,22 +56,14 @@ func TestAddRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -92,43 +77,25 @@ func TestAddRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -142,43 +109,25 @@ func TestAddRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
@@ -15,18 +15,15 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDisableGitHubAppApprovals(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		pOpts := &persistent.Options{
@@ -39,12 +36,8 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 	t.Run("invalid signer", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -59,35 +52,21 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 	t.Run("success already untrusted", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -99,40 +78,24 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 	t.Run("success disable trusted app", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		key, err := gittuf.LoadPublicKey(keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = repo.AddGitHubApp(t.Context(), signer, "github-app", key, false)
 		assert.NoError(t, err)
@@ -168,40 +131,24 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 	t.Run("success disable trusted app with RSL entry", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		key, err := gittuf.LoadPublicKey(keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		err = repo.AddGitHubApp(t.Context(), signer, "github-app", key, false)
 		assert.NoError(t, err)

--- a/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
+++ b/internal/cmd/trust/disablegithubappapprovals/disablegithubappapprovals_test.go
@@ -27,9 +27,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -47,9 +45,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -69,9 +65,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -111,9 +105,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -182,9 +174,7 @@ func TestDisableGitHubAppApprovals(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
@@ -25,9 +25,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -49,9 +47,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -81,9 +77,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -113,9 +107,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -146,9 +138,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -205,9 +195,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -261,9 +249,7 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
+++ b/internal/cmd/trust/enablegithubappapprovals/enablegithubappapprovals_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEnableGitHubAppApprovals(t *testing.T) {
@@ -22,14 +23,10 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -44,14 +41,10 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -66,22 +59,14 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -96,22 +81,14 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -127,49 +104,29 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Add GitHub App and set trusted to true
-		if err := repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false); err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.TrustGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false))
+		require.NoError(t, repo.TrustGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -184,46 +141,28 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Add GitHub App (untrusted by default)
-		if err := repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -238,46 +177,28 @@ func TestEnableGitHubAppApprovals(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		appKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Add GitHub App (untrusted by default)
-		if err := repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, appKey, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/incrementversion/incrementversion_test.go
+++ b/internal/cmd/trust/incrementversion/incrementversion_test.go
@@ -25,9 +25,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -111,9 +105,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -144,9 +136,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -190,9 +180,7 @@ func TestIncrementVersion(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/incrementversion/incrementversion_test.go
+++ b/internal/cmd/trust/incrementversion/incrementversion_test.go
@@ -15,6 +15,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIncrementVersion(t *testing.T) {
@@ -22,14 +23,10 @@ func TestIncrementVersion(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -64,22 +57,14 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -94,22 +79,14 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,
@@ -125,36 +102,22 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -169,36 +132,22 @@ func TestIncrementVersion(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/init/init_test.go
+++ b/internal/cmd/trust/init/init_test.go
@@ -23,9 +23,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -46,9 +44,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +74,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -110,9 +104,7 @@ func TestInit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/init/init_test.go
+++ b/internal/cmd/trust/init/init_test.go
@@ -13,6 +13,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInit(t *testing.T) {
@@ -20,14 +21,10 @@ func TestInit(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -41,14 +38,10 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -62,23 +55,15 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
 
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -92,23 +77,15 @@ func TestInit(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
 
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/listglobalrules/listglobalrules_test.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules_test.go
@@ -26,9 +26,7 @@ func TestListGlobalRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -46,9 +44,7 @@ func TestListGlobalRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -74,9 +70,7 @@ func TestListGlobalRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -117,9 +111,7 @@ func TestListGlobalRules(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/listglobalrules/listglobalrules_test.go
+++ b/internal/cmd/trust/listglobalrules/listglobalrules_test.go
@@ -16,6 +16,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListGlobalRules(t *testing.T) {
@@ -23,14 +24,10 @@ func TestListGlobalRules(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -41,14 +38,10 @@ func TestListGlobalRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to find RSL entry")
@@ -59,36 +52,22 @@ func TestListGlobalRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)
@@ -100,46 +79,28 @@ func TestListGlobalRules(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Add threshold global rule
-		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "require-approval-for-main", []string{"git:refs/heads/main", "file:src/*"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleThreshold(t.Context(), signer, "require-approval-for-main", []string{"git:refs/heads/main", "file:src/*"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		// Add block force pushes global rule
-		if err := repo.AddGlobalRuleBlockForcePushes(t.Context(), signer, "block-force-pushes-for-main", []string{"git:refs/heads/main"}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleBlockForcePushes(t.Context(), signer, "block-force-pushes-for-main", []string{"git:refs/heads/main"}, false, trustpolicyopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)

--- a/internal/cmd/trust/listhooks/listhooks_test.go
+++ b/internal/cmd/trust/listhooks/listhooks_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListHooks(t *testing.T) {
@@ -28,14 +29,10 @@ func TestListHooks(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -46,14 +43,10 @@ func TestListHooks(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to find RSL entry")
@@ -64,36 +57,22 @@ func TestListHooks(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)
@@ -105,45 +84,27 @@ func TestListHooks(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		keyID, err := signer.KeyID()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("echo test"), tuf.HookEnvironmentLua, []string{keyID}, 100, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("echo test"), tuf.HookEnvironmentLua, []string{keyID}, 100, false, trustpolicyopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)

--- a/internal/cmd/trust/listhooks/listhooks_test.go
+++ b/internal/cmd/trust/listhooks/listhooks_test.go
@@ -31,9 +31,7 @@ func TestListHooks(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -51,9 +49,7 @@ func TestListHooks(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -79,9 +75,7 @@ func TestListHooks(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -122,9 +116,7 @@ func TestListHooks(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
+++ b/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
@@ -16,6 +16,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestListPropagationDirectives(t *testing.T) {
@@ -23,14 +24,10 @@ func TestListPropagationDirectives(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -41,14 +38,10 @@ func TestListPropagationDirectives(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to find RSL entry")
@@ -59,36 +52,22 @@ func TestListPropagationDirectives(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)
@@ -104,40 +83,24 @@ func TestListPropagationDirectives(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "https://github.com/test/repo", "refs/heads/main", "upstream/", "refs/heads/main", "downstream/", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPropagationDirective(t.Context(), signer, "test-directive", "https://github.com/test/repo", "refs/heads/main", "upstream/", "refs/heads/main", "downstream/", false, trustpolicyopts.WithRSLEntry()))
 
 		_, stdout, _, err := cmd.ExecuteCommandC(New(), "--target-ref", "policy-staging")
 		assert.NoError(t, err)

--- a/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
+++ b/internal/cmd/trust/listpropagationdirectives/listpropagationdirectives_test.go
@@ -26,9 +26,7 @@ func TestListPropagationDirectives(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -46,9 +44,7 @@ func TestListPropagationDirectives(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -74,9 +70,7 @@ func TestListPropagationDirectives(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -121,9 +115,7 @@ func TestListPropagationDirectives(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/makecontroller/makecontroller_test.go
+++ b/internal/cmd/trust/makecontroller/makecontroller_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeController(t *testing.T) {
@@ -21,14 +22,10 @@ func TestMakeController(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestMakeController(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,35 +58,21 @@ func TestMakeController(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -108,35 +87,21 @@ func TestMakeController(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/makecontroller/makecontroller_test.go
+++ b/internal/cmd/trust/makecontroller/makecontroller_test.go
@@ -24,9 +24,7 @@ func TestMakeController(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestMakeController(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestMakeController(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -125,9 +119,7 @@ func TestMakeController(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removegithubapp/removegithubapp_test.go
+++ b/internal/cmd/trust/removegithubapp/removegithubapp_test.go
@@ -17,6 +17,7 @@ import (
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveGitHubApp(t *testing.T) {
@@ -24,14 +25,10 @@ func TestRemoveGitHubApp(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -46,14 +43,10 @@ func TestRemoveGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -68,42 +61,26 @@ func TestRemoveGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		key := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, artifacts.SSHED25519PublicSSH))
 
-		if err := repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, key, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, key, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -118,42 +95,26 @@ func TestRemoveGitHubApp(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		key := tufv01.NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, artifacts.SSHED25519PublicSSH))
 
-		if err := repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, key, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGitHubApp(t.Context(), signer, tuf.GitHubAppRoleName, key, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/removegithubapp/removegithubapp_test.go
+++ b/internal/cmd/trust/removegithubapp/removegithubapp_test.go
@@ -27,9 +27,7 @@ func TestRemoveGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -51,9 +49,7 @@ func TestRemoveGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -83,9 +79,7 @@ func TestRemoveGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -135,9 +129,7 @@ func TestRemoveGitHubApp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removeglobalrule/removeglobalrule_test.go
+++ b/internal/cmd/trust/removeglobalrule/removeglobalrule_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveGlobalRule(t *testing.T) {
@@ -21,14 +22,10 @@ func TestRemoveGlobalRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestRemoveGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,40 +58,24 @@ func TestRemoveGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -113,40 +90,24 @@ func TestRemoveGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/removeglobalrule/removeglobalrule_test.go
+++ b/internal/cmd/trust/removeglobalrule/removeglobalrule_test.go
@@ -24,9 +24,7 @@ func TestRemoveGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestRemoveGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestRemoveGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -130,9 +124,7 @@ func TestRemoveGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removehook/removehook_test.go
+++ b/internal/cmd/trust/removehook/removehook_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveHook(t *testing.T) {
@@ -31,14 +32,10 @@ func TestRemoveHook(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -55,14 +52,10 @@ func TestRemoveHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -79,40 +72,24 @@ func TestRemoveHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("echo hi"), tuf.HookEnvironmentLua, []string{}, 100, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("echo hi"), tuf.HookEnvironmentLua, []string{}, 100, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -129,40 +106,24 @@ func TestRemoveHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []byte("echo hi"), tuf.HookEnvironmentLua, []string{}, 100, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []byte("echo hi"), tuf.HookEnvironmentLua, []string{}, 100, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/removehook/removehook_test.go
+++ b/internal/cmd/trust/removehook/removehook_test.go
@@ -34,9 +34,7 @@ func TestRemoveHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -60,9 +58,7 @@ func TestRemoveHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -94,9 +90,7 @@ func TestRemoveHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -146,9 +140,7 @@ func TestRemoveHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removepolicykey/removepolicykey_test.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey_test.go
@@ -24,9 +24,7 @@ func TestRemovePolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestRemovePolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -86,9 +82,7 @@ func TestRemovePolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -159,9 +153,7 @@ func TestRemovePolicyKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removepolicykey/removepolicykey_test.go
+++ b/internal/cmd/trust/removepolicykey/removepolicykey_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemovePolicyKey(t *testing.T) {
@@ -21,14 +22,10 @@ func TestRemovePolicyKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestRemovePolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,63 +56,37 @@ func TestRemovePolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		targetsKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Also add the signer's own public key as a targets key so that after
 		// removing targetsKey, at least one key remains to meet the threshold.
 		signerPubKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, signerPubKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, signerPubKey, true))
 
 		// Add the RSA key so we can remove it
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, true))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -134,63 +101,37 @@ func TestRemovePolicyKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		targetsKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Also add the signer's own public key as a targets key so that after
 		// removing targetsKey, at least one key remains to meet the threshold.
 		signerPubKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, signerPubKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, signerPubKey, true))
 
 		// Add the RSA key so we can remove it
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, true))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/removepropagationdirective/removepropagationdirective_test.go
+++ b/internal/cmd/trust/removepropagationdirective/removepropagationdirective_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemovePropagationDirective(t *testing.T) {
@@ -21,14 +22,10 @@ func TestRemovePropagationDirective(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestRemovePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,40 +58,24 @@ func TestRemovePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -113,40 +90,24 @@ func TestRemovePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
-		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/removepropagationdirective/removepropagationdirective_test.go
+++ b/internal/cmd/trust/removepropagationdirective/removepropagationdirective_test.go
@@ -24,9 +24,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -130,9 +124,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removerootkey/removerootkey_test.go
+++ b/internal/cmd/trust/removerootkey/removerootkey_test.go
@@ -24,9 +24,7 @@ func TestRemoveRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestRemoveRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -86,9 +82,7 @@ func TestRemoveRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -149,9 +143,7 @@ func TestRemoveRootKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/removerootkey/removerootkey_test.go
+++ b/internal/cmd/trust/removerootkey/removerootkey_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemoveRootKey(t *testing.T) {
@@ -21,14 +22,10 @@ func TestRemoveRootKey(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestRemoveRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,53 +56,31 @@ func TestRemoveRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		rootKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Add the key first so we can remove it
-		if err := repo.AddRootKey(t.Context(), signer, rootKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddRootKey(t.Context(), signer, rootKey, true))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -124,53 +95,31 @@ func TestRemoveRootKey(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		newKeyPath := filepath.Join(tmpDir, "new-test-key")
-		if err := os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(newKeyPath, artifacts.SSHRSAPrivate, 0o600))
+		require.NoError(t, os.WriteFile(newKeyPath+".pub", artifacts.SSHRSAPublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		rootKey, err := gittuf.LoadPublicKey(newKeyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Add the key first so we can remove it
-		if err := repo.AddRootKey(t.Context(), signer, rootKey, true); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddRootKey(t.Context(), signer, rootKey, true))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
+++ b/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSetRepositoryLocation(t *testing.T) {
@@ -21,14 +22,10 @@ func TestSetRepositoryLocation(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestSetRepositoryLocation(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,36 +58,22 @@ func TestSetRepositoryLocation(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -109,36 +88,22 @@ func TestSetRepositoryLocation(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
+++ b/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
@@ -24,9 +24,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -36,7 +34,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: "dummy-key",
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.ErrorContains(t, err, "unable to identify git directory")
 	})
 
@@ -48,9 +46,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -60,7 +56,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: "non-existent-key",
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.Error(t, err)
 	})
 
@@ -80,9 +76,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -106,7 +100,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: keyPath,
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.NoError(t, err)
 	})
 
@@ -126,9 +120,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -153,7 +145,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			WithRSLEntry: true,
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.NoError(t, err)
 	})
 }

--- a/internal/cmd/trust/sign/sign_test.go
+++ b/internal/cmd/trust/sign/sign_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSign(t *testing.T) {
@@ -21,14 +22,10 @@ func TestSign(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,36 +58,22 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -109,36 +88,22 @@ func TestSign(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/sign/sign_test.go
+++ b/internal/cmd/trust/sign/sign_test.go
@@ -24,9 +24,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -126,9 +120,7 @@ func TestSign(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updateglobalrule/updateglobalrule_test.go
+++ b/internal/cmd/trust/updateglobalrule/updateglobalrule_test.go
@@ -27,9 +27,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -51,9 +49,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -83,9 +79,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -115,9 +109,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -147,9 +139,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -179,9 +169,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -229,9 +217,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -279,9 +265,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updateglobalrule/updateglobalrule_test.go
+++ b/internal/cmd/trust/updateglobalrule/updateglobalrule_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateGlobalRule(t *testing.T) {
@@ -24,14 +25,10 @@ func TestUpdateGlobalRule(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -46,14 +43,10 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -68,22 +61,14 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -98,22 +83,14 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -128,22 +105,14 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -158,40 +127,24 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -206,40 +159,24 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddGlobalRuleBlockForcePushes(t.Context(), signer, "test-rule-bfp", []string{"git:refs/heads/main"}, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleBlockForcePushes(t.Context(), signer, "test-rule-bfp", []string{"git:refs/heads/main"}, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -254,40 +191,24 @@ func TestUpdateGlobalRule(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddGlobalRuleThreshold(t.Context(), signer, "test-rule", []string{"git:refs/heads/main"}, 1, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/updatehook/updatehook_test.go
+++ b/internal/cmd/trust/updatehook/updatehook_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateHook(t *testing.T) {
@@ -73,14 +74,10 @@ func TestUpdateHook(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -102,14 +99,10 @@ func TestUpdateHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -131,34 +124,20 @@ func TestUpdateHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -180,44 +159,26 @@ func TestUpdateHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Add the hook first so it exists to be updated
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -239,44 +200,26 @@ func TestUpdateHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Add the hook first so it exists to be updated
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -298,44 +241,26 @@ func TestUpdateHook(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		scriptPath := filepath.Join(tmpDir, "script.lua")
-		if err := os.WriteFile(scriptPath, []byte("print('hello')"), 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(scriptPath, []byte("print('hello')"), 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Add the hook first so it exists to be updated
-		if err := repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddHook(t.Context(), signer, []tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []byte("print('hello')"), tuf.HookEnvironmentLua, []string{"test-principal"}, 10, false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/updatehook/updatehook_test.go
+++ b/internal/cmd/trust/updatehook/updatehook_test.go
@@ -76,9 +76,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -107,9 +105,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -146,9 +142,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -202,9 +196,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -263,9 +255,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -324,9 +314,7 @@ func TestUpdateHook(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
@@ -24,9 +24,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -48,9 +46,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -80,9 +76,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -134,9 +128,7 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
+++ b/internal/cmd/trust/updatepolicythreshold/updatepolicythreshold_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdatePolicyThreshold(t *testing.T) {
@@ -21,14 +22,10 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -43,14 +40,10 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -65,44 +58,26 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		targetsKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -117,44 +92,26 @@ func TestUpdatePolicyThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		targetsKey, err := gittuf.LoadPublicKey(keyPath + ".pub")
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.AddTopLevelTargetsKey(t.Context(), signer, targetsKey, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
+++ b/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
@@ -44,9 +44,7 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -75,9 +73,7 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -114,9 +110,7 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -172,9 +166,7 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
+++ b/internal/cmd/trust/updatepropagationdirective/updatepropagationdirective_test.go
@@ -17,6 +17,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdatePropagationDirective(t *testing.T) {
@@ -41,14 +42,10 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -70,14 +67,10 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -99,40 +92,24 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -155,40 +132,24 @@ func TestUpdatePropagationDirective(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
-		if err := repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.AddPropagationDirective(t.Context(), signer, "test-directive", "origin", "refs/heads/main", "foo", "refs/heads/main", "bar", false, trustpolicyopts.WithRSLEntry()))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold_test.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold_test.go
@@ -24,9 +24,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -47,9 +45,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -78,9 +74,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -123,9 +117,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trust/updaterootthreshold/updaterootthreshold_test.go
+++ b/internal/cmd/trust/updaterootthreshold/updaterootthreshold_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUpdateRootThreshold(t *testing.T) {
@@ -21,14 +22,10 @@ func TestUpdateRootThreshold(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "dummy-key",
@@ -42,14 +39,10 @@ func TestUpdateRootThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		pOpts := &persistent.Options{
 			SigningKey: "non-existent-key",
@@ -63,35 +56,21 @@ func TestUpdateRootThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
@@ -106,35 +85,21 @@ func TestUpdateRootThreshold(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		// Initialize the repository first
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := repo.InitializeRoot(t.Context(), signer, false); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false))
 
 		pOpts := &persistent.Options{
 			SigningKey:   keyPath,

--- a/internal/cmd/trustpolicy/apply/apply_test.go
+++ b/internal/cmd/trustpolicy/apply/apply_test.go
@@ -24,9 +24,7 @@ func TestApply(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -52,9 +50,7 @@ func TestApply(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trustpolicy/apply/apply_test.go
+++ b/internal/cmd/trustpolicy/apply/apply_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestApply(t *testing.T) {
@@ -21,14 +22,10 @@ func TestApply(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
 		assert.ErrorContains(t, err, "not a git repository")
@@ -39,37 +36,23 @@ func TestApply(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Initialize root and generate policy-staging ref
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Apply the policy-staging changes locally
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")

--- a/internal/cmd/trustpolicy/remote/pull/pull_test.go
+++ b/internal/cmd/trustpolicy/remote/pull/pull_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPull(t *testing.T) {
@@ -17,14 +18,10 @@ func TestPull(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "origin")
 		assert.ErrorContains(t, err, "not a git repository")
@@ -35,14 +32,10 @@ func TestPull(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "non-existent-remote")
 		assert.ErrorContains(t, err, "unable to pull policy")

--- a/internal/cmd/trustpolicy/remote/pull/pull_test.go
+++ b/internal/cmd/trustpolicy/remote/pull/pull_test.go
@@ -20,9 +20,7 @@ func TestPull(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -40,9 +38,7 @@ func TestPull(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trustpolicy/remote/push/push_test.go
+++ b/internal/cmd/trustpolicy/remote/push/push_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPush(t *testing.T) {
@@ -17,14 +18,10 @@ func TestPush(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "origin")
 		assert.ErrorContains(t, err, "not a git repository")
@@ -35,14 +32,10 @@ func TestPush(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "non-existent-remote")
 		assert.ErrorContains(t, err, "unable to push policy")

--- a/internal/cmd/trustpolicy/remote/push/push_test.go
+++ b/internal/cmd/trustpolicy/remote/push/push_test.go
@@ -20,9 +20,7 @@ func TestPush(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -40,9 +38,7 @@ func TestPush(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trustpolicy/stage/stage_test.go
+++ b/internal/cmd/trustpolicy/stage/stage_test.go
@@ -24,9 +24,7 @@ func TestStage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
@@ -52,9 +50,7 @@ func TestStage(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(cwd)
-		}()
+		defer os.Chdir(cwd) //nolint:errcheck
 
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)

--- a/internal/cmd/trustpolicy/stage/stage_test.go
+++ b/internal/cmd/trustpolicy/stage/stage_test.go
@@ -14,6 +14,7 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStage(t *testing.T) {
@@ -21,14 +22,10 @@ func TestStage(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")
 		assert.ErrorContains(t, err, "not a git repository")
@@ -39,37 +36,23 @@ func TestStage(t *testing.T) {
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		keyPath := filepath.Join(tmpDir, "test-key")
-		if err := os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.WriteFile(keyPath, artifacts.SSHED25519Private, 0o600))
+		require.NoError(t, os.WriteFile(keyPath+".pub", artifacts.SSHED25519PublicSSH, 0o600))
 
 		cwd, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		defer os.Chdir(cwd) //nolint:errcheck
 
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, os.Chdir(tmpDir))
 
 		repo, err := gittuf.LoadRepository(".")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		signer, err := gittuf.LoadSigner(repo, keyPath)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		// Initialize root and generate policy-staging ref
-		if err := repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, repo.InitializeRoot(t.Context(), signer, false, rootopts.WithRSLEntry()))
 
 		// Stage the policy changes locally
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--local-only")

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/muesli/termenv"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -25,12 +26,8 @@ func init() {
 func TestTUI(t *testing.T) {
 	tmpDir := t.TempDir()
 	currentDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
 	defer os.Chdir(currentDir) //nolint:errcheck
 
 	gitinterface.CreateTestGitRepository(t, tmpDir, false)

--- a/internal/cmd/verifymergeable/verifymergeable_test.go
+++ b/internal/cmd/verifymergeable/verifymergeable_test.go
@@ -22,9 +22,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--base-branch", "main", "--feature-branch", "feature")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -39,9 +37,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -65,9 +61,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -84,9 +78,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/verifymergeable/verifymergeable_test.go
+++ b/internal/cmd/verifymergeable/verifymergeable_test.go
@@ -10,18 +10,15 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyMergeable(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "--base-branch", "main", "--feature-branch", "feature")
@@ -31,12 +28,8 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("missing required flags", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -55,12 +48,8 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("uninitialized repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -72,12 +61,8 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("bypass RSL", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)

--- a/internal/cmd/verifynetwork/verifynetwork_test.go
+++ b/internal/cmd/verifynetwork/verifynetwork_test.go
@@ -10,18 +10,15 @@ import (
 	"github.com/gittuf/gittuf/internal/cmd"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyNetwork(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
@@ -31,12 +28,8 @@ func TestVerifyNetwork(t *testing.T) {
 	t.Run("uninitialized repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)

--- a/internal/cmd/verifynetwork/verifynetwork_test.go
+++ b/internal/cmd/verifynetwork/verifynetwork_test.go
@@ -22,9 +22,7 @@ func TestVerifyNetwork(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New())
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -39,9 +37,7 @@ func TestVerifyNetwork(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/verifyref/verifyref_test.go
+++ b/internal/cmd/verifyref/verifyref_test.go
@@ -23,9 +23,7 @@ func TestVerifyRef(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "refs/heads/main")
 		assert.ErrorContains(t, err, "unable to identify git directory")
@@ -40,9 +38,7 @@ func TestVerifyRef(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -61,9 +57,7 @@ func TestVerifyRef(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -82,9 +76,7 @@ func TestVerifyRef(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
@@ -102,9 +94,7 @@ func TestVerifyRef(t *testing.T) {
 		if err := os.Chdir(tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		defer func() {
-			_ = os.Chdir(currentDir)
-		}()
+		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
 

--- a/internal/cmd/verifyref/verifyref_test.go
+++ b/internal/cmd/verifyref/verifyref_test.go
@@ -11,18 +11,15 @@ import (
 	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestVerifyRef(t *testing.T) {
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		_, _, _, err = cmd.ExecuteCommandC(New(), "refs/heads/main")
@@ -32,12 +29,8 @@ func TestVerifyRef(t *testing.T) {
 	t.Run("mutually exclusive flags", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -51,12 +44,8 @@ func TestVerifyRef(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -70,12 +59,8 @@ func TestVerifyRef(t *testing.T) {
 
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)
@@ -88,12 +73,8 @@ func TestVerifyRef(t *testing.T) {
 	t.Run("uninitialized repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		currentDir, err := os.Getwd()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+		require.NoError(t, os.Chdir(tmpDir))
 		defer os.Chdir(currentDir) //nolint:errcheck
 
 		gitinterface.CreateTestGitRepository(t, tmpDir, false)


### PR DESCRIPTION
## Description

This pull request standardizes the directory restoration pattern in the CLI command test suites under `internal/cmd/` to match the rest of the gittuf codebase:

- Refactored redundant deferred anonymous functions used to restore directories (e.g., `defer func() { _ = os.Chdir(cwd) }()`) to direct deferred calls (e.g., `defer os.Chdir(cwd) //nolint:errcheck`) across 64 CLI test files.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Generative AI was used to identify files using the non-standard deferred anonymous function pattern, automate the refactoring replacement across the 64 test files and analyze the subsequent test run results.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).