### PR TITLE
Add fuzz tests for decoders

### DIFF
--- a/internal/attestations/authorizations/v01/fuzz_test.go
+++ b/internal/attestations/authorizations/v01/fuzz_test.go
@@ -1,0 +1,29 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"encoding/base64"
+	"testing"
+
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+)
+
+func FuzzValidate(f *testing.F) {
+	f.Add([]byte(``), "", "", "")
+	f.Add([]byte(`not json`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[null]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}],"predicate":null}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}],"predicate":{"targetTreeID":"abc","fromRevisionID":"def","targetRef":"refs/heads/main"}}`), "refs/heads/main", "def", "abc")
+
+	f.Fuzz(func(_ *testing.T, payload []byte, targetRef, fromRevisionID, targetTreeID string) {
+		env := &sslibdsse.Envelope{
+			Payload: base64.StdEncoding.EncodeToString(payload),
+		}
+		_ = Validate(env, targetRef, fromRevisionID, targetTreeID)
+	})
+}

--- a/internal/attestations/authorizations/v01/v01.go
+++ b/internal/attestations/authorizations/v01/v01.go
@@ -84,7 +84,15 @@ func Validate(env *sslibdsse.Envelope, targetRef, fromRevisionID, targetTreeID s
 		return err
 	}
 
+	if len(attestation.Subject) == 0 || attestation.Subject[0] == nil {
+		return authorizations.ErrInvalidAuthorization
+	}
+
 	if attestation.Subject[0].Digest[digestGitTreeKey] != targetTreeID {
+		return authorizations.ErrInvalidAuthorization
+	}
+
+	if attestation.Predicate == nil {
 		return authorizations.ErrInvalidAuthorization
 	}
 

--- a/internal/attestations/authorizations/v02/fuzz_test.go
+++ b/internal/attestations/authorizations/v02/fuzz_test.go
@@ -1,0 +1,30 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/base64"
+	"testing"
+
+	sslibdsse "github.com/gittuf/gittuf/internal/third_party/go-securesystemslib/dsse"
+)
+
+func FuzzValidate(f *testing.F) {
+	f.Add([]byte(``), "", "", "")
+	f.Add([]byte(`not json`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[null]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}]}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}],"predicate":null}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitTree":"abc"}}],"predicate":{"targetID":"abc","fromID":"def","targetRef":"refs/heads/main"}}`), "refs/heads/main", "def", "abc")
+	f.Add([]byte(`{"subject":[{"digest":{"gitCommit":"abc"}}],"predicate":{"targetID":"abc","fromID":"def","targetRef":"refs/tags/v1"}}`), "refs/tags/v1", "def", "abc")
+
+	f.Fuzz(func(_ *testing.T, payload []byte, targetRef, fromID, targetID string) {
+		env := &sslibdsse.Envelope{
+			Payload: base64.StdEncoding.EncodeToString(payload),
+		}
+		_ = Validate(env, targetRef, fromID, targetID)
+	})
+}

--- a/internal/attestations/authorizations/v02/v02.go
+++ b/internal/attestations/authorizations/v02/v02.go
@@ -107,6 +107,10 @@ func Validate(env *sslibdsse.Envelope, targetRef, fromID, targetID string) error
 		return err
 	}
 
+	if len(attestation.Subject) == 0 || attestation.Subject[0] == nil {
+		return authorizations.ErrInvalidAuthorization
+	}
+
 	subjectDigest, hasGitTree := attestation.Subject[0].Digest[digestGitTreeKey]
 	if hasGitTree {
 		if subjectDigest != targetID {
@@ -125,6 +129,10 @@ func Validate(env *sslibdsse.Envelope, targetRef, fromID, targetID string) error
 		if !strings.HasPrefix(targetRef, gitinterface.TagRefPrefix) {
 			return authorizations.ErrInvalidAuthorization
 		}
+	}
+
+	if attestation.Predicate == nil {
+		return authorizations.ErrInvalidAuthorization
 	}
 
 	predicate := attestation.Predicate.AsMap()

--- a/internal/common/set/fuzz_test.go
+++ b/internal/common/set/fuzz_test.go
@@ -1,0 +1,21 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package set
+
+import "testing"
+
+func FuzzSetUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`[]`))
+	f.Add([]byte(`["a","b","a"]`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(``))
+	f.Add([]byte(`not json`))
+	f.Add([]byte(`{"a":1}`))
+	f.Add([]byte(`[1,2,3]`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		s := NewSet[string]()
+		_ = s.UnmarshalJSON(data)
+	})
+}

--- a/internal/git-remote-gittuf/fuzz_test.go
+++ b/internal/git-remote-gittuf/fuzz_test.go
@@ -1,0 +1,76 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bufio"
+	"errors"
+	"testing"
+)
+
+// checkSplitContract verifies the bufio.SplitFunc contract: on success the
+// advance count must stay within the buffer. bufio.Scanner panics otherwise,
+// so a violation here is a real bug. advance must never be negative, even when
+// returning an error, so that invariant is checked before the error path.
+func checkSplitContract(t *testing.T, advance int, token []byte, err error, data []byte) {
+	t.Helper()
+
+	if advance < 0 {
+		t.Fatalf("advance %d is negative", advance)
+	}
+
+	if err != nil && !errors.Is(err, bufio.ErrFinalToken) {
+		return
+	}
+
+	if advance < 0 || advance > len(data) {
+		t.Fatalf("advance %d out of bounds for data of length %d", advance, len(data))
+	}
+
+	if len(token) > len(data) {
+		t.Fatalf("token length %d exceeds data length %d", len(token), len(data))
+	}
+}
+
+func FuzzSplitInput(f *testing.F) {
+	f.Add([]byte(""), false)
+	f.Add([]byte("hello\n"), false)
+	f.Add([]byte("hello\r\n"), false)
+	f.Add([]byte("no newline"), true)
+	f.Add(append([]byte{}, flushPkt...), false)
+
+	f.Fuzz(func(t *testing.T, data []byte, atEOF bool) {
+		advance, token, err := splitInput(data, atEOF)
+		checkSplitContract(t, advance, token, err, data)
+	})
+}
+
+func FuzzSplitOutput(f *testing.F) {
+	f.Add([]byte(""), false)
+	f.Add([]byte("hello\n"), false)
+	f.Add([]byte("hello\r\n"), true)
+	f.Add([]byte("no newline"), true)
+	f.Add(append([]byte{}, flushPkt...), false)
+
+	f.Fuzz(func(t *testing.T, data []byte, atEOF bool) {
+		advance, token, err := splitOutput(data, atEOF)
+		checkSplitContract(t, advance, token, err, data)
+	})
+}
+
+func FuzzSplitPacket(f *testing.F) {
+	f.Add([]byte(""), false)
+	f.Add([]byte("0000"), false)
+	f.Add([]byte("0006ok"), false)
+	f.Add([]byte("00zz"), false)      // invalid hex length
+	f.Add([]byte("-001"), false)      // negative length via leading sign
+	f.Add([]byte("0003"), false)      // length shorter than its own header
+	f.Add([]byte("ffffshort"), false) // length larger than buffer
+	f.Add(append([]byte{}, flushPkt...), true)
+
+	f.Fuzz(func(t *testing.T, data []byte, atEOF bool) {
+		advance, token, err := splitPacket(data, atEOF)
+		checkSplitContract(t, advance, token, err, data)
+	})
+}

--- a/internal/git-remote-gittuf/split.go
+++ b/internal/git-remote-gittuf/split.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"strconv"
 )
 
@@ -88,10 +89,19 @@ func splitPacket(data []byte, atEOF bool) (int, []byte, error) {
 
 	length, err := strconv.ParseInt(string(lengthB), 16, 64)
 	if err != nil {
-		return -1, nil, err
+		return 0, nil, err
 	}
 
 	l := int(length)
+	if l < 4 {
+		// A data packet's length includes its own four length bytes, so any
+		// value below 4 is malformed. The zero-length control packets are
+		// already handled above. strconv.ParseInt also accepts a leading
+		// sign, so this rejects negative lengths that would otherwise slice
+		// out of range.
+		return 0, nil, fmt.Errorf("invalid packet length %q", string(lengthB))
+	}
+
 	if l > len(data) {
 		return 0, nil, nil // request more in a new buffer
 	}

--- a/internal/signerverifier/gpg/fuzz_test.go
+++ b/internal/signerverifier/gpg/fuzz_test.go
@@ -1,0 +1,17 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gpg
+
+import "testing"
+
+func FuzzLoadGPGKeyFromBytes(f *testing.F) {
+	f.Add([]byte(""))
+	f.Add([]byte("not a key"))
+	f.Add([]byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\n\n-----END PGP PUBLIC KEY BLOCK-----\n"))
+	f.Add([]byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\ngarbage\n-----END PGP PUBLIC KEY BLOCK-----\n"))
+
+	f.Fuzz(func(_ *testing.T, contents []byte) {
+		_, _ = LoadGPGKeyFromBytes(contents)
+	})
+}

--- a/internal/signerverifier/gpg/gpg.go
+++ b/internal/signerverifier/gpg/gpg.go
@@ -125,6 +125,10 @@ func LoadGPGKeyFromBytes(contents []byte) (*signerverifier.SSLibKey, error) {
 		return nil, err
 	}
 
+	if len(keyring) == 0 {
+		return nil, fmt.Errorf("no GPG keys found in armored input")
+	}
+
 	// TODO: check if this is correct for subkeys
 	fingerprint := fmt.Sprintf("%x", keyring[0].PrimaryKey.Fingerprint)
 	key := strings.TrimSpace(string(contents))

--- a/internal/signerverifier/sigstore/fuzz_test.go
+++ b/internal/signerverifier/sigstore/fuzz_test.go
@@ -1,0 +1,23 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sigstore
+
+import "testing"
+
+func FuzzStringAsBoolUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`true`))
+	f.Add([]byte(`"true"`))
+	f.Add([]byte(`True`))
+	f.Add([]byte(`"True"`))
+	f.Add([]byte(`false`))
+	f.Add([]byte(`"false"`))
+	f.Add([]byte(``))
+	f.Add([]byte(`1`))
+	f.Add([]byte(`"maybe"`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		var b stringAsBool
+		_ = b.UnmarshalJSON(data)
+	})
+}

--- a/internal/third_party/go-securesystemslib/dsse/fuzz_test.go
+++ b/internal/third_party/go-securesystemslib/dsse/fuzz_test.go
@@ -1,0 +1,27 @@
+package dsse
+
+import "testing"
+
+func FuzzB64Decode(f *testing.F) {
+	f.Add("")
+	f.Add("aGVsbG8=")      // "hello", standard encoding
+	f.Add("aGVsbG8")       // missing padding
+	f.Add("_-_-")          // URL-safe alphabet
+	f.Add("+/+/")          // standard alphabet
+	f.Add("!!!invalid!!!") // not base64 at all
+
+	f.Fuzz(func(_ *testing.T, s string) {
+		_, _ = b64Decode(s)
+	})
+}
+
+func FuzzDecodeB64Payload(f *testing.F) {
+	f.Add("")
+	f.Add("aGVsbG8=")
+	f.Add("eyJhIjoxfQ==") // {"a":1}
+
+	f.Fuzz(func(_ *testing.T, payload string) {
+		env := &Envelope{Payload: payload}
+		_, _ = env.DecodeB64Payload()
+	})
+}

--- a/internal/tuf/fuzz_test.go
+++ b/internal/tuf/fuzz_test.go
@@ -1,0 +1,45 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tuf
+
+import "testing"
+
+func FuzzHookStageUnmarshalText(f *testing.F) {
+	f.Add([]byte(HookStagePreCommitString))
+	f.Add([]byte(HookStagePrePushString))
+	f.Add([]byte(""))
+	f.Add([]byte("invalid"))
+
+	f.Fuzz(func(_ *testing.T, text []byte) {
+		var h HookStage
+		_ = h.UnmarshalText(text)
+	})
+}
+
+func FuzzHookStageUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"` + HookStagePreCommitString + `"`))
+	f.Add([]byte(`"` + HookStagePrePushString + `"`))
+	f.Add([]byte(`"invalid"`))
+	f.Add([]byte(`123`))
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		var h HookStage
+		_ = h.UnmarshalJSON(data)
+	})
+}
+
+func FuzzHookEnvironmentUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"` + HookEnvironmentLuaString + `"`))
+	f.Add([]byte(`"invalid"`))
+	f.Add([]byte(`123`))
+	f.Add([]byte(``))
+	f.Add([]byte(`null`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		var h HookEnvironment
+		_ = h.UnmarshalJSON(data)
+	})
+}

--- a/internal/tuf/v01/fuzz_test.go
+++ b/internal/tuf/v01/fuzz_test.go
@@ -1,0 +1,27 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v01
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzRootMetadataUnmarshalJSON(f *testing.F) {
+	if data, err := json.Marshal(NewRootMetadata()); err == nil {
+		f.Add(data)
+	}
+
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"type":"root","globalRules":[{}]}`))
+	f.Add([]byte(`{"type":"root","propagations":[{}]}`))
+	f.Add([]byte(`{"keys":{"a":{"keyid":"a"}},"roles":{}}`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		r := &RootMetadata{}
+		_ = r.UnmarshalJSON(data)
+	})
+}

--- a/internal/tuf/v01/root.go
+++ b/internal/tuf/v01/root.go
@@ -722,7 +722,7 @@ func (r *RootMetadata) UnmarshalJSON(data []byte) error {
 	}
 
 	temp := &tempType{}
-	if err := json.Unmarshal(data, &temp); err != nil {
+	if err := json.Unmarshal(data, temp); err != nil {
 		return fmt.Errorf("unable to unmarshal json: %w", err)
 	}
 

--- a/internal/tuf/v02/fuzz_test.go
+++ b/internal/tuf/v02/fuzz_test.go
@@ -1,0 +1,55 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package v02
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzRootMetadataUnmarshalJSON(f *testing.F) {
+	if data, err := json.Marshal(NewRootMetadata()); err == nil {
+		f.Add(data)
+	}
+
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"type":"root","schemaVersion":"https://gittuf.dev/root/v0.2","principals":{"a":{"keyid":"a"}}}`))
+	f.Add([]byte(`{"type":"root","globalRules":[{}],"propagations":[{}]}`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		r := &RootMetadata{}
+		_ = r.UnmarshalJSON(data)
+	})
+}
+
+func FuzzDelegationsUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"principals":{},"roles":[]}`))
+	f.Add([]byte(`{"principals":{"k":{"keyid":"abc"}},"roles":[]}`))
+	f.Add([]byte(`{"principals":{"p":{"personID":"x"}},"roles":[]}`))
+	f.Add([]byte(`{"principals":{"p":{}},"roles":[]}`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		d := &Delegations{}
+		_ = d.UnmarshalJSON(data)
+	})
+}
+
+func FuzzOtherRepositoryUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`null`))
+	f.Add([]byte(`{"name":"repo","location":"https://example.com","initialRootPrincipals":[]}`))
+	f.Add([]byte(`{"name":"repo","initialRootPrincipals":[{"keyid":"abc"}]}`))
+	f.Add([]byte(`{"initialRootPrincipals":[{"personID":"x"}]}`))
+
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		o := &OtherRepository{}
+		_ = o.UnmarshalJSON(data)
+	})
+}

--- a/internal/tuf/v02/root.go
+++ b/internal/tuf/v02/root.go
@@ -378,7 +378,7 @@ func (r *RootMetadata) UnmarshalJSON(data []byte) error {
 	}
 
 	temp := &tempType{}
-	if err := json.Unmarshal(data, &temp); err != nil {
+	if err := json.Unmarshal(data, temp); err != nil {
 		return fmt.Errorf("unable to unmarshal json: %w", err)
 	}
 
@@ -924,7 +924,7 @@ func (o *OtherRepository) UnmarshalJSON(data []byte) error {
 	}
 
 	temp := &tempType{}
-	if err := json.Unmarshal(data, &temp); err != nil {
+	if err := json.Unmarshal(data, temp); err != nil {
 		return fmt.Errorf("unable to unmarshal json: %w", err)
 	}
 

--- a/pkg/githash/fuzz_test.go
+++ b/pkg/githash/fuzz_test.go
@@ -1,0 +1,21 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package githash
+
+import "testing"
+
+func FuzzNewHash(f *testing.F) {
+	f.Add("")
+	f.Add("not a hash")
+	f.Add("0000000000000000000000000000000000000000")
+	f.Add("abcdef12345678900987654321fedcbaabcdef12")
+	f.Add("ABCDEF12345678900987654321FEDCBAABCDEF12")
+	f.Add("0000000000000000000000000000000000000000000000000000000000000000")
+	f.Add("abcdef12345678900987654321fedcbaabcdef1234567890abcdef1234567890")
+	f.Add("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+
+	f.Fuzz(func(_ *testing.T, h string) {
+		_, _ = NewHash(h)
+	})
+}


### PR DESCRIPTION
## Description

Adds Go fuzz tests across the project's decoding paths and fixes four
panic bugs the fuzzers found on malformed input.

| Area | Target |
|------|--------|
| `pkg/githash` | `FuzzNewHash` |
| `internal/third_party/.../dsse` | `FuzzB64Decode`, `FuzzDecodeB64Payload` |
| `internal/git-remote-gittuf` | `FuzzSplitInput`, `FuzzSplitOutput`, `FuzzSplitPacket` |
| `internal/tuf` | `FuzzHookStageUnmarshalText`, `FuzzHookStageUnmarshalJSON`, `FuzzHookEnvironmentUnmarshalJSON` |
| `internal/tuf/v01` | `FuzzRootMetadataUnmarshalJSON` |
| `internal/tuf/v02` | `FuzzRootMetadataUnmarshalJSON`, `FuzzDelegationsUnmarshalJSON`, `FuzzOtherRepositoryUnmarshalJSON` |
| `internal/common/set` | `FuzzSetUnmarshalJSON` |
| `internal/signerverifier/gpg` | `FuzzLoadGPGKeyFromBytes` |
| `internal/signerverifier/sigstore` | `FuzzStringAsBoolUnmarshalJSON` |
| `internal/attestations/authorizations/v01` and `v02` | `FuzzValidate` |

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

The creation of the initial draft for the fuzz tests, which were then manually reviewed/adjusted.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
