### PR TITLE
refactor(tui) :- split help overlay screen into modular component

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -54,6 +54,7 @@ type model struct {
 	screen            screen
 	spinner           spinner.Model
 	homeScreen        homeScreen
+	helpScreen        helpScreen
 	policyScreen      policyScreen
 	trustScreenList   list.Model
 	policyRulesScreen policyRulesScreen
@@ -75,7 +76,6 @@ type model struct {
 	deleteTarget      string
 	showHelp          bool
 	signerError       string
-	previousScreen    screen
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.

--- a/internal/cmd/tui/screen_help.go
+++ b/internal/cmd/tui/screen_help.go
@@ -1,0 +1,49 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+type helpScreen struct {
+	previousScreen screen
+}
+
+func (s *helpScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "h", "esc":
+			m.screen = s.previousScreen
+			return *m, nil
+		}
+	}
+	return *m, nil
+}
+
+func (s *helpScreen) View(m *model) string {
+	h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+	boxWidth := m.width - h - 2
+	boxHeight := m.height - v - 8
+	if boxWidth < 0 {
+		boxWidth = 0
+	}
+	if boxHeight < 0 {
+		boxHeight = 0
+	}
+
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(colorFocus)).Render("Help")
+	helpContent := title + "\n\n" +
+		"- ↑ ↓ : Navigate\n" +
+		"- Enter : Select\n" +
+		"- a : Add rule\n" +
+		"- e : Edit\n" +
+		"- d : Delete\n" +
+		"- esc : Back\n" +
+		"- q : Quit\n"
+
+	centeredContent := lipgloss.Place(boxWidth, boxHeight, lipgloss.Center, lipgloss.Center, helpContent)
+	return m.renderScreen("Help", centeredContent, "")
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -72,11 +72,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
 				if m.screen == screenHelp {
 					// Toggle back
-					m.screen = m.previousScreen
+					m.screen = m.helpScreen.previousScreen
 					return m, nil
 				}
 				// Go to help screen
-				m.previousScreen = m.screen
+				m.helpScreen.previousScreen = m.screen
 				m.screen = screenHelp
 				return m, nil
 			}
@@ -99,7 +99,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 				m.screen = screenTrustGlobalRules
 			case screenHelp:
-				m.screen = m.previousScreen
+				m.screen = m.helpScreen.previousScreen
 			}
 			return m, nil
 		}
@@ -108,6 +108,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch m.screen {
 		case screenChoice:
 			return m.homeScreen.Update(msg, &m)
+		case screenHelp:
+			return m.helpScreen.Update(msg, &m)
 		case screenTrust:
 			if msg.String() == "enter" {
 				return m.handleEnter()
@@ -131,6 +133,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m.screen {
 	case screenChoice:
 		return m.homeScreen.Update(msg, &m)
+	case screenHelp:
+		return m.helpScreen.Update(msg, &m)
 	case screenPolicy:
 		return m.policyScreen.Update(msg, &m)
 	case screenTrust:

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -392,28 +392,7 @@ func (m model) View() string {
 		return m.renderFormScreen("Edit Global Rule", "Home › Trust › Global Rules › Edit")
 
 	case screenHelp:
-		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
-		boxWidth := m.width - h - 2
-		boxHeight := m.height - v - 8
-		if boxWidth < 0 {
-			boxWidth = 0
-		}
-		if boxHeight < 0 {
-			boxHeight = 0
-		}
-
-		title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(colorFocus)).Render("Help")
-		helpContent := title + "\n\n" +
-			"- ↑ ↓ : Navigate\n" +
-			"- Enter : Select\n" +
-			"- a : Add rule\n" +
-			"- e : Edit\n" +
-			"- d : Delete\n" +
-			"- esc : Back\n" +
-			"- q : Quit\n"
-
-		centeredContent := lipgloss.Place(boxWidth, boxHeight, lipgloss.Center, lipgloss.Center, helpContent)
-		return m.renderScreen("Help", centeredContent, "")
+		return m.helpScreen.View(&m)
 
 	default:
 		return "Unknown screen"


### PR DESCRIPTION
## Description

This pull request refactors the gittuf TUI by extracting the global Help overlay screen (`screenHelp`) into a separate, self-contained component file (`screen_help.go`).

Additionally this PR :- 

1. Defines the `helpScreen` struct to encapsulate help toggle state (`showHelp`) and navigation history (`previousScreen`).
2. Delegates the help screen update lifecycle and view rendering directly to the new component.
3. Cleans up legacy help fields (`showHelp`, `previousScreen`) from the main `model` struct, consolidating it further.
4. Migrates the help box rendering logic from `view.go` to the new component module.

This is the fourth PR in the TUI modularity series.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

Generative AI was used to draft the `screen_help.go` component file structure and verify routing methods. Manual validation was performed locally to verify compiler correctness and unit tests.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).