### PR TITLE
test :- add navigation tests for verify UI

### DIFF
--- a/internal/cmd/tui/screen_verify_test.go
+++ b/internal/cmd/tui/screen_verify_test.go
@@ -1,0 +1,59 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+func TestVerifyUINavigation(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+	// Wait for home screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Send Down arrow to move to Trust
+	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+	time.Sleep(time.Millisecond * 50)
+
+	// Send Down arrow to move to Verify
+	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+	time.Sleep(time.Millisecond * 50)
+
+	// Enter Verify screen
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Verify menu screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Home › Verify")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Enter Verify Reference form
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Verify Reference form screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		s := string(out)
+		return strings.Contains(s, "Verify Reference") || strings.Contains(s, "Target Ref")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Send ctrl+c to quit (since 'q' is captured by form text inputs)
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*10))
+}

--- a/internal/cmd/tui/screen_verify_test.go
+++ b/internal/cmd/tui/screen_verify_test.go
@@ -28,13 +28,18 @@ func TestVerifyUINavigation(t *testing.T) {
 		return strings.Contains(string(out), "Policy")
 	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
 
-	// Send Down arrow to move to Trust
-	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-	time.Sleep(time.Millisecond * 50)
+	var verifyIndex int
+	for i, it := range m.homeScreen.choiceList.Items() {
+		if it.(item).title == "Verify" {
+			verifyIndex = i
+			break
+		}
+	}
 
-	// Send Down arrow to move to Verify
-	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-	time.Sleep(time.Millisecond * 50)
+	for i := 0; i < verifyIndex; i++ {
+		tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+		time.Sleep(time.Millisecond * 50)
+	}
 
 	// Enter Verify screen
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})


### PR DESCRIPTION
## Description

This PR introduces modular unit tests for the Terminal User Interface (TUI) Verify navigation screen in `internal/cmd/tui/screen_verify_test.go`. It verifies state transitions using `teatest` to ensure navigation correctly moves from the Home screen to the Verify menu and opens the Verify Reference form.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to assist in drafting and refining teatest navigation test cases for the TUI verify screen.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).