### PR TITLE
refactor(tui):finish_extracting_the_trust_global_rules_screen_behavior

### DIFF
--- a/internal/cmd/tui/screen_trust_global_rules.go
+++ b/internal/cmd/tui/screen_trust_global_rules.go
@@ -90,6 +90,25 @@ func (s *trustGlobalRulesScreen) cycleFocus(key string) {
 	}
 }
 
+func (s *trustGlobalRulesScreen) handleEsc(m *model) bool {
+	switch m.screen {
+	case screenTrustGlobalRules:
+		if s.confirmDelete {
+			s.confirmDelete = false
+			s.deleteTarget = ""
+			return true
+		}
+
+		m.screen = screenTrust
+		return true
+	case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+		m.screen = screenTrustGlobalRules
+		return true
+	default:
+		return false
+	}
+}
+
 func (s *trustGlobalRulesScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -157,3 +157,40 @@ func TestSplitAndTrim(t *testing.T) {
 		})
 	}
 }
+
+func TestTrustGlobalRulesScreenHandleEsc(t *testing.T) {
+	t.Run("clears delete confirm before leaving list", func(t *testing.T) {
+		m := model{screen: screenTrustGlobalRules}
+		screen := trustGlobalRulesScreen{
+			confirmDelete: true,
+			deleteTarget:  "test-rule",
+		}
+
+		handled := screen.handleEsc(&m)
+
+		assert.True(t, handled)
+		assert.Equal(t, screenTrustGlobalRules, m.screen)
+		assert.False(t, screen.confirmDelete)
+		assert.Empty(t, screen.deleteTarget)
+	})
+
+	t.Run("returns to trust menu from list", func(t *testing.T) {
+		m := model{screen: screenTrustGlobalRules}
+		screen := trustGlobalRulesScreen{}
+
+		handled := screen.handleEsc(&m)
+
+		assert.True(t, handled)
+		assert.Equal(t, screenTrust, m.screen)
+	})
+
+	t.Run("returns to trust list from form", func(t *testing.T) {
+		m := model{screen: screenTrustAddGlobalRule}
+		screen := trustGlobalRulesScreen{}
+
+		handled := screen.handleEsc(&m)
+
+		assert.True(t, handled)
+		assert.Equal(t, screenTrustGlobalRules, m.screen)
+	})
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -85,19 +85,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.screen = screenPolicy
 				}
-			case screenTrustGlobalRules:
-				if m.trustGlobalRulesScreen.confirmDelete {
-					m.trustGlobalRulesScreen.confirmDelete = false
-					m.trustGlobalRulesScreen.deleteTarget = ""
-				} else {
-					m.screen = screenTrust
-				}
 			case screenPolicyAddRule, screenPolicyEditRule:
 				m.screen = screenPolicyRules
-			case screenTrustAddGlobalRule, screenTrustEditGlobalRule:
-				m.screen = screenTrustGlobalRules
 			case screenHelp:
 				m.screen = m.helpScreen.previousScreen
+			case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
+				m.trustGlobalRulesScreen.handleEsc(&m)
 			}
 			return m, nil
 		}


### PR DESCRIPTION
## Description

PR finish the trust global rules screen extraction by moving the back navigation and delete cancel behavior out of the shared TUI router and into the trust global-rules screen module.

- kept trust global rules screen behavior owned by screen_trust_global_rules.go
- moved trust global rules Esc handling into trustGlobalRulesScreen.handleEsc()
- kept a focused test for trust global-rules Esc behavior

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->
I used generative AI to help me verify the refactor and make sure I didn't introduce something unnecessary into the codebase. All code were manually reviewed and all tests were ran to make sure the code was not interferring with exiting codebase. 

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
