### PR TITLE
test :- add unit tests for trust helper functions

### DIFF
--- a/internal/cmd/tui/trusthelpers_test.go
+++ b/internal/cmd/tui/trusthelpers_test.go
@@ -1,0 +1,81 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/tuf"
+)
+
+func TestGetGlobalRulesNonExistentRepo(t *testing.T) {
+	o := &options{
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: ""},
+	}
+
+	rules := getGlobalRules(context.Background(), o)
+	if len(rules) != 0 {
+		t.Errorf("expected 0 global rules for non-existent repo, got %d", len(rules))
+	}
+}
+
+func TestRepoAddGlobalRuleNoRepoError(t *testing.T) {
+	o := &options{
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: ""},
+	}
+
+	ctx := context.Background()
+
+	grThreshold := globalRule{
+		ruleName:     "my-threshold",
+		ruleType:     tuf.GlobalRuleThresholdType,
+		rulePatterns: []string{"refs/heads/*"},
+		threshold:    1,
+	}
+
+	err := repoAddGlobalRule(ctx, o, grThreshold)
+	if err == nil {
+		t.Error("expected error when adding global rule without repo, got nil")
+	}
+}
+
+func TestRepoUpdateGlobalRuleNoRepoError(t *testing.T) {
+	o := &options{
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: ""},
+	}
+
+	ctx := context.Background()
+
+	grBlock := globalRule{
+		ruleName:     "my-block",
+		ruleType:     tuf.GlobalRuleBlockForcePushesType,
+		rulePatterns: []string{"refs/heads/main"},
+	}
+
+	err := repoUpdateGlobalRule(ctx, o, grBlock)
+	if err == nil {
+		t.Error("expected error when updating global rule without repo, got nil")
+	}
+}
+
+func TestRepoRemoveGlobalRuleNoRepoError(t *testing.T) {
+	o := &options{
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: ""},
+	}
+
+	gr := globalRule{
+		ruleName: "test-rule",
+	}
+
+	err := repoRemoveGlobalRule(context.Background(), o, gr)
+	if err == nil {
+		t.Error("expected error when removing global rule without repo, got nil")
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces unit tests for Trust helper functions in `internal/cmd/tui/trusthelpers_test.go`. It tests `getGlobalRules`, `repoAddGlobalRule`, `repoUpdateGlobalRule`, and `repoRemoveGlobalRule` under non-existent repository and error validation paths.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to assist in drafting unit test cases for trust helper repository interaction functions and error assertion logic.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).