### PR TITLE
gitinterface: ignore `refs/replace/` in git invocations

### DIFF
--- a/pkg/gitinterface/replace_ref_test.go
+++ b/pkg/gitinterface/replace_ref_test.go
@@ -1,0 +1,84 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gitinterface
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplaceRefsDoNotAffectVerificationReads(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tmpDir, false)
+	treeBuilder := NewTreeBuilder(repo)
+
+	allowedV1, err := repo.WriteBlob([]byte("allowed v1"))
+	require.NoError(t, err)
+	allowedV2, err := repo.WriteBlob([]byte("allowed v2"))
+	require.NoError(t, err)
+	secretBlob, err := repo.WriteBlob([]byte("secret payload"))
+	require.NoError(t, err)
+
+	// base:  { allowed: v1 }
+	// true:  { allowed: v1, secret }   -> the true commit changes protected "secret"
+	// decoy: { allowed: v2 }           -> the decoy changes only the allowed path
+	baseTree, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("allowed", allowedV1)})
+	require.NoError(t, err)
+	trueTree, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("allowed", allowedV1), NewEntryBlob("secret", secretBlob)})
+	require.NoError(t, err)
+	decoyTree, err := treeBuilder.WriteTreeFromEntries([]TreeEntry{NewEntryBlob("allowed", allowedV2)})
+	require.NoError(t, err)
+
+	mainRef := testNameToRefName(t.Name())
+	baseCommit, err := repo.Commit(baseTree, mainRef, "base\n", false)
+	require.NoError(t, err)
+
+	trueCommit, err := repo.Commit(trueTree, mainRef, "TRUE: adds secret\n", false)
+	require.NoError(t, err)
+
+	// Give the decoy the same parent as the true commit so the diffs are
+	// directly comparable.
+	decoyRef := mainRef + "-decoy"
+	require.NoError(t, repo.SetReference(decoyRef, baseCommit))
+	decoyCommit, err := repo.Commit(decoyTree, decoyRef, "DECOY: benign change\n", false)
+	require.NoError(t, err)
+
+	// Sanity: before any replacement, gittuf reads the true commit correctly.
+	paths, err := repo.GetFilePathsChangedByCommit(trueCommit)
+	require.NoError(t, err)
+	require.Equal(t, []string{"secret"}, paths, "test setup: true commit should change only 'secret'")
+
+	// Plant the malicious replacement: refs/replace/<trueCommit> -> <decoyCommit>.
+	_, err = repo.executor("replace", trueCommit.String(), decoyCommit.String()).executeString()
+	require.NoError(t, err, "unable to create replace ref")
+
+	// The signature path (go-git) is replace-blind and sees the true
+	// object.
+	goGitRepo, err := repo.GetGoGitRepository()
+	require.NoError(t, err)
+	goGitCommit, err := goGitRepo.CommitObject(plumbing.NewHash(trueCommit.String()))
+	require.NoError(t, err)
+	require.Equal(t, trueTree.String(), goGitCommit.TreeHash.String(),
+		"go-git (signature path) must read the true object")
+
+	gotTree, err := repo.GetCommitTreeID(trueCommit)
+	require.NoError(t, err)
+	assert.Equal(t, trueTree.String(), gotTree.String(),
+		"refs/replace/ must not alter the tree gittuf verifies")
+
+	gotPaths, err := repo.GetFilePathsChangedByCommit(trueCommit)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"secret"}, gotPaths,
+		"refs/replace/ must not hide the protected-path change from file-policy verification")
+
+	gotMessage, err := repo.GetCommitMessage(trueCommit)
+	require.NoError(t, err)
+	assert.Equal(t, "TRUE: adds secret", gotMessage,
+		"refs/replace/ must not alter the commit message gittuf reads")
+}

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -305,7 +305,8 @@ func (e *executor) execute() (io.Reader, io.Reader, error) {
 	}
 	cmd := exec.Command(binary, e.args...) //nolint:gosec
 	cmd.Env = e.env
-	cmd.Env = append(cmd.Env, "LC_ALL=C") // force git to the C (and thus english) locale
+	cmd.Env = append(cmd.Env, "LC_ALL=C")                 // force git to the C (and thus english) locale
+	cmd.Env = append(cmd.Env, "GIT_NO_REPLACE_OBJECTS=1") // ignore refs/replace/ so verification reads reflect the true objects, matching the replace-blind go-git reads
 	if e.dir != "" {
 		cmd.Dir = e.dir
 	}


### PR DESCRIPTION
## Description

gittuf calls the `git` binary for most operations, which abide by [replace](https://git-scm.com/docs/git-replace) semantics. `go-git` doesn't support this feature. This means that any process that depends on both Git back-ends have an inconsistent view of the Git repository when a given object is being replaced.

Additionally, being able to replace any object in a repository with an alternative means that theoretically it is possible to point key gittuf refs to other objects and make a verification process to pass (or fail) when it shouldn't. For example, by replacing the objects referenced by the tips of the gittuf refs. Parts of the logic that have a mix of `go-git` and `git` would fail closed. Anything that solely depends on git would potentially accept the difference in meaning for the given operation.

This PR adds a test to pin an example where the problem is visible, and disables it from `git` binary calls so that gittuf operations are blind to replaced objects.

Relates to https://github.com/gittuf/gittuf/issues/133.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [x] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
