### PR TITLE
refactor: remove gitinterface.ZeroHash

### DIFF
--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -73,7 +73,7 @@ func TestApplyAttestations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+	env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, repo.r.ZeroHash().String(), initialCommitID.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +252,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+		env, err := allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, repo.r.ZeroHash().String(), initialCommitID.String())
 		assert.Nil(t, err)
 		assert.Len(t, env.Signatures, 1)
 		assert.Equal(t, keyID, env.Signatures[0].KeyID)
@@ -271,7 +271,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		err = repo.AddReferenceAuthorization(testCtx, signer, targetTagRef, fromRef, false, attestopts.WithRSLEntry())
 		assert.ErrorIs(t, err, gitinterface.ErrTagAlreadyExists)
 
-		err = repo.RemoveReferenceAuthorization(testCtx, signer, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String(), false, attestopts.WithRSLEntry())
+		err = repo.RemoveReferenceAuthorization(testCtx, signer, targetTagRef, repo.r.ZeroHash().String(), initialCommitID.String(), false, attestopts.WithRSLEntry())
 		assert.Nil(t, err)
 
 		allAttestations, err = attestations.LoadCurrentAttestations(r)
@@ -279,7 +279,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+		_, err = allAttestations.GetReferenceAuthorizationFor(repo.r, targetTagRef, repo.r.ZeroHash().String(), initialCommitID.String())
 		assert.ErrorIs(t, err, authorizations.ErrAuthorizationNotFound)
 	})
 }
@@ -388,13 +388,13 @@ func TestIndexPathToComponents(t *testing.T) {
 	}{
 		"simple ref": {
 			baseRef: "refs/heads/main",
-			from:    gitinterface.ZeroHash.String(),
-			to:      gitinterface.ZeroHash.String(),
+			from:    testZeroHashID,
+			to:      testZeroHashID,
 		},
 		"complicated ref": {
 			baseRef: "refs/heads/jane.doe/feature-branch",
-			from:    gitinterface.ZeroHash.String(),
-			to:      gitinterface.ZeroHash.String(),
+			from:    testZeroHashID,
+			to:      testZeroHashID,
 		},
 	}
 
@@ -409,3 +409,5 @@ func TestIndexPathToComponents(t *testing.T) {
 		assert.Equal(t, test.to, to, fmt.Sprintf("unexpected 'to' in test '%s'", name))
 	}
 }
+
+const testZeroHashID = "0000000000000000000000000000000000000000"

--- a/experimental/gittuf/policy_test.go
+++ b/experimental/gittuf/policy_test.go
@@ -51,7 +51,7 @@ func TestPushPolicy(t *testing.T) {
 		remoteTmpDir := t.TempDir()
 		remoteRepo := gitinterface.CreateTestGitRepository(t, remoteTmpDir, false)
 
-		if err := rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(remoteRepo, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, remoteRepo.ZeroHash()).Commit(remoteRepo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -108,7 +108,7 @@ func TestPullPolicy(t *testing.T) {
 		localRepoR := gitinterface.CreateTestGitRepository(t, localTmpDir, false)
 		localRepo := &Repository{r: localRepoR}
 
-		if err := rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(localRepo.r, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, localRepoR.ZeroHash()).Commit(localRepo.r, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -239,7 +239,7 @@ func TestDiscardPolicy(t *testing.T) {
 		initialRef, err := repo.r.GetReference(policy.PolicyRef)
 		assert.Nil(t, err)
 
-		if err := repo.r.SetReference(policy.PolicyStagingRef, gitinterface.ZeroHash); err != nil {
+		if err := repo.r.SetReference(policy.PolicyStagingRef, repo.r.ZeroHash()); err != nil {
 			t.Fatal(err)
 		}
 

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -301,7 +301,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 
 	repo := &Repository{r: r}
 
-	err := repo.RecordRSLAnnotation(testCtx, []string{gitinterface.ZeroHash.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
+	err := repo.RecordRSLAnnotation(testCtx, []string{repo.r.ZeroHash().String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 
 	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
@@ -1242,7 +1242,7 @@ func TestPushRSL(t *testing.T) {
 		remoteTmpDir := t.TempDir()
 		remoteRepoR := gitinterface.CreateTestGitRepository(t, remoteTmpDir, false)
 
-		if err := rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(remoteRepoR, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, remoteRepoR.ZeroHash()).Commit(remoteRepoR, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1291,7 +1291,7 @@ func TestPullRSL(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(localRepo.r, false); err != nil {
+		if err := rsl.NewReferenceEntry(policy.PolicyRef, localRepo.r.ZeroHash()).Commit(localRepo.r, false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/attestations/attestations_test.go
+++ b/internal/attestations/attestations_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestLoadCurrentAttestations(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
@@ -63,7 +63,7 @@ func TestLoadCurrentAttestations(t *testing.T) {
 
 func TestLoadAttestationsForEntry(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
@@ -127,7 +127,7 @@ func TestLoadAttestationsForEntry(t *testing.T) {
 
 func TestAttestationsCommit(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	testAttestation, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 	if err != nil {
 		t.Fatal(err)
@@ -176,3 +176,5 @@ func TestAttestationsCommit(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, attestations.referenceAuthorizations, authorizations)
 }
+
+var testZeroHash = gitinterface.Hash(make([]byte, 20))

--- a/internal/attestations/authorization_test.go
+++ b/internal/attestations/authorization_test.go
@@ -21,7 +21,7 @@ func TestSetReferenceAuthorization(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
 		testRef := "refs/heads/main"
 		testAnotherRef := "refs/heads/feature"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		mainZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testRef, testID, testID, false)
 		featureZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testAnotherRef, testID, testID, false)
 
@@ -45,7 +45,7 @@ func TestSetReferenceAuthorization(t *testing.T) {
 
 	t.Run("for tag", func(t *testing.T) {
 		tagRef := "refs/tags/v1"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		tagApproval := createReferenceAuthorizationAttestationEnvelopes(t, tagRef, testID, testID, true)
 
 		tempDir := t.TempDir()
@@ -60,7 +60,7 @@ func TestSetReferenceAuthorization(t *testing.T) {
 
 	t.Run("v01", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		env := createReferenceAuthorizationAttestationEnvelopeV01(t, testRef, testID, testID)
 
 		tempDir := t.TempDir()
@@ -75,7 +75,7 @@ func TestSetReferenceAuthorization(t *testing.T) {
 
 	t.Run("unknown version", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		env := createReferenceAuthorizationAttestationEnvelopeWithPredicateType(t, testRef, testID, testID, "https://gittuf.dev/reference-authorization/unknown")
 
 		tempDir := t.TempDir()
@@ -112,7 +112,7 @@ func TestRemoveReferenceAuthorization(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
 		testRef := "refs/heads/main"
 		testAnotherRef := "refs/heads/feature"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		mainZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testRef, testID, testID, false)
 		featureZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testAnotherRef, testID, testID, false)
 
@@ -148,7 +148,7 @@ func TestRemoveReferenceAuthorization(t *testing.T) {
 
 	t.Run("for tag", func(t *testing.T) {
 		tagRef := "refs/tags/v1"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		tagApproval := createReferenceAuthorizationAttestationEnvelopes(t, tagRef, testID, testID, true)
 
 		tempDir := t.TempDir()
@@ -172,7 +172,7 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
 		testRef := "refs/heads/main"
 		testAnotherRef := "refs/heads/feature"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		mainZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testRef, testID, testID, false)
 		featureZeroZero := createReferenceAuthorizationAttestationEnvelopes(t, testAnotherRef, testID, testID, false)
 
@@ -201,7 +201,7 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 
 	t.Run("for tag", func(t *testing.T) {
 		tagRef := "refs/tags/v1"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		tagApproval := createReferenceAuthorizationAttestationEnvelopes(t, tagRef, testID, testID, true)
 
 		tempDir := t.TempDir()
@@ -222,7 +222,7 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 
 	t.Run("v01", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		env := createReferenceAuthorizationAttestationEnvelopeV01(t, testRef, testID, testID)
 
 		tempDir := t.TempDir()
@@ -240,7 +240,7 @@ func TestGetReferenceAuthorizationFor(t *testing.T) {
 
 	t.Run("unknown version", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := testZeroHash.String()
 		env := createReferenceAuthorizationAttestationEnvelopeWithPredicateType(t, testRef, testID, testID, "https://gittuf.dev/reference-authorization/unknown")
 
 		tempDir := t.TempDir()

--- a/internal/attestations/authorizations/v01/v01_test.go
+++ b/internal/attestations/authorizations/v01/v01_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetters(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := zeroHashID
 
 	authorization := ReferenceAuthorization{
 		TargetRef:      testRef,
@@ -32,7 +32,7 @@ func TestGetters(t *testing.T) {
 
 func TestNewReferenceAuthorization(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := zeroHashID
 
 	authorization, err := NewReferenceAuthorization(testRef, testID, testID)
 	assert.Nil(t, err)
@@ -58,7 +58,7 @@ func TestNewReferenceAuthorization(t *testing.T) {
 func TestValidate(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
-	testID := gitinterface.ZeroHash.String()
+	testID := zeroHashID
 	mainZeroZero := createTestEnvelope(t, testRef, testID, testID)
 	featureZeroZero := createTestEnvelope(t, testAnotherRef, testID, testID)
 
@@ -104,3 +104,5 @@ func createTestEnvelope(t *testing.T, refName, fromID, toID string) *sslibdsse.E
 
 	return env
 }
+
+var zeroHashID = gitinterface.Hash(make([]byte, 20)).String()

--- a/internal/attestations/authorizations/v02/v02_test.go
+++ b/internal/attestations/authorizations/v02/v02_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetters(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := zeroHashID
 
 	authorization := ReferenceAuthorization{
 		TargetRef: testRef,
@@ -33,7 +33,7 @@ func TestGetters(t *testing.T) {
 func TestNewReferenceAuthorization(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 
 		authorization, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 		assert.Nil(t, err)
@@ -58,7 +58,7 @@ func TestNewReferenceAuthorization(t *testing.T) {
 
 	t.Run("for tag", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 
 		authorization, err := NewReferenceAuthorizationForTag(testRef, testID, testID)
 		assert.Nil(t, err)
@@ -86,7 +86,7 @@ func TestValidate(t *testing.T) {
 	t.Run("for commit", func(t *testing.T) {
 		testRef := "refs/heads/main"
 		testAnotherRef := "refs/heads/feature"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 		mainZeroZero := createTestEnvelope(t, testRef, testID, testID, false)
 		featureZeroZero := createTestEnvelope(t, testAnotherRef, testID, testID, false)
 
@@ -102,7 +102,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("for tag", func(t *testing.T) {
 		testRef := "refs/tags/v1"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 		authorization := createTestEnvelope(t, testRef, testID, testID, true)
 
 		err := Validate(authorization, testRef, testID, testID)
@@ -111,7 +111,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("invalid subject", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 
 		authorization, err := NewReferenceAuthorizationForCommit(testRef, testID, testID)
 		if err != nil {
@@ -131,7 +131,7 @@ func TestValidate(t *testing.T) {
 
 	t.Run("mismatch ref (non tag) and subject digest key (commit)", func(t *testing.T) {
 		testRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := zeroHashID
 		authorization := createTestEnvelope(t, testRef, testID, testID, true)
 
 		err := Validate(authorization, testRef, testID, testID)
@@ -180,3 +180,5 @@ func createTestEnvelope(t *testing.T, refName, fromID, toID string, tag bool) *s
 
 	return env
 }
+
+var zeroHashID = gitinterface.Hash(make([]byte, 20)).String()

--- a/internal/attestations/github/v01/approval_test.go
+++ b/internal/attestations/github/v01/approval_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gittuf/gittuf/internal/common/set"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
-	"github.com/gittuf/gittuf/pkg/gitinterface"
 	ita "github.com/in-toto/attestation/go/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -36,7 +35,7 @@ func TestGetters(t *testing.T) {
 
 func TestNewGitHubPullRequestApprovalAttestation(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := "0000000000000000000000000000000000000000"
 
 	approvers := []string{"jane.doe@example.com"}
 
@@ -69,7 +68,7 @@ func TestNewGitHubPullRequestApprovalAttestation(t *testing.T) {
 func TestValidatePullRequestApproval(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
-	testID := gitinterface.ZeroHash.String()
+	testID := "0000000000000000000000000000000000000000"
 
 	approvers := []string{"jane.doe@example.com"}
 

--- a/internal/attestations/github_test.go
+++ b/internal/attestations/github_test.go
@@ -20,7 +20,7 @@ import (
 func TestSetGitHubPullRequestApprovalAttestation(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	baseURL := "https://github.com"
 	baseHost := "github.com"
 	appName := "github"
@@ -71,7 +71,7 @@ func TestSetGitHubPullRequestApprovalAttestation(t *testing.T) {
 func TestGetGitHubPullRequestApprovalAttestation(t *testing.T) {
 	testRef := "refs/heads/main"
 	testAnotherRef := "refs/heads/feature"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	baseURL := "https://github.com"
 	appName := "github"
 
@@ -170,7 +170,7 @@ func TestGitHubReviewID(t *testing.T) {
 
 func TestGetGitHubPullRequestApprovalAttestationForReviewID(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	baseURL := "https://github.com"
 	appName := "github"
 
@@ -236,7 +236,7 @@ func TestGetGitHubPullRequestApprovalAttestationForIndexPath(t *testing.T) {
 
 func TestGetGitHubPullRequestApprovalIndexPathForReviewID(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 	baseURL := "https://github.com"
 	appName := "github"
 	reviewID := int64(123)
@@ -275,7 +275,7 @@ func TestGetGitHubPullRequestApprovalIndexPathForReviewID(t *testing.T) {
 
 func TestSetGitHubPullRequestAuthorization(t *testing.T) {
 	testRef := "refs/heads/main"
-	testID := gitinterface.ZeroHash.String()
+	testID := testZeroHash.String()
 
 	// Create a simple envelope for testing using the same approach as existing tests
 	approvers := []string{"jane.doe@example.com"}

--- a/internal/cache/attestations_test.go
+++ b/internal/cache/attestations_test.go
@@ -66,7 +66,7 @@ func TestInsertAttestationEntryNumber(t *testing.T) {
 			AttestationEntries: []RSLEntryIndex{},
 		}
 
-		p.InsertAttestationEntryNumber(uint64(0), gitinterface.ZeroHash)
+		p.InsertAttestationEntryNumber(uint64(0), testZeroHash)
 		assert.Equal(t, []RSLEntryIndex{}, p.AttestationEntries) // inserting entry number 0 should result in noop
 	})
 

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -149,7 +149,7 @@ func TestPopulatePersistentCache(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		err := rsl.NewReferenceEntry(policyRef, testZeroHash).Commit(repo, false)
 		require.Nil(t, err)
 
 		err = PopulatePersistentCache(repo)
@@ -189,7 +189,7 @@ func TestLoadPersistantCache(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		err := rsl.NewReferenceEntry(policyRef, testZeroHash).Commit(repo, false)
 		require.Nil(t, err)
 
 		err = PopulatePersistentCache(repo)
@@ -216,7 +216,7 @@ func TestLoadPersistantCache(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		err := rsl.NewReferenceEntry(attestations.Ref, gitinterface.ZeroHash).Commit(repo, false)
+		err := rsl.NewReferenceEntry(attestations.Ref, testZeroHash).Commit(repo, false)
 		require.Nil(t, err)
 
 		err = PopulatePersistentCache(repo)
@@ -253,7 +253,7 @@ func TestDeletePersistentCache(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		err := rsl.NewReferenceEntry(policyRef, gitinterface.ZeroHash).Commit(repo, false)
+		err := rsl.NewReferenceEntry(policyRef, testZeroHash).Commit(repo, false)
 		require.Nil(t, err)
 
 		err = PopulatePersistentCache(repo)
@@ -277,3 +277,5 @@ func TestRSLEntryMethods(t *testing.T) {
 	expectedID, _ := gitinterface.NewHash("e69de29bb2d1d6434b8b29ae775ad8c2e48c5391")
 	assert.Equal(t, expectedID, id)
 }
+
+var testZeroHash = gitinterface.Hash(make([]byte, 20))

--- a/internal/cache/policy.go
+++ b/internal/cache/policy.go
@@ -17,12 +17,12 @@ func (p *Persistent) GetPolicyEntries() []RSLEntryIndex {
 
 func (p *Persistent) HasPolicyEntryNumber(entryNumber uint64) (gitinterface.Hash, bool) {
 	if len(p.PolicyEntries) == 0 || entryNumber == 0 {
-		return gitinterface.ZeroHash, false
+		return nil, false
 	}
 
 	index, has := slices.BinarySearchFunc(p.PolicyEntries, RSLEntryIndex{EntryNumber: entryNumber}, binarySearch)
 	if !has {
-		return gitinterface.ZeroHash, false
+		return nil, false
 	}
 
 	// Unlike Find... we're actively checking if a policy number has been

--- a/internal/cache/policy_test.go
+++ b/internal/cache/policy_test.go
@@ -16,7 +16,7 @@ func TestHasPolicyEntryNumber(t *testing.T) {
 		p := &Persistent{}
 		hash, has := p.HasPolicyEntryNumber(1)
 		assert.False(t, has)
-		assert.Equal(t, gitinterface.ZeroHash, hash)
+		assert.Nil(t, hash)
 	})
 
 	t.Run("entries exist", func(t *testing.T) {
@@ -46,7 +46,7 @@ func TestHasPolicyEntryNumber(t *testing.T) {
 
 		hash, has := p.HasPolicyEntryNumber(uint64(1))
 		assert.False(t, has)
-		assert.Equal(t, gitinterface.ZeroHash, hash) // function returns ZeroHash when entry doesn't exist
+		assert.Nil(t, hash) // function returns nil when entry does not exist
 	})
 }
 
@@ -144,7 +144,7 @@ func TestInsertPolicyEntryNumber(t *testing.T) {
 			PolicyEntries: []RSLEntryIndex{},
 		}
 
-		p.InsertPolicyEntryNumber(uint64(0), gitinterface.ZeroHash)
+		p.InsertPolicyEntryNumber(uint64(0), testZeroHash)
 		assert.Equal(t, []RSLEntryIndex{}, p.PolicyEntries) // inserting entry number 0 should result in noop
 	})
 

--- a/internal/cache/verification.go
+++ b/internal/cache/verification.go
@@ -23,12 +23,12 @@ func (p *Persistent) SetLastVerifiedEntryForRef(ref string, entryNumber uint64, 
 
 func (p *Persistent) GetLastVerifiedEntryForRef(ref string) (uint64, gitinterface.Hash) {
 	if p.LastVerifiedEntryForRef == nil {
-		return 0, gitinterface.ZeroHash
+		return 0, nil
 	}
 
 	currentIndex, hasEntryForRef := p.LastVerifiedEntryForRef[ref]
 	if !hasEntryForRef {
-		return 0, gitinterface.ZeroHash
+		return 0, nil
 	}
 
 	return currentIndex.GetEntryNumber(), currentIndex.GetEntryID()

--- a/internal/cache/verification_test.go
+++ b/internal/cache/verification_test.go
@@ -45,7 +45,7 @@ func TestGetLastVerifiedEntryForRef(t *testing.T) {
 
 		number, id := p.GetLastVerifiedEntryForRef(policyRef)
 		assert.Equal(t, uint64(0), number)
-		assert.Equal(t, gitinterface.ZeroHash, id) // if the map doesn't exist, should return 0 for entry number and zero hash for entry id
+		assert.Nil(t, id) // if the map does not exist, should return 0 for entry number and nil for entry id
 	})
 
 	t.Run("entry for ref doesn't exist", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestGetLastVerifiedEntryForRef(t *testing.T) {
 
 		number, id := p.GetLastVerifiedEntryForRef(attestations.Ref)
 		assert.Equal(t, uint64(0), number)
-		assert.Equal(t, gitinterface.ZeroHash, id)
+		assert.Nil(t, id)
 	})
 
 	t.Run("entry for ref exists", func(t *testing.T) {

--- a/internal/cmd/attest/authorize/authorize_test.go
+++ b/internal/cmd/attest/authorize/authorize_test.go
@@ -253,7 +253,7 @@ func TestAuthorize(t *testing.T) {
 		pOpts := &persistent.Options{
 			SigningKey: keyPath,
 		}
-		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--from-ref", fromRef, "--revoke", targetTagRef, gitinterface.ZeroHash.String(), initialCommitID.String())
+		_, _, _, err = cmd.ExecuteCommandC(New(pOpts), "--from-ref", fromRef, "--revoke", targetTagRef, "0000000000000000000000000000000000000000", initialCommitID.String())
 		assert.NoError(t, err)
 	})
 }

--- a/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
+++ b/internal/cmd/attest/github/dismissapproval/dismissapproval_test.go
@@ -82,7 +82,7 @@ func TestDismissApproval(t *testing.T) {
 		}
 
 		fromRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := "0000000000000000000000000000000000000000"
 		reviewID := int64(123)
 		approvers := []string{"jane.doe"}
 
@@ -156,7 +156,7 @@ func TestDismissApproval(t *testing.T) {
 		}
 
 		fromRef := "refs/heads/main"
-		testID := gitinterface.ZeroHash.String()
+		testID := "0000000000000000000000000000000000000000"
 		reviewID := int64(123)
 		approvers := []string{"jane.doe"}
 

--- a/internal/cmd/cache/delete/delete_test.go
+++ b/internal/cmd/cache/delete/delete_test.go
@@ -55,7 +55,7 @@ func TestCacheDelete(t *testing.T) {
 		}
 
 		gitRepo := repo.GetGitRepository()
-		err = rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(gitRepo, false)
+		err = rsl.NewReferenceEntry(policy.PolicyRef, gitRepo.ZeroHash()).Commit(gitRepo, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/cache/init/init_test.go
+++ b/internal/cmd/cache/init/init_test.go
@@ -55,7 +55,7 @@ func TestCacheInit(t *testing.T) {
 		}
 
 		gitRepo := repo.GetGitRepository()
-		err = rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(gitRepo, false)
+		err = rsl.NewReferenceEntry(policy.PolicyRef, gitRepo.ZeroHash()).Commit(gitRepo, false)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/rsl/annotate/annotate_test.go
+++ b/internal/cmd/rsl/annotate/annotate_test.go
@@ -132,7 +132,7 @@ func TestAnnotate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, _, _, err = cmd.ExecuteCommandC(New(), gitinterface.ZeroHash.String(), "-m", "annotation message", "--local-only")
+		_, _, _, err = cmd.ExecuteCommandC(New(), "0000000000000000000000000000000000000000", "-m", "annotation message", "--local-only")
 		assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 	})
 

--- a/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
+++ b/internal/cmd/rsl/skiprewritten/skiprewritten_test.go
@@ -90,7 +90,7 @@ func TestSkipRewritten(t *testing.T) {
 		err = libRepo.RecordRSLEntryForReference(t.Context(), "refs/heads/main", false, rslopts.WithRecordLocalOnly())
 		require.NoError(t, err)
 
-		err = r.SetReference("refs/heads/main", gitinterface.ZeroHash)
+		err = r.SetReference("refs/heads/main", r.ZeroHash())
 		require.NoError(t, err)
 
 		_, err = r.Commit(emptyTreeHash, "refs/heads/main", "Real initial commit\n", false)

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -19,7 +19,7 @@ func TestRSLLog(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// add first entry
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -34,12 +34,12 @@ func TestRSLLog(t *testing.T) {
 		}
 
 		// add another entry
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// add another entry
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -107,7 +107,7 @@ entry ae4467eaa656782fe9d04eaabfa30db47e9ea24b (skipped)
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// add first entry
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -122,12 +122,12 @@ entry ae4467eaa656782fe9d04eaabfa30db47e9ea24b (skipped)
 		}
 
 		// add another entry -- not for main
-		if err := rsl.NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/feature", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// add another entry
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -163,8 +163,8 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 	colorer = colorerOff
 
 	t.Run("simple without number, no parent", func(t *testing.T) {
-		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewReferenceEntry("refs/heads/main", testZeroHash)
+		entry.ID = testZeroHash
 
 		expectedOutput := `entry 0000000000000000000000000000000000000000
 
@@ -180,8 +180,8 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 	})
 
 	t.Run("simple without number, has parent", func(t *testing.T) {
-		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewReferenceEntry("refs/heads/main", testZeroHash)
+		entry.ID = testZeroHash
 
 		expectedOutput := `entry 0000000000000000000000000000000000000000
 
@@ -198,8 +198,8 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 	})
 
 	t.Run("simple with number, no parent", func(t *testing.T) {
-		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewReferenceEntry("refs/heads/main", testZeroHash)
+		entry.ID = testZeroHash
 		entry.Number = 1
 		expectedOutput := `entry 0000000000000000000000000000000000000000
 
@@ -216,8 +216,8 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 	})
 
 	t.Run("simple with number, has parent", func(t *testing.T) {
-		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewReferenceEntry("refs/heads/main", testZeroHash)
+		entry.ID = testZeroHash
 		entry.Number = 1
 		expectedOutput := `entry 0000000000000000000000000000000000000000
 
@@ -238,7 +238,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -280,7 +280,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -323,7 +323,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -365,7 +365,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -408,7 +408,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -450,7 +450,7 @@ func TestWriteRSLReferenceEntry(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, true)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", testZeroHash).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -495,8 +495,8 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 	colorer = colorerOff
 
 	t.Run("simple, without number, without parent", func(t *testing.T) {
-		entry := rsl.NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://git.example.com/repository", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewPropagationEntry("refs/heads/main", testZeroHash, "https://git.example.com/repository", testZeroHash)
+		entry.ID = testZeroHash
 
 		expectedOutput := `propagation entry 0000000000000000000000000000000000000000
 
@@ -514,9 +514,9 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 	})
 
 	t.Run("simple, with number, without parent", func(t *testing.T) {
-		entry := rsl.NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://git.example.com/repository", gitinterface.ZeroHash)
+		entry := rsl.NewPropagationEntry("refs/heads/main", testZeroHash, "https://git.example.com/repository", testZeroHash)
 		entry.Number = 1
-		entry.ID = gitinterface.ZeroHash
+		entry.ID = testZeroHash
 
 		expectedOutput := `propagation entry 0000000000000000000000000000000000000000
 
@@ -535,8 +535,8 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 	})
 
 	t.Run("simple, without number, with parent", func(t *testing.T) {
-		entry := rsl.NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://git.example.com/repository", gitinterface.ZeroHash)
-		entry.ID = gitinterface.ZeroHash
+		entry := rsl.NewPropagationEntry("refs/heads/main", testZeroHash, "https://git.example.com/repository", testZeroHash)
+		entry.ID = testZeroHash
 
 		expectedOutput := `propagation entry 0000000000000000000000000000000000000000
 
@@ -555,9 +555,9 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 	})
 
 	t.Run("simple, with number, with parent", func(t *testing.T) {
-		entry := rsl.NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://git.example.com/repository", gitinterface.ZeroHash)
+		entry := rsl.NewPropagationEntry("refs/heads/main", testZeroHash, "https://git.example.com/repository", testZeroHash)
 		entry.Number = 1
-		entry.ID = gitinterface.ZeroHash
+		entry.ID = testZeroHash
 
 		expectedOutput := `propagation entry 0000000000000000000000000000000000000000
 
@@ -576,3 +576,5 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 		assert.Equal(t, expectedOutput, output.String())
 	})
 }
+
+var testZeroHash = gitinterface.Hash(make([]byte, 20))

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -559,7 +559,7 @@ func (s *State) Verify(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := rootVerifier.Verify(ctx, gitinterface.ZeroHash, s.Metadata.RootEnvelope); err != nil {
+	if _, err := rootVerifier.Verify(ctx, nil, s.Metadata.RootEnvelope); err != nil {
 		return err
 	}
 
@@ -590,7 +590,7 @@ func (s *State) Verify(ctx context.Context) error {
 			return err
 		}
 
-		if _, err := targetsVerifier.Verify(ctx, gitinterface.ZeroHash, s.Metadata.TargetsEnvelope); err != nil {
+		if _, err := targetsVerifier.Verify(ctx, nil, s.Metadata.TargetsEnvelope); err != nil {
 			return err
 		}
 
@@ -631,7 +631,7 @@ func (s *State) Verify(ctx context.Context) error {
 					threshold:  delegation.GetThreshold(),
 				}
 
-				if _, err := verifier.Verify(ctx, gitinterface.ZeroHash, env); err != nil {
+				if _, err := verifier.Verify(ctx, nil, env); err != nil {
 					return err
 				}
 
@@ -678,7 +678,7 @@ func (s *State) Verify(ctx context.Context) error {
 
 			// We need to LoadState() the state from which the root is derived
 			// For that, we need to know when it was propagated into this repository
-			upstreamEntryID := gitinterface.ZeroHash
+			var upstreamEntryID gitinterface.Hash
 			if entry, isPropagationEntry := s.loadedEntry.(*rsl.PropagationEntry); isPropagationEntry {
 				// Check this entry
 				if entry.RefName == PolicyRef && entry.UpstreamRepository == controllerRepositoryDetail.GetLocation() {

--- a/internal/policy/searcher_test.go
+++ b/internal/policy/searcher_test.go
@@ -22,7 +22,7 @@ func TestRegularSearcher(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -46,7 +46,7 @@ func TestRegularSearcher(t *testing.T) {
 		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
 
 		// Requested entry is policy entry
-		if err := rsl.NewReferenceEntry(PolicyRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -65,7 +65,7 @@ func TestRegularSearcher(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -111,7 +111,7 @@ func TestRegularSearcher(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedPolicyEntries, policyEntries)
 
-		if err := rsl.NewReferenceEntry(PolicyRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -125,7 +125,7 @@ func TestRegularSearcher(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedPolicyEntries, policyEntries)
 
-		if err := rsl.NewReferenceEntry(PolicyStagingRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyStagingRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -155,7 +155,7 @@ func TestRegularSearcher(t *testing.T) {
 		}
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -179,7 +179,7 @@ func TestRegularSearcher(t *testing.T) {
 		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
 
 		// Requested entry is attestations entry
-		if err := rsl.NewReferenceEntry(attestations.Ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(attestations.Ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -198,7 +198,7 @@ func TestRegularSearcher(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -231,7 +231,7 @@ func TestRegularSearcher(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -287,7 +287,7 @@ func TestCacheSearcher(t *testing.T) {
 			t.Fatal(err)
 		}
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -311,7 +311,7 @@ func TestCacheSearcher(t *testing.T) {
 		assert.Equal(t, expectedPolicyEntry.GetID(), policyEntry.GetID())
 
 		// Requested entry is policy entry
-		if err := rsl.NewReferenceEntry(PolicyRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -331,7 +331,7 @@ func TestCacheSearcher(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -401,7 +401,7 @@ func TestCacheSearcher(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedPolicyEntries, policyEntries)
 
-		if err := rsl.NewReferenceEntry(PolicyRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -415,7 +415,7 @@ func TestCacheSearcher(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expectedPolicyEntries, policyEntries)
 
-		if err := rsl.NewReferenceEntry(PolicyStagingRef, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(PolicyStagingRef, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -456,7 +456,7 @@ func TestCacheSearcher(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -489,7 +489,7 @@ func TestCacheSearcher(t *testing.T) {
 		}
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -521,7 +521,7 @@ func TestCacheSearcher(t *testing.T) {
 		assert.Equal(t, expectedAttestationsEntry.GetID(), attestationsEntry.GetID())
 
 		// Requested entry is annotations entry
-		if err := rsl.NewReferenceEntry(attestations.Ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry(attestations.Ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -541,7 +541,7 @@ func TestCacheSearcher(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
 		// Add an entry after
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -596,7 +596,7 @@ func TestCacheSearcher(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := rsl.NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -76,7 +76,7 @@ func (v *PolicyVerifier) VerifyRef(ctx context.Context, target string) (gitinter
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	return latestEntry.GetTargetID(), v.VerifyRelativeForRef(ctx, latestEntry, latestEntry, target)
@@ -99,7 +99,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 		if entryNumber != 0 {
 			firstEntry, err = loadRSLReferenceUpdaterEntry(v.repo, entryID)
 			if err != nil {
-				return gitinterface.ZeroHash, err
+				return nil, err
 			}
 
 			// break because we've loaded the entry and don't need to fallthrough
@@ -110,7 +110,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 	case false:
 		firstEntry, _, err = rsl.GetFirstReferenceUpdaterEntryForRef(v.repo, target)
 		if err != nil {
-			return gitinterface.ZeroHash, err
+			return nil, err
 		}
 	}
 
@@ -118,7 +118,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (giti
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	slog.Debug("Verifying all entries...")
@@ -133,21 +133,21 @@ func (v *PolicyVerifier) VerifyRefFromEntry(ctx context.Context, target string, 
 	slog.Debug("Identifying starting RSL entry...")
 	fromEntryT, err := rsl.GetEntry(v.repo, entryID)
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	fromEntry, isRefEntry := fromEntryT.(*rsl.ReferenceEntry)
 	if !isRefEntry {
 		// TODO: we should instead find the latest reference entry
 		// before the entryID and use that
-		return gitinterface.ZeroHash, fmt.Errorf("starting entry is not an RSL reference entry")
+		return nil, fmt.Errorf("starting entry is not an RSL reference entry")
 	}
 
 	// Find latest entry for target
 	slog.Debug(fmt.Sprintf("Identifying latest RSL entry for '%s'...", target))
 	latestEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(v.repo, rsl.ForReference(target))
 	if err != nil {
-		return gitinterface.ZeroHash, err
+		return nil, err
 	}
 
 	// Do a relative verify from start entry to the latest entry
@@ -271,7 +271,7 @@ func (v *PolicyVerifier) verifyMergeable(ctx context.Context, targetRef string, 
 		return false, err
 	}
 
-	_, rslEntrySignatureNeededForThreshold, err := verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, targetRef), gitinterface.ZeroHash, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withVerifyMergeable())
+	_, rslEntrySignatureNeededForThreshold, err := verifyGitObjectAndAttestations(ctx, currentPolicy, fmt.Sprintf("%s:%s", gitReferenceRuleScheme, targetRef), nil, authorizationAttestation, withApproverPrincipalIDs(approverIDs), withVerifyMergeable())
 	if err != nil {
 		return false, fmt.Errorf("not enough approvals to meet Git namespace policies, %w", ErrVerificationFailed)
 	}
@@ -817,7 +817,7 @@ func (s *State) VerifyNewState(ctx context.Context, newPolicy *State) error {
 		return err
 	}
 
-	if _, err := rootVerifier.Verify(ctx, gitinterface.ZeroHash, newPolicy.Metadata.RootEnvelope); err != nil {
+	if _, err := rootVerifier.Verify(ctx, nil, newPolicy.Metadata.RootEnvelope); err != nil {
 		return err
 	}
 
@@ -1075,7 +1075,7 @@ func getCommits(repo *gitinterface.Repository, entry *rsl.ReferenceEntry) ([]git
 	}
 
 	if firstEntry {
-		return repo.GetCommitsBetweenRange(entry.TargetID, gitinterface.ZeroHash)
+		return repo.GetCommitsBetweenRange(entry.TargetID, nil)
 	}
 
 	return repo.GetCommitsBetweenRange(entry.TargetID, priorRefEntry.GetTargetID())
@@ -1128,7 +1128,7 @@ func withTagObjectID(objID gitinterface.Hash) verifyGitObjectAndAttestationsOpti
 }
 
 func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target string, gitID gitinterface.Hash, authorizationAttestation *sslibdsse.Envelope, opts ...verifyGitObjectAndAttestationsOption) (string, bool, error) {
-	options := &verifyGitObjectAndAttestationsOptions{tagObjectID: gitinterface.ZeroHash}
+	options := &verifyGitObjectAndAttestationsOptions{}
 	for _, fn := range opts {
 		fn(options)
 	}

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -85,7 +85,7 @@ func TestVerifyRefFromEntry(t *testing.T) {
 
 	verifier := NewPolicyVerifier(repo)
 
-	_, err := verifier.VerifyRefFromEntry(testCtx, "main", gitinterface.ZeroHash)
+	_, err := verifier.VerifyRefFromEntry(testCtx, "main", repo.ZeroHash())
 	assert.ErrorContains(t, err, rsl.ErrRSLEntryNotFound.Error())
 
 	repo, _ = createTestRepository(t, createTestStateWithPolicy)
@@ -787,7 +787,7 @@ func TestVerifyMergeable(t *testing.T) {
 		}
 
 		// Set up approval attestation with "john.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -810,7 +810,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -854,7 +854,7 @@ func TestVerifyMergeable(t *testing.T) {
 		}
 
 		// Set up approval attestation with "jill.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jill.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -872,12 +872,12 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
 		// Set up reference authorization from "john.doe"
-		refAuthorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		refAuthorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -894,7 +894,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -934,7 +934,7 @@ func TestVerifyMergeable(t *testing.T) {
 		}
 
 		// Add approval with "jane.doe" and "john.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jane.doe", "john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jane.doe", "john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -957,7 +957,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -997,7 +997,7 @@ func TestVerifyMergeable(t *testing.T) {
 
 		// Add approval with "alice" and "bob"
 		// These are untrusted identities
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"alice", "bob"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"alice", "bob"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1020,7 +1020,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -1424,7 +1424,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 		}
 
 		// Set up approval attestation with "john.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1447,7 +1447,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -1489,7 +1489,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 		}
 
 		// Set up approval attestation with "jill.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jill.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1507,12 +1507,12 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
 		// Set up reference authorization from "john.doe"
-		refAuthorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		refAuthorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1529,7 +1529,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1567,7 +1567,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 		}
 
 		// Add approval with "jane.doe" and "john.doe"
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jane.doe", "john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jane.doe", "john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1590,7 +1590,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -1628,7 +1628,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 
 		// Add approval with "alice" and "bob"
 		// These are untrusted identities
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"alice", "bob"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"alice", "bob"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1651,7 +1651,7 @@ func TestVerifyMergeableForCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -2808,7 +2808,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		authorization, err := authorizationsv02.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := authorizationsv02.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2824,7 +2824,7 @@ func TestVerifyRelativeForRef(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -2964,7 +2964,7 @@ func TestVerifyEntry(t *testing.T) {
 		// Create authorization for this change
 		// We're explicitly using the old type here to ensure policy
 		// verification still works
-		authorization, err := authorizationsv01.NewReferenceAuthorization(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := authorizationsv01.NewReferenceAuthorization(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2980,7 +2980,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3079,7 +3079,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Create authorization for this change using john.doe trusted as approver
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3097,7 +3097,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3136,7 +3136,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Create authorization for this change using john.doe trusted as approver
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3154,7 +3154,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3191,7 +3191,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Approved by jill.doe
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jill.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3209,7 +3209,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3219,7 +3219,7 @@ func TestVerifyEntry(t *testing.T) {
 		// Add reference authorization for john.doe
 		signer = setupSSHKeysForSigning(t, targets2KeyBytes, targets2PubKeyBytes)
 
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3233,7 +3233,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3270,7 +3270,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Approved by jill.doe
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jill.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3288,7 +3288,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3298,7 +3298,7 @@ func TestVerifyEntry(t *testing.T) {
 		// Add reference authorization for john.doe
 		signer = setupSSHKeysForSigning(t, targets2KeyBytes, targets2PubKeyBytes)
 
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3312,7 +3312,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3348,7 +3348,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Create approval for jill.doe -> NOT TRUSTED in this policy
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"jill.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"jill.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3366,7 +3366,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3402,7 +3402,7 @@ func TestVerifyEntry(t *testing.T) {
 		}
 
 		// Create approval for john.doe
-		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, gitinterface.ZeroHash.String(), commitTreeID.String(), []string{"john.doe"}, nil)
+		githubAppApproval, err := attestations.NewGitHubPullRequestApprovalAttestation(refName, repo.ZeroHash().String(), commitTreeID.String(), []string{"john.doe"}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3420,7 +3420,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetGitHubPullRequestApprovalAttestation(repo, env, "https://github.com", 1, tuf.GitHubAppRoleName, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add GitHub pull request approval", true, false); err != nil {
@@ -3435,7 +3435,7 @@ func TestVerifyEntry(t *testing.T) {
 		// Add reference authorization for john.doe
 		signer = setupSSHKeysForSigning(t, targets2KeyBytes, targets2PubKeyBytes)
 
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3449,7 +3449,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3489,7 +3489,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		// Create authorization for this change
 		// This uses the latest reference authorization version
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3505,7 +3505,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3542,7 +3542,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		// Create authorization for this change
 		// This uses the latest reference authorization version
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, repo.ZeroHash().String(), commitTreeID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3558,7 +3558,7 @@ func TestVerifyEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, refName, repo.ZeroHash().String(), commitTreeID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3608,7 +3608,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		// Rewrite history altogether
 		// Delete ref
-		if err := repo.SetReference(refName, gitinterface.ZeroHash); err != nil {
+		if err := repo.SetReference(refName, repo.ZeroHash()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3655,7 +3655,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		// Rewrite history altogether
 		// Delete ref
-		if err := repo.SetReference(refName, gitinterface.ZeroHash); err != nil {
+		if err := repo.SetReference(refName, repo.ZeroHash()); err != nil {
 			t.Fatal(err)
 		}
 
@@ -3747,7 +3747,7 @@ func TestVerifyEntry(t *testing.T) {
 
 		// Create authorization for this change
 		// This uses the latest reference authorization version
-		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForCommit(refName, networkRepository.ZeroHash().String(), commitTreeID.String())
 		require.Nil(t, err)
 
 		env, err := dsse.CreateEnvelope(authorization)
@@ -3755,7 +3755,7 @@ func TestVerifyEntry(t *testing.T) {
 		env, err = dsse.SignEnvelope(testCtx, env, signer)
 		require.Nil(t, err)
 
-		err = currentAttestations.SetReferenceAuthorization(networkRepository, env, refName, gitinterface.ZeroHash.String(), commitTreeID.String())
+		err = currentAttestations.SetReferenceAuthorization(networkRepository, env, refName, networkRepository.ZeroHash().String(), commitTreeID.String())
 		require.Nil(t, err)
 		err = currentAttestations.Commit(networkRepository, "Add authorization", true, false)
 		require.Nil(t, err)
@@ -3839,7 +3839,7 @@ func TestVerifyTagEntry(t *testing.T) {
 		// This uses the latest reference authorization version
 		// As this is for a tag, the target is the commit the tag points to,
 		// taken from the RSL entry we just created for it
-		authorization, err := attestations.NewReferenceAuthorizationForTag(tagRefName, gitinterface.ZeroHash.String(), entry.TargetID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForTag(tagRefName, repo.ZeroHash().String(), entry.TargetID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3860,7 +3860,7 @@ func TestVerifyTagEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, tagRefName, gitinterface.ZeroHash.String(), entry.TargetID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, tagRefName, repo.ZeroHash().String(), entry.TargetID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {
@@ -3918,7 +3918,7 @@ func TestVerifyTagEntry(t *testing.T) {
 		// This uses the latest reference authorization version
 		// As this is for a tag, the target is the commit the tag points to,
 		// taken from the RSL entry we just created for it
-		authorization, err := attestations.NewReferenceAuthorizationForTag(tagRefName, gitinterface.ZeroHash.String(), entry.TargetID.String())
+		authorization, err := attestations.NewReferenceAuthorizationForTag(tagRefName, repo.ZeroHash().String(), entry.TargetID.String())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -3940,7 +3940,7 @@ func TestVerifyTagEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := currentAttestations.SetReferenceAuthorization(repo, env, tagRefName, gitinterface.ZeroHash.String(), entry.TargetID.String()); err != nil {
+		if err := currentAttestations.SetReferenceAuthorization(repo, env, tagRefName, repo.ZeroHash().String(), entry.TargetID.String()); err != nil {
 			t.Fatal(err)
 		}
 		if err := currentAttestations.Commit(repo, "Add authorization", true, false); err != nil {

--- a/internal/rsl/cache_test.go
+++ b/internal/rsl/cache_test.go
@@ -13,7 +13,7 @@ import (
 func TestRSLCache(t *testing.T) {
 	// Add test entries
 	// Using fake hashes (these are commits in the gittuf repo itself)
-	entry1 := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+	entry1 := NewReferenceEntry("refs/heads/main", testZeroHash)
 	entry1.Number = 1
 	hash, err := gitinterface.NewHash("4dcd174e182cedf597b8a84f24ea5a53dae7e1e7")
 	if err != nil {
@@ -21,7 +21,7 @@ func TestRSLCache(t *testing.T) {
 	}
 	entry1.ID = hash
 
-	entry2 := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash)
+	entry2 := NewReferenceEntry("refs/heads/feature", testZeroHash)
 	entry2.Number = 2
 	hash, err = gitinterface.NewHash("5bf80ffecacfde7e6b8281e65223b139a76160e1")
 	if err != nil {
@@ -58,3 +58,5 @@ func TestRSLCache(t *testing.T) {
 	assert.Equal(t, entry1, entry)
 	assert.True(t, has)
 }
+
+var testZeroHash = gitinterface.Hash(make([]byte, 20))

--- a/internal/rsl/rsl.go
+++ b/internal/rsl/rsl.go
@@ -664,10 +664,7 @@ func GetLatestEntry(repo *gitinterface.Repository) (Entry, error) {
 // GetLatestReferenceUpdaterEntry returns the latest reference updater entry in
 // the local RSL that matches the specified conditions.
 func GetLatestReferenceUpdaterEntry(repo *gitinterface.Repository, opts ...GetLatestReferenceUpdaterEntryOption) (ReferenceUpdaterEntry, []*AnnotationEntry, error) {
-	options := GetLatestReferenceUpdaterEntryOptions{
-		BeforeEntryID: gitinterface.ZeroHash,
-		UntilEntryID:  gitinterface.ZeroHash,
-	}
+	options := GetLatestReferenceUpdaterEntryOptions{}
 	for _, fn := range opts {
 		fn(&options)
 	}

--- a/internal/rsl/rsl_test.go
+++ b/internal/rsl/rsl_test.go
@@ -58,7 +58,7 @@ func TestNewReferenceEntry(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,11 +77,11 @@ func TestNewReferenceEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMessage := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), NumberKey, 1)
+	expectedMessage := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, repo.ZeroHash().String(), NumberKey, 1)
 	assert.Equal(t, expectedMessage, commitMessage)
 	assert.Nil(t, parentIDs)
 
-	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -100,7 +100,7 @@ func TestNewReferenceEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expectedMessage = fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), NumberKey, 2)
+	expectedMessage = fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, repo.ZeroHash().String(), NumberKey, 2)
 	assert.Equal(t, expectedMessage, commitMessage)
 	assert.Contains(t, parentIDs, currentTip)
 }
@@ -168,7 +168,7 @@ func testCommitUsingSpecificKey(t *testing.T, objectFormat gitinterface.ObjectFo
 
 func TestReferenceUpdaterEntry(t *testing.T) {
 	refName := "refs/heads/main"
-	gitID := gitinterface.ZeroHash
+	gitID := testZeroHash
 	upstreamRepository := "http://git.example.com/repository"
 
 	t.Run("reference entry", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestGetLatestEntry(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,9 +200,9 @@ func TestGetLatestEntry(t *testing.T) {
 	assert.Nil(t, err)
 	e := entry.(*ReferenceEntry)
 	assert.Equal(t, "refs/heads/main", e.RefName)
-	assert.Equal(t, gitinterface.ZeroHash, e.TargetID)
+	assert.Equal(t, repo.ZeroHash(), e.TargetID)
 
-	if err := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/heads/feature", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,7 +210,7 @@ func TestGetLatestEntry(t *testing.T) {
 	assert.Nil(t, err)
 	e = entry.(*ReferenceEntry)
 	assert.Equal(t, "refs/heads/feature", e.RefName)
-	assert.Equal(t, gitinterface.ZeroHash, e.TargetID)
+	assert.Equal(t, repo.ZeroHash(), e.TargetID)
 
 	latestTip, err := repo.GetReference(Ref)
 	if err != nil {
@@ -237,7 +237,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		refName := "refs/heads/main"
 		otherRefName := "refs/heads/feature"
 
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -257,7 +257,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Nil(t, annotations)
 		assert.Equal(t, rslRef, entry.GetID())
 
-		if err := NewReferenceEntry(otherRefName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(otherRefName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -298,14 +298,14 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrInvalidGetLatestReferenceUpdaterEntryOptions)
 
 		// Until number is greater than latest entry in the RSL
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 		_, _, err = GetLatestReferenceUpdaterEntry(repo, UntilEntryNumber(10))
 		assert.ErrorIs(t, err, ErrInvalidUntilEntryNumberCondition)
 
 		// a reference older than until entry number is being asked for (configuration mismatch)
-		if err := NewReferenceEntry("feature", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("feature", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, ForReference("main"), BeforeEntryID(emptyTreeID), UntilEntryNumber(2))
@@ -318,7 +318,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -327,7 +327,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -348,7 +348,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		refName := "refs/heads/main"
 		otherRefName := "refs/heads/feature"
 
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -365,7 +365,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Nil(t, annotations)
 		assert.Equal(t, rslRef, entry.GetID())
 
-		if err := NewReferenceEntry(otherRefName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(otherRefName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -402,7 +402,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		testRefs := []string{"main", "feature", "main", "feature", "main"}
 		entryIDs := []gitinterface.Hash{}
 		for _, ref := range testRefs {
-			if err := NewReferenceEntry(ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			if err := NewReferenceEntry(ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 				t.Fatal(err)
 			}
 			latest, err := GetLatestEntry(repo)
@@ -445,7 +445,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		testRefs := []string{"main", "feature", "main", "feature", "main"}
 		entryIDs := []gitinterface.Hash{}
 		for _, ref := range testRefs {
-			if err := NewReferenceEntry(ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			if err := NewReferenceEntry(ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 				t.Fatal(err)
 			}
 			latest, err := GetLatestEntry(repo)
@@ -509,7 +509,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		testRefs := []string{"main", "feature", "main", "feature", "main"}
 		entryIDs := []gitinterface.Hash{}
 		for _, ref := range testRefs {
-			if err := NewReferenceEntry(ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			if err := NewReferenceEntry(ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 				t.Fatal(err)
 			}
 			latest, err := GetLatestEntry(repo)
@@ -564,7 +564,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		// main <- feature
 		testRefs := []string{"main", "feature"}
 		for _, ref := range testRefs {
-			if err := NewReferenceEntry(ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			if err := NewReferenceEntry(ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -587,7 +587,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		testRefs := []string{"main", "feature", "main", "feature", "main"}
 		entryIDs := []gitinterface.Hash{}
 		for _, ref := range testRefs {
-			if err := NewReferenceEntry(ref, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+			if err := NewReferenceEntry(ref, repo.ZeroHash()).Commit(repo, false); err != nil {
 				t.Fatal(err)
 			}
 			latest, err := GetLatestEntry(repo)
@@ -660,7 +660,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		entryIDs := []gitinterface.Hash{}
 
 		// Add an entry
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -677,7 +677,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Equal(t, entryIDs[len(entryIDs)-1], entry.GetID())
 
 		// Add another entry
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -725,7 +725,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		entryIDs := []gitinterface.Hash{}
 
 		// Add an entry
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -737,7 +737,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		entryIDs = append(entryIDs, e.GetID())
 
 		// Add another entry
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -760,7 +760,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		}
 
 		// Now even the latest unskipped entry with zero hash should return the first one
-		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, ForReference(refName), BeforeEntryID(gitinterface.ZeroHash), IsUnskipped())
+		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, ForReference(refName), BeforeEntryID(repo.ZeroHash()), IsUnskipped())
 		assert.Nil(t, err)
 		assert.Empty(t, annotations)
 		assert.Equal(t, entryIDs[0], entry.GetID())
@@ -770,7 +770,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, ForReference(refName), BeforeEntryID(gitinterface.ZeroHash), IsUnskipped())
+		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, ForReference(refName), BeforeEntryID(repo.ZeroHash()), IsUnskipped())
 		assert.Nil(t, entry)
 		assert.Empty(t, annotations)
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
@@ -780,7 +780,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -798,12 +798,12 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Add the first gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// Add non gittuf entries
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -818,7 +818,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.Equal(t, expectedLatestEntry, latestEntry)
 
 		// Add another gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/not-policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/not-policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -849,7 +849,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Add the first gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -857,7 +857,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 
 		// Add another gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/not-policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/not-policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -869,7 +869,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -878,7 +878,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -893,7 +893,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Add non-numbered entries, including an annotation
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).commitWithoutNumber(repo); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).commitWithoutNumber(repo); err != nil {
 			t.Fatal(err)
 		}
 
@@ -913,7 +913,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrCannotUseEntryNumberFilter)
 
 		// Add numbered entries
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -932,12 +932,12 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		upstreamRepository := "http://git.example.com/repository"
-		if err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/main", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -955,12 +955,12 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		upstreamRepository := "http://git.example.com/repository"
-		if err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/main", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -974,12 +974,12 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		upstreamRepository := "http://git.example.com/repository"
-		if err := NewPropagationEntry("refs/heads/feature", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/feature", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -988,7 +988,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/main", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1001,7 +1001,7 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1011,11 +1011,11 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		}
 
 		upstreamRepository := "http://git.example.com/repository"
-		if err := NewPropagationEntry("refs/heads/feature", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/feature", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/main", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1029,11 +1029,11 @@ func TestGetLatestReferenceUpdaterEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		upstreamRepository := "http://git.example.com/repository"
-		if err := NewPropagationEntry("refs/heads/feature", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/feature", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
-		if err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, upstreamRepository, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewPropagationEntry("refs/heads/main", repo.ZeroHash(), upstreamRepository, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1056,7 +1056,7 @@ func TestGetEntry(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1074,7 +1074,7 @@ func TestGetEntry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Error(err)
 	}
 
@@ -1082,7 +1082,7 @@ func TestGetEntry(t *testing.T) {
 	assert.Nil(t, err)
 	e := entry.(*ReferenceEntry)
 	assert.Equal(t, "main", e.RefName)
-	assert.Equal(t, gitinterface.ZeroHash, e.TargetID)
+	assert.Equal(t, repo.ZeroHash(), e.TargetID)
 
 	entry, err = GetEntry(repo, annotationID)
 	assert.Nil(t, err)
@@ -1098,7 +1098,7 @@ func TestGetParentForEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Assert no parent for first entry
-		if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1112,7 +1112,7 @@ func TestGetParentForEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 
 		// Find parent for an entry
-		if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1146,7 +1146,7 @@ func TestGetParentForEntry(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).commitWithoutNumber(repo); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).commitWithoutNumber(repo); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1155,7 +1155,7 @@ func TestGetParentForEntry(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1179,12 +1179,12 @@ func TestGetNonGittufParentReferenceUpdaterEntryForEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Add the first gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
 		// Add non gittuf entry
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1194,7 +1194,7 @@ func TestGetNonGittufParentReferenceUpdaterEntryForEntry(t *testing.T) {
 		}
 
 		// Add non gittuf entry
-		if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/heads/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1211,10 +1211,10 @@ func TestGetNonGittufParentReferenceUpdaterEntryForEntry(t *testing.T) {
 		// Add another gittuf entry and then a non gittuf entry
 		expectedEntry = latestEntry
 
-		if err := NewReferenceEntry("refs/gittuf/not-policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/not-policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
-		if err := NewReferenceEntry("refs/gittuf/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1245,7 +1245,7 @@ func TestGetNonGittufParentReferenceUpdaterEntryForEntry(t *testing.T) {
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
 		// Add the first gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1257,7 +1257,7 @@ func TestGetNonGittufParentReferenceUpdaterEntryForEntry(t *testing.T) {
 		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 
 		// Add another gittuf entry
-		if err := NewReferenceEntry("refs/gittuf/not-policy", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("refs/gittuf/not-policy", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1276,7 +1276,7 @@ func TestGetFirstEntry(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	if err := NewReferenceEntry("first", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("first", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1287,7 +1287,7 @@ func TestGetFirstEntry(t *testing.T) {
 	firstEntry := firstEntryT.(*ReferenceEntry)
 
 	for i := 0; i < 5; i++ {
-		if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1314,7 +1314,7 @@ func TestGetFirstReferenceUpdaterEntryForRef(t *testing.T) {
 	tempDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	if err := NewReferenceEntry("first", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("first", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1325,7 +1325,7 @@ func TestGetFirstReferenceUpdaterEntryForRef(t *testing.T) {
 	firstEntry := firstEntryT.(*ReferenceEntry)
 
 	for i := 0; i < 5; i++ {
-		if err := NewReferenceEntry("main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry("main", repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1368,7 +1368,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		require.Nil(t, err)
 
 		// Create a different commit and override the ref
-		if err := repo.SetReference("refs/heads/main", gitinterface.ZeroHash); err != nil {
+		if err := repo.SetReference("refs/heads/main", repo.ZeroHash()); err != nil {
 			t.Fatal(err)
 		}
 		newCommitHash, err := repo.Commit(emptyTreeHash, "refs/heads/main", "Real initial commit\n", false)
@@ -1427,7 +1427,7 @@ func TestSkipAllInvalidReferenceEntriesForRef(t *testing.T) {
 		skippedEntries = append(skippedEntries, toBeSkippedEntry.GetID())
 
 		// Create a different commit and override the ref
-		if err := repo.SetReference("refs/heads/main", gitinterface.ZeroHash); err != nil {
+		if err := repo.SetReference("refs/heads/main", repo.ZeroHash()); err != nil {
 			t.Fatal(err)
 		}
 		newCommitHash, err := repo.Commit(emptyTreeHash, "refs/heads/main", "Real initial commit\n", false)
@@ -1668,7 +1668,7 @@ func TestGetReferenceUpdaterEntriesInRange(t *testing.T) {
 
 	// Add some entries to main
 	for i := 0; i < 3; i++ {
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1700,7 +1700,7 @@ func TestGetReferenceUpdaterEntriesInRange(t *testing.T) {
 	assert.Equal(t, expectedAnnotationMap, annotationMap)
 
 	// Add an entry and annotation for feature branch
-	if err := NewReferenceEntry(anotherRefName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry(anotherRefName, repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 	latestEntry, err := GetLatestEntry(repo)
@@ -1742,7 +1742,7 @@ func TestGetReferenceUpdaterEntriesInRange(t *testing.T) {
 	assert.Equal(t, expectedAnnotationMap, annotationMap)
 
 	// Add a gittuf namespace entry and ensure it's returned as relevant
-	if err := NewReferenceEntry("refs/gittuf/relevant", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/gittuf/relevant", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 	latestEntry, err = GetLatestEntry(repo)
@@ -1772,7 +1772,7 @@ func TestGetReferenceUpdaterEntriesInRangeForRef(t *testing.T) {
 
 	// Add some entries to main
 	for i := 0; i < 3; i++ {
-		if err := NewReferenceEntry(refName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		if err := NewReferenceEntry(refName, repo.ZeroHash()).Commit(repo, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -1804,7 +1804,7 @@ func TestGetReferenceUpdaterEntriesInRangeForRef(t *testing.T) {
 	assert.Equal(t, expectedAnnotationMap, annotationMap)
 
 	// Add an entry and annotation for feature branch
-	if err := NewReferenceEntry(anotherRefName, gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry(anotherRefName, repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 	latestEntry, err := GetLatestEntry(repo)
@@ -1840,7 +1840,7 @@ func TestGetReferenceUpdaterEntriesInRangeForRef(t *testing.T) {
 	assert.Equal(t, expectedAnnotationMap, annotationMap)
 
 	// Add a gittuf namespace entry and ensure it's returned as relevant
-	if err := NewReferenceEntry("refs/gittuf/relevant", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+	if err := NewReferenceEntry("refs/gittuf/relevant", repo.ZeroHash()).Commit(repo, false); err != nil {
 		t.Fatal(err)
 	}
 	latestEntry, err = GetLatestEntry(repo)
@@ -2017,12 +2017,12 @@ func TestAnnotationEntryRefersTo(t *testing.T) {
 		},
 		"annotation refers to single entry, returns false": {
 			annotation:     NewAnnotationEntry([]gitinterface.Hash{emptyBlobID}, false, annotationMessage),
-			entryID:        gitinterface.ZeroHash,
+			entryID:        repo.ZeroHash(),
 			expectedResult: false,
 		},
 		"annotation refers to multiple entries, returns false": {
 			annotation:     NewAnnotationEntry([]gitinterface.Hash{emptyTreeID, emptyBlobID}, false, annotationMessage),
-			entryID:        gitinterface.ZeroHash,
+			entryID:        repo.ZeroHash(),
 			expectedResult: false,
 		},
 	}
@@ -2046,7 +2046,7 @@ func TestReferenceEntryCreateCommitMessage(t *testing.T) {
 		"entry, fully resolved ref": {
 			entry: &ReferenceEntry{
 				RefName:  "refs/heads/main",
-				TargetID: gitinterface.ZeroHash,
+				TargetID: testZeroHash,
 			},
 			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, plumbing.ZeroHash.String()),
 		},
@@ -2060,7 +2060,7 @@ func TestReferenceEntryCreateCommitMessage(t *testing.T) {
 		"entry, fully resolved ref, small number": {
 			entry: &ReferenceEntry{
 				RefName:  "refs/heads/main",
-				TargetID: gitinterface.ZeroHash,
+				TargetID: testZeroHash,
 				Number:   1,
 			},
 			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, plumbing.ZeroHash.String(), NumberKey, 1),
@@ -2068,7 +2068,7 @@ func TestReferenceEntryCreateCommitMessage(t *testing.T) {
 		"entry, fully resolved ref, large number": {
 			entry: &ReferenceEntry{
 				RefName:  "refs/heads/main",
-				TargetID: gitinterface.ZeroHash,
+				TargetID: testZeroHash,
 				Number:   math.MaxUint64,
 			},
 			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, plumbing.ZeroHash.String(), NumberKey, uint64(math.MaxUint64)),
@@ -2092,61 +2092,61 @@ func TestAnnotationEntryCreateCommitMessage(t *testing.T) {
 	}{
 		"annotation, no message": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "",
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true"),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true"),
 		},
 		"annotation, with message": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "message",
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
 		},
 		"annotation, with multi-line message": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "message1\nmessage2",
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message1\nmessage2")), EndMessage),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message1\nmessage2")), EndMessage),
 		},
 		"annotation, no message, skip false": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        false,
 				Message:     "",
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "false"),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "false"),
 		},
 		"annotation, no message, skip false, multiple entry IDs": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash, gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash, testZeroHash},
 				Skip:        false,
 				Message:     "",
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "false"),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), EntryIDKey, testZeroHash.String(), SkipKey, "false"),
 		},
 		"annotation, no message, small number": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "",
 				Number:      1,
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", NumberKey, 1),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", NumberKey, 1),
 		},
 		"annotation, no message, large number": {
 			entry: &AnnotationEntry{
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "",
 				Number:      math.MaxUint64,
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", NumberKey, uint64(math.MaxUint64)),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", NumberKey, uint64(math.MaxUint64)),
 		},
 	}
 
@@ -2178,11 +2178,11 @@ func TestPropagationEntryCreateCommitMessage(t *testing.T) {
 		"entry, fully resolved ref": {
 			entry: &PropagationEntry{
 				RefName:            "refs/heads/main",
-				TargetID:           gitinterface.ZeroHash,
+				TargetID:           testZeroHash,
 				UpstreamRepository: upstreamRepository,
-				UpstreamEntryID:    gitinterface.ZeroHash,
+				UpstreamEntryID:    testZeroHash,
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String()),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, testZeroHash.String()),
 		},
 		"entry, non-zero commit": {
 			entry: &PropagationEntry{
@@ -2196,22 +2196,22 @@ func TestPropagationEntryCreateCommitMessage(t *testing.T) {
 		"entry, fully resolved ref, small number": {
 			entry: &PropagationEntry{
 				RefName:            "refs/heads/main",
-				TargetID:           gitinterface.ZeroHash,
+				TargetID:           testZeroHash,
 				UpstreamRepository: upstreamRepository,
-				UpstreamEntryID:    gitinterface.ZeroHash,
+				UpstreamEntryID:    testZeroHash,
 				Number:             1,
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String(), NumberKey, 1),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, testZeroHash.String(), NumberKey, 1),
 		},
 		"entry, fully resolved ref, large number": {
 			entry: &PropagationEntry{
 				RefName:            "refs/heads/main",
-				TargetID:           gitinterface.ZeroHash,
+				TargetID:           testZeroHash,
 				UpstreamRepository: upstreamRepository,
-				UpstreamEntryID:    gitinterface.ZeroHash,
+				UpstreamEntryID:    testZeroHash,
 				Number:             math.MaxUint64,
 			},
-			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String(), NumberKey, uint64(math.MaxUint64)),
+			expectedMessage: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, testZeroHash.String(), NumberKey, uint64(math.MaxUint64)),
 		},
 	}
 
@@ -2240,15 +2240,15 @@ func TestParseRSLEntryText(t *testing.T) {
 	}{
 		"entry, fully resolved ref": {
 			expectedEntry: &ReferenceEntry{
-				ID:       gitinterface.ZeroHash,
+				ID:       testZeroHash,
 				RefName:  "refs/heads/main",
-				TargetID: gitinterface.ZeroHash,
+				TargetID: testZeroHash,
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String()),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String()),
 		},
 		"entry, non-zero commit": {
 			expectedEntry: &ReferenceEntry{
-				ID:       gitinterface.ZeroHash,
+				ID:       testZeroHash,
 				RefName:  "refs/heads/main",
 				TargetID: nonZeroHash,
 			},
@@ -2256,7 +2256,7 @@ func TestParseRSLEntryText(t *testing.T) {
 		},
 		"entry, missing header": {
 			expectedError: ErrInvalidRSLEntry,
-			message:       fmt.Sprintf("%s: %s\n%s: %s", RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String()),
+			message:       fmt.Sprintf("%s: %s\n%s: %s", RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String()),
 		},
 		"entry, missing information": {
 			expectedError: ErrInvalidRSLEntry,
@@ -2264,70 +2264,70 @@ func TestParseRSLEntryText(t *testing.T) {
 		},
 		"annotation, no message": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "",
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true"),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true"),
 		},
 		"annotation, with message": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "message",
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
 		},
 		"annotation, with multi-line message": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Message:     "message1\nmessage2",
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message1\nmessage2")), EndMessage),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message1\nmessage2")), EndMessage),
 		},
 		"annotation, no message, skip false": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        false,
 				Message:     "",
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "false"),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "false"),
 		},
 		"annotation, no message, skip false, multiple entry IDs": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash, gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash, testZeroHash},
 				Skip:        false,
 				Message:     "",
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "false"),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), EntryIDKey, testZeroHash.String(), SkipKey, "false"),
 		},
 		"annotation, missing header": {
 			expectedError: ErrInvalidRSLEntry,
-			message:       fmt.Sprintf("%s: %s\n%s: %s\n%s\n%s\n%s", EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
+			message:       fmt.Sprintf("%s: %s\n%s: %s\n%s\n%s\n%s", EntryIDKey, testZeroHash.String(), SkipKey, "true", BeginMessage, base64.StdEncoding.EncodeToString([]byte("message")), EndMessage),
 		},
 		"annotation, missing information": {
 			expectedError: ErrInvalidRSLEntry,
-			message:       fmt.Sprintf("%s\n\n%s: %s", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String()),
+			message:       fmt.Sprintf("%s\n\n%s: %s", AnnotationEntryHeader, EntryIDKey, testZeroHash.String()),
 		},
 		"propagation entry, fully resolved ref": {
 			expectedEntry: &PropagationEntry{
-				ID:                 gitinterface.ZeroHash,
+				ID:                 testZeroHash,
 				RefName:            "refs/heads/main",
-				TargetID:           gitinterface.ZeroHash,
+				TargetID:           testZeroHash,
 				UpstreamRepository: upstreamRepository,
-				UpstreamEntryID:    gitinterface.ZeroHash,
+				UpstreamEntryID:    testZeroHash,
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String()),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, testZeroHash.String()),
 		},
 		"propagation entry, non-zero commit": {
 			expectedEntry: &PropagationEntry{
-				ID:                 gitinterface.ZeroHash,
+				ID:                 testZeroHash,
 				RefName:            "refs/heads/main",
 				TargetID:           nonZeroHash,
 				UpstreamRepository: upstreamRepository,
@@ -2341,7 +2341,7 @@ func TestParseRSLEntryText(t *testing.T) {
 		},
 		"entry, with number": {
 			expectedEntry: &ReferenceEntry{
-				ID:       gitinterface.ZeroHash,
+				ID:       testZeroHash,
 				RefName:  "refs/heads/main",
 				TargetID: nonZeroHash,
 				Number:   42,
@@ -2350,29 +2350,29 @@ func TestParseRSLEntryText(t *testing.T) {
 		},
 		"annotation, with number": {
 			expectedEntry: &AnnotationEntry{
-				ID:          gitinterface.ZeroHash,
-				RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash},
+				ID:          testZeroHash,
+				RSLEntryIDs: []gitinterface.Hash{testZeroHash},
 				Skip:        true,
 				Number:      7,
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, gitinterface.ZeroHash.String(), SkipKey, "true", NumberKey, 7),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %d", AnnotationEntryHeader, EntryIDKey, testZeroHash.String(), SkipKey, "true", NumberKey, 7),
 		},
 		"propagation entry, with number": {
 			expectedEntry: &PropagationEntry{
-				ID:                 gitinterface.ZeroHash,
+				ID:                 testZeroHash,
 				RefName:            "refs/heads/main",
-				TargetID:           gitinterface.ZeroHash,
+				TargetID:           testZeroHash,
 				UpstreamRepository: upstreamRepository,
-				UpstreamEntryID:    gitinterface.ZeroHash,
+				UpstreamEntryID:    testZeroHash,
 				Number:             3,
 			},
-			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, gitinterface.ZeroHash.String(), NumberKey, 3),
+			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, testZeroHash.String(), UpstreamRepositoryKey, upstreamRepository, UpstreamEntryIDKey, testZeroHash.String(), NumberKey, 3),
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			entry, err := parseRSLEntryText(gitinterface.ZeroHash, test.message)
+			entry, err := parseRSLEntryText(testZeroHash, test.message)
 			if err != nil {
 				assert.ErrorIs(t, err, test.expectedError)
 			} else if !assert.Equal(t, test.expectedEntry, entry) {
@@ -2385,7 +2385,7 @@ func TestParseRSLEntryText(t *testing.T) {
 func TestParseRSLEntryTextRejectsMalformed(t *testing.T) {
 	t.Parallel()
 
-	zero := gitinterface.ZeroHash.String()
+	zero := testZeroHash.String()
 	upstream := "https://git.example.com/example/repository"
 
 	// Each message below is malformed in exactly one way and must be rejected
@@ -2436,7 +2436,7 @@ func TestParseRSLEntryTextRejectsMalformed(t *testing.T) {
 	for name, message := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			entry, err := parseRSLEntryText(testZeroHash, message)
 			assert.True(t, entry == nil, "expected a true nil Entry, not a typed nil pointer")
 			assert.ErrorIs(t, err, ErrInvalidRSLEntry)
 		})
@@ -2446,7 +2446,7 @@ func TestParseRSLEntryTextRejectsMalformed(t *testing.T) {
 func TestParseRSLEntryTextForwardCompatibility(t *testing.T) {
 	t.Parallel()
 
-	zero := gitinterface.ZeroHash.String()
+	zero := testZeroHash.String()
 	upstream := "https://git.example.com:8443/example/repository"
 
 	tests := map[string]struct {
@@ -2456,29 +2456,29 @@ func TestParseRSLEntryTextForwardCompatibility(t *testing.T) {
 		"reference, unknown trailing key ignored": {
 			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\nfutureField: someValue",
 				ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
-			expectedEntry: &ReferenceEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			expectedEntry: &ReferenceEntry{ID: testZeroHash, RefName: "refs/heads/main", TargetID: testZeroHash},
 		},
 		"reference, unknown leading key ignored": {
 			message: fmt.Sprintf("%s\n\nfutureField: someValue\n%s: %s\n%s: %s",
 				ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
-			expectedEntry: &ReferenceEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			expectedEntry: &ReferenceEntry{ID: testZeroHash, RefName: "refs/heads/main", TargetID: testZeroHash},
 		},
 		"annotation, unknown key ignored between fields": {
 			message: fmt.Sprintf("%s\n\n%s: %s\nfutureField: someValue\n%s: %s",
 				AnnotationEntryHeader, EntryIDKey, zero, SkipKey, "false"),
-			expectedEntry: &AnnotationEntry{ID: gitinterface.ZeroHash, RSLEntryIDs: []gitinterface.Hash{gitinterface.ZeroHash}, Skip: false},
+			expectedEntry: &AnnotationEntry{ID: testZeroHash, RSLEntryIDs: []gitinterface.Hash{testZeroHash}, Skip: false},
 		},
 		"propagation, upstreamRepository with colons preserved": {
 			message: fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s",
 				PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, upstream, UpstreamEntryIDKey, zero),
-			expectedEntry: &PropagationEntry{ID: gitinterface.ZeroHash, RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash, UpstreamRepository: upstream, UpstreamEntryID: gitinterface.ZeroHash},
+			expectedEntry: &PropagationEntry{ID: testZeroHash, RefName: "refs/heads/main", TargetID: testZeroHash, UpstreamRepository: upstream, UpstreamEntryID: testZeroHash},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			entry, err := parseRSLEntryText(gitinterface.ZeroHash, test.message)
+			entry, err := parseRSLEntryText(testZeroHash, test.message)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedEntry, entry)
 		})
@@ -2498,7 +2498,7 @@ func FuzzParseRSLEntryText(f *testing.F) {
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com:8443/repo", UpstreamEntryIDKey, fuzzNonZeroHash))
 
 	f.Fuzz(func(_ *testing.T, text string) {
-		_, _ = parseRSLEntryText(gitinterface.ZeroHash, text)
+		_, _ = parseRSLEntryText(testZeroHash, text)
 	})
 }
 
@@ -2509,7 +2509,7 @@ func FuzzParseReferenceEntryText(f *testing.F) {
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, TargetIDKey, fuzzZeroHash, RefKey, "refs/heads/main"))
 
 	f.Fuzz(func(_ *testing.T, text string) {
-		_, _ = parseReferenceEntryText(gitinterface.ZeroHash, text)
+		_, _ = parseReferenceEntryText(testZeroHash, text)
 	})
 }
 
@@ -2519,7 +2519,7 @@ func FuzzParseAnnotationEntryText(f *testing.F) {
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s\n%s\n%s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, EntryIDKey, fuzzNonZeroHash, SkipKey, "false", BeginMessage, base64.StdEncoding.EncodeToString([]byte("note")), EndMessage))
 
 	f.Fuzz(func(_ *testing.T, text string) {
-		_, _ = parseAnnotationEntryText(gitinterface.ZeroHash, text)
+		_, _ = parseAnnotationEntryText(testZeroHash, text)
 	})
 }
 
@@ -2529,7 +2529,7 @@ func FuzzParsePropagationEntryText(f *testing.F) {
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: %d", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com/repo", UpstreamEntryIDKey, fuzzNonZeroHash, NumberKey, 9))
 
 	f.Fuzz(func(_ *testing.T, text string) {
-		_, _ = parsePropagationEntryText(gitinterface.ZeroHash, text)
+		_, _ = parsePropagationEntryText(testZeroHash, text)
 	})
 }
 
@@ -2538,7 +2538,7 @@ func BenchmarkParseReferenceEntryText(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := parseReferenceEntryText(gitinterface.ZeroHash, text); err != nil {
+		if _, err := parseReferenceEntryText(testZeroHash, text); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -2549,7 +2549,7 @@ func BenchmarkParseAnnotationEntryText(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := parseAnnotationEntryText(gitinterface.ZeroHash, text); err != nil {
+		if _, err := parseAnnotationEntryText(testZeroHash, text); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -2560,7 +2560,7 @@ func BenchmarkParseAnnotationEntryTextNoMessage(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := parseAnnotationEntryText(gitinterface.ZeroHash, text); err != nil {
+		if _, err := parseAnnotationEntryText(testZeroHash, text); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -2571,7 +2571,7 @@ func BenchmarkParsePropagationEntryText(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := parsePropagationEntryText(gitinterface.ZeroHash, text); err != nil {
+		if _, err := parsePropagationEntryText(testZeroHash, text); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -2582,7 +2582,7 @@ func BenchmarkParseRSLEntryText(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if _, err := parseRSLEntryText(gitinterface.ZeroHash, text); err != nil {
+		if _, err := parseRSLEntryText(testZeroHash, text); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/internal/tuf/v01/root_test.go
+++ b/internal/tuf/v01/root_test.go
@@ -18,7 +18,6 @@ import (
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
-	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -921,7 +920,7 @@ func TestHook(t *testing.T) {
 	hook := &Hook{
 		Name:         "test-hook",
 		PrincipalIDs: set.NewSetFromItems(key.KeyID),
-		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
+		Hashes:       map[string]string{"sha1": "0000000000000000000000000000000000000000"},
 		Environment:  tuf.HookEnvironmentLua,
 		Timeout:      100,
 	}
@@ -935,7 +934,7 @@ func TestHook(t *testing.T) {
 	})
 
 	t.Run("GetHashes", func(t *testing.T) {
-		hashes := map[string]string{"sha1": gitinterface.ZeroHash.String()}
+		hashes := map[string]string{"sha1": "0000000000000000000000000000000000000000"}
 		assert.Equal(t, hook.GetHashes(), hashes)
 	})
 
@@ -959,22 +958,22 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	_, err := rootMetadata.GetHooks(tuf.HookStagePreCommit)
 	assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrDuplicatedHookName)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrInvalidHookStage)
 
 	preCommitHook := []*Hook{{
 		Name:         "test-hook",
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
-		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
+		Hashes:       map[string]string{"sha1": "0000000000000000000000000000000000000000"},
 		Environment:  tuf.HookEnvironmentLua,
 		Timeout:      100,
 	}}
@@ -983,7 +982,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	prePushHook := []*Hook{{
 		Name:         "test-hook",
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
-		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
+		Hashes:       map[string]string{"sha1": "0000000000000000000000000000000000000000"},
 		Environment:  tuf.HookEnvironmentLua,
 		Timeout:      100,
 	}}
@@ -1007,10 +1006,10 @@ func TestUpdateHook(t *testing.T) {
 	key1 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 	key2 := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets2PubKeyBytes))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
 	err = rootMetadata.UpdateHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha256": "newhash"}, tuf.HookEnvironmentLua, 200)
@@ -1049,16 +1048,16 @@ func TestRemoveHook(t *testing.T) {
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
 	// Add additional hook to test hook search loop later
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook-2", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook-2", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePrePush]))
 

--- a/internal/tuf/v02/root_test.go
+++ b/internal/tuf/v02/root_test.go
@@ -20,7 +20,6 @@ import (
 	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
-	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -974,22 +973,22 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	_, err := rootMetadata.GetHooks(tuf.HookStagePreCommit)
 	assert.ErrorIs(t, err, tuf.ErrNoHooksDefined)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.Nil(t, err)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrDuplicatedHookName)
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{invalidStage}, "test-hook", []string{key1.KeyID, key2.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	assert.ErrorIs(t, err, tuf.ErrInvalidHookStage)
 
 	preCommitHook := []*Hook{{
 		Name:         "test-hook",
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
-		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
+		Hashes:       map[string]string{"sha1": "0000000000000000000000000000000000000000"},
 		Environment:  tuf.HookEnvironmentLua,
 		Timeout:      100,
 	}}
@@ -998,7 +997,7 @@ func TestAddHookAndGetHooks(t *testing.T) {
 	prePushHook := []*Hook{{
 		Name:         "test-hook",
 		PrincipalIDs: set.NewSetFromItems(key1.KeyID, key2.KeyID),
-		Hashes:       map[string]string{"sha1": gitinterface.ZeroHash.String()},
+		Hashes:       map[string]string{"sha1": "0000000000000000000000000000000000000000"},
 		Environment:  tuf.HookEnvironmentLua,
 		Timeout:      100,
 	}}
@@ -1021,11 +1020,11 @@ func TestUpdateHook(t *testing.T) {
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePrePush]))
 
@@ -1050,7 +1049,7 @@ func TestUpdateHook(t *testing.T) {
 	prePushHook := rootMetadata.Hooks[tuf.HookStagePrePush][0]
 	assert.Equal(t, "test-hook", prePushHook.Name)
 	assert.Equal(t, set.NewSetFromItems(key.KeyID), prePushHook.PrincipalIDs)
-	assert.Equal(t, map[string]string{"sha1": gitinterface.ZeroHash.String(), "sha256": "anotherhash"}, prePushHook.Hashes)
+	assert.Equal(t, map[string]string{"sha1": "0000000000000000000000000000000000000000", "sha256": "anotherhash"}, prePushHook.Hashes)
 	assert.Equal(t, tuf.HookEnvironmentLua, prePushHook.Environment)
 	assert.Equal(t, 150, prePushHook.Timeout)
 }
@@ -1063,16 +1062,16 @@ func TestRemoveHook(t *testing.T) {
 
 	key := NewKeyFromSSLibKey(ssh.NewKeyFromBytes(t, targets1PubKeyBytes))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
 	// Add additional hook to test hook search loop later
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook-2", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePreCommit}, "test-hook-2", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 2, len(rootMetadata.Hooks[tuf.HookStagePreCommit]))
 
-	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": gitinterface.ZeroHash.String()}, tuf.HookEnvironmentLua, 100)
+	_, err = rootMetadata.AddHook([]tuf.HookStage{tuf.HookStagePrePush}, "test-hook", []string{key.KeyID}, map[string]string{"sha1": "0000000000000000000000000000000000000000"}, tuf.HookEnvironmentLua, 100)
 	require.Nil(t, err)
 	assert.Equal(t, 1, len(rootMetadata.Hooks[tuf.HookStagePrePush]))
 

--- a/pkg/gitinterface/blob.go
+++ b/pkg/gitinterface/blob.go
@@ -32,12 +32,12 @@ func (r *Repository) WriteBlob(contents []byte) (Hash, error) {
 	stdInBuf := bytes.NewBuffer(contents)
 	objID, err := r.executor("hash-object", "-t", "blob", "-w", "--stdin").withStdIn(stdInBuf).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to write blob: %w", err)
+		return nil, fmt.Errorf("unable to write blob: %w", err)
 	}
 
 	hash, err := NewHash(objID)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid Git ID for blob: %w", err)
+		return nil, fmt.Errorf("invalid Git ID for blob: %w", err)
 	}
 
 	return hash, nil

--- a/pkg/gitinterface/blob_test.go
+++ b/pkg/gitinterface/blob_test.go
@@ -31,7 +31,7 @@ func TestRepositoryReadBlob(t *testing.T) {
 	})
 
 	t.Run("read non-existing blob", func(t *testing.T) {
-		_, err := repo.ReadBlob(ZeroHash)
+		_, err := repo.ReadBlob(repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to inspect if object is blob")
 	})
 

--- a/pkg/gitinterface/commit.go
+++ b/pkg/gitinterface/commit.go
@@ -28,7 +28,7 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 	currentGitID, err := r.GetReference(targetRef)
 	if err != nil {
 		if !errors.Is(err, ErrReferenceNotFound) {
-			return ZeroHash, err
+			return nil, err
 		}
 	}
 
@@ -49,11 +49,11 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 
 	stdOut, err := r.executor(args...).withEnv(env...).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to create commit: %w", err)
+		return nil, fmt.Errorf("unable to create commit: %w", err)
 	}
 	commitID, err := NewHash(stdOut)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("received invalid commit ID: %w", err)
+		return nil, fmt.Errorf("received invalid commit ID: %w", err)
 	}
 
 	return commitID, r.CheckAndSetReference(targetRef, commitID, currentGitID)
@@ -67,7 +67,7 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message string, signingKeyPEMBytes []byte) (Hash, error) {
 	gitConfig, err := r.GetGitConfig()
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	commitMetadata := object.Signature{
@@ -86,7 +86,7 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 	refTip, err := r.GetReference(targetRef)
 	if err != nil {
 		if !errors.Is(err, ErrReferenceNotFound) {
-			return ZeroHash, err
+			return nil, err
 		}
 	}
 
@@ -96,11 +96,11 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 
 	commitContents, err := getCommitBytesWithoutSignature(commit)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	signature, err := signGitObjectUsingKey(commitContents, signingKeyPEMBytes)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	// SHA-256 repositories store the signature under the `gpgsig-sha256`
 	// header (go-git's SignatureSHA256), matching Git's own behavior, so it
@@ -113,21 +113,21 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 
 	goGitRepo, err := r.GetGoGitRepository()
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	obj := goGitRepo.Storer.NewEncodedObject()
 	if err := commit.Encode(obj); err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	commitID, err := goGitRepo.Storer.SetEncodedObject(obj)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	commitIDHash, err := NewHash(commitID.String())
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	return commitIDHash, r.CheckAndSetReference(targetRef, commitIDHash, refTip)
@@ -233,17 +233,17 @@ func (r *Repository) GetCommitMessage(commitID Hash) (string, error) {
 // GetCommitTreeID returns the commit's Git tree ID.
 func (r *Repository) GetCommitTreeID(commitID Hash) (Hash, error) {
 	if err := r.ensureIsCommit(commitID); err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	stdOut, err := r.executor("rev-parse", fmt.Sprintf("%s^{tree}", commitID.String())).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to identify tree for commit '%s': %w", commitID.String(), err)
+		return nil, fmt.Errorf("unable to identify tree for commit '%s': %w", commitID.String(), err)
 	}
 
 	hash, err := NewHash(stdOut)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid tree for commit ID '%s': %w", commitID, err)
+		return nil, fmt.Errorf("invalid tree for commit ID '%s': %w", commitID, err)
 	}
 	return hash, nil
 }

--- a/pkg/gitinterface/commit_test.go
+++ b/pkg/gitinterface/commit_test.go
@@ -891,7 +891,7 @@ func TestEnsureIsCommit(t *testing.T) {
 	})
 
 	t.Run("non-existent object", func(t *testing.T) {
-		err := repo.ensureIsCommit(ZeroHash)
+		err := repo.ensureIsCommit(repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to inspect if object is commit")
 	})
 }

--- a/pkg/gitinterface/hash.go
+++ b/pkg/gitinterface/hash.go
@@ -36,10 +36,10 @@ func (h Hash) String() string {
 	return hex.EncodeToString(h[:])
 }
 
-// IsZero compares the hash to see if it's the zero hash for either SHA-1 or
-// SHA-256.
+// IsZero returns true if the hash denotes "no object": a nil / empty value or
+// the zero hash for either SHA-1 or SHA-256.
 func (h Hash) IsZero() bool {
-	return bytes.Equal(h[:], zeroSHA1HashBytes[:]) || bytes.Equal(h[:], zeroSHA256HashBytes[:])
+	return len(h) == 0 || bytes.Equal(h[:], zeroSHA1HashBytes[:]) || bytes.Equal(h[:], zeroSHA256HashBytes[:])
 }
 
 // Equal compares the hash to another provided Hash to see if they're equal.
@@ -52,13 +52,6 @@ func (h Hash) Equal(other Hash) bool {
 func (h Hash) IsSHA256() bool {
 	return len(h) == sha256.Size
 }
-
-// ZeroHash represents an empty SHA-1 Hash. It is safe to use as an
-// error-return sentinel and in comparisons via Hash.IsZero (which matches both
-// SHA-1 and SHA-256 zero hashes). When the value is passed to Git or compared
-// against a Git-produced ID, prefer Repository.ZeroHash, which returns the zero
-// hash matching the repository's object format.
-var ZeroHash = Hash(zeroSHA1HashBytes[:])
 
 // ZeroHash returns the all-zeroes Hash for the repository's object format. Git
 // uses this value to denote, for example, the absence of a previous value when
@@ -74,12 +67,12 @@ func (r *Repository) ZeroHash() Hash {
 // encoded.
 func NewHash(h string) (Hash, error) {
 	if len(h) != (sha1.Size*2) && len(h) != (sha256.Size*2) {
-		return ZeroHash, ErrInvalidHashLength
+		return nil, ErrInvalidHashLength
 	}
 
 	hash, err := hex.DecodeString(h)
 	if err != nil {
-		return ZeroHash, ErrInvalidHashEncoding
+		return nil, ErrInvalidHashEncoding
 	}
 
 	return Hash(hash), nil

--- a/pkg/gitinterface/hash_test.go
+++ b/pkg/gitinterface/hash_test.go
@@ -61,3 +61,21 @@ func TestNewHash(t *testing.T) {
 		}
 	}
 }
+
+func TestHashIsZero(t *testing.T) {
+	tests := map[string]struct {
+		hash     Hash
+		expected bool
+	}{
+		"nil":              {nil, true},
+		"empty":            {Hash{}, true},
+		"sha1 zero":        {Hash(zeroSHA1HashBytes[:]), true},
+		"sha256 zero":      {Hash(zeroSHA256HashBytes[:]), true},
+		"sha1 non-zero":    {Hash{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, false},
+		"wrong length all": {Hash{0, 0, 0}, false},
+	}
+
+	for name, test := range tests {
+		assert.Equal(t, test.expected, test.hash.IsZero(), name)
+	}
+}

--- a/pkg/gitinterface/log_test.go
+++ b/pkg/gitinterface/log_test.go
@@ -181,7 +181,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 	})
 
 	t.Run("Get all commits", func(t *testing.T) {
-		commits, err := repo.GetCommitsBetweenRange(allCommits[4], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(allCommits[4], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := allCommits
@@ -192,7 +192,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 	})
 
 	t.Run("Get commits from invalid range", func(t *testing.T) {
-		_, err := repo.GetCommitsBetweenRange(ZeroHash, ZeroHash)
+		_, err := repo.GetCommitsBetweenRange(repo.ZeroHash(), repo.ZeroHash())
 		assert.NotNil(t, err)
 	})
 
@@ -200,7 +200,7 @@ func TestGetCommitsBetweenRangeRepository(t *testing.T) {
 		nonExistentHash, err := repo.WriteBlob([]byte{})
 		assert.Nil(t, err)
 
-		commits, err := repo.GetCommitsBetweenRange(nonExistentHash, ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(nonExistentHash, repo.ZeroHash())
 		assert.Nil(t, err)
 		assert.Empty(t, commits)
 	})
@@ -251,7 +251,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 1", func(t *testing.T) {
 		// commit 1 is the first commit, so it should be the only commit returned
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[0], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[0], repo.ZeroHash())
 		assert.Nil(t, err)
 		expectedCommits := []Hash{commitIDs[0]}
 		assert.Equal(t, expectedCommits, commits)
@@ -259,7 +259,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 2", func(t *testing.T) {
 		// commit 2 is the first child of commit 1, so only it and commit 1 should be returned
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[1], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[1], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := []Hash{commitIDs[1], commitIDs[0]}
@@ -272,7 +272,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 3", func(t *testing.T) {
 		// commit 3 is the second child of commit 1, so only it and commit 1 should be returned
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[2], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[2], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := []Hash{commitIDs[0], commitIDs[2]}
@@ -285,7 +285,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 4", func(t *testing.T) {
 		// commit 4 is the child of commit 2, so only it, commit 2, and commit 2's parent commit 1 should be returned
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[3], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[3], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := []Hash{commitIDs[1], commitIDs[0], commitIDs[3]}
@@ -298,7 +298,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 5, the merge commit", func(t *testing.T) {
 		// commit 5 is the merge commit of commit 2 and commit 3, so it should return commit 5, commit 2, commit 3, and commit 1 (the parent of commit 2 and commit 3)
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[4], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[4], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := []Hash{commitIDs[4], commitIDs[1], commitIDs[0], commitIDs[2]}
@@ -311,7 +311,7 @@ func TestGetCommitsBetweenRangeForMergeCommits(t *testing.T) {
 
 	t.Run("Test commit 6", func(t *testing.T) {
 		// commit 6 is the child of commit 3, so it should return commit 6, commit 3, and commit 1 (the parent of commit 3)
-		commits, err := repo.GetCommitsBetweenRange(commitIDs[5], ZeroHash)
+		commits, err := repo.GetCommitsBetweenRange(commitIDs[5], repo.ZeroHash())
 		assert.Nil(t, err)
 
 		expectedCommits := []Hash{commitIDs[0], commitIDs[5], commitIDs[2]}

--- a/pkg/gitinterface/object_test.go
+++ b/pkg/gitinterface/object_test.go
@@ -99,7 +99,7 @@ func TestGetObjectType(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, TagObjectType, objType)
 
-	_, err = repo.GetObjectType(ZeroHash)
+	_, err = repo.GetObjectType(repo.ZeroHash())
 	assert.ErrorContains(t, err, "unable to inspect object type")
 }
 
@@ -114,6 +114,6 @@ func TestGetObjectSize(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, uint64(6), objSize)
 
-	_, err = repo.GetObjectSize(ZeroHash)
+	_, err = repo.GetObjectSize(repo.ZeroHash())
 	assert.ErrorContains(t, err, "unable to inspect object size")
 }

--- a/pkg/gitinterface/sync_test.go
+++ b/pkg/gitinterface/sync_test.go
@@ -739,7 +739,7 @@ func TestFetchObject(t *testing.T) {
 	assert.True(t, has)
 
 	t.Run("fetch from non-existent remote", func(t *testing.T) {
-		err := downstreamRepo.FetchObject("nonexistent", ZeroHash)
+		err := downstreamRepo.FetchObject("nonexistent", downstreamRepo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to fetch object")
 	})
 }

--- a/pkg/gitinterface/tag.go
+++ b/pkg/gitinterface/tag.go
@@ -28,17 +28,17 @@ var ErrTagAlreadyExists = errors.New("tag already exists")
 func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, signingKeyPEMBytes []byte) (Hash, error) {
 	gitConfig, err := r.GetGitConfig()
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	goGitRepo, err := r.GetGoGitRepository()
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	targetObj, err := goGitRepo.Object(plumbing.AnyObject, plumbing.NewHash(target.String()))
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	if !strings.HasSuffix(message, "\n") {
@@ -59,11 +59,11 @@ func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, sign
 
 	tagContents, err := getTagBytesWithoutSignature(tag)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	signature, err := signGitObjectUsingKey(tagContents, signingKeyPEMBytes)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	// Git appends tag signatures to the tag payload regardless of the object
 	// format; only commits store the signature under a header named for the
@@ -72,16 +72,16 @@ func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, sign
 
 	obj := goGitRepo.Storer.NewEncodedObject()
 	if err := tag.Encode(obj); err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 	tagID, err := goGitRepo.Storer.SetEncodedObject(obj)
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	tagIDHash, err := NewHash(tagID.String())
 	if err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	return tagIDHash, r.SetReference(TagReferenceName(name), tagIDHash)
@@ -91,12 +91,12 @@ func (r *Repository) TagUsingSpecificKey(target Hash, name, message string, sign
 func (r *Repository) GetTagTarget(tagID Hash) (Hash, error) {
 	targetID, err := r.executor("rev-list", "-n", "1", tagID.String()).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to resolve tag's target ID: %w", err)
+		return nil, fmt.Errorf("unable to resolve tag's target ID: %w", err)
 	}
 
 	hash, err := NewHash(targetID)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid format for target ID: %w", err)
+		return nil, fmt.Errorf("invalid format for target ID: %w", err)
 	}
 
 	return hash, nil

--- a/pkg/gitinterface/tag_test.go
+++ b/pkg/gitinterface/tag_test.go
@@ -47,7 +47,7 @@ func TestGetTagTarget(t *testing.T) {
 	assert.Equal(t, commitID, targetID)
 
 	t.Run("non-existent tag", func(t *testing.T) {
-		_, err := repo.GetTagTarget(ZeroHash)
+		_, err := repo.GetTagTarget(repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to resolve tag's target ID")
 	})
 }
@@ -370,7 +370,7 @@ func TestEnsureIsTag(t *testing.T) {
 	err = repo.ensureIsTag(commitID)
 	assert.ErrorContains(t, err, "is not a tag object")
 
-	err = repo.ensureIsTag(ZeroHash)
+	err = repo.ensureIsTag(repo.ZeroHash())
 	assert.ErrorContains(t, err, "unable to inspect if object is tag")
 }
 
@@ -379,7 +379,7 @@ func TestTagUsingSpecificKey(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := CreateTestGitRepository(t, tmpDir, false)
 
-		_, err := repo.TagUsingSpecificKey(ZeroHash, "test-tag", "test-tag\n", artifacts.SSHED25519Private)
+		_, err := repo.TagUsingSpecificKey(repo.ZeroHash(), "test-tag", "test-tag\n", artifacts.SSHED25519Private)
 		assert.ErrorContains(t, err, "not found")
 	})
 }

--- a/pkg/gitinterface/tree.go
+++ b/pkg/gitinterface/tree.go
@@ -21,12 +21,12 @@ var (
 func (r *Repository) EmptyTree() (Hash, error) {
 	treeID, err := r.executor("hash-object", "-t", "tree", "--stdin").executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to hash empty tree: %w", err)
+		return nil, fmt.Errorf("unable to hash empty tree: %w", err)
 	}
 
 	hash, err := NewHash(treeID)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("empty tree has invalid Git ID: %w", err)
+		return nil, fmt.Errorf("empty tree has invalid Git ID: %w", err)
 	}
 
 	return hash, nil
@@ -160,7 +160,7 @@ func (r *Repository) GetAllFilesInTree(treeID Hash) (map[string]Hash, error) {
 // the second commit's tree is returned.
 func (r *Repository) GetMergeTree(commitAID, commitBID Hash) (Hash, error) {
 	if err := r.ensureIsCommit(commitBID); err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	if commitAID.IsZero() {
@@ -171,17 +171,17 @@ func (r *Repository) GetMergeTree(commitAID, commitBID Hash) (Hash, error) {
 	// Only commitB needs to be non-zero, we can allow fast-forward merges when
 	// the base commit is zero. So, check this only after above
 	if err := r.ensureIsCommit(commitAID); err != nil {
-		return ZeroHash, err
+		return nil, err
 	}
 
 	stdOut, err := r.executor("merge-tree", commitAID.String(), commitBID.String()).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to compute merge tree: %w", err)
+		return nil, fmt.Errorf("unable to compute merge tree: %w", err)
 	}
 
 	treeHash, err := NewHash(stdOut)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid merge tree ID: %w", err)
+		return nil, fmt.Errorf("invalid merge tree ID: %w", err)
 	}
 
 	return treeHash, nil
@@ -402,7 +402,7 @@ func (t *TreeBuilder) populateTree(parent, fullPath string, entry TreeEntry) {
 		// => This is an intermediate node, has to be a tree that we must build
 		entryObj = &entryTree{
 			name:          path.Base(fullPath),
-			gitID:         ZeroHash,
+			gitID:         nil,
 			alreadyExists: false,
 		}
 		t.trees[fullPath] = &entryTree{}
@@ -426,7 +426,7 @@ func (t *TreeBuilder) writeTrees(parent string, tree *entryTree) (Hash, error) {
 			p := path.Join(parent, e.name)
 			entryID, err := t.writeTrees(p, t.trees[p])
 			if err != nil {
-				return ZeroHash, err
+				return nil, err
 			}
 			e.gitID = entryID
 
@@ -462,12 +462,12 @@ func (t *TreeBuilder) writeTree(entries []TreeEntry) (Hash, error) {
 
 	stdOut, err := t.repo.executor("mktree").withStdIn(bytes.NewBufferString(input)).executeString()
 	if err != nil {
-		return ZeroHash, fmt.Errorf("unable to write Git tree: %w", err)
+		return nil, fmt.Errorf("unable to write Git tree: %w", err)
 	}
 
 	treeID, err := NewHash(stdOut)
 	if err != nil {
-		return ZeroHash, fmt.Errorf("invalid tree ID: %w", err)
+		return nil, fmt.Errorf("invalid tree ID: %w", err)
 	}
 
 	return treeID, nil
@@ -496,11 +496,11 @@ func (e *entryTree) getID() Hash {
 }
 
 // NewEntryTree creates a TreeEntry that represents a Git tree. If the tree
-// doesn't exist, i.e., it must be created, gitID must be set to ZeroHash. The
-// name must be set to the full path of the tree object.
+// doesn't exist, i.e., it must be created, gitID must be nil or a zero hash.
+// The name must be set to the full path of the tree object.
 func NewEntryTree(name string, gitID Hash) TreeEntry {
 	entry := &entryTree{name: name, gitID: gitID}
-	if gitID == nil || !gitID.IsZero() {
+	if !gitID.IsZero() {
 		entry.alreadyExists = true
 	}
 	return entry

--- a/pkg/gitinterface/tree_test.go
+++ b/pkg/gitinterface/tree_test.go
@@ -148,7 +148,7 @@ func TestGetPathIDInTree(t *testing.T) {
 	})
 
 	t.Run("non-existent id", func(t *testing.T) {
-		_, err := repo.GetPathIDInTree("a", ZeroHash)
+		_, err := repo.GetPathIDInTree("a", repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to enumerate items in tree")
 	})
 }
@@ -266,7 +266,7 @@ func TestGetTreeItems(t *testing.T) {
 	})
 
 	t.Run("non-existent id", func(t *testing.T) {
-		_, err := repo.GetTreeItems(ZeroHash)
+		_, err := repo.GetTreeItems(repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to enumerate items in tree")
 	})
 }
@@ -471,7 +471,7 @@ func TestGetMergeTree(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		mergeTreeID, err := repo.GetMergeTree(ZeroHash, commitID)
+		mergeTreeID, err := repo.GetMergeTree(repo.ZeroHash(), commitID)
 		assert.Nil(t, err)
 		assert.Equal(t, treeID, mergeTreeID)
 	})
@@ -485,7 +485,7 @@ func TestGetMergeTree(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = repo.GetMergeTree(ZeroHash, blobID)
+		_, err = repo.GetMergeTree(repo.ZeroHash(), blobID)
 		assert.ErrorContains(t, err, "is not a commit object")
 	})
 
@@ -1191,7 +1191,7 @@ func TestEnsureIsTree(t *testing.T) {
 	err = repo.ensureIsTree(blobID)
 	assert.NotNil(t, err)
 
-	err = repo.ensureIsTree(ZeroHash)
+	err = repo.ensureIsTree(repo.ZeroHash())
 	assert.ErrorContains(t, err, "unable to inspect if object is tree")
 }
 
@@ -1208,7 +1208,7 @@ func TestGetAllFilesInTree(t *testing.T) {
 		_, err = repo.GetAllFilesInTree(blobID)
 		assert.ErrorContains(t, err, "unable to enumerate all files in tree")
 
-		_, err = repo.GetAllFilesInTree(ZeroHash)
+		_, err = repo.GetAllFilesInTree(repo.ZeroHash())
 		assert.ErrorContains(t, err, "unable to enumerate all files in tree")
 	})
 }


### PR DESCRIPTION
## Description

The package-level SHA-1 zero hash made it easy to leak a 40-zero ID
into SHA-256 repositories. This removes it to ensure that can no longer
happen.

Error paths now return nil, 'no object' markers are nil (Hash.IsZero
now treats nil/empty as zero), and anything that stringifies a zero
hash or hands it to Git must derive it from the repository via
`Repository.ZeroHash`.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

AI was used to expand test coverage, and doing the leg work across the touch points of the refactoring. All AI-assisted output was iteratively reviewed, refined, and validated through continuous developer feedback before being included in the PR.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
