### PR TITLE
test :- add unit tests for home screen

### DIFF
--- a/internal/cmd/tui/screen_home_test.go
+++ b/internal/cmd/tui/screen_home_test.go
@@ -1,0 +1,66 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestHomeScreenMenuSelections(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.homeScreen
+	m.screen = screenChoice
+
+	// 1. Select Policy
+	s.choiceList = list.New([]list.Item{item{title: "Policy"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicy {
+		t.Errorf("expected screenPolicy, got %v", resModel.screen)
+	}
+
+	// 2. Select Trust
+	s.choiceList = list.New([]list.Item{item{title: "Trust"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenTrust {
+		t.Errorf("expected screenTrust, got %v", resModel.screen)
+	}
+
+	// 3. Select Verify
+	s.choiceList = list.New([]list.Item{item{title: "Verify"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenVerify {
+		t.Errorf("expected screenVerify, got %v", resModel.screen)
+	}
+}
+
+func TestHomeScreenViewRendering(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.homeScreen
+
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home") {
+		t.Errorf("expected view to contain 'Home', got %q", viewStr)
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces unit tests for the Home screen in `internal/cmd/tui/screen_home_test.go`. It achieves 100% statement coverage on `screen_home.go`, testing menu item selections ("Policy", "Trust", "Verify") and view rendering.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Used AI to assist in drafting unit test cases for home screen menu navigation and view rendering.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).