### PR TITLE
test :- standardize repository location URLs in CLI tests

### DIFF
--- a/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
+++ b/internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go
@@ -36,7 +36,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: "dummy-key",
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.ErrorContains(t, err, "unable to identify git directory")
 	})
 
@@ -60,7 +60,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: "non-existent-key",
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.Error(t, err)
 	})
 
@@ -106,7 +106,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			SigningKey: keyPath,
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.NoError(t, err)
 	})
 
@@ -153,7 +153,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 			WithRSLEntry: true,
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://github.com/foo/bar")
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--location", "https://example.com/repository/location")
 		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

This pull request standardizes the dummy repository location URL used in the CLI command test suites to match the rest of the gittuf codebase :- 

- Updated the repository location URL in `internal/cmd/trust/setrepositorylocation/setrepositorylocation_test.go` from `https://github.com/foo/bar` to the standard codebase dummy URL `https://example.com/repository/location`.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Generative AI was used to locate inconsistent repository URL patterns in the test files, execute codebase-wide audits for other occurrences and generate the PR description.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).