### PR TITLE
feat(tui) :- add verify section for refs, mergeability and network

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -13,6 +13,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -35,6 +36,9 @@ const (
 	screenTrustGlobalRules                   // Global rule management screen
 	screenTrustAddGlobalRule                 // Form: add a new global rule
 	screenTrustEditGlobalRule                // Form: edit selected global rule (prefilled)
+	screenVerify                             // Menu for Verify operations
+	screenVerifyRefForm                      // Form: verify reference
+	screenVerifyMergeableForm                // Form: verify mergeability
 	screenHelp                               // Generic Help screen displaying keybindings
 )
 
@@ -61,6 +65,7 @@ type model struct {
 	ctx                        context.Context
 	screen                     screen
 	spinner                    spinner.Model
+	logViewport                viewport.Model
 	homeScreen                 homeScreen
 	helpScreen                 helpScreen
 	policyScreen               policyScreen
@@ -70,6 +75,9 @@ type model struct {
 	trustGlobalRulesScreen     trustGlobalRulesScreen
 	policyPrincipalsScreen     policyPrincipalsScreen
 	policyPrincipalsFormScreen policyPrincipalsFormScreen
+	verifyScreen               verifyScreen
+	verifyRefScreen            verifyRefScreen
+	verifyMergeableScreen      verifyMergeableScreen
 	cursorMode                 cursor.Mode
 	repo                       *gittuf.Repository
 	signer                     dsse.SignerVerifier
@@ -83,6 +91,10 @@ type model struct {
 	height                     int
 	showHelp                   bool
 	signerError                string
+	verifying                  bool
+	loadingMsg                 string
+	logsBuf                    *strings.Builder
+	logCh                      chan string
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -95,6 +107,17 @@ type initDoneMsg struct {
 	footer      string
 	signerError string
 	err         error
+}
+
+// verifyResultMsg carries the result of an async verification command.
+type verifyResultMsg struct {
+	err        error
+	successMsg string
+}
+
+// logBatchMsg carries a batch of log lines for the verification viewport.
+type logBatchMsg struct {
+	lines []string
 }
 
 // inputField describes a single text input's placeholder and prompt label.
@@ -172,17 +195,20 @@ func initialModel(ctx context.Context, o *options) model {
 	delegateMultiline := newDelegate(4)
 
 	m := model{
-		ctx:        ctx,
-		screen:     screenLoading,
-		spinner:    s,
-		cursorMode: cursor.CursorBlink,
-		policyName: o.policyName,
-		options:    o,
+		ctx:         ctx,
+		screen:      screenLoading,
+		spinner:     s,
+		cursorMode:  cursor.CursorBlink,
+		policyName:  o.policyName,
+		options:     o,
+		logViewport: viewport.New(80, 20),
+		logsBuf:     &strings.Builder{},
 
 		homeScreen: homeScreen{
 			choiceList: newMenuList("gittuf TUI", []list.Item{
 				item{title: "Policy", desc: "View and manage gittuf Policy"},
 				item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
+				item{title: "Verify", desc: "Verify references and mergeability"},
 			}, delegate),
 		},
 		policyScreen: policyScreen{
@@ -217,6 +243,13 @@ func initialModel(ctx context.Context, o *options) model {
 		},
 		policyPrincipalsScreen: policyPrincipalsScreen{
 			list: newMenuList("Policy Principals", []list.Item{}, delegateMultiline),
+		},
+		verifyScreen: verifyScreen{
+			choiceList: newMenuList("gittuf Verify Operations", []list.Item{
+				item{title: "Verify Reference", desc: "Verify a specific reference"},
+				item{title: "Verify Mergeability", desc: "Check if a feature branch can be merged"},
+				item{title: "Verify Network", desc: "Verify state of network repositories"},
+			}, delegate),
 		},
 	}
 
@@ -267,6 +300,7 @@ func (m *model) resizeLists() {
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)
 	m.trustGlobalRulesScreen.globalRuleList.SetSize(innerWidth, innerHeight)
 	m.policyPrincipalsScreen.list.SetSize(innerWidth, innerHeight)
+	m.verifyScreen.choiceList.SetSize(innerWidth, innerHeight)
 }
 
 // loadRepoCmd performs all heavy TUI initialization asynchronously and sends

--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -4,6 +4,7 @@
 package tui
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gittuf/gittuf/experimental/gittuf"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -35,6 +37,9 @@ const (
 	screenTrustGlobalRules                   // Global rule management screen
 	screenTrustAddGlobalRule                 // Form: add a new global rule
 	screenTrustEditGlobalRule                // Form: edit selected global rule (prefilled)
+	screenVerify                             // Menu for Verify operations
+	screenVerifyRefForm                      // Form: verify reference
+	screenVerifyMergeableForm                // Form: verify mergeability
 	screenHelp                               // Generic Help screen displaying keybindings
 )
 
@@ -56,6 +61,7 @@ type model struct {
 	ctx                        context.Context
 	screen                     screen
 	spinner                    spinner.Model
+	logViewport                viewport.Model
 	homeScreen                 homeScreen
 	helpScreen                 helpScreen
 	policyScreen               policyScreen
@@ -65,6 +71,9 @@ type model struct {
 	trustGlobalRulesScreen     trustGlobalRulesScreen
 	policyPrincipalsScreen     policyPrincipalsScreen
 	policyPrincipalsFormScreen policyPrincipalsFormScreen
+	verifyScreen               verifyScreen
+	verifyRefScreen            verifyRefScreen
+	verifyMergeableScreen      verifyMergeableScreen
 	cursorMode                 cursor.Mode
 	repo                       *gittuf.Repository
 	signer                     dsse.SignerVerifier
@@ -77,6 +86,9 @@ type model struct {
 	height                     int
 	showHelp                   bool
 	signerError                string
+	verifying                  bool
+	loadingMsg                 string
+	logs                       string
 }
 
 // initDoneMsg carries the result of the asynchronous TUI initialization.
@@ -89,6 +101,18 @@ type initDoneMsg struct {
 	footer      string
 	signerError string
 	err         error
+}
+
+// verifyResultMsg carries the result of an async verification command.
+type verifyResultMsg struct {
+	err        error
+	successMsg string
+}
+
+// logUpdateMsg carries a new line of log output for the verification viewport.
+type logUpdateMsg struct {
+	line    string
+	scanner *bufio.Scanner
 }
 
 // inputField describes a single text input's placeholder and prompt label.
@@ -153,17 +177,19 @@ func initialModel(ctx context.Context, o *options) model {
 	delegateMultiline := newDelegate(4)
 
 	m := model{
-		ctx:        ctx,
-		screen:     screenLoading,
-		spinner:    s,
-		cursorMode: cursor.CursorBlink,
-		policyName: o.policyName,
-		options:    o,
+		ctx:         ctx,
+		screen:      screenLoading,
+		spinner:     s,
+		cursorMode:  cursor.CursorBlink,
+		policyName:  o.policyName,
+		options:     o,
+		logViewport: viewport.New(80, 20),
 
 		homeScreen: homeScreen{
 			choiceList: newMenuList("gittuf TUI", []list.Item{
 				item{title: "Policy", desc: "View and manage gittuf Policy"},
 				item{title: "Trust", desc: "View and manage gittuf Root of Trust"},
+				item{title: "Verify", desc: "Verify references and mergeability"},
 			}, delegate),
 		},
 		policyScreen: policyScreen{
@@ -198,6 +224,13 @@ func initialModel(ctx context.Context, o *options) model {
 		},
 		policyPrincipalsScreen: policyPrincipalsScreen{
 			list: newMenuList("Policy Principals", []list.Item{}, delegateMultiline),
+		},
+		verifyScreen: verifyScreen{
+			choiceList: newMenuList("gittuf Verify Operations", []list.Item{
+				item{title: "Verify Reference", desc: "Verify a specific reference"},
+				item{title: "Verify Mergeability", desc: "Check if a feature branch can be merged"},
+				item{title: "Verify Network", desc: "Verify state of network repositories"},
+			}, delegate),
 		},
 	}
 
@@ -248,6 +281,7 @@ func (m *model) resizeLists() {
 	m.policyRulesScreen.ruleList.SetSize(innerWidth, innerHeight)
 	m.trustGlobalRulesScreen.globalRuleList.SetSize(innerWidth, innerHeight)
 	m.policyPrincipalsScreen.list.SetSize(innerWidth, innerHeight)
+	m.verifyScreen.choiceList.SetSize(innerWidth, innerHeight)
 }
 
 // loadRepoCmd performs all heavy TUI initialization asynchronously and sends

--- a/internal/cmd/tui/screen_home.go
+++ b/internal/cmd/tui/screen_home.go
@@ -23,6 +23,8 @@ func (s *homeScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
 					m.screen = screenPolicy
 				case "Trust":
 					m.screen = screenTrust
+				case "Verify":
+					m.screen = screenVerify
 				}
 			}
 			return *m, nil

--- a/internal/cmd/tui/screen_verify.go
+++ b/internal/cmd/tui/screen_verify.go
@@ -1,0 +1,72 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"bufio"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type verifyScreen struct {
+	choiceList list.Model
+}
+
+func (s *verifyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if keyMsg.String() == "enter" {
+			if sel, ok := s.choiceList.SelectedItem().(item); ok {
+				switch sel.title {
+				case "Verify Reference":
+					m.screen = screenVerifyRefForm
+					m.verifyRefScreen.reset()
+				case "Verify Mergeability":
+					m.screen = screenVerifyMergeableForm
+					m.verifyMergeableScreen.reset()
+				case "Verify Network":
+					m.verifying = true
+					m.logsBuf.Reset()
+					m.logViewport.SetContent("")
+					m.loadingMsg = "Verifying network repositories..."
+
+					pr, pw := io.Pipe()
+					logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+					slog.SetDefault(logger)
+
+					scanner := bufio.NewScanner(pr)
+					scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+					m.logCh = make(chan string, 4096)
+
+					return *m, tea.Batch(
+						m.spinner.Tick,
+						collectLogsCmd(scanner, m.logCh),
+						logFlushTick(m.logCh),
+						func() tea.Msg {
+							defer pw.Close()
+							err := m.repo.VerifyNetwork(m.ctx)
+
+							slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+							return verifyResultMsg{err: err, successMsg: "Network verification successful!"}
+						},
+					)
+				}
+			}
+			return *m, nil
+		}
+	}
+
+	s.choiceList, cmd = s.choiceList.Update(msg)
+	return *m, cmd
+}
+
+func (s *verifyScreen) View(m *model) string {
+	return m.renderScreen("Home › Verify", s.choiceList.View(), renderActionHints(m.readOnly))
+}

--- a/internal/cmd/tui/screen_verify.go
+++ b/internal/cmd/tui/screen_verify.go
@@ -1,0 +1,69 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"bufio"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type verifyScreen struct {
+	choiceList list.Model
+}
+
+func (s *verifyScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		if keyMsg.String() == "enter" {
+			if sel, ok := s.choiceList.SelectedItem().(item); ok {
+				switch sel.title {
+				case "Verify Reference":
+					m.screen = screenVerifyRefForm
+					m.verifyRefScreen.reset()
+				case "Verify Mergeability":
+					m.screen = screenVerifyMergeableForm
+					m.verifyMergeableScreen.reset()
+				case "Verify Network":
+					m.verifying = true
+					m.logs = ""
+					m.logViewport.SetContent("")
+					m.loadingMsg = "Verifying network repositories..."
+
+					pr, pw := io.Pipe()
+					logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+					slog.SetDefault(logger)
+
+					scanner := bufio.NewScanner(pr)
+
+					return *m, tea.Batch(
+						m.spinner.Tick,
+						waitForLog(scanner),
+						func() tea.Msg {
+							defer pw.Close()
+							err := m.repo.VerifyNetwork(m.ctx)
+
+							slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+							return verifyResultMsg{err: err, successMsg: "Network verification successful!"}
+						},
+					)
+				}
+			}
+			return *m, nil
+		}
+	}
+
+	s.choiceList, cmd = s.choiceList.Update(msg)
+	return *m, cmd
+}
+
+func (s *verifyScreen) View(m *model) string {
+	return m.renderScreen("Home › Verify", s.choiceList.View(), renderActionHints(m.readOnly))
+}

--- a/internal/cmd/tui/screen_verify_forms.go
+++ b/internal/cmd/tui/screen_verify_forms.go
@@ -1,0 +1,251 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	verifyopts "github.com/gittuf/gittuf/experimental/gittuf/options/verify"
+	verifymergeableopts "github.com/gittuf/gittuf/experimental/gittuf/options/verifymergeable"
+)
+
+//
+// Verify Reference Form
+//
+
+type verifyRefScreen struct {
+	form formComponent
+}
+
+func (s *verifyRefScreen) reset() {
+	s.form = newFormComponent([]inputField{
+		{"Target Reference (e.g. refs/heads/main)", "Target Ref: "},
+	})
+}
+
+func (s *verifyRefScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "tab", "shift+tab", "up", "down":
+			m.footer = ""
+		}
+	}
+	cmd, isSubmit := s.form.Update(msg)
+	if isSubmit {
+		return s.handleSubmit(m)
+	}
+	return *m, cmd
+}
+
+func (s *verifyRefScreen) View(m *model) string {
+	var b strings.Builder
+	b.WriteString("Verify a specific reference against gittuf policies\n\n")
+	b.WriteString(s.form.View())
+	b.WriteString("\n\nPress Enter to submit.")
+	return m.renderScreen("Home › Verify › Verify Reference", b.String(), renderActionHints(m.readOnly))
+}
+
+func (s *verifyRefScreen) handleSubmit(m *model) (tea.Model, tea.Cmd) {
+	targetRef := strings.TrimSpace(s.form.inputs[0].Value())
+	if targetRef == "" {
+		m.errorMsg = "Target reference is required"
+		return *m, nil
+	}
+
+	m.verifying = true
+	m.logs = ""
+	m.logViewport.SetContent("")
+	m.loadingMsg = fmt.Sprintf("Verifying reference %s...", targetRef)
+
+	pr, pw := io.Pipe()
+	logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+
+	scanner := bufio.NewScanner(pr)
+
+	return *m, tea.Batch(
+		m.spinner.Tick,
+		waitForLog(scanner),
+		func() tea.Msg {
+			defer pw.Close()
+
+			opts := []verifyopts.Option{}
+			err := m.repo.VerifyRef(m.ctx, targetRef, opts...)
+
+			// Reset logger
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+			successMsg := fmt.Sprintf("Successfully verified %s!", targetRef)
+			return verifyResultMsg{err: err, successMsg: successMsg}
+		},
+	)
+}
+
+//
+// Verify Mergeability Form
+//
+
+type verifyMergeableScreen struct {
+	form formComponent
+}
+
+func (s *verifyMergeableScreen) reset() {
+	s.form = newFormComponent([]inputField{
+		{"Feature Branch (e.g. refs/heads/feature)", "Feature Branch: "},
+		{"Base Branch (e.g. refs/heads/main)", "Base Branch: "},
+	})
+}
+
+func (s *verifyMergeableScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "tab", "shift+tab", "up", "down":
+			m.footer = ""
+		}
+	}
+	cmd, isSubmit := s.form.Update(msg)
+	if isSubmit {
+		return s.handleSubmit(m)
+	}
+	return *m, cmd
+}
+
+func (s *verifyMergeableScreen) View(m *model) string {
+	var b strings.Builder
+	b.WriteString("Verify if a feature branch can be merged into a base branch\n\n")
+	b.WriteString(s.form.View())
+	b.WriteString("\n\nPress Tab to advance, Enter to submit.")
+	return m.renderScreen("Home › Verify › Verify Mergeability", b.String(), renderActionHints(m.readOnly))
+}
+
+func (s *verifyMergeableScreen) handleSubmit(m *model) (tea.Model, tea.Cmd) {
+	featureBranch := strings.TrimSpace(s.form.inputs[0].Value())
+	baseBranch := strings.TrimSpace(s.form.inputs[1].Value())
+
+	if featureBranch == "" || baseBranch == "" {
+		m.errorMsg = "Both Feature Branch and Base Branch are required"
+		return *m, nil
+	}
+
+	m.verifying = true
+	m.logs = ""
+	m.logViewport.SetContent("")
+	m.loadingMsg = fmt.Sprintf("Verifying if %s is mergeable into %s...", featureBranch, baseBranch)
+
+	pr, pw := io.Pipe()
+	logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+
+	scanner := bufio.NewScanner(pr)
+
+	return *m, tea.Batch(
+		m.spinner.Tick,
+		waitForLog(scanner),
+		func() tea.Msg {
+			defer pw.Close()
+			opts := []verifymergeableopts.Option{}
+			mergeable, err := m.repo.VerifyMergeable(m.ctx, baseBranch, featureBranch, opts...)
+
+			// Reset logger
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+			if err == nil && !mergeable {
+				err = fmt.Errorf("branch %s is NOT mergeable into %s", featureBranch, baseBranch)
+			}
+
+			successMsg := fmt.Sprintf("Successfully verified %s is mergeable into %s!", featureBranch, baseBranch)
+			return verifyResultMsg{err: err, successMsg: successMsg}
+		},
+	)
+}
+
+// formComponent represents a generic form with text inputs.
+type formComponent struct {
+	inputs     []textinput.Model
+	focusIndex int
+}
+
+// newFormComponent initializes a new form component with the given fields.
+func newFormComponent(fields []inputField) formComponent {
+	return formComponent{
+		inputs:     initInputs(fields),
+		focusIndex: 0,
+	}
+}
+
+// cycleFocus changes the focused input field based on the key pressed.
+func (f *formComponent) cycleFocus(key string) {
+	if len(f.inputs) <= 1 {
+		return
+	}
+
+	if key == "up" || key == "shift+tab" {
+		if f.focusIndex > 0 {
+			f.focusIndex--
+		} else {
+			f.focusIndex = len(f.inputs) - 1
+		}
+	} else {
+		if f.focusIndex < len(f.inputs)-1 {
+			f.focusIndex++
+		} else {
+			f.focusIndex = 0
+		}
+	}
+
+	for i := range f.inputs {
+		if i == f.focusIndex {
+			f.inputs[i].Focus()
+			f.inputs[i].PromptStyle = focusedStyle
+			f.inputs[i].TextStyle = focusedStyle
+		} else {
+			f.inputs[i].Blur()
+			f.inputs[i].PromptStyle = blurredStyle
+			f.inputs[i].TextStyle = blurredStyle
+		}
+	}
+}
+
+// Update handles common key bindings for a form and updates the inputs.
+// It returns a command and a boolean indicating if the form was submitted (Enter pressed).
+func (f *formComponent) Update(msg tea.Msg) (tea.Cmd, bool) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "enter":
+			return nil, true
+		case "tab", "shift+tab", "up", "down":
+			f.cycleFocus(keyMsg.String())
+			return nil, false
+		}
+	}
+
+	if len(f.inputs) > 0 {
+		f.inputs[f.focusIndex], cmd = f.inputs[f.focusIndex].Update(msg)
+	}
+
+	return cmd, false
+}
+
+// View renders the form fields.
+func (f *formComponent) View() string {
+	var b strings.Builder
+
+	for i := range f.inputs {
+		b.WriteString(f.inputs[i].View())
+		if i < len(f.inputs)-1 {
+			b.WriteRune('\n')
+		}
+	}
+
+	return b.String()
+}

--- a/internal/cmd/tui/screen_verify_forms.go
+++ b/internal/cmd/tui/screen_verify_forms.go
@@ -1,0 +1,257 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	verifyopts "github.com/gittuf/gittuf/experimental/gittuf/options/verify"
+	verifymergeableopts "github.com/gittuf/gittuf/experimental/gittuf/options/verifymergeable"
+)
+
+//
+// Verify Reference Form
+//
+
+type verifyRefScreen struct {
+	form formComponent
+}
+
+func (s *verifyRefScreen) reset() {
+	s.form = newFormComponent([]inputField{
+		{"Target Reference (e.g. refs/heads/main)", "Target Ref: "},
+	})
+}
+
+func (s *verifyRefScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "tab", "shift+tab", "up", "down":
+			m.footer = ""
+		}
+	}
+	cmd, isSubmit := s.form.Update(msg)
+	if isSubmit {
+		return s.handleSubmit(m)
+	}
+	return *m, cmd
+}
+
+func (s *verifyRefScreen) View(m *model) string {
+	var b strings.Builder
+	b.WriteString("Verify a specific reference against gittuf policies\n\n")
+	b.WriteString(s.form.View())
+	b.WriteString("\n\nPress Enter to submit.")
+	return m.renderScreen("Home › Verify › Verify Reference", b.String(), renderActionHints(m.readOnly))
+}
+
+func (s *verifyRefScreen) handleSubmit(m *model) (tea.Model, tea.Cmd) {
+	targetRef := strings.TrimSpace(s.form.inputs[0].Value())
+	if targetRef == "" {
+		m.errorMsg = "Target reference is required"
+		return *m, nil
+	}
+
+	m.verifying = true
+	m.logsBuf.Reset()
+	m.logViewport.SetContent("")
+	m.loadingMsg = fmt.Sprintf("Verifying reference %s...", targetRef)
+
+	pr, pw := io.Pipe()
+	logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	m.logCh = make(chan string, 4096)
+
+	return *m, tea.Batch(
+		m.spinner.Tick,
+		collectLogsCmd(scanner, m.logCh),
+		logFlushTick(m.logCh),
+		func() tea.Msg {
+			defer pw.Close()
+
+			opts := []verifyopts.Option{}
+			err := m.repo.VerifyRef(m.ctx, targetRef, opts...)
+
+			// Reset logger
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+			successMsg := fmt.Sprintf("Successfully verified %s!", targetRef)
+			return verifyResultMsg{err: err, successMsg: successMsg}
+		},
+	)
+}
+
+//
+// Verify Mergeability Form
+//
+
+type verifyMergeableScreen struct {
+	form formComponent
+}
+
+func (s *verifyMergeableScreen) reset() {
+	s.form = newFormComponent([]inputField{
+		{"Feature Branch (e.g. refs/heads/feature)", "Feature Branch: "},
+		{"Base Branch (e.g. refs/heads/main)", "Base Branch: "},
+	})
+}
+
+func (s *verifyMergeableScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "tab", "shift+tab", "up", "down":
+			m.footer = ""
+		}
+	}
+	cmd, isSubmit := s.form.Update(msg)
+	if isSubmit {
+		return s.handleSubmit(m)
+	}
+	return *m, cmd
+}
+
+func (s *verifyMergeableScreen) View(m *model) string {
+	var b strings.Builder
+	b.WriteString("Verify if a feature branch can be merged into a base branch\n\n")
+	b.WriteString(s.form.View())
+	b.WriteString("\n\nPress Tab to advance, Enter to submit.")
+	return m.renderScreen("Home › Verify › Verify Mergeability", b.String(), renderActionHints(m.readOnly))
+}
+
+func (s *verifyMergeableScreen) handleSubmit(m *model) (tea.Model, tea.Cmd) {
+	featureBranch := strings.TrimSpace(s.form.inputs[0].Value())
+	baseBranch := strings.TrimSpace(s.form.inputs[1].Value())
+
+	if featureBranch == "" || baseBranch == "" {
+		m.errorMsg = "Both Feature Branch and Base Branch are required"
+		return *m, nil
+	}
+
+	m.verifying = true
+	m.logsBuf.Reset()
+	m.logViewport.SetContent("")
+	m.loadingMsg = fmt.Sprintf("Verifying if %s is mergeable into %s...", featureBranch, baseBranch)
+
+	pr, pw := io.Pipe()
+	logger := slog.New(slog.NewTextHandler(pw, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slog.SetDefault(logger)
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	m.logCh = make(chan string, 4096)
+
+	return *m, tea.Batch(
+		m.spinner.Tick,
+		collectLogsCmd(scanner, m.logCh),
+		logFlushTick(m.logCh),
+		func() tea.Msg {
+			defer pw.Close()
+			opts := []verifymergeableopts.Option{}
+			mergeable, err := m.repo.VerifyMergeable(m.ctx, baseBranch, featureBranch, opts...)
+
+			// Reset logger
+			slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+			if err == nil && !mergeable {
+				err = fmt.Errorf("branch %s is NOT mergeable into %s", featureBranch, baseBranch)
+			}
+
+			successMsg := fmt.Sprintf("Successfully verified %s is mergeable into %s!", featureBranch, baseBranch)
+			return verifyResultMsg{err: err, successMsg: successMsg}
+		},
+	)
+}
+
+// formComponent represents a generic form with text inputs.
+type formComponent struct {
+	inputs     []textinput.Model
+	focusIndex int
+}
+
+// newFormComponent initializes a new form component with the given fields.
+func newFormComponent(fields []inputField) formComponent {
+	return formComponent{
+		inputs:     initInputs(fields),
+		focusIndex: 0,
+	}
+}
+
+// cycleFocus changes the focused input field based on the key pressed.
+func (f *formComponent) cycleFocus(key string) {
+	if len(f.inputs) <= 1 {
+		return
+	}
+
+	if key == "up" || key == "shift+tab" {
+		if f.focusIndex > 0 {
+			f.focusIndex--
+		} else {
+			f.focusIndex = len(f.inputs) - 1
+		}
+	} else {
+		if f.focusIndex < len(f.inputs)-1 {
+			f.focusIndex++
+		} else {
+			f.focusIndex = 0
+		}
+	}
+
+	for i := range f.inputs {
+		if i == f.focusIndex {
+			f.inputs[i].Focus()
+			f.inputs[i].PromptStyle = focusedStyle
+			f.inputs[i].TextStyle = focusedStyle
+		} else {
+			f.inputs[i].Blur()
+			f.inputs[i].PromptStyle = blurredStyle
+			f.inputs[i].TextStyle = blurredStyle
+		}
+	}
+}
+
+// Update handles common key bindings for a form and updates the inputs.
+// It returns a command and a boolean indicating if the form was submitted (Enter pressed).
+func (f *formComponent) Update(msg tea.Msg) (tea.Cmd, bool) {
+	var cmd tea.Cmd
+
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "enter":
+			return nil, true
+		case "tab", "shift+tab", "up", "down":
+			f.cycleFocus(keyMsg.String())
+			return nil, false
+		}
+	}
+
+	if len(f.inputs) > 0 {
+		f.inputs[f.focusIndex], cmd = f.inputs[f.focusIndex].Update(msg)
+	}
+
+	return cmd, false
+}
+
+// View renders the form fields.
+func (f *formComponent) View() string {
+	var b strings.Builder
+
+	for i := range f.inputs {
+		b.WriteString(f.inputs[i].View())
+		if i < len(f.inputs)-1 {
+			b.WriteRune('\n')
+		}
+	}
+
+	return b.String()
+}

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -4,6 +4,7 @@
 package tui
 
 import (
+	"bufio"
 	"fmt"
 	"strings"
 
@@ -45,7 +46,7 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if m.screen == screenLoading {
+		if m.screen == screenLoading || m.verifying {
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
 		}
@@ -54,9 +55,44 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resizeLists()
+		if msg.Width > 4 {
+			m.logViewport.Width = msg.Width - 4
+		} else {
+			m.logViewport.Width = msg.Width
+		}
+		if msg.Height > 6 {
+			m.logViewport.Height = msg.Height - 6
+		} else {
+			m.logViewport.Height = msg.Height
+		}
+		return m, nil
+
+	case logUpdateMsg:
+		m.logs += msg.line
+		m.logViewport.SetContent(m.logs)
+		m.logViewport.GotoBottom()
+		return m, waitForLog(msg.scanner)
+
+	case verifyResultMsg:
+		m.verifying = false
+		if msg.err != nil {
+			m.errorMsg = fmt.Sprintf("Verification failed: %v", msg.err)
+		} else {
+			m.errorMsg = ""
+			m.footer = msg.successMsg
+			m.screen = screenVerify // Go back to Verify menu
+		}
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.verifying {
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			m.logViewport, cmd = m.logViewport.Update(msg)
+			return m, cmd
+		}
+
 		// Global handlers (quit, back navigation)
 		switch msg.String() {
 		case "ctrl+c":
@@ -65,14 +101,18 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm &&
+				m.screen != screenVerifyRefForm && m.screen != screenVerifyMergeableForm {
 				return m, tea.Quit
 			}
 		case "h":
 			// Toggle help screen if not in form mode
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm &&
+				m.screen != screenVerifyRefForm && m.screen != screenVerifyMergeableForm {
+				m.footer = ""
+				m.errorMsg = ""
 				if m.screen == screenHelp {
 					// Toggle back
 					m.screen = m.helpScreen.previousScreen
@@ -87,7 +127,7 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.footer = ""
 			m.errorMsg = ""
 			switch m.screen {
-			case screenPolicy, screenTrust:
+			case screenPolicy, screenTrust, screenVerify:
 				m.screen = screenChoice
 			case screenPolicyRules:
 				if m.policyRulesScreen.confirmDelete {
@@ -110,6 +150,8 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = m.helpScreen.previousScreen
 			case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 				m.trustGlobalRulesScreen.handleEsc(&m)
+			case screenVerifyRefForm, screenVerifyMergeableForm:
+				m.screen = screenVerify
 			}
 			return m, nil
 		}
@@ -132,6 +174,12 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.policyPrincipalsScreen.Update(msg, &m)
 		case screenPolicyPrincipalsForm:
 			return m.policyPrincipalsFormScreen.Update(msg, &m)
+		case screenVerify:
+			return m.verifyScreen.Update(msg, &m)
+		case screenVerifyRefForm:
+			return m.verifyRefScreen.Update(msg, &m)
+		case screenVerifyMergeableForm:
+			return m.verifyMergeableScreen.Update(msg, &m)
 		}
 	}
 
@@ -178,4 +226,13 @@ func splitAndTrim(s string) []string {
 		parts[i] = strings.TrimSpace(parts[i])
 	}
 	return parts
+}
+
+func waitForLog(scanner *bufio.Scanner) tea.Cmd {
+	return func() tea.Msg {
+		if scanner.Scan() {
+			return logUpdateMsg{line: scanner.Text() + "\n", scanner: scanner}
+		}
+		return nil
+	}
 }

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -4,8 +4,10 @@
 package tui
 
 import (
+	"bufio"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -46,7 +48,7 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if m.screen == screenLoading {
+		if m.screen == screenLoading || m.verifying {
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
 		}
@@ -55,9 +57,64 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resizeLists()
+		if msg.Width > 4 {
+			m.logViewport.Width = msg.Width - 4
+		} else {
+			m.logViewport.Width = msg.Width
+		}
+		if msg.Height > 6 {
+			m.logViewport.Height = msg.Height - 6
+		} else {
+			m.logViewport.Height = msg.Height
+		}
+		return m, nil
+
+	case logBatchMsg:
+		if len(msg.lines) > 0 {
+			for _, line := range msg.lines {
+				m.logsBuf.WriteString(line)
+				m.logsBuf.WriteByte('\n')
+			}
+			m.logViewport.SetContent(m.logsBuf.String())
+			m.logViewport.GotoBottom()
+		}
+		if m.verifying {
+			return m, logFlushTick(m.logCh)
+		}
+		return m, nil
+
+	case verifyResultMsg:
+		m.verifying = false
+		// Drain any lines that arrived before the result message
+		if m.logCh != nil {
+			remaining := drainLogChannel(m.logCh)
+			for _, line := range remaining {
+				m.logsBuf.WriteString(line)
+				m.logsBuf.WriteByte('\n')
+			}
+			if len(remaining) > 0 {
+				m.logViewport.SetContent(m.logsBuf.String())
+				m.logViewport.GotoBottom()
+			}
+			m.logCh = nil
+		}
+		if msg.err != nil {
+			m.errorMsg = fmt.Sprintf("Verification failed: %v", msg.err)
+		} else {
+			m.errorMsg = ""
+			m.footer = msg.successMsg
+			m.screen = screenVerify // Go back to Verify menu
+		}
 		return m, nil
 
 	case tea.KeyMsg:
+		if m.verifying {
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			m.logViewport, cmd = m.logViewport.Update(msg)
+			return m, cmd
+		}
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
@@ -77,14 +134,18 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm &&
+				m.screen != screenVerifyRefForm && m.screen != screenVerifyMergeableForm {
 				return m, tea.Quit
 			}
 		case "h":
 			// Toggle help screen if not in form mode
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&
 				m.screen != screenTrustAddGlobalRule && m.screen != screenTrustEditGlobalRule &&
-				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm {
+				m.screen != screenPolicyPrincipalsForm && m.screen != screenPolicyLifecycleForm &&
+				m.screen != screenVerifyRefForm && m.screen != screenVerifyMergeableForm {
+				m.footer = ""
+				m.errorMsg = ""
 				if m.screen == screenHelp {
 					// Toggle back
 					m.screen = m.helpScreen.previousScreen
@@ -99,7 +160,7 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.footer = ""
 			m.errorMsg = ""
 			switch m.screen {
-			case screenPolicy, screenTrust:
+			case screenPolicy, screenTrust, screenVerify:
 				m.screen = screenChoice
 			case screenPolicyRules:
 				if m.policyRulesScreen.confirmDelete {
@@ -129,6 +190,8 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.screen = m.helpScreen.previousScreen
 			case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
 				m.trustGlobalRulesScreen.handleEsc(&m)
+			case screenVerifyRefForm, screenVerifyMergeableForm:
+				m.screen = screenVerify
 			}
 			return m, nil
 		}
@@ -151,6 +214,12 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.policyPrincipalsScreen.Update(msg, &m)
 		case screenPolicyPrincipalsForm:
 			return m.policyPrincipalsFormScreen.Update(msg, &m)
+		case screenVerify:
+			return m.verifyScreen.Update(msg, &m)
+		case screenVerifyRefForm:
+			return m.verifyRefScreen.Update(msg, &m)
+		case screenVerifyMergeableForm:
+			return m.verifyMergeableScreen.Update(msg, &m)
 		}
 	}
 
@@ -197,4 +266,39 @@ func splitAndTrim(s string) []string {
 		parts[i] = strings.TrimSpace(parts[i])
 	}
 	return parts
+}
+
+// collectLogsCmd reads lines from scanner into a buffered channel.
+// It runs as a goroutine and does not send a tea.Msg per line.
+func collectLogsCmd(scanner *bufio.Scanner, ch chan<- string) tea.Cmd {
+	return func() tea.Msg {
+		for scanner.Scan() {
+			ch <- scanner.Text()
+		}
+		close(ch)
+		return nil
+	}
+}
+
+// drainLogChannel reads all available lines from ch without blocking.
+func drainLogChannel(ch <-chan string) []string {
+	var lines []string
+	for {
+		select {
+		case line, ok := <-ch:
+			if !ok {
+				return lines
+			}
+			lines = append(lines, line)
+		default:
+			return lines
+		}
+	}
+}
+
+// logFlushTick sends a logBatchMsg every 100ms by draining the log channel.
+func logFlushTick(ch <-chan string) tea.Cmd {
+	return tea.Tick(100*time.Millisecond, func(_ time.Time) tea.Msg {
+		return logBatchMsg{lines: drainLogChannel(ch)}
+	})
 }

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -313,13 +313,18 @@ func (m model) renderScreen(title string, listContent string, overlays string) s
 
 	content := screenBoxStyle.Width(boxWidth).Height(boxHeight).Render(contentBody)
 
+	errMsg := ""
+	if m.errorMsg != "" {
+		errMsg = "\n" + renderErrorMsg(m.errorMsg)
+	}
+
 	return lipgloss.JoinVertical(lipgloss.Left,
 		renderStatusBar(title, m.readOnly, m.width),
 		renderWithMargin(
 			content+"\n"+
 				overlays+
 				renderFooterBox(m)+
-				renderErrorMsg(m.errorMsg),
+				errMsg,
 		),
 	)
 }
@@ -359,6 +364,21 @@ func (m model) renderListOrEmpty(l list.Model, length int, emptyTitleText string
 func (m model) View() string {
 	if m.width == 0 || m.height == 0 {
 		return m.spinner.View() + " Loading TUI...\n"
+	}
+
+	if m.verifying {
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			m.spinner.View()+" "+m.loadingMsg,
+			"",
+			lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				Width(m.logViewport.Width).
+				Height(m.logViewport.Height).
+				Render(m.logViewport.View()),
+		)
+		return renderWithMargin(
+			titleStyle.Render("gittuf TUI") + "\n\n" + content,
+		)
 	}
 
 	var view string
@@ -406,6 +426,15 @@ func (m model) View() string {
 
 	case screenHelp:
 		view = m.helpScreen.View(&m)
+
+	case screenVerify:
+		return m.verifyScreen.View(&m)
+
+	case screenVerifyRefForm:
+		return m.verifyRefScreen.View(&m)
+
+	case screenVerifyMergeableForm:
+		return m.verifyMergeableScreen.View(&m)
 
 	default:
 		view = "Unknown screen"

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -263,13 +263,18 @@ func (m model) renderScreen(title string, listContent string, overlays string) s
 
 	content := screenBoxStyle.Width(boxWidth).Height(boxHeight).Render(listContent)
 
+	errMsg := ""
+	if m.errorMsg != "" {
+		errMsg = "\n" + renderErrorMsg(m.errorMsg)
+	}
+
 	return lipgloss.JoinVertical(lipgloss.Left,
 		renderStatusBar(title, m.readOnly, m.width),
 		renderWithMargin(
 			content+"\n"+
 				overlays+
 				renderFooterBox(m)+
-				renderErrorMsg(m.errorMsg),
+				errMsg,
 		),
 	)
 }
@@ -309,6 +314,21 @@ func (m model) renderListOrEmpty(l list.Model, length int, emptyTitleText string
 func (m model) View() string {
 	if m.width == 0 || m.height == 0 {
 		return m.spinner.View() + " Loading TUI...\n"
+	}
+
+	if m.verifying {
+		content := lipgloss.JoinVertical(lipgloss.Left,
+			m.spinner.View()+" "+m.loadingMsg,
+			"",
+			lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				Width(m.logViewport.Width).
+				Height(m.logViewport.Height).
+				Render(m.logViewport.View()),
+		)
+		return renderWithMargin(
+			titleStyle.Render("gittuf TUI") + "\n\n" + content,
+		)
 	}
 
 	switch m.screen {
@@ -354,6 +374,15 @@ func (m model) View() string {
 
 	case screenHelp:
 		return m.helpScreen.View(&m)
+
+	case screenVerify:
+		return m.verifyScreen.View(&m)
+
+	case screenVerifyRefForm:
+		return m.verifyRefScreen.View(&m)
+
+	case screenVerifyMergeableForm:
+		return m.verifyMergeableScreen.View(&m)
 
 	default:
 		return "Unknown screen"


### PR DESCRIPTION
### Description
This pull request introduces the **Verify** section to the Gittuf TUI, allowing users to perform verification checks interactively.

The following verification screens have been added:
- **Verify Reference:** A form to input and check a specific Git reference against Gittuf policies.
- **Verify Mergeability:** A form to verify if a feature branch can be securely merged into a base branch according to policy constraints.
- **Verify Network:** An immediate action to verify the state and integrity of network repositories.

**Performance Optimization (Live Log Streaming):**
To ensure the TUI performs as fast as the CLI during long-running verifications, we implemented a buffered channel and ticker-based batching strategy (`logBatchMsg`). This decouples the verification output from the BubbleTea rendering cycle, effectively eliminating the UI rendering overhead and allowing thousands of log lines to stream efficiently in real-time.

**Note on Read-only mode:** Verify operations are inherently read-only. Therefore, they are fully accessible even when the TUI operates in fallback Read-only mode (e.g., missing signing key).

### AI Usage
- [x] I did use generative AI in some form in making the content of this pull request.

**Details on AI Usage:**
I used AI coding assistant to help diagnose the BubbleTea UI rendering bottleneck. The AI assisted in researching the optimal concurrency pattern, refactoring the `waitForLog` implementation into a ticker-based batch flushing mechanism (`collectLogsCmd` and `logFlushTick`), and resolving subsequent merge conflicts. All generated code was manually reviewed, tested and validated locally before pushing.

### Contributor Checklist
- [x] I have manually reviewed all content submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).