### PR TITLE
Fix GitHub pullrequest token check

### DIFF
--- a/internal/cmd/attest/github/pullrequest/pullrequest_test.go
+++ b/internal/cmd/attest/github/pullrequest/pullrequest_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestPullRequest(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "")
+
 	t.Run("no repository", func(t *testing.T) {
 		tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Description

Makes a change to set GITHUB_TOKEN local env to null at the top of TestPullRequest so that the env var is isolated for all the subtests, made sure that it's consistent with all the other env var isolations in the other test cases to avoid config leakage.

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull
  request.

## Contributor Checklist

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
