### PR TITLE
test :- add navigation and menu selection tests for policy screen

### DIFF
--- a/internal/cmd/tui/screen_policy_test.go
+++ b/internal/cmd/tui/screen_policy_test.go
@@ -1,0 +1,80 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+func TestPolicyUINavigationMenu(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenPolicy
+
+	// Test View rendering
+	viewStr := m.policyScreen.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy") {
+		t.Errorf("expected view to contain header Home › Policy, got %q", viewStr)
+	}
+
+	// Test selecting "View Rules" (first item, index 0)
+	updatedModel, _ := m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicyRules {
+		t.Errorf("expected screenPolicyRules, got %v", resModel.screen)
+	}
+
+	// Test selecting "Manage Principals" (second item, index 1)
+	m.policyScreen.policyScreenList.Select(1)
+	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyPrincipals {
+		t.Errorf("expected screenPolicyPrincipals, got %v", resModel.screen)
+	}
+
+	// Test selecting "Manage Lifecycle" (third item, index 2)
+	m.policyScreen.policyScreenList.Select(2)
+	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyLifecycle {
+		t.Errorf("expected screenPolicyLifecycle, got %v", resModel.screen)
+	}
+}
+
+func TestPolicyUINavigationInteractive(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+	// Wait for home screen Policy option
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Press Enter to navigate to Policy screen (Policy is 1st item)
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Policy screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Home › Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Quit with 'q' from non-form screen
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*10))
+}

--- a/internal/cmd/tui/screen_policy_test.go
+++ b/internal/cmd/tui/screen_policy_test.go
@@ -9,9 +9,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 )
+
+func selectItemByTitle(t *testing.T, l *list.Model, title string) {
+	t.Helper()
+	for i, it := range l.Items() {
+		if item, ok := it.(item); ok && item.title == title {
+			l.Select(i)
+			return
+		}
+	}
+	t.Fatalf("menu item %q not found", title)
+}
 
 func TestPolicyUINavigationMenu(t *testing.T) {
 	o := &options{
@@ -28,27 +40,31 @@ func TestPolicyUINavigationMenu(t *testing.T) {
 		t.Errorf("expected view to contain header Home › Policy, got %q", viewStr)
 	}
 
-	// Test selecting "View Rules" (first item, index 0)
+	// Test selecting "View Rules"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "View Rules")
 	updatedModel, _ := m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
 	resModel := updatedModel.(model)
 	if resModel.screen != screenPolicyRules {
-		t.Errorf("expected screenPolicyRules, got %v", resModel.screen)
+		t.Errorf("expected screenPolicyRules (%v), got %v", screenPolicyRules, resModel.screen)
 	}
 
-	// Test selecting "Manage Principals" (second item, index 1)
-	m.policyScreen.policyScreenList.Select(1)
+	// Test selecting "Manage Principals"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "Manage Principals")
 	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
 	resModel = updatedModel.(model)
 	if resModel.screen != screenPolicyPrincipals {
-		t.Errorf("expected screenPolicyPrincipals, got %v", resModel.screen)
+		t.Errorf("expected screenPolicyPrincipals (%v), got %v", screenPolicyPrincipals, resModel.screen)
 	}
 
-	// Test selecting "Manage Lifecycle" (third item, index 2)
-	m.policyScreen.policyScreenList.Select(2)
+	// Test selecting "Manage Lifecycle"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "Manage Lifecycle")
 	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
 	resModel = updatedModel.(model)
 	if resModel.screen != screenPolicyLifecycle {
-		t.Errorf("expected screenPolicyLifecycle, got %v", resModel.screen)
+		t.Errorf("expected screenPolicyLifecycle (%v), got %v", screenPolicyLifecycle, resModel.screen)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR introduces comprehensive unit tests for the Policy menu screen in `internal/cmd/tui/screen_policy_test.go`. It achieves 100% statement coverage on `screen_policy.go` by verifying view rendering and menu item selection state transitions ("View Rules", "Manage Principals", "Manage Lifecycle").

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to draft unit test cases for Policy screen menu selection and teatest navigation.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).