### PR TITLE
feat(tui) :- add policy principals management screen

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -21,17 +21,19 @@ import (
 type screen int
 
 const (
-	screenLoading             screen = iota // Loading screen shown on startup
-	screenChoice                            // Initial menu
-	screenPolicy                            // Menu for Policy operations
-	screenPolicyRules                       // Rule management screen
-	screenPolicyAddRule                     // Form: add a new policy rule
-	screenPolicyEditRule                    // Form: edit selected rule (prefilled)
-	screenTrust                             // Menu for Trust operations
-	screenTrustGlobalRules                  // Global rule management screen
-	screenTrustAddGlobalRule                // Form: add a new global rule
-	screenTrustEditGlobalRule               // Form: edit selected global rule (prefilled)
-	screenHelp                              // Generic Help screen displaying keybindings
+	screenLoading              screen = iota // Loading screen shown on startup
+	screenChoice                             // Initial menu
+	screenPolicy                             // Menu for Policy operations
+	screenPolicyRules                        // Rule management screen
+	screenPolicyAddRule                      // Form: add a new policy rule
+	screenPolicyEditRule                     // Form: edit selected rule (prefilled)
+	screenPolicyPrincipals                   // Principals management screen
+	screenPolicyPrincipalsForm               // Form: Add/Edit principal or add key
+	screenTrust                              // Menu for Trust operations
+	screenTrustGlobalRules                   // Global rule management screen
+	screenTrustAddGlobalRule                 // Form: add a new global rule
+	screenTrustEditGlobalRule                // Form: edit selected global rule (prefilled)
+	screenHelp                               // Generic Help screen displaying keybindings
 )
 
 type item struct {
@@ -49,27 +51,29 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type model struct {
-	ctx                    context.Context
-	screen                 screen
-	spinner                spinner.Model
-	homeScreen             homeScreen
-	helpScreen             helpScreen
-	policyScreen           policyScreen
-	trustScreen            trustScreen
-	policyRulesScreen      policyRulesScreen
-	trustGlobalRulesScreen trustGlobalRulesScreen
-	cursorMode             cursor.Mode
-	repo                   *gittuf.Repository
-	signer                 dsse.SignerVerifier
-	policyName             string
-	options                *options
-	footer                 string
-	errorMsg               string
-	readOnly               bool
-	width                  int
-	height                 int
-	showHelp               bool
-	signerError            string
+	ctx                        context.Context
+	screen                     screen
+	spinner                    spinner.Model
+	homeScreen                 homeScreen
+	helpScreen                 helpScreen
+	policyScreen               policyScreen
+	trustScreen                trustScreen
+	policyRulesScreen          policyRulesScreen
+	trustGlobalRulesScreen     trustGlobalRulesScreen
+	policyPrincipalsScreen     policyPrincipalsScreen
+	policyPrincipalsFormScreen policyPrincipalsFormScreen
+	cursorMode                 cursor.Mode
+	repo                       *gittuf.Repository
+	signer                     dsse.SignerVerifier
+	policyName                 string
+	options                    *options
+	footer                     string
+	errorMsg                   string
+	readOnly                   bool
+	width                      int
+	height                     int
+	showHelp                   bool
+	signerError                string
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -91,8 +95,9 @@ type inputField struct {
 }
 
 // newDelegate creates a styled list delegate for use in all list.Model instances.
-func newDelegate() list.DefaultDelegate {
+func newDelegate(height int) list.DefaultDelegate {
 	d := list.NewDefaultDelegate()
+	d.SetHeight(height)
 	d.Styles.SelectedTitle = selectedItemStyle
 	d.Styles.SelectedDesc = selectedItemStyle
 	d.Styles.NormalTitle = itemStyle
@@ -118,7 +123,7 @@ func initInputs(fields []inputField) []textinput.Model {
 	for i, f := range fields {
 		t := textinput.New()
 		t.Cursor.Style = cursorStyle
-		t.CharLimit = 64
+		t.CharLimit = 0
 		t.Placeholder = f.placeholder
 		t.Prompt = f.prompt
 		if i == 0 {
@@ -141,7 +146,8 @@ func initialModel(ctx context.Context, o *options) model {
 	s := spinner.New()
 	s.Spinner = spinner.Dot
 
-	delegate := newDelegate()
+	delegate := newDelegate(2)
+	delegateMultiline := newDelegate(4)
 
 	m := model{
 		ctx:        ctx,
@@ -160,6 +166,7 @@ func initialModel(ctx context.Context, o *options) model {
 		policyScreen: policyScreen{
 			policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
 				item{title: "View Rules", desc: "View and manage policy rules"},
+				item{title: "Manage Principals", desc: "View and manage policy principals and keys"},
 			}, delegate),
 		},
 		trustScreen: trustScreen{
@@ -172,6 +179,9 @@ func initialModel(ctx context.Context, o *options) model {
 		},
 		trustGlobalRulesScreen: trustGlobalRulesScreen{
 			globalRuleList: newMenuList("Global Rules", []list.Item{}, delegate),
+		},
+		policyPrincipalsScreen: policyPrincipalsScreen{
+			list: newMenuList("Policy Principals", []list.Item{}, delegateMultiline),
 		},
 	}
 
@@ -218,6 +228,7 @@ func (m *model) resizeLists() {
 	m.trustScreen.trustScreenList.SetSize(innerWidth, innerHeight)
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)
 	m.trustGlobalRulesScreen.globalRuleList.SetSize(innerWidth, innerHeight)
+	m.policyPrincipalsScreen.list.SetSize(innerWidth, innerHeight)
 }
 
 // loadRepoCmd performs all heavy TUI initialization asynchronously and sends

--- a/internal/cmd/tui/screen_policy.go
+++ b/internal/cmd/tui/screen_policy.go
@@ -16,9 +16,15 @@ func (s *policyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	if msg, ok := msg.(tea.KeyMsg); ok {
 		if msg.String() == "enter" {
-			if _, ok := s.policyScreenList.SelectedItem().(item); ok {
-				m.screen = screenPolicyRules
-				m.policyRulesScreen.refreshRules(m.ctx, m.options)
+			if i, ok := s.policyScreenList.SelectedItem().(item); ok {
+				switch i.title {
+				case "View Rules":
+					m.screen = screenPolicyRules
+					m.policyRulesScreen.refreshRules(m.ctx, m.options)
+				case "Manage Principals":
+					m.screen = screenPolicyPrincipals
+					m.policyPrincipalsScreen.refreshPrincipals(m.ctx, m.options)
+				}
 			}
 			return *m, nil
 		}

--- a/internal/cmd/tui/screen_policy_principals.go
+++ b/internal/cmd/tui/screen_policy_principals.go
@@ -1,0 +1,398 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+)
+
+type policyPrincipalsScreen struct {
+	principals    []tuf.Principal
+	list          list.Model
+	confirmDelete bool
+	deleteTarget  string
+}
+
+type policyPrincipalsFormScreen struct {
+	inputs     []textinput.Model
+	focusIndex int
+	action     string // "Add Person", "Edit Person"
+}
+
+func (s *policyPrincipalsScreen) refreshPrincipals(ctx context.Context, o *options) {
+	s.principals = getCurrPrincipals(ctx, o)
+	s.updatePrincipalsList()
+}
+
+func (s *policyPrincipalsScreen) updatePrincipalsList() {
+	items := make([]list.Item, len(s.principals))
+	for i, p := range s.principals {
+		var desc strings.Builder
+		keys := p.Keys()
+		if len(keys) > 0 {
+			desc.WriteString("Keys: ")
+			for j, k := range keys {
+				if j > 0 {
+					desc.WriteString(", ")
+				}
+				desc.WriteString(k.KeyID)
+			}
+		} else {
+			desc.WriteString("Keys: None")
+		}
+
+		if person, ok := p.(*tufv02.Person); ok {
+			if len(person.AssociatedIdentities) > 0 {
+				desc.WriteString("\nIdentities: ")
+				count := 0
+				for provider, id := range person.AssociatedIdentities {
+					if count > 0 {
+						desc.WriteString(", ")
+					}
+					fmt.Fprintf(&desc, "%s::%s", provider, id)
+					count++
+				}
+			}
+		}
+
+		if len(p.CustomMetadata()) > 0 {
+			desc.WriteString("\nCustom: ")
+			count := 0
+			for k, v := range p.CustomMetadata() {
+				if count > 0 {
+					desc.WriteString(", ")
+				}
+				fmt.Fprintf(&desc, "%s=%s", k, v)
+				count++
+			}
+		}
+
+		items[i] = item{title: p.ID(), desc: desc.String()}
+	}
+	s.list.SetItems(items)
+}
+
+func (f *policyPrincipalsFormScreen) initInputs(action string) {
+	f.action = action
+	f.inputs = initInputs([]inputField{
+		{"Enter Principal ID", "Principal ID:"},
+		{"Enter Public Keys (paths or IDs, comma-separated)", "Public Keys:"},
+		{"Enter Associated Identities (provider::identity, comma-separated)", "Identities:"},
+		{"Enter Custom Metadata (Key=Value, comma-separated)", "Custom Metadata:"},
+	})
+	f.focusIndex = 0
+}
+
+func (f *policyPrincipalsFormScreen) initInputsPrefilled(p tuf.Principal) {
+	f.initInputs("Edit Person")
+	f.inputs[0].SetValue(p.ID())
+
+	keys := []string{}
+	for _, k := range p.Keys() {
+		keys = append(keys, k.KeyID)
+	}
+	f.inputs[1].SetValue(strings.Join(keys, ", "))
+
+	// Extracting Associated Identities is tricky because tuf.Principal doesn't expose it directly.
+	// But it's stored in Custom Metadata for Person if we cast it, or we just leave it blank for manual edit.
+	// We'll leave Identities blank or parse it if we can cast to *tufv02.Person.
+	if person, ok := p.(*tufv02.Person); ok {
+		identities := []string{}
+		for provider, id := range person.AssociatedIdentities {
+			identities = append(identities, fmt.Sprintf("%s::%s", provider, id))
+		}
+		f.inputs[2].SetValue(strings.Join(identities, ", "))
+	}
+
+	customs := []string{}
+	for k, v := range p.CustomMetadata() {
+		customs = append(customs, fmt.Sprintf("%s=%s", k, v))
+	}
+	f.inputs[3].SetValue(strings.Join(customs, ", "))
+}
+
+func (f *policyPrincipalsFormScreen) cycleFocus(key string) {
+	if key == "up" || key == "shift+tab" {
+		if f.focusIndex > 0 {
+			f.focusIndex--
+		} else {
+			f.focusIndex = len(f.inputs) - 1
+		}
+	} else {
+		if f.focusIndex < len(f.inputs)-1 {
+			f.focusIndex++
+		} else {
+			f.focusIndex = 0
+		}
+	}
+
+	for i := range f.inputs {
+		if i == f.focusIndex {
+			f.inputs[i].Focus()
+			f.inputs[i].PromptStyle = focusedStyle
+			f.inputs[i].TextStyle = focusedStyle
+		} else {
+			f.inputs[i].Blur()
+			f.inputs[i].PromptStyle = blurredStyle
+			f.inputs[i].TextStyle = blurredStyle
+		}
+	}
+}
+
+func (s *policyPrincipalsScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	if s.confirmDelete {
+		return s.handleDeleteConfirm(msg, m)
+	}
+
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		if !m.readOnly {
+			switch msg.String() {
+			case "a":
+				m.policyPrincipalsFormScreen.initInputs("Add Person")
+				m.screen = screenPolicyPrincipalsForm
+				return *m, nil
+			case "e":
+				if sel, ok := s.list.SelectedItem().(item); ok {
+					for _, p := range s.principals {
+						if p.ID() == sel.title {
+							m.policyPrincipalsFormScreen.initInputsPrefilled(p)
+							m.screen = screenPolicyPrincipalsForm
+							return *m, nil
+						}
+					}
+				}
+			case "d":
+				if sel, ok := s.list.SelectedItem().(item); ok {
+					s.confirmDelete = true
+					s.deleteTarget = sel.title
+					return *m, nil
+				}
+			}
+		}
+	}
+	s.list, cmd = s.list.Update(msg)
+	return *m, cmd
+}
+
+func (s *policyPrincipalsScreen) handleDeleteConfirm(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if keyMsg.String() == "y" {
+			if err := repoRemovePrincipal(m.ctx, m.options, s.deleteTarget); err != nil {
+				m.errorMsg = fmt.Sprintf("Error removing principal: %v", err)
+			} else {
+				m.footer = "Principal removed successfully!"
+				s.refreshPrincipals(m.ctx, m.options)
+			}
+		}
+		s.confirmDelete = false
+		s.deleteTarget = ""
+	}
+	return *m, nil
+}
+
+func (s *policyPrincipalsScreen) View(m *model) string {
+	overlay := ""
+	if s.confirmDelete {
+		overlay = "\n" + renderDeleteOverlay(s.deleteTarget) + "\n"
+	}
+	hint := ""
+	if !m.readOnly {
+		hint = "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorSubtext)).Render(
+			"Run `gittuf policy apply` to apply staged changes to the selected policy file.",
+		)
+	}
+
+	listView := m.renderListOrEmpty(s.list, len(s.principals), "No principals configured")
+	overlays := overlay + renderActionHints(m.readOnly) + hint
+
+	return m.renderScreen("Home › Policy › Principals", listView, overlays)
+}
+
+func (f *policyPrincipalsFormScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	if msg, ok := msg.(tea.KeyMsg); ok {
+		switch msg.String() {
+		case "enter":
+			return f.handleFormSubmit(m)
+		case "tab", "shift+tab", "up", "down":
+			f.cycleFocus(msg.String())
+			m.footer = ""
+			return *m, nil
+		}
+	}
+	f.inputs[f.focusIndex], cmd = f.inputs[f.focusIndex].Update(msg)
+	return *m, cmd
+}
+
+func (f *policyPrincipalsFormScreen) handleFormSubmit(m *model) (tea.Model, tea.Cmd) {
+	if f.focusIndex < len(f.inputs)-1 {
+		f.cycleFocus("tab")
+		return *m, nil
+	}
+
+	personID := f.inputs[0].Value()
+	publicKeysRaw := splitAndTrim(f.inputs[1].Value())
+	identitiesRaw := splitAndTrim(f.inputs[2].Value())
+	customRaw := splitAndTrim(f.inputs[3].Value())
+
+	if personID == "" {
+		m.errorMsg = "Error: Principal ID is required"
+		return *m, nil
+	}
+
+	publicKeys := map[string]*tufv02.Key{}
+	for _, keyPath := range publicKeysRaw {
+		if keyPath == "" {
+			continue
+		}
+		key, err := gittuf.LoadPublicKey(keyPath)
+		if err != nil {
+			m.errorMsg = fmt.Sprintf("Error loading public key '%s': %v", keyPath, err)
+			return *m, nil
+		}
+		publicKeys[key.ID()] = key.(*tufv02.Key)
+	}
+
+	associatedIdentities := map[string]string{}
+	for _, idRaw := range identitiesRaw {
+		if idRaw == "" {
+			continue
+		}
+		split := strings.Split(idRaw, "::")
+		if len(split) != 2 {
+			m.errorMsg = fmt.Sprintf("Error: invalid format for associated identity '%s'", idRaw)
+			return *m, nil
+		}
+		associatedIdentities[split[0]] = split[1]
+	}
+
+	custom := map[string]string{}
+	for _, cRaw := range customRaw {
+		if cRaw == "" {
+			continue
+		}
+		split := strings.Split(cRaw, "=")
+		if len(split) != 2 {
+			m.errorMsg = fmt.Sprintf("Error: invalid format for custom metadata '%s'", cRaw)
+			return *m, nil
+		}
+		custom[split[0]] = split[1]
+	}
+
+	person := &tufv02.Person{
+		PersonID:             personID,
+		PublicKeys:           publicKeys,
+		AssociatedIdentities: associatedIdentities,
+		Custom:               custom,
+	}
+
+	var err error
+	switch f.action {
+	case "Add Person":
+		err = repoAddPrincipal(m.ctx, m.options, person)
+	case "Edit Person":
+		err = repoUpdatePrincipal(m.ctx, m.options, person)
+	}
+
+	if err != nil {
+		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		return *m, nil
+	}
+
+	m.policyPrincipalsScreen.refreshPrincipals(m.ctx, m.options)
+	if f.action == "Add Person" {
+		m.footer = "Principal added successfully!"
+	} else {
+		m.footer = "Principal updated successfully!"
+	}
+	m.screen = screenPolicyPrincipals
+	return *m, nil
+}
+
+func (f *policyPrincipalsFormScreen) View(m *model) string {
+	breadcrumb := fmt.Sprintf("Home › Policy › Principals › %s", f.action)
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(f.action))
+	b.WriteString("\n\n")
+	for _, input := range f.inputs {
+		b.WriteString(input.View())
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString("Press Tab to advance, Enter to advance/submit, and Esc to go back.")
+	b.WriteString("\n")
+	b.WriteString(renderFooterBox(*m))
+	if m.errorMsg != "" {
+		b.WriteString("\n")
+		b.WriteString(renderErrorMsg(m.errorMsg))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left,
+		renderStatusBar(breadcrumb, m.readOnly, m.width),
+		renderWithMargin(b.String()),
+	)
+}
+
+func getCurrPrincipals(ctx context.Context, o *options) []tuf.Principal {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return nil
+	}
+	principalsMap, err := repo.ListPrincipals(ctx, "policy", o.policyName)
+	if err != nil {
+		return nil
+	}
+	var principals []tuf.Principal
+	for _, p := range principalsMap {
+		principals = append(principals, p)
+	}
+	return principals
+}
+
+func repoAddPrincipal(ctx context.Context, o *options, person *tufv02.Person) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	return repo.AddPrincipalToTargets(ctx, signer, o.policyName, []tuf.Principal{person}, true)
+}
+
+func repoUpdatePrincipal(ctx context.Context, o *options, person *tufv02.Person) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	return repo.UpdatePrincipalInTargets(ctx, signer, o.policyName, person, true)
+}
+
+func repoRemovePrincipal(ctx context.Context, o *options, personID string) error {
+	repo, err := gittuf.LoadRepository(".")
+	if err != nil {
+		return err
+	}
+	signer, err := gittuf.LoadSigner(repo, o.p.SigningKey)
+	if err != nil {
+		return err
+	}
+	return repo.RemovePrincipalFromTargets(ctx, signer, o.policyName, personID, true)
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -56,13 +56,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q":
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
-				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
+				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
+				m.screen != screenPolicyPrincipalsForm {
 				return m, tea.Quit
 			}
 		case "h":
 			// Toggle help screen if not in form mode
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
-				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule {
+				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
+				m.screen != screenPolicyPrincipalsForm {
 				if m.screen == screenHelp {
 					// Toggle back
 					m.screen = m.helpScreen.previousScreen
@@ -87,6 +89,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case screenPolicyAddRule, screenPolicyEditRule:
 				m.screen = screenPolicyRules
+			case screenPolicyPrincipalsForm:
+				m.screen = screenPolicyPrincipals
+			case screenPolicyPrincipals:
+				m.screen = screenPolicy
 			case screenHelp:
 				m.screen = m.helpScreen.previousScreen
 			case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
@@ -107,6 +113,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.policyRulesScreen.Update(msg, &m)
 		case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 			return m.trustGlobalRulesScreen.Update(msg, &m)
+		case screenPolicyPrincipals:
+			return m.policyPrincipalsScreen.Update(msg, &m)
+		case screenPolicyPrincipalsForm:
+			return m.policyPrincipalsFormScreen.Update(msg, &m)
 		}
 	}
 
@@ -124,6 +134,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.policyRulesScreen.Update(msg, &m)
 	case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 		return m.trustGlobalRulesScreen.Update(msg, &m)
+	case screenPolicyPrincipals:
+		return m.policyPrincipalsScreen.Update(msg, &m)
+	case screenPolicyPrincipalsForm:
+		return m.policyPrincipalsFormScreen.Update(msg, &m)
 	}
 
 	return m, cmd

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -352,6 +352,12 @@ func (m model) View() string {
 	case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 		return m.trustGlobalRulesScreen.View(&m)
 
+	case screenPolicyPrincipals:
+		return m.policyPrincipalsScreen.View(&m)
+
+	case screenPolicyPrincipalsForm:
+		return m.policyPrincipalsFormScreen.View(&m)
+
 	case screenPolicyAddRule, screenPolicyEditRule:
 		return m.policyRulesScreen.View(&m)
 


### PR DESCRIPTION
## Description

This pull request introduces a new dedicated screen for managing Policy Principals within the gittuf TUI (`gittuf tui`). Users can now view, add, edit, and delete policy principals directly from the interface. 

Additionally, this PR includes:
- UI layout adjustments to fix spacing and action hint overlaps across menus.
- A bug fix to prevent an internal panic (`panic: assignment to entry in nil map`) that occurred when attempting to add a delegation to an uninitialized role.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used generative AI (an AI coding assistant) to help draft the boilerplate BubbleTea UI components for the Principals screen, adjust the layout formatting to fix overlapping action hints, and help trace/debug the internal panic logic. The AI-generated code was thoroughly tested and manually reviewed for correctness.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).