### PR TITLE
feat(tui): show action failure in a tui popup window instead of inline errors

### DIFF
--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -42,6 +42,11 @@ type item struct {
 	title, desc string
 }
 
+type errorDialog struct {
+	title   string
+	message string
+}
+
 // Note: virtual methods must be implemented for the item struct
 // Title returns the title of the item.
 func (i item) Title() string { return i.title }
@@ -72,6 +77,7 @@ type model struct {
 	options                    *options
 	footer                     string
 	errorMsg                   string
+	errorDialog                *errorDialog
 	readOnly                   bool
 	width                      int
 	height                     int
@@ -141,6 +147,19 @@ func initInputs(fields []inputField) []textinput.Model {
 		inputs[i] = t
 	}
 	return inputs
+}
+
+func (m *model) openErrorDialog(title, message string) {
+	m.footer = ""
+	m.errorMsg = ""
+	m.errorDialog = &errorDialog{
+		title:   title,
+		message: message,
+	}
+}
+
+func (m *model) closeErrorDialog() {
+	m.errorDialog = nil
 }
 
 // initialModel returns a lightweight loading model for the Terminal UI.

--- a/internal/cmd/tui/screen_policy_lifecycle.go
+++ b/internal/cmd/tui/screen_policy_lifecycle.go
@@ -23,8 +23,9 @@ type policyLifecycleScreen struct {
 }
 
 type policyLifecycleResultMsg struct {
-	msg string
-	err error
+	action string
+	msg    string
+	err    error
 }
 
 func (s *policyLifecycleScreen) initInputs(action string, m *model) {
@@ -100,7 +101,7 @@ func (s *policyLifecycleScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cm
 			case "enter":
 				if selectedItem, ok := s.list.SelectedItem().(item); ok {
 					if m.readOnly {
-						m.errorMsg = "cannot perform action in read-only mode"
+						m.openErrorDialog(selectedItem.title+" Failed", "cannot perform action in read-only mode")
 						return *m, nil
 					}
 					m.errorMsg = ""
@@ -238,8 +239,9 @@ func handlePolicyLifecycleCommand(m *model, action string, policyName string, re
 	if m.readOnly {
 		return func() tea.Msg {
 			return policyLifecycleResultMsg{
-				msg: "",
-				err: fmt.Errorf("cannot perform action in read-only mode"),
+				action: action,
+				msg:    "",
+				err:    fmt.Errorf("cannot perform action in read-only mode"),
 			}
 		}
 	}
@@ -291,8 +293,9 @@ func handlePolicyLifecycleCommand(m *model, action string, policyName string, re
 
 	return tea.Exec(backendExec{run: runFn}, func(err error) tea.Msg {
 		return policyLifecycleResultMsg{
-			msg: successMsg,
-			err: err,
+			action: action,
+			msg:    successMsg,
+			err:    err,
 		}
 	})
 }

--- a/internal/cmd/tui/screen_policy_principals.go
+++ b/internal/cmd/tui/screen_policy_principals.go
@@ -191,7 +191,7 @@ func (s *policyPrincipalsScreen) handleDeleteConfirm(msg tea.Msg, m *model) (tea
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		if keyMsg.String() == "y" {
 			if err := repoRemovePrincipal(m.ctx, m.options, s.deleteTarget); err != nil {
-				m.errorMsg = fmt.Sprintf("Error removing principal: %v", err)
+				m.openErrorDialog("Remove Principal Failed", err.Error())
 			} else {
 				m.footer = "Principal removed successfully!"
 				s.refreshPrincipals(m.ctx, m.options)
@@ -308,7 +308,11 @@ func (f *policyPrincipalsFormScreen) handleFormSubmit(m *model) (tea.Model, tea.
 	}
 
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		title := "Update Principal Failed"
+		if f.action == "Add Person" {
+			title = "Add Principal Failed"
+		}
+		m.openErrorDialog(title, err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/screen_policy_rules.go
+++ b/internal/cmd/tui/screen_policy_rules.go
@@ -155,7 +155,7 @@ func (s *policyRulesScreen) handleDeleteConfirm(msg tea.Msg, m *model) (tea.Mode
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		if keyMsg.String() == "y" {
 			if err := repoRemoveRule(m.ctx, m.options, rule{name: s.deleteTarget}); err != nil {
-				m.errorMsg = fmt.Sprintf("Error removing rule: %v", err)
+				m.openErrorDialog("Remove Rule Failed", err.Error())
 			} else {
 				m.footer = "Rule removed successfully!"
 				s.refreshRules(m.ctx, m.options)
@@ -171,7 +171,7 @@ func (s *policyRulesScreen) handleReorderUp(m *model) (tea.Model, tea.Cmd) {
 	if i := s.ruleList.Index(); i > 0 {
 		s.rules[i], s.rules[i-1] = s.rules[i-1], s.rules[i]
 		if err := repoReorderRules(m.ctx, m.options, s.rules); err != nil {
-			m.errorMsg = fmt.Sprintf("Error reordering rules: %v", err)
+			m.openErrorDialog("Reorder Rules Failed", err.Error())
 			return *m, nil
 		}
 		s.updateRuleList()
@@ -184,7 +184,7 @@ func (s *policyRulesScreen) handleReorderDown(m *model) (tea.Model, tea.Cmd) {
 	if i := s.ruleList.Index(); i < len(s.rules)-1 {
 		s.rules[i], s.rules[i+1] = s.rules[i+1], s.rules[i]
 		if err := repoReorderRules(m.ctx, m.options, s.rules); err != nil {
-			m.errorMsg = fmt.Sprintf("Error reordering rules: %v", err)
+			m.openErrorDialog("Reorder Rules Failed", err.Error())
 			return *m, nil
 		}
 		s.updateRuleList()
@@ -218,7 +218,11 @@ func (s *policyRulesScreen) handlePolicyFormSubmit(m *model) (tea.Model, tea.Cmd
 	}
 
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		title := "Update Rule Failed"
+		if m.screen == screenPolicyAddRule {
+			title = "Add Rule Failed"
+		}
+		m.openErrorDialog(title, err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/screen_trust_global_rules.go
+++ b/internal/cmd/tui/screen_trust_global_rules.go
@@ -169,7 +169,7 @@ func (s *trustGlobalRulesScreen) handleDeleteConfirm(msg tea.Msg, m *model) (tea
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		if keyMsg.String() == "y" {
 			if err := repoRemoveGlobalRule(m.ctx, m.options, globalRule{ruleName: s.deleteTarget}); err != nil {
-				m.errorMsg = fmt.Sprintf("Error removing global rule: %v", err)
+				m.openErrorDialog("Remove Global Rule Failed", err.Error())
 			} else {
 				m.footer = "Global rule removed!"
 				s.refreshGlobalRules(m.ctx, m.options)
@@ -208,7 +208,11 @@ func (s *trustGlobalRulesScreen) handleGlobalFormSubmit(m *model) (tea.Model, te
 	}
 
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error: %v", err)
+		title := "Update Global Rule Failed"
+		if m.screen == screenTrustAddGlobalRule {
+			title = "Add Global Rule Failed"
+		}
+		m.openErrorDialog(title, err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -5,6 +5,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -190,4 +191,126 @@ func TestTrustGlobalRulesScreenHandleEsc(t *testing.T) {
 		assert.True(t, handled)
 		assert.Equal(t, screenTrustGlobalRules, m.screen)
 	})
+}
+
+func TestPolicyLifecycleResultShowsErrorDialog(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+
+	updated, _ := m.Update(policyLifecycleResultMsg{
+		action: "Apply Changes",
+		err:    errors.New("boom"),
+	})
+	typed := updated.(model)
+
+	require.NotNil(t, typed.errorDialog)
+	assert.Equal(t, "Apply Changes Failed", typed.errorDialog.title)
+	assert.Equal(t, "boom", typed.errorDialog.message)
+	assert.Empty(t, typed.footer)
+	assert.Empty(t, typed.errorMsg)
+}
+
+func TestPolicyLifecycleResultSuccessKeepsFooter(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.errorDialog = &errorDialog{title: "old", message: "old"}
+
+	updated, _ := m.Update(policyLifecycleResultMsg{
+		action: "Apply Changes",
+		msg:    "ok",
+	})
+	typed := updated.(model)
+
+	assert.Nil(t, typed.errorDialog)
+	assert.Equal(t, "ok", typed.footer)
+}
+
+func TestLifecycleReadOnlyUsesErrorDialog(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: true, targetRef: "policy"})
+	m.screen = screenPolicyLifecycle
+	m.readOnly = true
+
+	updated, _ := m.policyLifecycleScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	typed := updated.(model)
+
+	require.NotNil(t, typed.errorDialog)
+	assert.Equal(t, "Initialize Policy Failed", typed.errorDialog.title)
+	assert.Equal(t, "cannot perform action in read-only mode", typed.errorDialog.message)
+	assert.Empty(t, typed.errorMsg)
+}
+
+func TestErrorDialogBlocksInputAndDismisses(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenPolicyLifecycle
+	m.width = 80
+	m.height = 24
+	m.openErrorDialog("Stage Changes Failed", "boom")
+
+	startIndex := m.policyLifecycleScreen.list.Index()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	typed := updated.(model)
+	require.NotNil(t, typed.errorDialog)
+	assert.Equal(t, startIndex, typed.policyLifecycleScreen.list.Index())
+
+	updated, _ = typed.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	typed = updated.(model)
+	assert.Nil(t, typed.errorDialog)
+	assert.Equal(t, startIndex, typed.policyLifecycleScreen.list.Index())
+}
+
+func TestErrorDialogDismissesOnEsc(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenPolicyLifecycle
+	m.openErrorDialog("Apply Changes Failed", "boom")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	typed := updated.(model)
+
+	assert.Nil(t, typed.errorDialog)
+}
+
+func TestPrincipalValidationStaysInline(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenPolicyPrincipalsForm
+	m.policyPrincipalsFormScreen = policyPrincipalsFormScreen{
+		action: "Add Person",
+		inputs: initInputs([]inputField{
+			{placeholder: "Person ID", prompt: "Person ID: "},
+			{placeholder: "Keys", prompt: "Public Keys: "},
+			{placeholder: "Identities", prompt: "Associated Identities: "},
+			{placeholder: "Custom", prompt: "Custom: "},
+		}),
+		focusIndex: 3,
+	}
+
+	updated, _ := m.policyPrincipalsFormScreen.handleFormSubmit(&m)
+	typed := updated.(model)
+
+	assert.Nil(t, typed.errorDialog)
+	assert.Equal(t, "Error: Principal ID is required", typed.errorMsg)
+}
+
+func TestErrorDialogAllowsQuit(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenPolicyLifecycle
+	m.openErrorDialog("Apply Changes Failed", "boom")
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	typed := updated.(model)
+
+	require.NotNil(t, cmd)
+	assert.NotNil(t, typed.errorDialog)
+}
+
+func TestViewRendersErrorDialog(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenPolicyLifecycle
+	m.width = 80
+	m.height = 24
+	m.openErrorDialog("Apply Changes Failed", "remote rejected update")
+
+	view := m.View()
+
+	assert.Contains(t, view, "Apply Changes Failed")
+	assert.Contains(t, view, "remote rejected update")
+	assert.Contains(t, view, "Press Enter or Esc to close.")
 }

--- a/internal/cmd/tui/update.go
+++ b/internal/cmd/tui/update.go
@@ -38,8 +38,9 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case policyLifecycleResultMsg:
 		if msg.err != nil {
-			m.errorMsg = msg.err.Error()
+			m.openErrorDialog(msg.action+" Failed", msg.err.Error())
 		} else {
+			m.closeErrorDialog()
 			m.footer = msg.msg
 		}
 		return m, nil
@@ -57,10 +58,21 @@ func (m model) updateInternal(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+		if m.errorDialog != nil {
+			switch msg.String() {
+			case "q":
+				return m, tea.Quit
+			case "enter", "esc":
+				m.closeErrorDialog()
+			}
+			return m, nil
+		}
+
 		// Global handlers (quit, back navigation)
 		switch msg.String() {
-		case "ctrl+c":
-			return m, tea.Quit
 		case "q":
 			// Only quit from non-form screens (avoid consuming 'q' in text inputs)
 			if m.screen != screenPolicyAddRule && m.screen != screenPolicyEditRule &&

--- a/internal/cmd/tui/view.go
+++ b/internal/cmd/tui/view.go
@@ -90,6 +90,12 @@ var (
 	helpDescStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color(colorBlur)).
 			Padding(0, 1)
+
+	errorDialogStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color(colorErrorMsg)).
+				Background(lipgloss.Color(colorStatusBg)).
+				Padding(1, 2)
 )
 
 // renderWithMargin wraps content in the standard margin used by all screens.
@@ -154,6 +160,45 @@ func renderErrorMsg(text string) string {
 		return ""
 	}
 	return "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color(colorErrorMsg)).Render(text)
+}
+
+func renderErrorDialog(m model) string {
+	if m.errorDialog == nil {
+		return ""
+	}
+
+	width := m.width - 12
+	if width > 72 {
+		width = 72
+	}
+	if width < 24 {
+		width = 24
+	}
+
+	title := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(colorErrorMsg)).
+		Bold(true).
+		Render(m.errorDialog.title)
+	message := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(colorRegularText)).
+		Width(width - 6).
+		Render(m.errorDialog.message)
+	hint := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(colorSubtext)).
+		Render("Press Enter or Esc to close.")
+
+	return errorDialogStyle.Width(width).Render(
+		lipgloss.JoinVertical(lipgloss.Left, title, "", message, "", hint),
+	)
+}
+
+func renderPopupDialog(m model) string {
+	dialog := renderErrorDialog(m)
+	if dialog == "" {
+		return ""
+	}
+
+	return dialog
 }
 
 // renderStatusBar renders the top status bar showing screen name and current mode.
@@ -261,7 +306,12 @@ func (m model) renderScreen(title string, listContent string, overlays string) s
 		boxHeight = 0
 	}
 
-	content := screenBoxStyle.Width(boxWidth).Height(boxHeight).Render(listContent)
+	contentBody := listContent
+	if dialog := renderPopupDialog(m); dialog != "" {
+		contentBody = lipgloss.Place(boxWidth-2, boxHeight, lipgloss.Center, lipgloss.Center, dialog)
+	}
+
+	content := screenBoxStyle.Width(boxWidth).Height(boxHeight).Render(contentBody)
 
 	return lipgloss.JoinVertical(lipgloss.Left,
 		renderStatusBar(title, m.readOnly, m.width),
@@ -311,51 +361,55 @@ func (m model) View() string {
 		return m.spinner.View() + " Loading TUI...\n"
 	}
 
+	var view string
 	switch m.screen {
 	case screenLoading:
 		if m.errorMsg != "" {
-			return renderWithMargin(
+			view = renderWithMargin(
 				titleStyle.Render("gittuf TUI") + "\n\n" +
 					renderErrorMsg(m.errorMsg) + "\n\n" +
 					lipgloss.NewStyle().Foreground(lipgloss.Color(colorBlur)).Render("Press Q or Ctrl+C to quit."),
 			)
+			break
 		}
-		return renderWithMargin(
+		view = renderWithMargin(
 			titleStyle.Render("gittuf TUI") + "\n\n" +
 				m.spinner.View() + " Loading, please wait...\n",
 		)
 
 	case screenChoice:
-		return m.homeScreen.View(&m)
+		view = m.homeScreen.View(&m)
 
 	case screenPolicy:
-		return m.policyScreen.View(&m)
+		view = m.policyScreen.View(&m)
 
 	case screenPolicyLifecycle, screenPolicyLifecycleForm:
-		return m.policyLifecycleScreen.View(&m)
+		view = m.policyLifecycleScreen.View(&m)
 
 	case screenTrust:
-		return m.trustScreen.View(&m)
+		view = m.trustScreen.View(&m)
 
 	case screenPolicyRules:
-		return m.policyRulesScreen.View(&m)
+		view = m.policyRulesScreen.View(&m)
 
 	case screenTrustGlobalRules, screenTrustAddGlobalRule, screenTrustEditGlobalRule:
-		return m.trustGlobalRulesScreen.View(&m)
+		view = m.trustGlobalRulesScreen.View(&m)
 
 	case screenPolicyPrincipals:
-		return m.policyPrincipalsScreen.View(&m)
+		view = m.policyPrincipalsScreen.View(&m)
 
 	case screenPolicyPrincipalsForm:
-		return m.policyPrincipalsFormScreen.View(&m)
+		view = m.policyPrincipalsFormScreen.View(&m)
 
 	case screenPolicyAddRule, screenPolicyEditRule:
-		return m.policyRulesScreen.View(&m)
+		view = m.policyRulesScreen.View(&m)
 
 	case screenHelp:
-		return m.helpScreen.View(&m)
+		view = m.helpScreen.View(&m)
 
 	default:
-		return "Unknown screen"
+		view = "Unknown screen"
 	}
+
+	return view
 }


### PR DESCRIPTION
## Description

changes TUI action failures from inline error at the bottom of the screen to a pop up error window
- adding a shared error dialog state to the tui model
- render a centered popup for all action failures (windows closable with enter or esc)
- currently wried lifecycle, rule, principal, and global rule failures to the pop up window

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->
Used ai coding agent for help with tui styling and error debugging. All code were manually checked and testing with unit tests to make sure it doesn't break existing code

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
