### PR TITLE
refector(tui): split trust menu into its own component

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -55,7 +55,7 @@ type model struct {
 	spinner           spinner.Model
 	homeScreen        homeScreen
 	policyScreen      policyScreen
-	trustScreenList   list.Model
+	trustScreen       trustScreen
 	policyRulesScreen policyRulesScreen
 	globalRules       []globalRule
 	globalRuleList    list.Model
@@ -168,9 +168,11 @@ func initialModel(ctx context.Context, o *options) model {
 				item{title: "View Rules", desc: "View and manage policy rules"},
 			}, delegate),
 		},
-		trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
-			item{title: "View Global Rules", desc: "View and manage global rules"},
-		}, delegate),
+		trustScreen: trustScreen{
+			trustScreenList: newMenuList("gittuf Trust Operations", []list.Item{
+				item{title: "View Global Rules", desc: "View and manage global rules"},
+			}, delegate),
+		},
 		policyRulesScreen: policyRulesScreen{
 			ruleList: newMenuList("Policy Rules", []list.Item{}, delegate),
 		},
@@ -217,7 +219,7 @@ func (m *model) resizeLists() {
 
 	m.homeScreen.choiceList.SetSize(innerWidth, innerHeight)
 	m.policyScreen.policyScreenList.SetSize(innerWidth, innerHeight)
-	m.trustScreenList.SetSize(innerWidth, innerHeight)
+	m.trustScreen.trustScreenList.SetSize(innerWidth, innerHeight)
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)
 	m.globalRuleList.SetSize(innerWidth, innerHeight)
 }

--- a/internal/cmd/tui/screen_trust.go
+++ b/internal/cmd/tui/screen_trust.go
@@ -1,0 +1,32 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type trustScreen struct {
+	trustScreenList list.Model
+}
+
+func (s *trustScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		if msg.String() == "enter" {
+			if _, ok := s.trustScreenList.SelectedItem().(item); ok {
+				m.screen = screenTrustGlobalRules
+				m.refreshGlobalRules()
+			}
+			return *m, nil
+		}
+	}
+	s.trustScreenList, cmd = s.trustScreenList.Update(msg)
+	return *m, cmd
+}
+
+func (s *trustScreen) View(m *model) string {
+	return m.renderScreen("Home › Trust", s.trustScreenList.View(), renderActionHints(m.readOnly))
+}

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -62,8 +62,6 @@ func TestTUI(t *testing.T) {
 		m := initialModel(context.Background(), o)
 
 		tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
-
-		// Wait for main menu to render
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
 			return strings.Contains(string(out), "Policy")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
@@ -87,6 +85,43 @@ func TestTUI(t *testing.T) {
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 
 		// Send "q" to quit
+		tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+		tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*15))
+	})
+
+	t.Run("Trust UI Navigation", func(t *testing.T) {
+		o := &options{
+			readOnly:  true,
+			targetRef: "policy",
+		}
+
+		m := initialModel(context.Background(), o)
+
+		tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			return strings.Contains(string(out), "Policy")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// select "Trust" from the main menu (click down arrow to move selection, then press enter to select)
+		tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			return strings.Contains(string(out), "Home › Trust")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// select "View Global Rules" (already selected by default)
+		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+		// Now we should end up on the Trust Global Rules screen.
+		// check for the screen title OR the screen-specific empty-state message.
+		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+			content := string(out)
+			return strings.Contains(content, "Home › Trust › Global Rules") || strings.Contains(content, "No global rules configured")
+		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
+
+		// Click "q" to quit
 		tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 		tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*15))
 	})

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -109,9 +109,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case screenChoice:
 			return m.homeScreen.Update(msg, &m)
 		case screenTrust:
-			if msg.String() == "enter" {
-				return m.handleEnter()
-			}
+			return m.trustScreen.Update(msg, &m)
 		case screenPolicyRules, screenPolicyAddRule, screenPolicyEditRule:
 			return m.policyRulesScreen.Update(msg, &m)
 		case screenTrustGlobalRules:
@@ -134,7 +132,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenPolicy:
 		return m.policyScreen.Update(msg, &m)
 	case screenTrust:
-		m.trustScreenList, cmd = m.trustScreenList.Update(msg)
+		return m.trustScreen.Update(msg, &m)
 	case screenPolicyRules, screenPolicyAddRule, screenPolicyEditRule:
 		return m.policyRulesScreen.Update(msg, &m)
 	case screenTrustGlobalRules:
@@ -144,17 +142,6 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, cmd
-}
-
-// handleEnter handles the enter key press on selection menu screens.
-func (m model) handleEnter() (tea.Model, tea.Cmd) {
-	if m.screen == screenTrust {
-		if _, ok := m.trustScreenList.SelectedItem().(item); ok {
-			m.screen = screenTrustGlobalRules
-			m.refreshGlobalRules()
-		}
-	}
-	return m, nil
 }
 
 // handleRulesListKey handles keybindings on rule list screens (rules and global rules).

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -360,7 +360,7 @@ func (m model) View() string {
 		return m.policyScreen.View(&m)
 
 	case screenTrust:
-		return m.renderScreen("Home › Trust", m.trustScreenList.View(), renderActionHints(m.readOnly))
+		return m.trustScreen.View(&m)
 
 	case screenPolicyRules:
 		return m.policyRulesScreen.View(&m)


### PR DESCRIPTION
## Description

The PR extracts the existing trust submenu into its own TUI component. It moves the trust submenu update/render out of the shared TUI core and into a dedicated file: `screen_trust.go`
**Changes**:
- add trustScreen in `internal/cmd/tui/screen_trust.go`
- move trust submenu update into trustScreen.Update()
- move trust submenu rendering into trustScreen.View()
- replace the `trustScreenList` in the root model with `trustSceen`
- add a trust navigation test in `internal/cmd/tui/tui_test.go`


## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used generative AI to help with Go/bubbletea syntax + code structure, and used to brainstorm for the unit test. Manually reviewed all code generated and compared with my original plan, and also conduct manual testing on the tui to make sure the change doesn't interfere with existing code.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
