### PR TITLE
rsl: Add support for application-defined custom fields

### DIFF
--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -342,20 +342,27 @@ custom.<namespace>/<name>: <value>
 
 RSL entries may include application-defined custom fields after their standard
 fields and before an annotation's message block. Custom field names begin with
-`custom.` followed by one or more of `[A-Za-z0-9._/-]`, and are unique in the
-canonical format. Values may contain `[A-Za-z0-9-+./,()]`. These character sets
-are enforced on write. Readers accept whatever is stored. Writers sort fields by
-name so their encoding is deterministic. Readers accept fields in any order and,
-when a non-canonical entry repeats a name, use its first value. Custom fields
-are part of the RSL commit message and are therefore covered by the entry's Git
-signature.
+`custom.` and follow the Kubernetes annotation convention: a lowercase DNS
+subdomain the application controls (for example `gitforge.com`), a `/`, and a
+name of at most 63 lowercase characters that starts and ends alphanumeric with
+`.`, `_`, or `-` allowed in between. Namespacing keys to a domain you control
+avoids collisions between applications. The whole key is fewer than 250
+characters and unique in the canonical format. Values may contain
+`[A-Za-z0-9-+./,()_ ]`, have no leading or trailing spaces, and are fewer than
+500 characters. An entry carries at most 20 custom fields, and empty values are
+dropped. These constraints are enforced on write. Writers sort fields by name so
+their encoding is deterministic. Readers accept fields in any order and, when a
+non-canonical entry repeats a name, use its first value; fields exceeding the
+length limits are ignored and the count is capped, so a crafted entry cannot
+force gittuf to surface unbounded data. Custom fields are part of the RSL commit
+message and are therefore covered by the entry's Git signature.
 
 For example, a forge might record who pushed a change and the server version
 that processed it:
 
 ```
 custom.gitforge.com/pusher: <handle>(<id>)
-custom.gitforge.com/server-version: v4.2.0-coffee
+custom.gitforge.com/server-version: v4.2.0-c0ffee
 ```
 
 Custom fields do not impact gittuf verification. gittuf treats them as opaque

--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -309,6 +309,7 @@ RSL Reference Entry
 ref: <ref name>
 targetID: <target ID>
 number: <number>
+custom.<namespace>/<name>: <value>
 ```
 
 The `targetID` is typically the ID of a commit for references that are branches.
@@ -333,10 +334,34 @@ entryID: <RSL entry ID 2>
 ...
 skip: <true/false>
 number: <number>
+custom.<namespace>/<name>: <value>
 -----BEGIN MESSAGE-----
 <message>
 ------END MESSAGE------
 ```
+
+RSL entries may include application-defined custom fields after their standard
+fields and before an annotation's message block. Custom field names begin with
+`custom.` followed by one or more of `[A-Za-z0-9._/-]`, and are unique in the
+canonical format. Values may contain `[A-Za-z0-9-+./,()]`. These character sets
+are enforced on write. Readers accept whatever is stored. Writers sort fields by
+name so their encoding is deterministic. Readers accept fields in any order and,
+when a non-canonical entry repeats a name, use its first value. Custom fields
+are part of the RSL commit message and are therefore covered by the entry's Git
+signature.
+
+For example, a forge might record who pushed a change and the server version
+that processed it:
+
+```
+custom.gitforge.com/pusher: <handle>(<id>)
+custom.gitforge.com/server-version: v4.2.0-coffee
+```
+
+Custom fields do not impact gittuf verification. gittuf treats them as opaque
+metadata: their presence, absence, or contents never change a verification
+outcome. The entry's signature still covers them, so they cannot be tampered
+with, but interpreting them is left entirely to the application.
 
 ##### Example Entries
 

--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -309,6 +309,7 @@ RSL Reference Entry
 ref: <ref name>
 targetID: <target ID>
 number: <number>
+custom.<namespace>/<name>: <value>
 ```
 
 The `targetID` is typically the ID of a commit for references that are branches.
@@ -333,9 +334,30 @@ entryID: <RSL entry ID 2>
 ...
 skip: <true/false>
 number: <number>
+custom.<namespace>/<name>: <value>
 -----BEGIN MESSAGE-----
 <message>
 ------END MESSAGE------
+```
+
+RSL entries may carry application-defined custom fields after their standard
+fields (for annotation entries, before the message block), each a
+`custom.<namespace>/<name>: <value>` line. Custom fields are advisory only:
+gittuf treats them as opaque metadata whose presence, absence, or contents
+never change a verification outcome. Applications must not make security
+decisions based on them and should treat values as untrusted input unless
+they generated the data themselves. Because the fields are part of the
+entry's commit message, they are covered by the entry's signature and are as
+tamper-evident as the entry itself. The key grammar, value alphabet, length
+and count limits, along with how writers and readers handle malformed fields,
+are specified in [GAP-7](/docs/gaps/7/README.md).
+
+For example, a forge might record who pushed a change and the server version
+that processed it:
+
+```
+custom.gitforge.com/pusher: <id> (<handle>)
+custom.gitforge.com/server-version: v4.2.0-c0ffee
 ```
 
 ##### Example Entries
@@ -348,6 +370,9 @@ entry a5ea2c6ee7e8b577f6be6fcee5b06e6cac7166fa (skipped)
   Ref:    refs/heads/main
   Target: 6cb8e5c546eab3d0e1d245014de8003febb8e9b3
   Number: 5
+  Custom Fields:
+    custom.gitforge.com/pusher: 01ARZ3NDEKTSV4RRFFQ69G5FAV (jane)
+    custom.gitforge.com/server-version: v4.2.0-c0ffee
 
     Annotation ID: cccfb6f27b2a71c33e9a55bc82f084e2445aa398
     Skip:          yes
@@ -404,6 +429,8 @@ RSL Reference Entry
 ref: refs/heads/main
 targetID: 6cb8e5c546eab3d0e1d245014de8003febb8e9b3
 number: 5
+custom.gitforge.com/pusher: 01ARZ3NDEKTSV4RRFFQ69G5FAV (jane)
+custom.gitforge.com/server-version: v4.2.0-c0ffee
 ```
 
 Similarly, the commit object for the annotation entry is as follows:

--- a/docs/gaps/7/README.md
+++ b/docs/gaps/7/README.md
@@ -1,0 +1,327 @@
+# Application-Defined Custom Fields
+
+## Metadata
+
+* **Number:** 7
+* **Title:** Application-Defined Custom Fields
+* **Implemented:** Yes
+* **Withdrawn/Rejected:** No
+* **Sponsors:** Paulo Gomes (pjbgf)
+* **Related GAPs:** [GAP-2](/docs/gaps/2/README.md), [GAP-3](/docs/gaps/3/README.md)
+* **Last Modified:** August 27, 2026
+
+## Abstract
+
+gittuf records every reference update as a signed entry in the Reference State
+Log (RSL). Applications that build on gittuf often have context about a change
+that the standard entry does not capture, such as the actor who pushed it or
+the server that processed it. This GAP introduces custom fields,
+application-defined key-value pairs carried inside an RSL entry's commit
+message. Custom fields are opaque to gittuf and are never consulted during
+verification.
+
+## Motivation
+
+gittuf's RSL is increasingly used as a building block by other software rather
+than only through the gittuf CLI. A forge, a mirroring service, or an internal
+platform tool may want to attach its own context to the record of a reference
+update. Until now the entry schema was closed: the only way to associate extra
+data with an entry was to model it as a separate gittuf construct (e.g., a
+separate annotation entry or an attestation).
+
+The concrete driver is applications that want the RSL to double as an audit
+ledger for a repository. Each push already produces a signed, ordered, and
+tamper-evident record. If that record can also carry a small amount of
+application context, the application gains a durable audit trail that is
+co-located with the change it describes and covered by the same signature.
+
+## Specification
+
+### Field Structure
+
+An RSL entry may carry zero or more custom fields after its standard fields.
+For an annotation entry, they appear before the message block. A field is a
+single line of the form `custom.<namespace>/<name>: <value>`.
+
+```
+RSL Reference Entry
+
+ref: <ref name>
+targetID: <target ID>
+number: <number>
+custom.<namespace>/<name>: <value>
+```
+
+Field names follow the Kubernetes annotation convention: a lowercase DNS
+subdomain the application controls (for example `gitforge.com`), a `/`, and a
+name of at most 63 lowercase characters that starts and ends alphanumeric,
+with `.`, `_`, or `-` permitted in between. Namespacing a key to a domain the
+application controls avoids collisions between applications writing to the
+same RSL.
+
+The whole key, including the `custom.` prefix, MUST be fewer than 250
+characters and MUST be unique within a canonical entry. Values MAY contain
+ASCII letters, digits, and the characters `-+./,()_@:=%#?&~` as well as
+internal spaces. This covers common value shapes such as emails, URLs,
+RFC 3339 timestamps, and base64. Values MUST NOT have leading or trailing
+spaces and MUST be fewer than 500 characters. An entry MUST NOT carry more
+than 20 custom fields.
+
+A recorded reference entry carrying one field looks like:
+
+```
+RSL Reference Entry
+
+ref: refs/heads/main
+targetID: a1b2c3d4e5f60718293a4b5c6d7e8f9012345678
+number: 42
+custom.gitforge.com/pusher: jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+```
+
+Parentheses and internal spaces are in the value alphabet, so pairing a handle
+with the forge's account identifier needs no encoding.
+
+Values SHOULD be human-readable, so that an operator inspecting an entry with
+standard Git tooling can read them directly without decoding. Where content
+needs characters the value alphabet does not permit, such as line breaks, the
+application SHOULD base64 the value rather than expect the grammar to widen.
+
+Custom fields are not intended to carry large amounts of data. An application
+with such a payload is better off storing it elsewhere and recording only a
+pointer to it here, for example a URL to an external service or an internal
+Git ref that points to a blob.
+
+### Supported Types
+
+All three RSL entry types carry custom fields: reference entries, annotation
+entries, and propagation entries. The key grammar, value alphabet, and length
+and count limits are identical across them and are enforced by a single shared
+implementation.
+
+Nothing outside the RSL carries custom fields, including policy metadata and
+the commits that record it. The RSL is where an application's context about a
+change belongs, because the record of the change and the context describing it
+then live in one signed object. Policy states describe who is trusted to do
+what, and a policy change is already recorded by an RSL entry, so an
+application that wants to mark one has somewhere to put the mark without
+widening the documents verification reads.
+
+### Reading and Writing
+
+These constraints are enforced on write. Writers drop fields with empty values
+and sort the rest by name so the encoding is deterministic and the resulting
+commit is stable across implementations. An empty value therefore means the
+field is absent rather than present and blank.
+
+Readers require custom fields to appear after the standard fields and reject
+entries that interleave them, but accept the custom fields themselves in any
+order. When a non-canonical entry repeats a name, the reader uses the first
+value it encounters. A field whose key or value falls outside the grammar is
+ignored, as is a field with an empty value, and the total count is capped. The
+rule is the same on both sides, so a field a canonical writer could not have
+produced is never surfaced by a read. This matters because consumers, and
+`gittuf rsl log`, render values as recorded, and an entry is a commit message
+into which anything can be written directly with Git.
+
+Ignoring such a field rather than rejecting the entry keeps a single bad line
+from making an entry unreadable, which would turn a cosmetic defect into a
+traversal failure for a log gittuf still has to walk.
+
+### Relationship to Verification
+
+Custom fields MUST NOT influence verification. gittuf treats them as opaque
+metadata whose presence, absence, or contents never change a verification
+outcome. The entry's signature covers the whole commit message, including the
+custom fields, so they cannot be altered without invalidating the entry. This
+is the only property gittuf provides for them.
+
+### Tooling
+
+The gittuf CLI does not create custom fields. They are aimed at applications
+that embed gittuf as a library and populate the fields programmatically.
+`gittuf rsl log` does render the fields an entry carries, so an operator can
+read them without knowing which names to ask for:
+
+```
+entry a5ea2c6ee7e8b577f6be6fcee5b06e6cac7166fa
+
+  Ref:    refs/heads/main
+  Target: 6cb8e5c546eab3d0e1d245014de8003febb8e9b3
+  Number: 42
+  Custom Fields:
+    custom.gitforge.com/pusher: jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+```
+
+The fields remain readable with standard Git tooling as well, since they are
+plain lines in a commit message:
+
+```
+git cat-file -p <rsl-entry-oid>
+```
+
+## Reasoning
+
+### Why not attestations
+
+Attestations (see [GAP-3](/docs/gaps/3/README.md)) are the right tool when the
+extra data is itself security-relevant and needs an independent, verifiable
+structure: a DSSE envelope with a predicate type, stored under a path in
+`refs/gittuf/attestations`. Each attestation is a blob under a path, so
+recording one writes the blob, the trees along its path, and a commit on the
+attestations ref. Because the attestations ref itself moves, that movement in
+turn requires its own RSL entry. A single enriched change can therefore add on
+the order of five objects to the repository. Custom fields are text inside a
+commit message that already exists, so recording a reference update with them
+writes exactly the same single entry commit that gittuf would write anyway.
+For advisory context that does not need to be independently verifiable, the
+attestation cost per change is disproportionate.
+
+### Why not annotations
+
+Annotations are entries in their own right. Using one to attach context to a
+change means writing a second commit on the RSL ref that points back at the
+original entry. That roughly doubles the object cost of recording a change and
+splits the context away from the entry it describes, so a reader has to
+correlate two objects to reconstruct one event.
+
+### Cost of storing data outside the RSL Entry
+
+An RSL reference entry is a single commit whose tree is the empty tree. The
+empty tree object is written once and shared by every entry thereafter, so
+each recorded change contributes one new object to the repository. Custom
+fields change the bytes of that commit but not the number of objects.
+
+Measured against a year of real reference activity, in Git objects. The
+entry-only row counts the reference updates GitHub records for `go-git` and
+`kubernetes` over a twelve-month window, one RSL entry per update. The other
+two rows apply the per-change object multipliers described above to that
+count, so only the first row is measured:
+
+| Recording strategy | go-git | kubernetes |
+| ------------------ | -----: | ---------: |
+| Entry only         |    924 |      3,581 |
+| + annotation (2x)  |  1,848 |      7,162 |
+| + attestation (5x) |  4,620 |     17,905 |
+
+Higher-traffic repositories see larger numbers, but the cost stays at one
+object per change, so an entry-only RSL remains cheap to store, walk, and
+pack. The multipliers understate the difference, because the added objects are
+heavier: distinct blobs and trees delta far less cleanly than near-identical
+RSL commits do. Object count is what connectivity checks, reachability walks,
+and bitmap builds pay for, so keeping enrichment inside the entry keeps those
+operations cheap.
+
+### Not providing native support for custom fields
+
+gittuf could carry no fields at all and leave applications to craft the commit
+objects themselves, writing an RSL entry with whatever message they want.
+Nothing in the object format prevents it.
+
+That trades a small extension point for a much larger one. An application
+writing its own objects needs the primitives to build a commit, sign it, move
+the reference, and record the update, so gittuf would have to publish those as
+API and keep them stable across releases. A field grammar and a validator are
+the narrower contract: an extension point that is specified, versioned with
+the entry format, and stable enough to build on, while the objects stay
+gittuf's to write.
+
+It also keeps the log interoperable. Without a grammar each application
+invents its own key and value syntax, so an entry is readable only by whoever
+wrote it, and a hand-rolled line could produce an entry gittuf itself refuses
+to parse.
+
+## Backwards Compatibility
+
+This GAP does not impact the backwards compatibility of gittuf. Entries
+without custom fields are unchanged, byte for byte, and the standard fields
+keep their existing order and meaning. The entry grammar is otherwise
+untouched: a body a reader accepted before this GAP is still accepted, and one
+it rejected is still rejected. Custom fields are additive lines appended after
+the standard fields. Readers that predate this GAP ignore unknown lines in an
+entry body, so they tolerate custom fields without modification, though they
+will not surface them. Because custom fields are excluded from verification,
+an older client and a newer client reach the same verification decision for
+the same entry.
+
+Policy metadata schemas are not modified by this GAP.
+
+## Security
+
+Custom fields MUST NOT influence verification. Because gittuf never reads them
+when deciding whether a change is authorized, a malicious or malformed field
+cannot change a verification outcome. Applications MUST NOT make security
+decisions based on custom fields.
+
+The fields are tamper-evident only to the degree the enclosing entry is. The
+signature over the entry's commit message covers them, so a recorded value
+cannot be altered without detection, but this does not mean the value was true
+when it was written. A forge that records `custom.gitforge.com/pusher` is
+asserting that claim, and gittuf attests only that the claim has not changed
+since the entry was signed. Data that needs to be independently verifiable
+belongs in an attestation (see [GAP-3](/docs/gaps/3/README.md)), not a custom
+field.
+
+Consumers MUST treat custom fields as untrusted input and make no assumptions
+about their contents unless they generated the data themselves, validated by the signature on the object. The intended
+pattern is that the producer is the consumer: a forge reads back the fields
+it stamped under its own namespace and treats everything else as opaque. A
+field is asserted by whoever created and signed the entry that contains it,
+and entries in the same log may be signed by different actors over time. The
+namespace in a key identifies a writer by convention only: nothing prevents a
+writer from using another application's namespace, so the key alone MUST NOT
+be used to attribute a value. An application that controls the write path can
+enforce the convention it relies on, for example a forge that rejects pushed
+entries carrying fields under its own namespace, leaving only the fields it
+stamped itself. None of this changes gittuf's stance: gittuf never consults
+custom fields during verification.
+
+The read path is bounded against hostile input. Keys and values are limited in
+length, the number of fields per entry is capped, and oversized fields are
+dropped rather than rejected during traversal, so a crafted entry cannot force
+a reader to allocate unbounded memory or stall while walking the log. On the
+write path the character sets and length limits are enforced, and values are
+constrained to a single line so a field cannot inject additional entry lines
+or forge a message block.
+
+## Implementation
+
+The key grammar, value alphabet, and limits are implemented once in a shared
+validation package, so every entry type validates the same field set the same
+way. The reader and the writer both go through the same per-field validation,
+`ValidateField`, with the writer additionally enforcing the set-level count
+limit. The value alphabet is exported, so an application that maps its own input
+into a value, such as a forge sanitizing a user handle, sanitizes against the
+same alphabet gittuf validates rather than restating it.
+
+The line encoding itself lives in the RSL package next to the parser rather
+than in the validation package, because it is the shape of an RSL entry body
+and not of a custom field. Keeping the writer and the reader in one place is
+what makes the rule "a field a canonical writer could not have produced is
+never surfaced by a read" checkable, and leaves the validation package free of
+any assumption that custom fields are carried as commit message lines.
+
+In the RSL package, `ReferenceEntry`, `AnnotationEntry`, and
+`PropagationEntry` each carry a `CustomFields` map. The keyed read lives on a
+`CustomFieldEntry` interface rather than on `Entry`, so adding it does not
+break existing implementations of `Entry`: they continue to satisfy `Entry`,
+and simply do not satisfy `CustomFieldEntry`. Callers holding an `Entry` reach
+the fields with a type assertion. The read is keyed: a caller asks for a
+specific field by name and gets its value without copying the map, so
+per-entry reads during log traversal do not allocate. There is deliberately no
+accessor that enumerates fields. An application knows the names of the fields
+it wrote, and a keyed interface steers consumers toward reading their own
+fields rather than data they cannot vouch for. Validation, encoding, and
+parsing follow the Specification. Fields are supplied when an entry is built,
+so an invalid field set fails while the commit message is assembled and before
+any object is written.
+
+The gittuf CLI exposes no command to set custom fields. They are populated by
+applications that use gittuf as a library. Rendering the log is the one place
+gittuf enumerates fields, so `gittuf rsl log` reads the map on the concrete
+entry type rather than through the interface.
+
+## References
+
+* [gittuf Design Document](/docs/design-document.md)
+* [GAP-2: gittuf on the Forge](/docs/gaps/2/README.md)
+* [GAP-3: Authentication Evidence Attestations](/docs/gaps/3/README.md)

--- a/docs/gaps/README.md
+++ b/docs/gaps/README.md
@@ -30,6 +30,7 @@ the gittuf/community repository.
 | 4 | [Supporting Global Constraints in gittuf](/docs/gaps/4/README.md) | No | No |
 | 5 | [Principals, not Keys](/docs/gaps/5/README.md) | No | No |
 | 6 | [Code Review Tool Attestations](/docs/gaps/6/README.md) | No | No |
+| 7 | [Application-Defined Custom Fields](/docs/gaps/7/README.md) | Yes | No |
 
 ## GAP Format
 

--- a/experimental/gittuf/options/rsl/rsl.go
+++ b/experimental/gittuf/options/rsl/rsl.go
@@ -9,6 +9,7 @@ type RecordOptions struct {
 	LocalOnly             bool
 	SkipCheckForDuplicate bool
 	SigningKeyBytes       []byte
+	CustomFields          map[string]string
 }
 
 type RecordOption func(o *RecordOptions)
@@ -51,10 +52,20 @@ func WithRecordSigningKeyBytes(pem []byte) RecordOption {
 	}
 }
 
+// WithRecordCustomFields adds application-defined fields to the RSL entry. The
+// fields are copied into the entry when it is built, so the caller keeps
+// ownership of the supplied map and no copy is made here.
+func WithRecordCustomFields(fields map[string]string) RecordOption {
+	return func(o *RecordOptions) {
+		o.CustomFields = fields
+	}
+}
+
 type AnnotateOptions struct {
 	RemoteName      string
 	LocalOnly       bool
 	SigningKeyBytes []byte
+	CustomFields    map[string]string
 }
 
 type AnnotateOption func(o *AnnotateOptions)
@@ -76,5 +87,14 @@ func WithAnnotateLocalOnly() AnnotateOption {
 func WithAnnotateSigningKeyBytes(pem []byte) AnnotateOption {
 	return func(o *AnnotateOptions) {
 		o.SigningKeyBytes = pem
+	}
+}
+
+// WithAnnotateCustomFields adds application-defined fields to the annotation.
+// The fields are copied into the entry when it is built, so the caller keeps
+// ownership of the supplied map and no copy is made here.
+func WithAnnotateCustomFields(fields map[string]string) AnnotateOption {
+	return func(o *AnnotateOptions) {
+		o.CustomFields = fields
 	}
 }

--- a/experimental/gittuf/options/rsl/rsl_test.go
+++ b/experimental/gittuf/options/rsl/rsl_test.go
@@ -68,3 +68,21 @@ func TestWithAnnotateLocalOnly(t *testing.T) {
 
 	assert.True(t, options.LocalOnly)
 }
+
+func TestWithRecordCustomFields(t *testing.T) {
+	fields := map[string]string{"custom.example.com/field": "value"}
+	options := &RecordOptions{}
+
+	WithRecordCustomFields(fields)(options)
+
+	assert.Equal(t, fields, options.CustomFields)
+}
+
+func TestWithAnnotateCustomFields(t *testing.T) {
+	fields := map[string]string{"custom.example.com/field": "value"}
+	options := &AnnotateOptions{}
+
+	WithAnnotateCustomFields(fields)(options)
+
+	assert.Equal(t, fields, options.CustomFields)
+}

--- a/experimental/gittuf/options/rsl/rsl_test.go
+++ b/experimental/gittuf/options/rsl/rsl_test.go
@@ -88,3 +88,21 @@ func TestWithAnnotateSigningKeyBytes(t *testing.T) {
 
 	assert.Equal(t, []byte("test-key"), options.SigningKeyBytes)
 }
+
+func TestWithRecordCustomFields(t *testing.T) {
+	fields := map[string]string{"custom.example.com/field": "value"}
+	options := &RecordOptions{}
+
+	WithRecordCustomFields(fields)(options)
+
+	assert.Equal(t, fields, options.CustomFields)
+}
+
+func TestWithAnnotateCustomFields(t *testing.T) {
+	fields := map[string]string{"custom.example.com/field": "value"}
+	options := &AnnotateOptions{}
+
+	WithAnnotateCustomFields(fields)(options)
+
+	assert.Equal(t, fields, options.CustomFields)
+}

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -112,7 +112,7 @@ func (r *Repository) RecordRSLEntryForReference(ctx context.Context, refName str
 	// signCommit must be verified for the refName in the delegation tree.
 
 	slog.Debug("Creating RSL reference entry...")
-	entry := rsl.NewReferenceEntry(refName, refTip)
+	entry := rsl.NewReferenceEntry(refName, refTip, rsl.WithCustomFields(rsl.CustomFields(options.CustomFields)))
 	if signCommit && options.SigningKeyBytes != nil {
 		if err := entry.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
 			return err
@@ -168,7 +168,7 @@ func (r *Repository) RecordRSLEntryForReferenceAtTarget(refName, targetID string
 	// signCommit must be verified for the refName in the delegation tree.
 
 	slog.Debug("Creating RSL reference entry...")
-	return rsl.NewReferenceEntry(refName, targetIDHash).CommitUsingSpecificKey(r.r, signingKeyBytes)
+	return rsl.NewReferenceEntry(refName, targetIDHash, rsl.WithCustomFields(rsl.CustomFields(options.CustomFields))).CommitUsingSpecificKey(r.r, signingKeyBytes)
 }
 
 func (r *Repository) SkipAllInvalidReferenceEntriesForRef(targetRef string, signCommit bool) error {
@@ -223,7 +223,7 @@ func (r *Repository) RecordRSLAnnotation(ctx context.Context, rslEntryIDs []stri
 	// signCommit must be verified for the refNames of the rslEntryIDs.
 
 	slog.Debug("Creating RSL annotation entry...")
-	annotation := rsl.NewAnnotationEntry(rslEntryHashes, skip, message)
+	annotation := rsl.NewAnnotationEntry(rslEntryHashes, skip, message, rsl.WithCustomFields(rsl.CustomFields(options.CustomFields)))
 	if signCommit && options.SigningKeyBytes != nil {
 		if err := annotation.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
 			return err
@@ -398,13 +398,15 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 		// entry may contain that is inferred at commit time
 		// For example, an incrementing number inferred from the
 		// parent entry
+		// WithCustomFields copies the fields into the new entry, so the
+		// original entry's map can be passed directly without cloning it first.
 		switch entry := localOnlyEntries[i].(type) {
 		case *rsl.ReferenceEntry:
-			if err := rsl.NewReferenceEntry(entry.RefName, entry.TargetID).Commit(r.r, sign); err != nil {
+			if err := rsl.NewReferenceEntry(entry.RefName, entry.TargetID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
 				return fmt.Errorf("unable to reapply reference entry '%s': %w", entry.ID.String(), err)
 			}
 		case *rsl.AnnotationEntry:
-			if err := rsl.NewAnnotationEntry(entry.RSLEntryIDs, entry.Skip, entry.Message).Commit(r.r, sign); err != nil {
+			if err := rsl.NewAnnotationEntry(entry.RSLEntryIDs, entry.Skip, entry.Message, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
 				return fmt.Errorf("unable to reapply annotation entry '%s': %w", entry.ID.String(), err)
 			}
 		}

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -42,7 +42,8 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()); err != nil {
+	customFields := map[string]string{"custom.example.com/source": "forge"}
+	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly(), rslopts.WithRecordCustomFields(customFields)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -57,6 +58,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	}
 	assert.Equal(t, "refs/heads/main", entry.RefName)
 	assert.Equal(t, commitID, entry.TargetID)
+	assert.Equal(t, customFields, map[string]string(entry.GetCustomFields()))
 
 	newCommitID, err := repo.r.Commit(emptyTreeHash, "refs/heads/main", "Another commit\n", false)
 	if err != nil {
@@ -325,7 +327,8 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	}
 	entryID := latestEntry.GetID()
 
-	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
+	customFields := map[string]string{"custom.example.com/source": "forge"}
+	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly(), rslopts.WithAnnotateCustomFields(customFields))
 	assert.Nil(t, err)
 
 	latestEntry, err = rsl.GetLatestEntry(repo.r)
@@ -338,6 +341,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	assert.Equal(t, "test annotation", annotation.Message)
 	assert.Equal(t, []githash.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.False(t, annotation.Skip)
+	assert.Equal(t, customFields, map[string]string(annotation.GetCustomFields()))
 
 	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, true, "skip annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.Nil(t, err)

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -42,7 +42,8 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()); err != nil {
+	customFields := map[string]string{"custom.example.com/source": "forge"}
+	if err := repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly(), rslopts.WithRecordCustomFields(customFields)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -57,6 +58,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	}
 	assert.Equal(t, "refs/heads/main", entry.RefName)
 	assert.Equal(t, commitID, entry.TargetID)
+	assert.Equal(t, customFields, map[string]string(entry.CustomFields))
 
 	newCommitID, err := repo.r.Commit(emptyTreeHash, "refs/heads/main", "Another commit\n", false)
 	if err != nil {
@@ -325,7 +327,8 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	}
 	entryID := latestEntry.GetID()
 
-	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
+	customFields := map[string]string{"custom.example.com/source": "forge"}
+	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly(), rslopts.WithAnnotateCustomFields(customFields))
 	assert.Nil(t, err)
 
 	latestEntry, err = rsl.GetLatestEntry(repo.r)
@@ -338,6 +341,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	assert.Equal(t, "test annotation", annotation.Message)
 	assert.Equal(t, []githash.Hash{entryID}, annotation.RSLEntryIDs)
 	assert.False(t, annotation.Skip)
+	assert.Equal(t, customFields, map[string]string(annotation.CustomFields))
 
 	err = repo.RecordRSLAnnotation(testCtx, []string{entryID.String()}, true, "skip annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.Nil(t, err)

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/gittuf/gittuf/internal/common/set"
@@ -125,10 +127,14 @@ func writeRSLReferenceEntry(writer io.WriteCloser, entry *rsl.ReferenceEntry, an
 	     Ref:    <refName>
 	     Target: <targetID>
 	     Number: <number>
+	     Custom Fields:
+	       <key>: <value>
 
 	       Annotation ID: <annotationID>
 	       Skip:          <yes/no>
 	       Number:        <number>
+	       Custom Fields:
+	         <key>: <value>
 	       Message:
 	         <message>
 
@@ -155,6 +161,7 @@ func writeRSLReferenceEntry(writer io.WriteCloser, entry *rsl.ReferenceEntry, an
 	if entry.Number != 0 {
 		text += fmt.Sprintf("\n  Number: %d", entry.Number)
 	}
+	text = appendCustomFields(text, entry.CustomFields, "  ")
 
 	for _, annotation := range annotations {
 		text += "\n\n"
@@ -168,6 +175,7 @@ func writeRSLReferenceEntry(writer io.WriteCloser, entry *rsl.ReferenceEntry, an
 		if annotation.Number != 0 {
 			text += fmt.Sprintf("\n    Number:        %d", annotation.Number)
 		}
+		text = appendCustomFields(text, annotation.CustomFields, "    ")
 		text += fmt.Sprintf("\n    Message:\n      %s", strings.TrimSpace(annotation.Message))
 	}
 
@@ -188,6 +196,8 @@ func writeRSLPropagationEntry(writer io.WriteCloser, entry *rsl.PropagationEntry
 		 UpstreamRepo:  <upstreamRepoLocation>
 		 UpstreamEntry: <upstreamEntryID>
 	     Number:        <number>
+	     Custom Fields:
+	       <key>: <value>
 	*/
 
 	text := colorer(fmt.Sprintf("propagation entry %s", entry.ID.String()), yellow)
@@ -200,6 +210,7 @@ func writeRSLPropagationEntry(writer io.WriteCloser, entry *rsl.PropagationEntry
 	if entry.Number != 0 {
 		text += fmt.Sprintf("\n  Number:        %d", entry.Number)
 	}
+	text = appendCustomFields(text, entry.CustomFields, "  ")
 
 	text += "\n" // single trailing newline by default
 	if hasParent {
@@ -208,4 +219,16 @@ func writeRSLPropagationEntry(writer io.WriteCloser, entry *rsl.PropagationEntry
 
 	_, err := writer.Write([]byte(text))
 	return err
+}
+
+func appendCustomFields(text string, fields rsl.CustomFields, indent string) string {
+	if len(fields) == 0 {
+		return text
+	}
+
+	text += fmt.Sprintf("\n%sCustom Fields:", indent)
+	for _, key := range slices.Sorted(maps.Keys(fields)) {
+		text += fmt.Sprintf("\n%s  %s: %s", indent, key, fields[key])
+	}
+	return text
 }

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -577,3 +577,169 @@ func TestWriteRSLPropagationEntry(t *testing.T) {
 		assert.Equal(t, expectedOutput, output.String())
 	})
 }
+
+func TestRSLLogWithCustomFields(t *testing.T) {
+	colorer = colorerOff
+
+	tmpDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+	referenceFields := rsl.CustomFields{
+		"custom.gitforge.com/server-version": "v4.2.0-c0ffee",
+		"custom.gitforge.com/pusher":         "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)",
+	}
+	if err := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, rsl.WithCustomFields(referenceFields)).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	entry, _, err := rsl.GetLatestReferenceUpdaterEntry(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	annotationFields := rsl.CustomFields{"custom.gitforge.com/reason": "force push"}
+	if err := rsl.NewAnnotationEntry([]githash.Hash{entry.GetID()}, true, "msg", rsl.WithCustomFields(annotationFields)).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	annotationEntry, err := rsl.GetLatestEntry(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput := fmt.Sprintf(`entry %s (skipped)
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+  Custom Fields:
+    custom.gitforge.com/pusher: jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+    custom.gitforge.com/server-version: v4.2.0-c0ffee
+
+    Annotation ID: %s
+    Skip:          yes
+    Number:        2
+    Custom Fields:
+      custom.gitforge.com/reason: force push
+    Message:
+      msg
+`, entry.GetID().String(), annotationEntry.GetID().String())
+
+	output := &bytes.Buffer{}
+	writer := &noopwritecloser{writer: output}
+	err = RSLLog(repo, writer)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedOutput, output.String())
+}
+
+func TestWriteRSLReferenceEntryWithCustomFields(t *testing.T) {
+	colorer = colorerOff
+
+	t.Run("fields sorted by key", func(t *testing.T) {
+		fields := rsl.CustomFields{
+			"custom.gitforge.com/server-version": "v4.2.0-c0ffee",
+			"custom.gitforge.com/pusher":         "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)",
+		}
+		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, rsl.WithCustomFields(fields))
+		entry.ID = gitinterface.ZeroHash
+		entry.Number = 1
+
+		expectedOutput := `entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+  Custom Fields:
+    custom.gitforge.com/pusher: jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+    custom.gitforge.com/server-version: v4.2.0-c0ffee
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLReferenceEntry(testWriter, entry, nil, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("without number", func(t *testing.T) {
+		fields := rsl.CustomFields{"custom.gitforge.com/pusher": "jane"}
+		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, rsl.WithCustomFields(fields))
+		entry.ID = gitinterface.ZeroHash
+
+		expectedOutput := `entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Custom Fields:
+    custom.gitforge.com/pusher: jane
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLReferenceEntry(testWriter, entry, nil, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("on the annotation only", func(t *testing.T) {
+		entry := rsl.NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash)
+		entry.ID = gitinterface.ZeroHash
+		entry.Number = 1
+
+		annotationFields := rsl.CustomFields{"custom.gitforge.com/reason": "force push"}
+		annotation := rsl.NewAnnotationEntry([]githash.Hash{entry.ID}, true, "msg", rsl.WithCustomFields(annotationFields))
+		annotation.ID = gitinterface.ZeroHash
+		annotation.Number = 2
+
+		expectedOutput := `entry 0000000000000000000000000000000000000000 (skipped)
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+  Number: 1
+
+    Annotation ID: 0000000000000000000000000000000000000000
+    Skip:          yes
+    Number:        2
+    Custom Fields:
+      custom.gitforge.com/reason: force push
+    Message:
+      msg
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLReferenceEntry(testWriter, entry, []*rsl.AnnotationEntry{annotation}, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+}
+
+func TestWriteRSLPropagationEntryWithCustomFields(t *testing.T) {
+	colorer = colorerOff
+
+	fields := rsl.CustomFields{
+		"custom.gitforge.com/mirror": "eu-west",
+		"custom.gitforge.com/job":    "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+	}
+	entry := rsl.NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://git.example.com/repository", gitinterface.ZeroHash, rsl.WithCustomFields(fields))
+	entry.ID = gitinterface.ZeroHash
+	entry.Number = 1
+
+	expectedOutput := `propagation entry 0000000000000000000000000000000000000000
+
+  Ref:           refs/heads/main
+  Target:        0000000000000000000000000000000000000000
+  UpstreamRepo:  https://git.example.com/repository
+  UpstreamEntry: 0000000000000000000000000000000000000000
+  Number:        1
+  Custom Fields:
+    custom.gitforge.com/job: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+    custom.gitforge.com/mirror: eu-west
+`
+
+	output := &bytes.Buffer{}
+	testWriter := &noopwritecloser{writer: output}
+	err := writeRSLPropagationEntry(testWriter, entry, false)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedOutput, output.String())
+}

--- a/pkg/customfields/customfields.go
+++ b/pkg/customfields/customfields.go
@@ -1,0 +1,151 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package customfields defines the format for signed, application-defined
+// custom fields carried by RSL entries.
+//
+// Custom fields are advisory only and must be treated as untrusted input.
+// gittuf treats them as opaque metadata and never consults them during
+// verification, so their presence, absence, or contents cannot change a
+// verification outcome.
+//
+// Consumers should make no assumptions about a value's
+// contents unless they generated the data themselves, for example a forge
+// reading back fields it stamped under its own namespace, and must not use
+// custom fields to make security decisions.
+package customfields
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const (
+	Prefix = "custom."
+
+	// MaxKeyLength bounds a key, Prefix included. A key must be fewer than
+	// MaxKeyLength characters, so a key of exactly this length is rejected.
+	MaxKeyLength = 250
+
+	// MaxValueLength bounds a value. A value must be fewer than
+	// MaxValueLength characters, so a value of exactly this length is
+	// rejected.
+	MaxValueLength = 500
+
+	// MaxCount is the largest number of fields a field set may carry. Unlike
+	// the length limits, it is inclusive: exactly MaxCount fields are valid.
+	MaxCount = 20
+
+	// ValuePunctuation is the punctuation a value may carry alongside ASCII
+	// letters and digits. It covers common value shapes: emails and handles
+	// (@), timestamps and URLs (:), base64 (=), and query strings (?, &, %, #,
+	// ~), as well as internal spaces. It is exported so an application that
+	// maps its own input into a value, such as a forge sanitizing a user
+	// handle, can do so against this alphabet instead of restating it.
+	ValuePunctuation = "-+./,()_ @:=%#?&~"
+)
+
+var (
+	ErrInvalid = errors.New("invalid custom fields")
+
+	// domainLabel matches a single lowercase DNS label.
+	domainLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+
+	// nameSegment matches a Kubernetes-style name segment: lowercase, starting
+	// and ending alphanumeric, with '.', '_', and '-' allowed in between.
+	nameSegment = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
+)
+
+func validValueRune(r rune) bool {
+	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' ||
+		r >= '0' && r <= '9' || strings.ContainsRune(ValuePunctuation, r)
+}
+
+// Validate checks that the fields are well formed. A field set
+// carries at most MaxCount fields. Every entry is checked with ValidateField.
+func Validate(fields map[string]string) error {
+	if len(fields) > MaxCount {
+		return fmt.Errorf("%w: %d fields exceed the maximum of %d", ErrInvalid, len(fields), MaxCount)
+	}
+	for key, value := range fields {
+		if err := ValidateField(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateField checks that a single field is well formed, returning an error
+// wrapping ErrInvalid otherwise. It is the one per-field check shared by
+// writers and readers of custom fields.
+//
+// A key is the Prefix, a lowercase DNS subdomain, a '/', and a name of at most
+// 63 characters that starts and ends with a lowercase letter or digit and may
+// carry '.', '_', and '-' in between. The whole key, Prefix included, must be
+// fewer than MaxKeyLength characters.
+//
+// A value is fewer than MaxValueLength characters, has no leading or trailing
+// spaces, and has every rune an ASCII letter, digit, or one of the characters
+// in ValuePunctuation. This is a check of a value's shape, so the empty string
+// passes. Emptiness means the field is absent, which writers handle by dropping
+// the field.
+func ValidateField(key, value string) error {
+	if !validKey(key) {
+		return fmt.Errorf("%w: invalid key %q", ErrInvalid, key)
+	}
+	if !validValue(value) {
+		return fmt.Errorf("%w: invalid value for %q", ErrInvalid, key)
+	}
+	return nil
+}
+
+// validKey reports whether key is a well-formed field key. See ValidateField
+// for the grammar.
+func validKey(key string) bool {
+	if !strings.HasPrefix(key, Prefix) || len(key) >= MaxKeyLength {
+		return false
+	}
+	domain, name, ok := strings.Cut(key[len(Prefix):], "/")
+	if !ok {
+		return false
+	}
+	return validDomain(domain) && validNameSegment(name)
+}
+
+func validDomain(domain string) bool {
+	if len(domain) == 0 || len(domain) > 253 {
+		return false
+	}
+	for label := range strings.SplitSeq(domain, ".") {
+		if len(label) > 63 || !domainLabel.MatchString(label) {
+			return false
+		}
+	}
+	return true
+}
+
+func validNameSegment(name string) bool {
+	return len(name) > 0 && len(name) <= 63 && nameSegment.MatchString(name)
+}
+
+// validValue reports whether value is a well-formed field value. See
+// ValidateField for the alphabet. The empty string passes.
+func validValue(value string) bool {
+	if len(value) >= MaxValueLength {
+		return false
+	}
+	// The RSL entry parser trims each value, so a leading or trailing space
+	// would not round-trip and would desync from the signed bytes. Reject it
+	// on write.
+	if value != strings.TrimSpace(value) {
+		return false
+	}
+	for _, character := range value {
+		if !validValueRune(character) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/customfields/customfields_test.go
+++ b/pkg/customfields/customfields_test.go
@@ -1,0 +1,137 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package customfields
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	invalid := map[string]map[string]string{
+		"missing namespace":    {"field": "value"},
+		"no custom prefix":     {"example.com/field": "value"},
+		"no name separator":    {"custom.example.com": "value"},
+		"empty name":           {"custom.example.com/": "value"},
+		"empty domain":         {"custom./field": "value"},
+		"uppercase key":        {"custom.example.com/Field": "value"},
+		"key with space":       {"custom.example.com/field name": "value"},
+		"bad domain label":     {"custom.-bad.com/field": "value"},
+		"name too long":        {"custom.example.com/" + strings.Repeat("a", 64): "value"},
+		"key too long":         {"custom." + strings.Repeat("a.", 125) + "com/field": "value"},
+		"multiline value":      {"custom.example.com/field": "first\nsecond"},
+		"value leading space":  {"custom.example.com/field": " value"},
+		"value trailing space": {"custom.example.com/field": "value "},
+		"value too long":       {"custom.example.com/field": strings.Repeat("a", MaxValueLength)},
+		"value with asterisk":  {"custom.example.com/field": "a*b"},
+		"value with quote":     {"custom.example.com/field": `a"b`},
+		"value with backslash": {"custom.example.com/field": `a\b`},
+		"value with semicolon": {"custom.example.com/field": "a;b"},
+		"value with angle":     {"custom.example.com/field": "<tag>"},
+		"non-ascii value":      {"custom.example.com/field": "café"},
+	}
+
+	for name, fields := range invalid {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.ErrorIs(t, Validate(fields), ErrInvalid)
+		})
+	}
+
+	valid := map[string]map[string]string{
+		"ulid":                {"custom.example.com/repository": "01ARZ3NDEKTSV4RRFFQ69G5FAV"},
+		"symbols":             {"custom.example.com/field": "v1.2.3-rc.1/build(42),ok"},
+		"internal space":      {"custom.example.com/field": "hello world"},
+		"underscore":          {"custom.example.com/field": "hello_world"},
+		"single label domain": {"custom.example/field": "value"},
+		"subdomains":          {"custom.a.b.example.com/x-y_z.1": "value"},
+		"max name length":     {"custom.example.com/" + strings.Repeat("a", 63): "value"},
+		"max value length":    {"custom.example.com/field": strings.Repeat("a", MaxValueLength-1)},
+		"email":               {"custom.example.com/pusher": "paulo@example.com"},
+		"url":                 {"custom.example.com/source": "https://github.com/gittuf/gittuf?tab=readme#usage"},
+		"rfc3339 timestamp":   {"custom.example.com/pushed-at": "2026-08-18T10:04:05Z"},
+		"base64":              {"custom.example.com/digest": "q1w2e3r4=="},
+		"percent encoding":    {"custom.example.com/path": "a%20b"},
+		"tilde":               {"custom.example.com/ref": "HEAD~1"},
+		"handle with id":      {"custom.gitforge.com/pusher": "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)"},
+		"template version":    {"custom.gitforge.com/policy-template-version": "2026-03-11.4"},
+	}
+
+	for name, fields := range valid {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.NoError(t, Validate(fields))
+		})
+	}
+}
+
+func TestValidateFieldKey(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, ValidateField("custom.example.com/field", "value"))
+	assert.ErrorIs(t, ValidateField("example.com/field", "value"), ErrInvalid)
+	assert.ErrorIs(t, ValidateField("custom.example.com", "value"), ErrInvalid)
+	assert.ErrorIs(t, ValidateField("custom."+strings.Repeat("a.", 125)+"com/field", "value"), ErrInvalid)
+}
+
+func TestValidateFieldKeyLengthBoundary(t *testing.T) {
+	t.Parallel()
+
+	domain := strings.Repeat("a", 63) + "." + strings.Repeat("a", 63) + "." + strings.Repeat("a", 51)
+	key := Prefix + domain + "/" + strings.Repeat("a", 63)
+	require.Len(t, key, MaxKeyLength)
+
+	assert.ErrorIs(t, ValidateField(key, "value"), ErrInvalid)
+	assert.NoError(t, ValidateField(key[:len(key)-1], "value"))
+}
+
+func TestValidateFieldValue(t *testing.T) {
+	t.Parallel()
+
+	const key = "custom.example.com/field"
+
+	assert.NoError(t, ValidateField(key, "paulo@example.com"))
+	assert.NoError(t, ValidateField(key, ""))
+	assert.ErrorIs(t, ValidateField(key, " padded "), ErrInvalid)
+	assert.ErrorIs(t, ValidateField(key, "first\nsecond"), ErrInvalid)
+	assert.ErrorIs(t, ValidateField(key, strings.Repeat("a", MaxValueLength)), ErrInvalid)
+}
+
+func TestValidValueRune(t *testing.T) {
+	t.Parallel()
+
+	for _, r := range "azAZ09" + ValuePunctuation {
+		assert.True(t, validValueRune(r), "expected %q to be valid", r)
+	}
+	for _, r := range "*\"\\;<>\n\t|$`é" {
+		assert.False(t, validValueRune(r), "expected %q to be invalid", r)
+	}
+}
+
+func TestValuePunctuationIsItselfAValidValue(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, ValidateField("custom.example.com/field", ValuePunctuation))
+}
+
+func TestValidateRejectsTooManyFields(t *testing.T) {
+	t.Parallel()
+
+	fields := map[string]string{}
+	for i := 0; i <= MaxCount; i++ {
+		fields[fmt.Sprintf("custom.example.com/field-%d", i)] = "v"
+	}
+	require.Len(t, fields, MaxCount+1)
+	assert.ErrorIs(t, Validate(fields), ErrInvalid)
+
+	delete(fields, fmt.Sprintf("custom.example.com/field-%d", MaxCount))
+	require.Len(t, fields, MaxCount)
+	assert.NoError(t, Validate(fields))
+}

--- a/pkg/rsl/customfields.go
+++ b/pkg/rsl/customfields.go
@@ -1,0 +1,92 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/gittuf/gittuf/pkg/customfields"
+)
+
+// CustomFields contains signed, application-defined metadata stored in an RSL
+// entry. Keys begin with customfields.Prefix.
+//
+// Custom fields are advisory only and must be treated as untrusted input.
+// gittuf treats them as opaque metadata and never consults them during
+// verification, so their presence, absence, or contents cannot change a
+// verification outcome. A field is asserted by whoever created and signed the
+// enclosing entry, and the namespace in a key identifies its writer by
+// convention only. The entry's signature proves only that a value has not
+// changed since the entry was signed, not that it was true when written. Make
+// no assumptions about a value's contents unless your application generated
+// it, for example a forge reading back fields it stamped under its own
+// namespace, and never use custom fields to make security decisions.
+type CustomFields map[string]string
+
+// CustomFieldEntry represents RSL entry types that carry application-defined
+// custom fields. It is a separate interface rather than an addition to Entry so
+// that adding GetCustomField does not break existing Entry implementations:
+// they continue to satisfy Entry, and simply do not satisfy CustomFieldEntry.
+// Callers holding an Entry reach the fields with a type assertion.
+type CustomFieldEntry interface {
+	Entry
+
+	// GetCustomField returns the value of the named custom field and whether
+	// it is set. Fields are advisory only: gittuf never consults them during
+	// verification. Treat values as untrusted input unless your application
+	// generated them. See CustomFields.
+	GetCustomField(key string) (string, bool)
+}
+
+// appendCustomFieldLines drops fields with empty values, validates the rest,
+// then appends them to lines as "<key>: <value>" sorted by key so the encoding
+// is deterministic and the resulting commit is stable across implementations.
+func appendCustomFieldLines(lines []string, fields CustomFields) ([]string, error) {
+	effective := make(CustomFields, len(fields))
+	for key, value := range fields {
+		if value == "" {
+			continue // an empty value means the field is absent
+		}
+		effective[key] = value
+	}
+	if len(effective) == 0 {
+		return lines, nil
+	}
+	if err := customfields.Validate(effective); err != nil {
+		return nil, err
+	}
+
+	keys := make([]string, 0, len(effective))
+	for key := range effective {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s: %s", key, effective[key]))
+	}
+	return lines, nil
+}
+
+func setCustomField(fields *CustomFields, key, value string) {
+	if err := customfields.ValidateField(key, value); err != nil {
+		return
+	}
+	if value == "" {
+		// An empty value means the field is absent. A canonical writer never
+		// emits one, and recording it would report a field as set whose value
+		// cannot round-trip.
+		return
+	}
+	if *fields == nil {
+		*fields = CustomFields{}
+	}
+	if _, exists := (*fields)[key]; exists {
+		return
+	}
+	if len(*fields) >= customfields.MaxCount {
+		return
+	}
+	(*fields)[key] = value
+}

--- a/pkg/rsl/customfields_test.go
+++ b/pkg/rsl/customfields_test.go
@@ -1,0 +1,81 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/pkg/customfields"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppendCustomFieldLines(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		lines    []string
+		fields   CustomFields
+		expected []string
+	}{
+		"no fields returns lines unchanged": {
+			lines:    []string{"ref: refs/heads/main"},
+			expected: []string{"ref: refs/heads/main"},
+		},
+		"fields sorted by key": {
+			lines: []string{"ref: refs/heads/main"},
+			fields: CustomFields{
+				"custom.example.com/zebra": "last",
+				"custom.example.com/alpha": "first",
+			},
+			expected: []string{"ref: refs/heads/main", "custom.example.com/alpha: first", "custom.example.com/zebra: last"},
+		},
+		"empty value dropped": {
+			fields: CustomFields{
+				"custom.example.com/set":   "value",
+				"custom.example.com/unset": "",
+			},
+			expected: []string{"custom.example.com/set: value"},
+		},
+		"only empty values leaves lines unchanged": {
+			lines:    []string{"ref: refs/heads/main"},
+			fields:   CustomFields{"custom.example.com/unset": ""},
+			expected: []string{"ref: refs/heads/main"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			lines, err := appendCustomFieldLines(test.lines, test.fields)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, lines)
+		})
+	}
+}
+
+func TestAppendCustomFieldLinesRejectsInvalidFields(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]CustomFields{
+		"missing prefix":  {"example.com/field": "value"},
+		"missing name":    {"custom.example.com": "value"},
+		"uppercase key":   {"custom.example.com/Field": "value"},
+		"newline value":   {"custom.example.com/field": "first\nsecond"},
+		"padded value":    {"custom.example.com/field": " value "},
+		"oversized value": {"custom.example.com/field": strings.Repeat("a", customfields.MaxValueLength)},
+	}
+
+	for name, fields := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			lines, err := appendCustomFieldLines([]string{"ref: refs/heads/main"}, fields)
+			assert.ErrorIs(t, err, customfields.ErrInvalid)
+			assert.Nil(t, lines)
+		})
+	}
+}

--- a/pkg/rsl/options.go
+++ b/pkg/rsl/options.go
@@ -5,6 +5,39 @@ package rsl
 
 import "github.com/gittuf/gittuf/pkg/githash"
 
+type entryOptions struct {
+	customFields CustomFields
+}
+
+type EntryOption func(*entryOptions)
+
+// WithCustomFields adds custom fields to an RSL entry. The fields are copied so
+// subsequent changes to the supplied map do not affect the entry, and the entry
+// holds the only defensive copy. Supplying no fields is a no-op, so an entry
+// without custom fields keeps a nil map rather than an empty one. A key repeated
+// across multiple WithCustomFields options keeps its first value, matching how
+// the reader resolves repeated fields.
+//
+// Fields with an empty value are skipped: an empty value means the field is
+// absent, and the encoder drops it, so keeping it in the entry would report a
+// field as set that no commit ever carries.
+func WithCustomFields(fields CustomFields) EntryOption {
+	return func(o *entryOptions) {
+		for key, value := range fields {
+			if value == "" {
+				continue
+			}
+			if o.customFields == nil {
+				o.customFields = make(CustomFields, len(fields))
+			}
+			if _, exists := o.customFields[key]; exists {
+				continue
+			}
+			o.customFields[key] = value
+		}
+	}
+}
+
 type GetLatestReferenceUpdaterEntryOptions struct {
 	Reference string
 

--- a/pkg/rsl/options.go
+++ b/pkg/rsl/options.go
@@ -5,6 +5,36 @@ package rsl
 
 import "github.com/gittuf/gittuf/pkg/githash"
 
+type entryOptions struct {
+	customFields CustomFields
+}
+
+// EntryOption configures an RSL entry.
+type EntryOption func(*entryOptions)
+
+// WithCustomFields adds custom fields to an RSL entry. The fields are copied so
+// subsequent changes to the supplied map do not affect the entry, and the entry
+// holds the only defensive copy. Supplying no fields is a no-op, so an entry
+// without custom fields keeps a nil map rather than an empty one. A key repeated
+// across multiple WithCustomFields options keeps its first value, matching how
+// the reader resolves repeated fields.
+func WithCustomFields(fields CustomFields) EntryOption {
+	return func(o *entryOptions) {
+		if len(fields) == 0 {
+			return
+		}
+		if o.customFields == nil {
+			o.customFields = make(CustomFields, len(fields))
+		}
+		for key, value := range fields {
+			if _, exists := o.customFields[key]; exists {
+				continue
+			}
+			o.customFields[key] = value
+		}
+	}
+}
+
 type GetLatestReferenceUpdaterEntryOptions struct {
 	Reference string
 

--- a/pkg/rsl/repository_test.go
+++ b/pkg/rsl/repository_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/gitstoretest"
@@ -18,6 +19,127 @@ import (
 )
 
 const annotationMessage = "test annotation"
+
+func TestCustomFieldsRoundTrip(t *testing.T) {
+	fields := CustomFields{
+		"custom.example.com/z-field": "v1.2.3-rc.1/build(42),ok",
+		"custom.example.com/a-field": "first",
+	}
+
+	tests := map[string]Entry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields)),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "message", WithCustomFields(fields)),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, WithCustomFields(fields)),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			message, err := entry.createCommitMessage(true)
+			require.NoError(t, err)
+			assert.Less(t, strings.Index(message, "custom.example.com/a-field"), strings.Index(message, "custom.example.com/z-field"))
+
+			parsed, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			assert.Equal(t, fields, parsed.GetCustomFields())
+		})
+	}
+}
+
+func TestCustomFieldsAreCopied(t *testing.T) {
+	fields := CustomFields{"custom.example.com/field": "original"}
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields))
+
+	fields["custom.example.com/field"] = "changed"
+	assert.Equal(t, "original", entry.GetCustomFields()["custom.example.com/field"])
+
+	got := entry.GetCustomFields()
+	got["custom.example.com/field"] = "changed again"
+	assert.Equal(t, "original", entry.GetCustomFields()["custom.example.com/field"])
+}
+
+func TestParseRSLEntryTextUsesFirstDuplicateCustomField(t *testing.T) {
+	zero := gitinterface.ZeroHash.String()
+	tests := map[string]string{
+		"reference": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"annotation": fmt.Sprintf("%s\n\n%s: %s\n%s: false\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey),
+		"propagation": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero),
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			assert.Equal(t, "first", entry.GetCustomFields()["custom.example.com/field"])
+		})
+	}
+}
+
+func TestParseRSLEntryTextAcceptsUnsortedCustomFields(t *testing.T) {
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/z-field: last\ncustom.example.com/a-field: first",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String())
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{
+		"custom.example.com/z-field": "last",
+		"custom.example.com/a-field": "first",
+	}, entry.GetCustomFields())
+}
+
+func TestWithCustomFieldsKeepsFirstValueForRepeatedKey(t *testing.T) {
+	first := WithCustomFields(CustomFields{"custom.example.com/field": "first"})
+	duplicate := WithCustomFields(CustomFields{"custom.example.com/field": "second"})
+	tests := map[string]Entry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, first, duplicate),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", first, duplicate),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, first, duplicate),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, CustomFields{"custom.example.com/field": "first"}, entry.GetCustomFields())
+		})
+	}
+}
+
+func TestValidateCustomFields(t *testing.T) {
+	invalid := map[string]CustomFields{
+		"missing namespace": {"field": "value"},
+		"empty name":        {CustomFieldPrefix: "value"},
+		"key with space":    {"custom.example.com/field name": "value"},
+		"value with space":  {"custom.example.com/field": "hello world"},
+		"value with colon":  {"custom.example.com/field": "a:b"},
+		"multiline value":   {"custom.example.com/field": "first\nsecond"},
+	}
+
+	for name, fields := range invalid {
+		t.Run(name, func(t *testing.T) {
+			assert.ErrorIs(t, ValidateCustomFields(fields), ErrInvalidCustomFields)
+		})
+	}
+
+	assert.NoError(t, ValidateCustomFields(CustomFields{"custom.example.com/field": "v1.2.3-rc.1/build(42),ok"}))
+}
+
+func TestCreateCommitMessageRejectsInvalidCustomFields(t *testing.T) {
+	invalid := WithCustomFields(CustomFields{"custom.example.com/field": "no spaces allowed"})
+	tests := map[string]Entry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, invalid),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", invalid),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, invalid),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			message, err := entry.createCommitMessage(true)
+			assert.Empty(t, message)
+			assert.ErrorIs(t, err, ErrInvalidCustomFields)
+		})
+	}
+}
 
 func TestRemoteTrackerRef(t *testing.T) {
 	assert.Equal(t, "refs/remotes/origin/gittuf/reference-state-log", RemoteTrackerRef("origin"))

--- a/pkg/rsl/repository_test.go
+++ b/pkg/rsl/repository_test.go
@@ -23,7 +23,7 @@ const annotationMessage = "test annotation"
 func TestCustomFieldsRoundTrip(t *testing.T) {
 	fields := CustomFields{
 		"custom.example.com/z-field": "v1.2.3-rc.1/build(42),ok",
-		"custom.example.com/a-field": "first",
+		"custom.example.com/a-field": "hello world_ok",
 	}
 
 	tests := map[string]Entry{
@@ -107,12 +107,20 @@ func TestWithCustomFieldsKeepsFirstValueForRepeatedKey(t *testing.T) {
 
 func TestValidateCustomFields(t *testing.T) {
 	invalid := map[string]CustomFields{
-		"missing namespace": {"field": "value"},
-		"empty name":        {CustomFieldPrefix: "value"},
-		"key with space":    {"custom.example.com/field name": "value"},
-		"value with space":  {"custom.example.com/field": "hello world"},
-		"value with colon":  {"custom.example.com/field": "a:b"},
-		"multiline value":   {"custom.example.com/field": "first\nsecond"},
+		"missing namespace":    {"field": "value"},
+		"no name separator":    {"custom.example.com": "value"},
+		"empty name":           {"custom.example.com/": "value"},
+		"empty domain":         {"custom./field": "value"},
+		"uppercase key":        {"custom.example.com/Field": "value"},
+		"key with space":       {"custom.example.com/field name": "value"},
+		"bad domain label":     {"custom.-bad.com/field": "value"},
+		"name too long":        {"custom.example.com/" + strings.Repeat("a", 64): "value"},
+		"key too long":         {"custom." + strings.Repeat("a.", 125) + "com/field": "value"},
+		"value with colon":     {"custom.example.com/field": "a:b"},
+		"multiline value":      {"custom.example.com/field": "first\nsecond"},
+		"value leading space":  {"custom.example.com/field": " value"},
+		"value trailing space": {"custom.example.com/field": "value "},
+		"value too long":       {"custom.example.com/field": strings.Repeat("a", maxCustomFieldValueLength)},
 	}
 
 	for name, fields := range invalid {
@@ -121,11 +129,74 @@ func TestValidateCustomFields(t *testing.T) {
 		})
 	}
 
-	assert.NoError(t, ValidateCustomFields(CustomFields{"custom.example.com/field": "v1.2.3-rc.1/build(42),ok"}))
+	valid := map[string]CustomFields{
+		"symbols":             {"custom.example.com/field": "v1.2.3-rc.1/build(42),ok"},
+		"internal space":      {"custom.example.com/field": "hello world"},
+		"underscore":          {"custom.example.com/field": "hello_world"},
+		"single label domain": {"custom.example/field": "value"},
+		"subdomains":          {"custom.a.b.example.com/x-y_z.1": "value"},
+		"max name length":     {"custom.example.com/" + strings.Repeat("a", 63): "value"},
+		"max value length":    {"custom.example.com/field": strings.Repeat("a", maxCustomFieldValueLength-1)},
+	}
+
+	for name, fields := range valid {
+		t.Run(name, func(t *testing.T) {
+			assert.NoError(t, ValidateCustomFields(fields))
+		})
+	}
+}
+
+func TestValidateCustomFieldsRejectsTooManyFields(t *testing.T) {
+	fields := CustomFields{}
+	for i := 0; i <= maxCustomFieldCount; i++ {
+		fields[fmt.Sprintf("custom.example.com/field-%d", i)] = "v"
+	}
+	require.Len(t, fields, maxCustomFieldCount+1)
+	assert.ErrorIs(t, ValidateCustomFields(fields), ErrInvalidCustomFields)
+}
+
+func TestParseRSLEntryTextDropsOverlongCustomFields(t *testing.T) {
+	longKey := CustomFieldPrefix + strings.Repeat("a", maxCustomFieldKeyLength)
+	longValue := strings.Repeat("a", maxCustomFieldValueLength)
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/ok: fine\n%s: value\ncustom.example.com/big: %s",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), longKey, longValue)
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{"custom.example.com/ok": "fine"}, entry.GetCustomFields())
+}
+
+func TestParseRSLEntryTextCapsCustomFieldCount(t *testing.T) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String())
+	for i := 0; i < maxCustomFieldCount+10; i++ {
+		fmt.Fprintf(&b, "\ncustom.example.com/field-%02d: v", i)
+	}
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, b.String())
+	require.NoError(t, err)
+	assert.Len(t, entry.GetCustomFields(), maxCustomFieldCount)
+}
+
+func TestCreateCommitMessageDropsEmptyCustomFields(t *testing.T) {
+	fields := CustomFields{
+		"custom.example.com/kept":  "value",
+		"custom.example.com/empty": "",
+	}
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields))
+
+	message, err := entry.createCommitMessage(true)
+	require.NoError(t, err)
+	assert.Contains(t, message, "custom.example.com/kept: value")
+	assert.NotContains(t, message, "custom.example.com/empty")
+
+	parsed, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{"custom.example.com/kept": "value"}, parsed.GetCustomFields())
 }
 
 func TestCreateCommitMessageRejectsInvalidCustomFields(t *testing.T) {
-	invalid := WithCustomFields(CustomFields{"custom.example.com/field": "no spaces allowed"})
+	invalid := WithCustomFields(CustomFields{"custom.example.com/Field": "value"})
 	tests := map[string]Entry{
 		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, invalid),
 		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", invalid),

--- a/pkg/rsl/repository_test.go
+++ b/pkg/rsl/repository_test.go
@@ -7,10 +7,12 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/internal/gitstoretest"
 	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/stretchr/testify/assert"
@@ -18,6 +20,336 @@ import (
 )
 
 const annotationMessage = "test annotation"
+
+func parsedCustomFieldEntry(t *testing.T, entry Entry) CustomFieldEntry {
+	t.Helper()
+
+	withFields, ok := entry.(CustomFieldEntry)
+	require.True(t, ok)
+	return withFields
+}
+
+func TestCustomFieldsRoundTrip(t *testing.T) {
+	fields := CustomFields{
+		"custom.example.com/z-field": "v1.2.3-rc.1/build(42),ok",
+		"custom.example.com/a-field": "hello world_ok",
+	}
+
+	tests := map[string]CustomFieldEntry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields)),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "message", WithCustomFields(fields)),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, WithCustomFields(fields)),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			message, err := entry.createCommitMessage(true)
+			require.NoError(t, err)
+			assert.Less(t, strings.Index(message, "custom.example.com/a-field"), strings.Index(message, "custom.example.com/z-field"))
+
+			parsed, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			parsedEntry := parsedCustomFieldEntry(t, parsed)
+			for key, want := range fields {
+				value, has := parsedEntry.GetCustomField(key)
+				assert.True(t, has)
+				assert.Equal(t, want, value)
+			}
+		})
+	}
+}
+
+func TestCustomFieldsAreCopied(t *testing.T) {
+	fields := CustomFields{"custom.example.com/field": "original"}
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields))
+
+	fields["custom.example.com/field"] = "changed"
+	value, has := entry.GetCustomField("custom.example.com/field")
+	assert.True(t, has)
+	assert.Equal(t, "original", value)
+}
+
+func TestParseRSLEntryTextUsesFirstDuplicateCustomField(t *testing.T) {
+	zero := gitinterface.ZeroHash.String()
+	tests := map[string]string{
+		"reference": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"annotation": fmt.Sprintf("%s\n\n%s: %s\n%s: false\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey),
+		"propagation": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\ncustom.example.com/field: first\ncustom.example.com/field: second",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero),
+	}
+
+	for name, message := range tests {
+		t.Run(name, func(t *testing.T) {
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			value, has := parsedCustomFieldEntry(t, entry).GetCustomField("custom.example.com/field")
+			assert.True(t, has)
+			assert.Equal(t, "first", value)
+		})
+	}
+}
+
+func TestParseRSLEntryTextAcceptsUnsortedCustomFields(t *testing.T) {
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/z-field: last\ncustom.example.com/a-field: first",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String())
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{
+		"custom.example.com/z-field": "last",
+		"custom.example.com/a-field": "first",
+	}, entry.(*ReferenceEntry).CustomFields)
+}
+
+func TestWithCustomFieldsKeepsFirstValueForRepeatedKey(t *testing.T) {
+	first := WithCustomFields(CustomFields{"custom.example.com/field": "first"})
+	duplicate := WithCustomFields(CustomFields{"custom.example.com/field": "second"})
+	tests := map[string]CustomFieldEntry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, first, duplicate),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", first, duplicate),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, first, duplicate),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, has := entry.GetCustomField("custom.example.com/field")
+			assert.True(t, has)
+			assert.Equal(t, "first", value)
+		})
+	}
+}
+
+func TestWithCustomFieldsSkipsEmptyValues(t *testing.T) {
+	mixed := WithCustomFields(CustomFields{
+		"custom.example.com/set":   "value",
+		"custom.example.com/empty": "",
+	})
+	tests := map[string]CustomFieldEntry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, mixed),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", mixed),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, mixed),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, has := entry.GetCustomField("custom.example.com/set")
+			assert.True(t, has)
+			assert.Equal(t, "value", value)
+
+			value, has = entry.GetCustomField("custom.example.com/empty")
+			assert.False(t, has, "an empty value means the field is absent")
+			assert.Empty(t, value)
+		})
+	}
+}
+
+func TestWithCustomFieldsAllEmptyKeepsNilMap(t *testing.T) {
+	empty := WithCustomFields(CustomFields{"custom.example.com/empty": ""})
+
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, empty)
+	assert.Nil(t, entry.CustomFields)
+
+	annotation := NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", empty)
+	assert.Nil(t, annotation.CustomFields)
+
+	propagation := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, empty)
+	assert.Nil(t, propagation.CustomFields)
+}
+
+func TestWithCustomFieldsEmptyValueDoesNotShadow(t *testing.T) {
+	empty := WithCustomFields(CustomFields{"custom.example.com/field": ""})
+	set := WithCustomFields(CustomFields{"custom.example.com/field": "value"})
+
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, empty, set)
+	value, has := entry.GetCustomField("custom.example.com/field")
+	assert.True(t, has)
+	assert.Equal(t, "value", value)
+}
+
+func TestGetCustomField(t *testing.T) {
+	fields := WithCustomFields(CustomFields{"custom.example.com/field": "value"})
+	tests := map[string]CustomFieldEntry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, fields),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", fields),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, fields),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			value, has := entry.GetCustomField("custom.example.com/field")
+			assert.True(t, has)
+			assert.Equal(t, "value", value)
+
+			value, has = entry.GetCustomField("custom.example.com/absent")
+			assert.False(t, has)
+			assert.Empty(t, value)
+		})
+	}
+
+	t.Run("entry without fields", func(t *testing.T) {
+		value, has := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).GetCustomField("custom.example.com/field")
+		assert.False(t, has)
+		assert.Empty(t, value)
+	})
+}
+
+func TestCreateCommitMessageHasNoTrailingNewline(t *testing.T) {
+	fields := WithCustomFields(CustomFields{"custom.example.com/field": "value"})
+
+	entries := map[string]Entry{
+		"reference":               NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash),
+		"reference with fields":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, fields),
+		"annotation":              NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, ""),
+		"annotation with fields":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", fields),
+		"propagation":             NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash),
+		"propagation with fields": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, fields),
+	}
+
+	for name, entry := range entries {
+		t.Run(name, func(t *testing.T) {
+			message, err := entry.createCommitMessage(true)
+			require.NoError(t, err)
+			assert.False(t, strings.HasSuffix(message, "\n"), "expected no trailing newline, got %q", message)
+		})
+	}
+}
+
+func TestParseRSLEntryTextRequiresCustomFieldsAfterBuiltInFields(t *testing.T) {
+	zero := gitinterface.ZeroHash.String()
+	custom := "custom.example.com/field: value"
+
+	invalid := map[string]string{
+		"reference custom before ref": fmt.Sprintf("%s\n\n%s\n%s: %s\n%s: %s",
+			ReferenceEntryHeader, custom, RefKey, "refs/heads/main", TargetIDKey, zero),
+		"reference custom between ref and targetID": fmt.Sprintf("%s\n\n%s: %s\n%s\n%s: %s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", custom, TargetIDKey, zero),
+		"reference number after custom": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s: 1",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, custom, NumberKey),
+		"annotation custom before entryID": fmt.Sprintf("%s\n\n%s\n%s: %s\n%s: false",
+			AnnotationEntryHeader, custom, EntryIDKey, zero, SkipKey),
+		"annotation custom between entryID and skip": fmt.Sprintf("%s\n\n%s: %s\n%s\n%s: false",
+			AnnotationEntryHeader, EntryIDKey, zero, custom, SkipKey),
+		"annotation number after custom": fmt.Sprintf("%s\n\n%s: %s\n%s: false\n%s\n%s: 1",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, custom, NumberKey),
+		"propagation custom between targetID and upstreamRepository": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s\n%s: https://example.com/repository\n%s: %s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, custom, UpstreamRepositoryKey, UpstreamEntryIDKey, zero),
+		"propagation number after custom": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\n%s\n%s: 1",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero, custom, NumberKey),
+	}
+
+	for name, message := range invalid {
+		t.Run(name, func(t *testing.T) {
+			_, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			assert.ErrorIs(t, err, ErrInvalidRSLEntry)
+		})
+	}
+
+	valid := map[string]string{
+		"reference custom without number": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, custom),
+		"reference custom after number": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: 1\n%s",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, NumberKey, custom),
+		"annotation custom without number": fmt.Sprintf("%s\n\n%s: %s\n%s: false\n%s",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, custom),
+		"annotation custom after number": fmt.Sprintf("%s\n\n%s: %s\n%s: false\n%s: 1\n%s",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, NumberKey, custom),
+		"propagation custom without number": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\n%s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero, custom),
+		"propagation custom after number": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\n%s: 1\n%s",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero, NumberKey, custom),
+	}
+
+	for name, message := range valid {
+		t.Run(name, func(t *testing.T) {
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			value, has := parsedCustomFieldEntry(t, entry).GetCustomField("custom.example.com/field")
+			assert.True(t, has)
+			assert.Equal(t, "value", value)
+		})
+	}
+}
+
+func TestParseRSLEntryTextDropsOverlongCustomFields(t *testing.T) {
+	longKey := customfields.Prefix + strings.Repeat("a", customfields.MaxKeyLength)
+	longValue := strings.Repeat("a", customfields.MaxValueLength)
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/ok: fine\n%s: value\ncustom.example.com/big: %s",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), longKey, longValue)
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{"custom.example.com/ok": "fine"}, entry.(*ReferenceEntry).CustomFields)
+}
+
+func TestParseRSLEntryTextDropsCustomFieldsOutsideTheGrammar(t *testing.T) {
+	tests := map[string]string{
+		"escape sequence in value": "custom.example.com/bad: \x1b[31mred",
+		"tab in value":             "custom.example.com/bad: a\tb",
+		"non-ascii value":          "custom.example.com/bad: café",
+		"uppercase key":            "custom.example.com/BAD: value",
+		"key without name":         "custom.example.com: value",
+		"key with bad domain":      "custom.-bad.com/field: value",
+	}
+
+	for name, field := range tests {
+		t.Run(name, func(t *testing.T) {
+			message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\ncustom.example.com/ok: fine\n%s",
+				ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String(), field)
+
+			entry, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+			require.NoError(t, err)
+			assert.Equal(t, CustomFields{"custom.example.com/ok": "fine"}, entry.(*ReferenceEntry).CustomFields)
+		})
+	}
+}
+
+func TestParseRSLEntryTextCapsCustomFieldCount(t *testing.T) {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, gitinterface.ZeroHash.String())
+	for i := 0; i < customfields.MaxCount+10; i++ {
+		fmt.Fprintf(&b, "\ncustom.example.com/field-%02d: v", i)
+	}
+
+	entry, err := parseRSLEntryText(gitinterface.ZeroHash, b.String())
+	require.NoError(t, err)
+	assert.Len(t, entry.(*ReferenceEntry).CustomFields, customfields.MaxCount)
+}
+
+func TestCreateCommitMessageDropsEmptyCustomFields(t *testing.T) {
+	fields := CustomFields{
+		"custom.example.com/kept":  "value",
+		"custom.example.com/empty": "",
+	}
+	entry := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, WithCustomFields(fields))
+
+	message, err := entry.createCommitMessage(true)
+	require.NoError(t, err)
+	assert.Contains(t, message, "custom.example.com/kept: value")
+	assert.NotContains(t, message, "custom.example.com/empty")
+
+	parsed, err := parseRSLEntryText(gitinterface.ZeroHash, message)
+	require.NoError(t, err)
+	assert.Equal(t, CustomFields{"custom.example.com/kept": "value"}, parsed.(*ReferenceEntry).CustomFields)
+}
+
+func TestCreateCommitMessageRejectsInvalidCustomFields(t *testing.T) {
+	invalid := WithCustomFields(CustomFields{"custom.example.com/Field": "value"})
+	tests := map[string]Entry{
+		"reference":   NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash, invalid),
+		"annotation":  NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "", invalid),
+		"propagation": NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repository", gitinterface.ZeroHash, invalid),
+	}
+
+	for name, entry := range tests {
+		t.Run(name, func(t *testing.T) {
+			message, err := entry.createCommitMessage(true)
+			assert.Empty(t, message)
+			assert.ErrorIs(t, err, customfields.ErrInvalid)
+		})
+	}
+}
 
 func TestRemoteTrackerRef(t *testing.T) {
 	assert.Equal(t, "refs/remotes/origin/gittuf/reference-state-log", RemoteTrackerRef("origin"))

--- a/pkg/rsl/repository_test.go
+++ b/pkg/rsl/repository_test.go
@@ -237,6 +237,14 @@ func TestParseRSLEntryTextRequiresCustomFieldsAfterBuiltInFields(t *testing.T) {
 			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, custom, UpstreamRepositoryKey, UpstreamEntryIDKey, zero),
 		"propagation number after custom": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\n%s\n%s: 1",
 			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero, custom, NumberKey),
+		"reference number after custom with invalid key": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: value\n%s: 1",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, customfields.Prefix+"INVALID", NumberKey),
+		"reference number after custom with empty value": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s:\n%s: 1",
+			ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, customfields.Prefix+"example.com/field", NumberKey),
+		"annotation number after custom with empty value": fmt.Sprintf("%s\n\n%s: %s\n%s: false\n%s:\n%s: 1",
+			AnnotationEntryHeader, EntryIDKey, zero, SkipKey, customfields.Prefix+"example.com/field", NumberKey),
+		"propagation number after custom with invalid key": fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: https://example.com/repository\n%s: %s\n%s: value\n%s: 1",
+			PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, UpstreamRepositoryKey, UpstreamEntryIDKey, zero, customfields.Prefix+"INVALID", NumberKey),
 	}
 
 	for name, message := range invalid {

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -40,6 +41,9 @@ const (
 	UpstreamRepositoryKey  = "upstreamRepository"
 	UpstreamEntryIDKey     = "upstreamEntryID"
 
+	// CustomFieldPrefix identifies extension fields in an RSL entry.
+	CustomFieldPrefix = "custom."
+
 	remoteTrackerRef       = "refs/remotes/%s/gittuf/reference-state-log"
 	gittufNamespacePrefix  = "refs/gittuf/"
 	gittufPolicyStagingRef = "refs/gittuf/policy-staging"
@@ -54,6 +58,7 @@ var (
 	ErrInvalidGetLatestReferenceUpdaterEntryOptions = errors.New("invalid options presented for getting latest reference updater entry (are both before or until conditions set or is the before number less than the until number?)")
 	ErrCannotUseEntryNumberFilter                   = errors.New("current RSL entries are not numbered, cannot use number range options")
 	ErrInvalidUntilEntryNumberCondition             = errors.New("cannot meet until entry number condition")
+	ErrInvalidCustomFields                          = errors.New("invalid RSL custom fields")
 )
 
 // commitEntry commits an RSL entry: an empty-tree commit on Ref carrying the
@@ -80,6 +85,10 @@ func commitEntryUsingSpecificKey(storer gitstore.Storer, message string, signing
 	return err
 }
 
+// CustomFields contains signed, application-defined metadata stored in an RSL
+// entry. Keys begin with CustomFieldPrefix.
+type CustomFields map[string]string
+
 // RemoteTrackerRef returns the remote tracking ref for the specified remote's
 // name. For example, for 'origin', the remote tracker ref is
 // 'refs/remotes/origin/gittuf/reference-state-log'.
@@ -92,6 +101,7 @@ type Entry interface {
 	GetID() githash.Hash
 	Commit(gitstore.Storer, bool) error
 	GetNumber() uint64
+	GetCustomFields() CustomFields
 	createCommitMessage(bool) (string, error)
 }
 
@@ -118,11 +128,15 @@ type ReferenceEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
 // NewReferenceEntry returns a ReferenceEntry object for a normal RSL entry.
-func NewReferenceEntry(refName string, targetID githash.Hash) *ReferenceEntry {
-	return &ReferenceEntry{RefName: refName, TargetID: targetID}
+func NewReferenceEntry(refName string, targetID githash.Hash, opts ...EntryOption) *ReferenceEntry {
+	options := applyEntryOptions(opts)
+	return &ReferenceEntry{RefName: refName, TargetID: targetID, CustomFields: options.customFields}
 }
 
 func (e *ReferenceEntry) GetID() githash.Hash {
@@ -147,10 +161,12 @@ func (e *ReferenceEntry) Commit(storer gitstore.Storer, sign bool) error {
 		return err
 	}
 
-	message, _ := e.createCommitMessage(true) // we have an error return for annotations, always nil here
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
 
-	err := commitEntry(storer, message, sign)
-	return err
+	return commitEntry(storer, message, sign)
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
@@ -165,14 +181,20 @@ func (e *ReferenceEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingK
 		return err
 	}
 
-	message, _ := e.createCommitMessage(true) // we have an error return for annotations, always nil here
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
 
-	err := commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
-	return err
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
 }
 
 func (e *ReferenceEntry) GetNumber() uint64 {
 	return e.Number
+}
+
+func (e *ReferenceEntry) GetCustomFields() CustomFields {
+	return cloneCustomFields(e.CustomFields)
 }
 
 // Skipped returns true if any of the annotations mark the entry as
@@ -213,6 +235,10 @@ func (e *ReferenceEntry) createCommitMessage(includeNumber bool) (string, error)
 	if includeNumber && e.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, e.Number))
 	}
+	lines, err := appendCustomFields(lines, e.CustomFields)
+	if err != nil {
+		return "", err
+	}
 	return strings.Join(lines, "\n"), nil
 }
 
@@ -220,10 +246,12 @@ func (e *ReferenceEntry) createCommitMessage(includeNumber bool) (string, error)
 // producing a legacy unnumbered entry. It exists to exercise the RSL's support
 // for repositories that transition from unnumbered to numbered entries.
 func (e *ReferenceEntry) CommitWithoutNumber(storer gitstore.Storer) error {
-	message, _ := e.createCommitMessage(true) // we have an error return for annotations, always nil here
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
 
-	err := commitEntry(storer, message, false)
-	return err
+	return commitEntry(storer, message, false)
 }
 
 // AnnotationEntry is a type of RSL record that references prior items in the
@@ -245,12 +273,16 @@ type AnnotationEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
 // NewAnnotationEntry returns an Annotation object that applies to one or more
 // prior RSL entries.
-func NewAnnotationEntry(rslEntryIDs []githash.Hash, skip bool, message string) *AnnotationEntry {
-	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message}
+func NewAnnotationEntry(rslEntryIDs []githash.Hash, skip bool, message string, opts ...EntryOption) *AnnotationEntry {
+	options := applyEntryOptions(opts)
+	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message, CustomFields: options.customFields}
 }
 
 func (a *AnnotationEntry) GetID() githash.Hash {
@@ -315,6 +347,10 @@ func (a *AnnotationEntry) GetNumber() uint64 {
 	return a.Number
 }
 
+func (a *AnnotationEntry) GetCustomFields() CustomFields {
+	return cloneCustomFields(a.CustomFields)
+}
+
 // RefersTo returns true if the specified entryID is referred to by the
 // annotation.
 func (a *AnnotationEntry) RefersTo(entryID githash.Hash) bool {
@@ -361,6 +397,11 @@ func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error
 
 	if includeNumber && a.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, a.Number))
+	}
+
+	lines, err := appendCustomFields(lines, a.CustomFields)
+	if err != nil {
+		return "", err
 	}
 
 	if len(a.Message) != 0 {
@@ -422,14 +463,19 @@ type PropagationEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
-func NewPropagationEntry(refName string, targetID githash.Hash, upstreamRepository string, upstreamEntryID githash.Hash) *PropagationEntry {
+func NewPropagationEntry(refName string, targetID githash.Hash, upstreamRepository string, upstreamEntryID githash.Hash, opts ...EntryOption) *PropagationEntry {
+	options := applyEntryOptions(opts)
 	return &PropagationEntry{
 		RefName:            refName,
 		TargetID:           targetID,
 		UpstreamRepository: upstreamRepository,
 		UpstreamEntryID:    upstreamEntryID,
+		CustomFields:       options.customFields,
 	}
 }
 
@@ -455,10 +501,12 @@ func (e *PropagationEntry) Commit(storer gitstore.Storer, sign bool) error {
 		return err
 	}
 
-	message, _ := e.createCommitMessage(true) // we have an error return for annotations, always nil here
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
 
-	err := commitEntry(storer, message, sign)
-	return err
+	return commitEntry(storer, message, sign)
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
@@ -473,14 +521,20 @@ func (e *PropagationEntry) CommitUsingSpecificKey(storer gitstore.Storer, signin
 		return err
 	}
 
-	message, _ := e.createCommitMessage(true) // we have an error return for annotations, always nil here
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
 
-	err := commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
-	return err
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
 }
 
 func (e PropagationEntry) GetNumber() uint64 {
 	return e.Number
+}
+
+func (e *PropagationEntry) GetCustomFields() CustomFields {
+	return cloneCustomFields(e.CustomFields)
 }
 
 func (e *PropagationEntry) setEntryNumber(storer gitstore.Storer) error {
@@ -511,7 +565,91 @@ func (e *PropagationEntry) createCommitMessage(includeNumber bool) (string, erro
 	if includeNumber && e.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, e.Number))
 	}
+	lines, err := appendCustomFields(lines, e.CustomFields)
+	if err != nil {
+		return "", err
+	}
 	return strings.Join(lines, "\n"), nil
+}
+
+func applyEntryOptions(opts []EntryOption) *entryOptions {
+	options := &entryOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+	return options
+}
+
+func cloneCustomFields(fields CustomFields) CustomFields {
+	if fields == nil {
+		return nil
+	}
+	cloned := make(CustomFields, len(fields))
+	for key, value := range fields {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+// ValidateCustomFields checks that keys and values use only supported
+// characters. A key must begin with CustomFieldPrefix followed by one or more of
+// [A-Za-z0-9._/-]. A value may contain [A-Za-z0-9-+./,()]. It is enforced on
+// write. Readers accept whatever is stored.
+func ValidateCustomFields(fields CustomFields) error {
+	for key, value := range fields {
+		if !validCustomFieldKey(key) {
+			return fmt.Errorf("%w: invalid key %q", ErrInvalidCustomFields, key)
+		}
+		if !validCustomFieldValue(value) {
+			return fmt.Errorf("%w: invalid value for %q", ErrInvalidCustomFields, key)
+		}
+	}
+	return nil
+}
+
+func validCustomFieldKey(key string) bool {
+	if !strings.HasPrefix(key, CustomFieldPrefix) || len(key) == len(CustomFieldPrefix) {
+		return false
+	}
+	for _, character := range key[len(CustomFieldPrefix):] {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || strings.ContainsRune("._/-", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validCustomFieldValue(value string) bool {
+	for _, character := range value {
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' || strings.ContainsRune("-+./,()", character) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// appendCustomFields validates the fields, then appends them to lines sorted by
+// key so the encoding is deterministic.
+func appendCustomFields(lines []string, fields CustomFields) ([]string, error) {
+	if len(fields) == 0 {
+		return lines, nil
+	}
+	if err := ValidateCustomFields(fields); err != nil {
+		return nil, err
+	}
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		lines = append(lines, fmt.Sprintf("%s: %s", key, fields[key]))
+	}
+	return lines, nil
 }
 
 // GetEntry returns the entry corresponding to entryID.
@@ -1107,7 +1245,8 @@ func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
 // parseReferenceEntryText parses a reference entry as a state machine. The
 // fields must appear in the order ref, targetID, number, each at most once;
 // number is optional and trailing. Out-of-order fields and duplicates are
-// rejected. Unknown keys are ignored for forward compatibility.
+// rejected. Custom fields may appear in any order and use the first value when
+// repeated. Other unknown keys are ignored for forward compatibility.
 func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, error) {
 	body, err := entryBody(text, ReferenceEntryHeader)
 	if err != nil {
@@ -1155,6 +1294,11 @@ func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, err
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, CustomFieldPrefix) {
+				setCustomField(&entry.CustomFields, key, value)
+			}
 		}
 	}
 
@@ -1168,7 +1312,8 @@ func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, err
 // parseAnnotationEntryText parses an annotation entry as a state machine. One or
 // more entryID fields come first, followed by skip, then an optional number,
 // then an optional PEM message block. The message is decoded separately, so the
-// state machine stops at its begin marker.
+// state machine stops at its begin marker. Custom fields may appear in any
+// order and use the first value when repeated.
 func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, error) {
 	annotation := &AnnotationEntry{
 		ID:          id,
@@ -1242,6 +1387,11 @@ func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, e
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, CustomFieldPrefix) {
+				setCustomField(&annotation.CustomFields, key, value)
+			}
 		}
 	}
 
@@ -1255,6 +1405,7 @@ func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, e
 // parsePropagationEntryText parses a propagation entry as a state machine. The
 // fields must appear in the order ref, targetID, upstreamRepository,
 // upstreamEntryID, number, each at most once; number is optional and trailing.
+// Custom fields may appear in any order and use the first value when repeated.
 func parsePropagationEntryText(id githash.Hash, text string) (*PropagationEntry, error) {
 	body, err := entryBody(text, PropagationEntryHeader)
 	if err != nil {
@@ -1322,6 +1473,11 @@ func parsePropagationEntryText(id githash.Hash, text string) (*PropagationEntry,
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, CustomFieldPrefix) {
+				setCustomField(&entry.CustomFields, key, value)
+			}
 		}
 	}
 
@@ -1358,6 +1514,17 @@ func setNumber(dst *uint64, value string) error {
 	}
 	*dst = number
 	return nil
+}
+
+// setCustomField records a custom field parsed from an entry body. The first
+// value for a repeated key wins.
+func setCustomField(fields *CustomFields, key, value string) {
+	if *fields == nil {
+		*fields = CustomFields{}
+	} else if _, exists := (*fields)[key]; exists {
+		return
+	}
+	(*fields)[key] = value
 }
 
 func filterAnnotationsForRelevantAnnotations(allAnnotations []*AnnotationEntry, entryID githash.Hash) []*AnnotationEntry {

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -43,6 +44,17 @@ const (
 
 	// CustomFieldPrefix identifies extension fields in an RSL entry.
 	CustomFieldPrefix = "custom."
+
+	// maxCustomFieldKeyLength is the exclusive upper bound on a custom field
+	// key's length, including CustomFieldPrefix. A key must be shorter than this.
+	maxCustomFieldKeyLength = 250
+
+	// maxCustomFieldValueLength is the exclusive upper bound on a custom field
+	// value's length. A value must be shorter than this.
+	maxCustomFieldValueLength = 500
+
+	// maxCustomFieldCount bounds how many custom fields a single entry may carry.
+	maxCustomFieldCount = 20
 
 	remoteTrackerRef       = "refs/remotes/%s/gittuf/reference-state-log"
 	gittufNamespacePrefix  = "refs/gittuf/"
@@ -591,11 +603,27 @@ func cloneCustomFields(fields CustomFields) CustomFields {
 	return cloned
 }
 
-// ValidateCustomFields checks that keys and values use only supported
-// characters. A key must begin with CustomFieldPrefix followed by one or more of
-// [A-Za-z0-9._/-]. A value may contain [A-Za-z0-9-+./,()]. It is enforced on
-// write. Readers accept whatever is stored.
+// customFieldDomainLabel matches a single lowercase DNS label. customFieldName
+// matches a Kubernetes-style name segment: lowercase, starting and ending
+// alphanumeric, with '.', '_', and '-' allowed in between.
+var (
+	customFieldDomainLabel = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+	customFieldName        = regexp.MustCompile(`^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$`)
+)
+
+// ValidateCustomFields checks that the fields are well formed. A key must begin
+// with CustomFieldPrefix and follow the Kubernetes annotation convention: a
+// lowercase DNS subdomain (the namespace an application controls), a '/', and a
+// name of at most 63 lowercase characters starting and ending alphanumeric. The
+// whole key must be shorter than maxCustomFieldKeyLength. A value may contain
+// [A-Za-z0-9-+./,()_ ], must have no leading or trailing spaces, and be shorter
+// than maxCustomFieldValueLength. An entry carries at most maxCustomFieldCount
+// fields. It is enforced on write. On read, fields exceeding the length limits
+// are dropped and the count is capped.
 func ValidateCustomFields(fields CustomFields) error {
+	if len(fields) > maxCustomFieldCount {
+		return fmt.Errorf("%w: %d fields exceed the maximum of %d", ErrInvalidCustomFields, len(fields), maxCustomFieldCount)
+	}
 	for key, value := range fields {
 		if !validCustomFieldKey(key) {
 			return fmt.Errorf("%w: invalid key %q", ErrInvalidCustomFields, key)
@@ -608,23 +636,46 @@ func ValidateCustomFields(fields CustomFields) error {
 }
 
 func validCustomFieldKey(key string) bool {
-	if !strings.HasPrefix(key, CustomFieldPrefix) || len(key) == len(CustomFieldPrefix) {
+	if !strings.HasPrefix(key, CustomFieldPrefix) || len(key) >= maxCustomFieldKeyLength {
 		return false
 	}
-	for _, character := range key[len(CustomFieldPrefix):] {
-		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
-			character >= '0' && character <= '9' || strings.ContainsRune("._/-", character) {
-			continue
-		}
+	domain, name, ok := strings.Cut(key[len(CustomFieldPrefix):], "/")
+	if !ok {
 		return false
+	}
+	return validCustomFieldDomain(domain) && validCustomFieldNameSegment(name)
+}
+
+// validCustomFieldDomain reports whether domain is a lowercase DNS subdomain, as
+// Kubernetes requires for an annotation key's prefix.
+func validCustomFieldDomain(domain string) bool {
+	if len(domain) == 0 || len(domain) > 253 {
+		return false
+	}
+	for _, label := range strings.Split(domain, ".") {
+		if len(label) > 63 || !customFieldDomainLabel.MatchString(label) {
+			return false
+		}
 	}
 	return true
+}
+
+func validCustomFieldNameSegment(name string) bool {
+	return len(name) > 0 && len(name) <= 63 && customFieldName.MatchString(name)
 }
 
 func validCustomFieldValue(value string) bool {
+	if len(value) >= maxCustomFieldValueLength {
+		return false
+	}
+	// The parser trims each value, so a leading or trailing space would not
+	// round-trip and would desync from the signed bytes. Reject it on write.
+	if value != strings.TrimSpace(value) {
+		return false
+	}
 	for _, character := range value {
 		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' ||
-			character >= '0' && character <= '9' || strings.ContainsRune("-+./,()", character) {
+			character >= '0' && character <= '9' || strings.ContainsRune("-+./,()_ ", character) {
 			continue
 		}
 		return false
@@ -632,22 +683,29 @@ func validCustomFieldValue(value string) bool {
 	return true
 }
 
-// appendCustomFields validates the fields, then appends them to lines sorted by
-// key so the encoding is deterministic.
+// appendCustomFields drops empty values, validates the rest, then appends them
+// to lines sorted by key so the encoding is deterministic.
 func appendCustomFields(lines []string, fields CustomFields) ([]string, error) {
-	if len(fields) == 0 {
+	effective := make(CustomFields, len(fields))
+	for key, value := range fields {
+		if value == "" {
+			continue // empty values are dropped on write
+		}
+		effective[key] = value
+	}
+	if len(effective) == 0 {
 		return lines, nil
 	}
-	if err := ValidateCustomFields(fields); err != nil {
+	if err := ValidateCustomFields(effective); err != nil {
 		return nil, err
 	}
-	keys := make([]string, 0, len(fields))
-	for key := range fields {
+	keys := make([]string, 0, len(effective))
+	for key := range effective {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	for _, key := range keys {
-		lines = append(lines, fmt.Sprintf("%s: %s", key, fields[key]))
+		lines = append(lines, fmt.Sprintf("%s: %s", key, effective[key]))
 	}
 	return lines, nil
 }
@@ -1516,12 +1574,21 @@ func setNumber(dst *uint64, value string) error {
 	return nil
 }
 
-// setCustomField records a custom field parsed from an entry body. The first
-// value for a repeated key wins.
+// setCustomField records a custom field parsed from an entry body. Fields whose
+// key or value exceeds the maximum lengths are ignored, and no more than
+// maxCustomFieldCount fields are kept, so a crafted entry cannot force gittuf to
+// surface unbounded data. The first value for a repeated key wins.
 func setCustomField(fields *CustomFields, key, value string) {
+	if len(key) >= maxCustomFieldKeyLength || len(value) >= maxCustomFieldValueLength {
+		return
+	}
 	if *fields == nil {
 		*fields = CustomFields{}
-	} else if _, exists := (*fields)[key]; exists {
+	}
+	if _, exists := (*fields)[key]; exists {
+		return
+	}
+	if len(*fields) >= maxCustomFieldCount {
 		return
 	}
 	(*fields)[key] = value

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/gittuf/gittuf/pkg/gitstore"
 )
@@ -118,11 +119,15 @@ type ReferenceEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
 // NewReferenceEntry returns a ReferenceEntry object for a normal RSL entry.
-func NewReferenceEntry(refName string, targetID githash.Hash) *ReferenceEntry {
-	return &ReferenceEntry{RefName: refName, TargetID: targetID}
+func NewReferenceEntry(refName string, targetID githash.Hash, opts ...EntryOption) *ReferenceEntry {
+	options := applyEntryOptions(opts)
+	return &ReferenceEntry{RefName: refName, TargetID: targetID, CustomFields: options.customFields}
 }
 
 func (e *ReferenceEntry) GetID() githash.Hash {
@@ -179,6 +184,11 @@ func (e *ReferenceEntry) GetNumber() uint64 {
 	return e.Number
 }
 
+func (e *ReferenceEntry) GetCustomField(key string) (string, bool) {
+	value, has := e.CustomFields[key]
+	return value, has
+}
+
 // Skipped returns true if any of the annotations mark the entry as
 // to-be-skipped.
 func (e *ReferenceEntry) SkippedBy(annotations []*AnnotationEntry) bool {
@@ -227,6 +237,10 @@ func (e *ReferenceEntry) createCommitMessage(includeNumber bool) (string, error)
 	if includeNumber && e.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, e.Number))
 	}
+	lines, err := appendCustomFieldLines(lines, e.CustomFields)
+	if err != nil {
+		return "", err
+	}
 	return strings.Join(lines, "\n"), nil
 }
 
@@ -261,12 +275,16 @@ type AnnotationEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
 // NewAnnotationEntry returns an Annotation object that applies to one or more
 // prior RSL entries.
-func NewAnnotationEntry(rslEntryIDs []githash.Hash, skip bool, message string) *AnnotationEntry {
-	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message}
+func NewAnnotationEntry(rslEntryIDs []githash.Hash, skip bool, message string, opts ...EntryOption) *AnnotationEntry {
+	options := applyEntryOptions(opts)
+	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message, CustomFields: options.customFields}
 }
 
 func (a *AnnotationEntry) GetID() githash.Hash {
@@ -331,6 +349,11 @@ func (a *AnnotationEntry) GetNumber() uint64 {
 	return a.Number
 }
 
+func (a *AnnotationEntry) GetCustomField(key string) (string, bool) {
+	value, has := a.CustomFields[key]
+	return value, has
+}
+
 // RefersTo returns true if the specified entryID is referred to by the
 // annotation.
 func (a *AnnotationEntry) RefersTo(entryID githash.Hash) bool {
@@ -377,6 +400,11 @@ func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error
 
 	if includeNumber && a.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, a.Number))
+	}
+
+	lines, err := appendCustomFieldLines(lines, a.CustomFields)
+	if err != nil {
+		return "", err
 	}
 
 	if len(a.Message) != 0 {
@@ -438,14 +466,19 @@ type PropagationEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
-func NewPropagationEntry(refName string, targetID githash.Hash, upstreamRepository string, upstreamEntryID githash.Hash) *PropagationEntry {
+func NewPropagationEntry(refName string, targetID githash.Hash, upstreamRepository string, upstreamEntryID githash.Hash, opts ...EntryOption) *PropagationEntry {
+	options := applyEntryOptions(opts)
 	return &PropagationEntry{
 		RefName:            refName,
 		TargetID:           targetID,
 		UpstreamRepository: upstreamRepository,
 		UpstreamEntryID:    upstreamEntryID,
+		CustomFields:       options.customFields,
 	}
 }
 
@@ -503,6 +536,11 @@ func (e PropagationEntry) GetNumber() uint64 {
 	return e.Number
 }
 
+func (e *PropagationEntry) GetCustomField(key string) (string, bool) {
+	value, has := e.CustomFields[key]
+	return value, has
+}
+
 func (e *PropagationEntry) setEntryNumber(storer gitstore.Storer) error {
 	latestEntry, err := GetLatestEntry(storer)
 	if err == nil {
@@ -537,7 +575,19 @@ func (e *PropagationEntry) createCommitMessage(includeNumber bool) (string, erro
 	if includeNumber && e.Number > 0 {
 		lines = append(lines, fmt.Sprintf("%s: %d", NumberKey, e.Number))
 	}
+	lines, err := appendCustomFieldLines(lines, e.CustomFields)
+	if err != nil {
+		return "", err
+	}
 	return strings.Join(lines, "\n"), nil
+}
+
+func applyEntryOptions(opts []EntryOption) *entryOptions {
+	options := &entryOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+	return options
 }
 
 // GetEntry returns the entry corresponding to entryID.
@@ -1133,7 +1183,9 @@ func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
 // parseReferenceEntryText parses a reference entry as a state machine. The
 // fields must appear in the order ref, targetID, number, each at most once;
 // number is optional and trailing. Out-of-order fields and duplicates are
-// rejected. Unknown keys are ignored for forward compatibility.
+// rejected. Custom fields must appear after the built-in fields. Among
+// themselves, they may appear in any order and use the first value when
+// repeated. Other unknown keys are ignored for forward compatibility.
 func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, error) {
 	body, err := entryBody(text, ReferenceEntryHeader)
 	if err != nil {
@@ -1181,6 +1233,15 @@ func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, err
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, customfields.Prefix) {
+				if state < expectNumber {
+					return nil, ErrInvalidRSLEntry
+				}
+				state = done
+				setCustomField(&entry.CustomFields, key, value)
+			}
 		}
 	}
 
@@ -1194,7 +1255,9 @@ func parseReferenceEntryText(id githash.Hash, text string) (*ReferenceEntry, err
 // parseAnnotationEntryText parses an annotation entry as a state machine. One or
 // more entryID fields come first, followed by skip, then an optional number,
 // then an optional PEM message block. The message is decoded separately, so the
-// state machine stops at its begin marker.
+// state machine stops at its begin marker. Custom fields must appear after the
+// built-in fields and before the message block. Among themselves they may
+// appear in any order and use the first value when repeated.
 func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, error) {
 	annotation := &AnnotationEntry{
 		ID:          id,
@@ -1268,6 +1331,15 @@ func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, e
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, customfields.Prefix) {
+				if state < expectNumber {
+					return nil, ErrInvalidRSLEntry
+				}
+				state = done
+				setCustomField(&annotation.CustomFields, key, value)
+			}
 		}
 	}
 
@@ -1281,6 +1353,8 @@ func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, e
 // parsePropagationEntryText parses a propagation entry as a state machine. The
 // fields must appear in the order ref, targetID, upstreamRepository,
 // upstreamEntryID, number, each at most once; number is optional and trailing.
+// Custom fields must appear after the built-in fields. Among themselves they
+// may appear in any order and use the first value when repeated.
 func parsePropagationEntryText(id githash.Hash, text string) (*PropagationEntry, error) {
 	body, err := entryBody(text, PropagationEntryHeader)
 	if err != nil {
@@ -1348,6 +1422,15 @@ func parsePropagationEntryText(id githash.Hash, text string) (*PropagationEntry,
 				return nil, err
 			}
 			state = done
+
+		default:
+			if strings.HasPrefix(key, customfields.Prefix) {
+				if state < expectNumber {
+					return nil, ErrInvalidRSLEntry
+				}
+				state = done
+				setCustomField(&entry.CustomFields, key, value)
+			}
 		}
 	}
 

--- a/pkg/rsl/rsl_test.go
+++ b/pkg/rsl/rsl_test.go
@@ -9,8 +9,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsRelevantGittufRef(t *testing.T) {
@@ -551,6 +553,47 @@ func TestParseRSLEntryTextForwardCompatibility(t *testing.T) {
 			assert.Equal(t, test.expectedEntry, entry)
 		})
 	}
+}
+
+func TestParseRSLEntryTextTreatsEmptyCustomFieldValueAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+	emptyKey := customfields.Prefix + "example.com/empty"
+	setKey := customfields.Prefix + "example.com/set"
+
+	// A canonical writer never emits an empty value, so an entry carrying one
+	// must not report the field as set: the value would not round-trip.
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s:\n%s: %s",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, emptyKey, setKey, "value")
+
+	entry, err := parseRSLEntryText(githash.ZeroHash, message)
+	require.NoError(t, err)
+
+	value, has := entry.(*ReferenceEntry).GetCustomField(emptyKey)
+	assert.False(t, has)
+	assert.Empty(t, value)
+
+	value, has = entry.(*ReferenceEntry).GetCustomField(setKey)
+	assert.True(t, has)
+	assert.Equal(t, "value", value)
+}
+
+func TestParseRSLEntryTextEmptyCustomFieldValueDoesNotShadow(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+	key := customfields.Prefix + "example.com/field"
+
+	message := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s:\n%s: %s",
+		ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, zero, key, key, "value")
+
+	entry, err := parseRSLEntryText(githash.ZeroHash, message)
+	require.NoError(t, err)
+
+	value, has := entry.(*ReferenceEntry).GetCustomField(key)
+	assert.True(t, has)
+	assert.Equal(t, "value", value)
 }
 
 const (


### PR DESCRIPTION
## Description

Add support for application-defined custom.* fields in RSL entries. This enables applications to enrich gittuf objects with signed, tamper-evident data, backed by the cryptographic assurances inherent in gittuf.

Keys and values are restricted to a supported character set, enforced on write. For readers, a field whose key or value falls outside the grammar is dropped rather than failing the entry, at most `MaxCount` fields are kept, and the first value for a repeated key wins, so a crafted entry cannot surface unbounded or non-canonical data while traversal still succeeds.

## AI Usage

- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Opus 4.8 was used mostly around prototyping and testing. All changes were then reviewed, manually tested and verified.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
