### PR TITLE
test :- add unit tests for trust main menu screen

### DIFF
--- a/internal/cmd/tui/screen_trust_test.go
+++ b/internal/cmd/tui/screen_trust_test.go
@@ -9,10 +9,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
 	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 )
+
+func selectItemByTitle(t *testing.T, l *list.Model, title string) {
+	t.Helper()
+	for i, it := range l.Items() {
+		if item, ok := it.(item); ok && item.title == title {
+			l.Select(i)
+			return
+		}
+	}
+	t.Fatalf("menu item %q not found", title)
+}
 
 func TestTrustScreenMenuSelectionAndRendering(t *testing.T) {
 	o := &options{
@@ -31,11 +43,12 @@ func TestTrustScreenMenuSelectionAndRendering(t *testing.T) {
 		t.Errorf("expected view to contain header Home › Trust, got %q", viewStr)
 	}
 
-	// Test pressing Enter to select View Global Rules
+	// Test selecting "View Global Rules"
+	selectItemByTitle(t, &s.trustScreenList, "View Global Rules")
 	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
 	resModel := updatedModel.(model)
 	if resModel.screen != screenTrustGlobalRules {
-		t.Errorf("expected screenTrustGlobalRules, got %v", resModel.screen)
+		t.Errorf("expected screenTrustGlobalRules (%v), got %v", screenTrustGlobalRules, resModel.screen)
 	}
 }
 
@@ -54,9 +67,21 @@ func TestTrustScreenInteractiveNavigation(t *testing.T) {
 		return strings.Contains(string(out), "Policy")
 	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
 
-	// Move down to Trust option and press Enter
-	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
-	time.Sleep(time.Millisecond * 50)
+	// Dynamically calculate number of Down presses to reach "Trust"
+	var trustIndex int
+	for i, it := range m.homeScreen.choiceList.Items() {
+		if it.(item).title == "Trust" {
+			trustIndex = i
+			break
+		}
+	}
+
+	for i := 0; i < trustIndex; i++ {
+		tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+		time.Sleep(time.Millisecond * 50)
+	}
+
+	// Press Enter to enter Trust screen
 	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 
 	// Wait for Trust screen

--- a/internal/cmd/tui/screen_trust_test.go
+++ b/internal/cmd/tui/screen_trust_test.go
@@ -1,0 +1,70 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestTrustScreenMenuSelectionAndRendering(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenTrust
+	s := &m.trustScreen
+
+	// Test View rendering
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home › Trust") {
+		t.Errorf("expected view to contain header Home › Trust, got %q", viewStr)
+	}
+
+	// Test pressing Enter to select View Global Rules
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenTrustGlobalRules {
+		t.Errorf("expected screenTrustGlobalRules, got %v", resModel.screen)
+	}
+}
+
+func TestTrustScreenInteractiveNavigation(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+	// Wait for home screen Policy option
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Move down to Trust option and press Enter
+	tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+	time.Sleep(time.Millisecond * 50)
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Trust screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Home › Trust")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Quit with 'q' from non-form screen
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*10))
+}


### PR DESCRIPTION
## Description

This PR introduces unit tests for the Trust main menu screen in `internal/cmd/tui/screen_trust_test.go`. It achieves 100% statement coverage on `screen_trust.go`, testing menu item selection, state transition to `screenTrustGlobalRules`, view rendering, and teatest interactive navigation.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to assist in drafting unit test cases for the trust menu selection and teatest interactive flow.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).