### PR TITLE
feat(tui) :- add policy remote operations screen

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -170,7 +170,7 @@ func initialModel(ctx context.Context, o *options) model {
 			policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
 				item{title: "View Rules", desc: "View and manage policy rules"},
 				item{title: "Manage Principals", desc: "View and manage policy principals and keys"},
-				item{title: "Manage Lifecycle", desc: "Initialize, sign, stage, apply or discard policy changes"},
+				item{title: "Manage Lifecycle", desc: "Initialize, sign, stage, apply, discard, pull or push policy changes"},
 			}, delegate),
 		},
 		policyLifecycleScreen: policyLifecycleScreen{
@@ -181,6 +181,8 @@ func initialModel(ctx context.Context, o *options) model {
 				item{title: "Stage Changes", desc: "Stage local policy changes"},
 				item{title: "Apply Changes", desc: "Apply staged policy changes"},
 				item{title: "Discard Changes", desc: "Discard staged policy changes"},
+				item{title: "Pull Policy", desc: "Pull policy from a remote repository"},
+				item{title: "Push Policy", desc: "Push policy to a remote repository"},
 			}, delegate),
 		},
 		trustScreen: trustScreen{
@@ -224,15 +226,17 @@ func (m *model) resizeLists() {
 	// readOnly: heightOffset_view=9 → innerHeight = m.height - 11
 	// readOnly+signerError: heightOffset_view = 7 + signerNoticeLines (dynamic)
 	//   → innerHeight = m.height - (2 + 7 + noticeLines) = m.height - 9 - noticeLines
-	heightOffset := 9
-	if m.readOnly {
-		heightOffset = 11
-		if m.signerError != "" {
-			// Same formula as view.go: v(2) + fixed(7) + dynamic notice lines
-			heightOffset = 9 + signerNoticeLines(m.signerError, m.width)
-		}
+	bottomHeight := 1
+	footerBox := renderFooterBox(*m)
+	if footerBox != "" {
+		bottomHeight += strings.Count(footerBox, "\n") + 1
 	}
-	innerHeight := m.height - heightOffset
+	errorMsg := renderErrorMsg(m.errorMsg)
+	if errorMsg != "" {
+		bottomHeight += strings.Count(errorMsg, "\n") + 1
+	}
+
+	innerHeight := m.height - 6 - bottomHeight
 	if innerHeight < 0 {
 		innerHeight = 0
 	}

--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -29,6 +29,8 @@ const (
 	screenPolicyEditRule                     // Form: edit selected rule (prefilled)
 	screenPolicyPrincipals                   // Principals management screen
 	screenPolicyPrincipalsForm               // Form: Add/Edit principal or add key
+	screenPolicyLifecycle                    // Menu for Policy lifecycle operations
+	screenPolicyLifecycleForm                // Form: policy lifecycle operation options
 	screenTrust                              // Menu for Trust operations
 	screenTrustGlobalRules                   // Global rule management screen
 	screenTrustAddGlobalRule                 // Form: add a new global rule
@@ -57,6 +59,7 @@ type model struct {
 	homeScreen                 homeScreen
 	helpScreen                 helpScreen
 	policyScreen               policyScreen
+	policyLifecycleScreen      policyLifecycleScreen
 	trustScreen                trustScreen
 	policyRulesScreen          policyRulesScreen
 	trustGlobalRulesScreen     trustGlobalRulesScreen
@@ -167,6 +170,17 @@ func initialModel(ctx context.Context, o *options) model {
 			policyScreenList: newMenuList("gittuf Policy Operations", []list.Item{
 				item{title: "View Rules", desc: "View and manage policy rules"},
 				item{title: "Manage Principals", desc: "View and manage policy principals and keys"},
+				item{title: "Manage Lifecycle", desc: "Initialize, sign, stage, apply or discard policy changes"},
+			}, delegate),
+		},
+		policyLifecycleScreen: policyLifecycleScreen{
+			list: newMenuList("Policy Lifecycle", []list.Item{
+				item{title: "Initialize Policy", desc: "Initialize a new gittuf policy file"},
+				item{title: "Increment Version", desc: "Increment the version of the specified rule file metadata"},
+				item{title: "Sign Policy", desc: "Sign the specified policy file"},
+				item{title: "Stage Changes", desc: "Stage local policy changes"},
+				item{title: "Apply Changes", desc: "Apply staged policy changes"},
+				item{title: "Discard Changes", desc: "Discard staged policy changes"},
 			}, delegate),
 		},
 		trustScreen: trustScreen{
@@ -225,6 +239,7 @@ func (m *model) resizeLists() {
 
 	m.homeScreen.choiceList.SetSize(innerWidth, innerHeight)
 	m.policyScreen.policyScreenList.SetSize(innerWidth, innerHeight)
+	m.policyLifecycleScreen.list.SetSize(innerWidth, innerHeight)
 	m.trustScreen.trustScreenList.SetSize(innerWidth, innerHeight)
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)
 	m.trustGlobalRulesScreen.globalRuleList.SetSize(innerWidth, innerHeight)

--- a/internal/cmd/tui/screen_policy.go
+++ b/internal/cmd/tui/screen_policy.go
@@ -17,6 +17,7 @@ func (s *policyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
 	if msg, ok := msg.(tea.KeyMsg); ok {
 		if msg.String() == "enter" {
 			if i, ok := s.policyScreenList.SelectedItem().(item); ok {
+				m.errorMsg = ""
 				switch i.title {
 				case "View Rules":
 					m.screen = screenPolicyRules
@@ -24,6 +25,8 @@ func (s *policyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
 				case "Manage Principals":
 					m.screen = screenPolicyPrincipals
 					m.policyPrincipalsScreen.refreshPrincipals(m.ctx, m.options)
+				case "Manage Lifecycle":
+					m.screen = screenPolicyLifecycle
 				}
 			}
 			return *m, nil

--- a/internal/cmd/tui/screen_policy_lifecycle.go
+++ b/internal/cmd/tui/screen_policy_lifecycle.go
@@ -42,15 +42,22 @@ func (s *policyLifecycleScreen) initInputs(action string, m *model) {
 		fields = []inputField{
 			{placeholder: "Enter remote name (leave blank for local-only)", prompt: "Remote Name: "},
 		}
+	case "Pull Policy", "Push Policy":
+		fields = []inputField{
+			{placeholder: "Enter remote name (default: origin)", prompt: "Remote Name: "},
+		}
 	}
 	s.inputs = initInputs(fields)
 	s.focusIndex = 0
-	if action == "Initialize Policy" || action == "Increment Version" || action == "Sign Policy" {
+	switch action {
+	case "Initialize Policy", "Increment Version", "Sign Policy":
 		defaultName := m.policyName
 		if defaultName == "" {
 			defaultName = "targets"
 		}
 		s.inputs[0].SetValue(defaultName)
+	case "Pull Policy", "Push Policy":
+		s.inputs[0].SetValue("origin")
 	}
 }
 
@@ -158,6 +165,11 @@ func (s *policyLifecycleScreen) handleFormSubmit(m *model) (tea.Model, tea.Cmd) 
 		localOnly := inputValue == ""
 		remoteName := inputValue
 		cmd = handlePolicyLifecycleCommand(m, s.action, "", remoteName, localOnly)
+	case "Pull Policy", "Push Policy":
+		if inputValue == "" {
+			inputValue = "origin"
+		}
+		cmd = handlePolicyLifecycleCommand(m, s.action, "", inputValue, false)
 	}
 
 	m.screen = screenPolicyLifecycle
@@ -253,6 +265,12 @@ func handlePolicyLifecycleCommand(m *model, action string, policyName string, re
 		case "Discard Changes":
 			err = m.repo.DiscardPolicy()
 			successMsg = "Successfully discarded policy changes."
+		case "Pull Policy":
+			err = m.repo.PullPolicy(remote)
+			successMsg = fmt.Sprintf("Successfully pulled policy from remote %q.", remote)
+		case "Push Policy":
+			err = m.repo.PushPolicy(remote)
+			successMsg = fmt.Sprintf("Successfully pushed policy to remote %q.", remote)
 		default:
 			err = fmt.Errorf("unknown action: %s", action)
 		}

--- a/internal/cmd/tui/screen_policy_lifecycle.go
+++ b/internal/cmd/tui/screen_policy_lifecycle.go
@@ -1,0 +1,265 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	trustpolicyopts "github.com/gittuf/gittuf/experimental/gittuf/options/trustpolicy"
+)
+
+type policyLifecycleScreen struct {
+	list       list.Model
+	inputs     []textinput.Model
+	focusIndex int
+	action     string
+}
+
+type policyLifecycleResultMsg struct {
+	msg string
+	err error
+}
+
+func (s *policyLifecycleScreen) initInputs(action string, m *model) {
+	s.action = action
+	var fields []inputField
+	switch action {
+	case "Initialize Policy", "Increment Version", "Sign Policy":
+		defaultName := m.policyName
+		if defaultName == "" {
+			defaultName = "targets"
+		}
+		fields = []inputField{
+			{placeholder: "Enter policy/role name (default: " + defaultName + ")", prompt: "Policy/Role Name: "},
+		}
+	case "Stage Changes", "Apply Changes":
+		fields = []inputField{
+			{placeholder: "Enter remote name (leave blank for local-only)", prompt: "Remote Name: "},
+		}
+	}
+	s.inputs = initInputs(fields)
+	s.focusIndex = 0
+	if action == "Initialize Policy" || action == "Increment Version" || action == "Sign Policy" {
+		defaultName := m.policyName
+		if defaultName == "" {
+			defaultName = "targets"
+		}
+		s.inputs[0].SetValue(defaultName)
+	}
+}
+
+func (s *policyLifecycleScreen) cycleFocus(key string) {
+	if key == "up" || key == "shift+tab" {
+		if s.focusIndex > 0 {
+			s.focusIndex--
+		} else {
+			s.focusIndex = len(s.inputs) - 1
+		}
+	} else {
+		if s.focusIndex < len(s.inputs)-1 {
+			s.focusIndex++
+		} else {
+			s.focusIndex = 0
+		}
+	}
+
+	for i := range s.inputs {
+		if i == s.focusIndex {
+			s.inputs[i].Focus()
+			s.inputs[i].PromptStyle = focusedStyle
+			s.inputs[i].TextStyle = focusedStyle
+		} else {
+			s.inputs[i].Blur()
+			s.inputs[i].PromptStyle = blurredStyle
+			s.inputs[i].TextStyle = blurredStyle
+		}
+	}
+}
+
+func (s *policyLifecycleScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch m.screen {
+	case screenPolicyLifecycle:
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "enter":
+				if selectedItem, ok := s.list.SelectedItem().(item); ok {
+					if m.readOnly {
+						m.errorMsg = "cannot perform action in read-only mode"
+						return *m, nil
+					}
+					m.errorMsg = ""
+					if selectedItem.title == "Discard Changes" {
+						return *m, handlePolicyLifecycleCommand(m, selectedItem.title, "", "", false)
+					}
+					s.initInputs(selectedItem.title, m)
+					m.screen = screenPolicyLifecycleForm
+					return *m, nil
+				}
+			case "esc", "backspace":
+				m.errorMsg = ""
+				m.screen = screenPolicy
+				return *m, nil
+			}
+		}
+		s.list, cmd = s.list.Update(msg)
+		return *m, cmd
+
+	case screenPolicyLifecycleForm:
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "enter":
+				return s.handleFormSubmit(m)
+			case "tab", "shift+tab", "up", "down":
+				s.cycleFocus(keyMsg.String())
+				m.footer = ""
+				return *m, nil
+			}
+		}
+		s.inputs[s.focusIndex], cmd = s.inputs[s.focusIndex].Update(msg)
+		return *m, cmd
+	}
+
+	return *m, nil
+}
+
+func (s *policyLifecycleScreen) handleFormSubmit(m *model) (tea.Model, tea.Cmd) {
+	inputValue := strings.TrimSpace(s.inputs[0].Value())
+
+	var cmd tea.Cmd
+	switch s.action {
+	case "Initialize Policy":
+		if inputValue == "" {
+			inputValue = "targets"
+		}
+		cmd = handlePolicyLifecycleCommand(m, s.action, inputValue, "", false)
+	case "Increment Version":
+		if inputValue == "" {
+			inputValue = "targets"
+		}
+		cmd = handlePolicyLifecycleCommand(m, s.action, inputValue, "", false)
+	case "Sign Policy":
+		if inputValue == "" {
+			inputValue = "targets"
+		}
+		cmd = handlePolicyLifecycleCommand(m, s.action, inputValue, "", false)
+	case "Stage Changes":
+		localOnly := inputValue == ""
+		remoteName := inputValue
+		cmd = handlePolicyLifecycleCommand(m, s.action, "", remoteName, localOnly)
+	case "Apply Changes":
+		localOnly := inputValue == ""
+		remoteName := inputValue
+		cmd = handlePolicyLifecycleCommand(m, s.action, "", remoteName, localOnly)
+	}
+
+	m.screen = screenPolicyLifecycle
+	return *m, cmd
+}
+
+func (s *policyLifecycleScreen) View(m *model) string {
+	switch m.screen {
+	case screenPolicyLifecycle:
+		hints := "\n" + renderStyledHelp([][2]string{
+			{"enter", "select"},
+			{"h", "help"},
+			{"esc", "back"},
+			{"q", "quit"},
+		})
+		return m.renderScreen("Home › Policy › Lifecycle", s.list.View(), hints)
+
+	case screenPolicyLifecycleForm:
+		breadcrumb := fmt.Sprintf("Home › Policy › Lifecycle › %s", s.action)
+		var b strings.Builder
+		b.WriteString(titleStyle.Render(s.action))
+		b.WriteString("\n\n")
+
+		if s.action == "Increment Version" {
+			warningStyle := lipgloss.NewStyle().
+				Foreground(lipgloss.Color(colorErrorMsg)).
+				Bold(true)
+			b.WriteString(warningStyle.Render("Warning: This is an advanced operation rarely needed under normal workflows.") + "\n\n")
+		}
+
+		for _, input := range s.inputs {
+			b.WriteString(input.View())
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+		b.WriteString("Press Tab to advance, Enter to advance/submit and Esc to go back.")
+		b.WriteString("\n")
+		b.WriteString(renderFooterBox(*m))
+		if m.errorMsg != "" {
+			b.WriteString("\n")
+			b.WriteString(renderErrorMsg(m.errorMsg))
+		}
+		return lipgloss.JoinVertical(lipgloss.Left,
+			renderStatusBar(breadcrumb, m.readOnly, m.width),
+			renderWithMargin(b.String()),
+		)
+	}
+
+	return ""
+}
+
+func handlePolicyLifecycleCommand(m *model, action string, policyName string, remote string, localOnly bool) tea.Cmd {
+	return func() tea.Msg {
+		if m.readOnly {
+			return policyLifecycleResultMsg{
+				msg: "",
+				err: fmt.Errorf("cannot perform action in read-only mode"),
+			}
+		}
+
+		var err error
+		var successMsg string
+
+		opts := []trustpolicyopts.Option{}
+		if m.options.p != nil && m.options.p.WithRSLEntry {
+			opts = append(opts, trustpolicyopts.WithRSLEntry())
+		}
+
+		switch action {
+		case "Initialize Policy":
+			err = m.repo.InitializeTargets(m.ctx, m.signer, policyName, true, opts...)
+			successMsg = fmt.Sprintf("Successfully initialized policy %q.", policyName)
+		case "Increment Version":
+			err = m.repo.IncrementTargetsVersion(m.ctx, m.signer, policyName, true, opts...)
+			successMsg = fmt.Sprintf("Successfully incremented policy version for %q.", policyName)
+		case "Sign Policy":
+			err = m.repo.SignTargets(m.ctx, m.signer, policyName, true, opts...)
+			successMsg = fmt.Sprintf("Successfully signed policy %q.", policyName)
+		case "Stage Changes":
+			err = m.repo.StagePolicy(m.ctx, remote, localOnly, true)
+			if localOnly {
+				successMsg = "Successfully staged policy changes locally."
+			} else {
+				successMsg = fmt.Sprintf("Successfully staged policy changes to remote %q.", remote)
+			}
+		case "Apply Changes":
+			err = m.repo.ApplyPolicy(m.ctx, remote, localOnly, true)
+			if localOnly {
+				successMsg = "Successfully applied policy changes locally."
+			} else {
+				successMsg = fmt.Sprintf("Successfully applied policy changes to remote %q.", remote)
+			}
+		case "Discard Changes":
+			err = m.repo.DiscardPolicy()
+			successMsg = "Successfully discarded policy changes."
+		default:
+			err = fmt.Errorf("unknown action: %s", action)
+		}
+
+		return policyLifecycleResultMsg{
+			msg: successMsg,
+			err: err,
+		}
+	}
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -36,6 +36,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.screen = screenChoice
 		return m, nil
 
+	case policyLifecycleResultMsg:
+		if msg.err != nil {
+			m.errorMsg = msg.err.Error()
+		} else {
+			m.footer = msg.msg
+		}
+		return m, nil
+
 	case spinner.TickMsg:
 		if m.screen == screenLoading {
 			m.spinner, cmd = m.spinner.Update(msg)
@@ -57,14 +65,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
 				return m, tea.Quit
 			}
 		case "h":
 			// Toggle help screen if not in form mode
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
 				if m.screen == screenHelp {
 					// Toggle back
 					m.screen = m.helpScreen.previousScreen
@@ -77,6 +85,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "esc":
 			m.footer = ""
+			m.errorMsg = ""
 			switch m.screen {
 			case screenPolicy, screenTrust:
 				m.screen = screenChoice
@@ -87,6 +96,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.screen = screenPolicy
 				}
+			case screenPolicyLifecycle:
+				m.screen = screenPolicy
+			case screenPolicyLifecycleForm:
+				m.screen = screenPolicyLifecycle
 			case screenPolicyAddRule, screenPolicyEditRule:
 				m.screen = screenPolicyRules
 			case screenPolicyPrincipalsForm:
@@ -109,6 +122,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.helpScreen.Update(msg, &m)
 		case screenTrust:
 			return m.trustScreen.Update(msg, &m)
+		case screenPolicyLifecycle, screenPolicyLifecycleForm:
+			return m.policyLifecycleScreen.Update(msg, &m)
 		case screenPolicyRules, screenPolicyAddRule, screenPolicyEditRule:
 			return m.policyRulesScreen.Update(msg, &m)
 		case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
@@ -128,6 +143,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.helpScreen.Update(msg, &m)
 	case screenPolicy:
 		return m.policyScreen.Update(msg, &m)
+	case screenPolicyLifecycle, screenPolicyLifecycleForm:
+		return m.policyLifecycleScreen.Update(msg, &m)
 	case screenTrust:
 		return m.trustScreen.Update(msg, &m)
 	case screenPolicyRules, screenPolicyAddRule, screenPolicyEditRule:

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Update updates the model based on the message received.
-func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 
 	switch msg := msg.(type) {
@@ -158,6 +158,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	return m, cmd
+}
+
+// Update updates the model based on the message received, ensuring list sizes are
+// dynamically recalculated to fit any runtime error messages or notice overlays.
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	resModel, cmd := m.updateInternal(msg)
+	if typedModel, ok := resModel.(model); ok {
+		typedModel.resizeLists()
+		return typedModel, cmd
+	}
+	return resModel, cmd
 }
 
 // splitAndTrim splits a comma-separated string and trims whitespace.

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -102,22 +102,6 @@ func renderFooter(text string) string {
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorFooter)).Render(text)
 }
 
-// signerNoticeLines returns how many terminal rows the signer-error notice will
-// occupy when rendered at the given terminal width. This matches the exact same
-// Width() call used in renderFooterBox so both the layout reservation and the
-// rendered output always agree.
-func signerNoticeLines(signerError string, termWidth int) int {
-	if signerError == "" {
-		return 0
-	}
-	noticeWidth := termWidth - 6
-	if noticeWidth < 20 {
-		noticeWidth = 20
-	}
-	wrapped := lipgloss.NewStyle().Width(noticeWidth).Render("Notice: " + signerError)
-	return strings.Count(wrapped, "\n") + 1
-}
-
 // renderFooterBox wraps the footer in a rich info box if the user requests help in read-only mode.
 func renderFooterBox(m model) string {
 	baseFooter := renderFooter(m.footer)
@@ -259,18 +243,20 @@ func (m model) renderScreen(title string, listContent string, overlays string) s
 		boxWidth = 0
 	}
 
-	heightOffset := 7
-	if m.readOnly {
-		heightOffset = 9
-		if m.signerError != "" {
-			// Dynamic: fixed overhead (7) + actual notice lines so the box
-			// perfectly fills any terminal regardless of width or screen size.
-			// Fixed overhead accounts for: 2 blank rows (between box and helpkeys),
-			// 1 helpkeys row, 1 blank gap (between helpkeys and notice).
-			heightOffset = 7 + signerNoticeLines(m.signerError, m.width)
-		}
+	bottomHeight := 1
+	if overlays != "" {
+		bottomHeight += strings.Count(overlays, "\n") + 1
 	}
-	boxHeight := m.height - v - heightOffset
+	footerBox := renderFooterBox(m)
+	if footerBox != "" {
+		bottomHeight += strings.Count(footerBox, "\n") + 1
+	}
+	errorMsg := renderErrorMsg(m.errorMsg)
+	if errorMsg != "" {
+		bottomHeight += strings.Count(errorMsg, "\n") + 1
+	}
+
+	boxHeight := m.height - v - 4 - bottomHeight
 	if boxHeight < 0 {
 		boxHeight = 0
 	}

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -165,9 +165,11 @@ func renderFooterBox(m model) string {
 	return baseFooter
 }
 
-// renderErrorMsg returns error messages styled in the error color.
 func renderErrorMsg(text string) string {
-	return lipgloss.NewStyle().Foreground(lipgloss.Color(colorErrorMsg)).Render(text)
+	if text == "" {
+		return ""
+	}
+	return "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorErrorMsg)).Render(text)
 }
 
 // renderStatusBar renders the top status bar showing screen name and current mode.
@@ -342,6 +344,9 @@ func (m model) View() string {
 
 	case screenPolicy:
 		return m.policyScreen.View(&m)
+
+	case screenPolicyLifecycle, screenPolicyLifecycleForm:
+		return m.policyLifecycleScreen.View(&m)
 
 	case screenTrust:
 		return m.trustScreen.View(&m)


### PR DESCRIPTION
## Description

This PR introduces a new "Remote Operations" screen to the TUI for managing Gittuf policies remotely. 
It provides an interactive menu that maps directly to the underlying `gittuf policy remote` CLI commands, allowing users to:
- **Pull Policy:** Fetch and apply the latest policies from a specified remote repository (defaults to `origin`).
- **Push Policy:** Push locally created or modified policies to a specified remote repository.

**Key Additions:**
- Interactive menu to select "Pull Policy" or "Push Policy".
- Input form to dynamically specify the Remote Name.
- Asynchronous execution of remote commands without blocking the UI.
- Secure fallback that prevents opening the form or executing remote operations when in Read-only mode.
- Clear success and error notifications in the status footer that automatically manage their own lifecycles to avoid layout overlap.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.


## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).