### PR TITLE
test :- add unit tests and fixes for policy TUI screens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,8 @@ jobs:
           pkg update -f
           pkg install -y git wget gnupg
 
+          git config --global --add safe.directory "*"
+
           wget https://go.dev/dl/go1.26.1.freebsd-amd64.tar.gz
           tar -C /usr/local -xzf go1.26.1.freebsd-amd64.tar.gz
 

--- a/internal/cmd/tui/model.go
+++ b/internal/cmd/tui/model.go
@@ -201,6 +201,7 @@ func initialModel(ctx context.Context, o *options) model {
 		cursorMode:  cursor.CursorBlink,
 		policyName:  o.policyName,
 		options:     o,
+		readOnly:    o.readOnly,
 		logViewport: viewport.New(80, 20),
 		logsBuf:     &strings.Builder{},
 

--- a/internal/cmd/tui/screen_policy_lifecycle.go
+++ b/internal/cmd/tui/screen_policy_lifecycle.go
@@ -130,6 +130,10 @@ func (s *policyLifecycleScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.Cm
 				s.cycleFocus(keyMsg.String())
 				m.footer = ""
 				return *m, nil
+			case "esc":
+				m.footer = ""
+				m.screen = screenPolicyLifecycle
+				return *m, nil
 			}
 		}
 		s.inputs[s.focusIndex], cmd = s.inputs[s.focusIndex].Update(msg)

--- a/internal/cmd/tui/screen_policy_lifecycle_test.go
+++ b/internal/cmd/tui/screen_policy_lifecycle_test.go
@@ -1,0 +1,217 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestPolicyLifecycleScreenInitialization(t *testing.T) {
+	o := &options{
+		readOnly:   false,
+		targetRef:  "policy",
+		policyName: "targets",
+		p:          &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyLifecycleScreen
+
+	// Test initInputs for Initialize Policy
+	s.initInputs("Initialize Policy", &m)
+	if s.inputs[0].Value() != "targets" {
+		t.Errorf("expected default policyName 'targets', got %q", s.inputs[0].Value())
+	}
+
+	// Test initInputs for Pull Policy (default: origin)
+	s.initInputs("Pull Policy", &m)
+	if s.inputs[0].Value() != "origin" {
+		t.Errorf("expected default remote 'origin', got %q", s.inputs[0].Value())
+	}
+
+	// Test initInputs for Stage Changes (default: empty for local)
+	s.initInputs("Stage Changes", &m)
+	if len(s.inputs) != 1 {
+		t.Fatalf("expected 1 input for Stage Changes, got %d", len(s.inputs))
+	}
+}
+
+func TestPolicyLifecycleScreenFocusCycle(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyLifecycleScreen
+	s.initInputs("Initialize Policy", &m)
+
+	if s.focusIndex != 0 {
+		t.Errorf("expected focus 0, got %d", s.focusIndex)
+	}
+
+	// Cycle tab
+	s.cycleFocus("tab")
+	if s.focusIndex != 0 { // single field form stays at 0
+		t.Errorf("expected focus 0 for single field, got %d", s.focusIndex)
+	}
+}
+
+func TestPolicyLifecycleScreenReadOnlyAction(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.readOnly = true
+	s := &m.policyLifecycleScreen
+	m.screen = screenPolicyLifecycle
+
+	s.list = list.New([]list.Item{item{title: "Initialize Policy"}}, list.NewDefaultDelegate(), 80, 20)
+
+	// Pressing enter in read-only mode should trigger error dialog
+	s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if m.errorDialog == nil {
+		t.Error("expected errorDialog in read-only mode, got nil")
+	}
+	if !strings.Contains(m.errorDialog.message, "cannot perform action in read-only mode") {
+		t.Errorf("expected read-only error message, got %q", m.errorDialog.message)
+	}
+}
+
+func TestPolicyLifecycleScreenFormSubmissions(t *testing.T) {
+	actions := []string{
+		"Initialize Policy",
+		"Increment Version",
+		"Sign Policy",
+		"Stage Changes",
+		"Apply Changes",
+		"Pull Policy",
+		"Push Policy",
+	}
+
+	for _, act := range actions {
+		t.Run(act, func(t *testing.T) {
+			o := &options{
+				readOnly:   false,
+				targetRef:  "policy",
+				policyName: "targets",
+				p:          &persistent.Options{SigningKey: "dummy-key"},
+			}
+
+			m := initialModel(context.Background(), o)
+			s := &m.policyLifecycleScreen
+			m.screen = screenPolicyLifecycleForm
+
+			s.initInputs(act, &m)
+			_, cmd := s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+			if m.screen != screenPolicyLifecycle {
+				t.Errorf("expected screen to return to screenPolicyLifecycle, got %v", m.screen)
+			}
+			if cmd == nil {
+				t.Error("expected non-nil cmd returned for lifecycle command submission")
+			}
+		})
+	}
+}
+
+func TestPolicyLifecycleScreenNavigationKeys(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyLifecycleScreen
+
+	// Esc from screenPolicyLifecycle returns to screenPolicy
+	m.screen = screenPolicyLifecycle
+	s.Update(tea.KeyMsg{Type: tea.KeyEsc}, &m)
+	if m.screen != screenPolicy {
+		t.Errorf("expected screenPolicy on Esc, got %v", m.screen)
+	}
+
+	// Esc from screenPolicyLifecycleForm returns to screenPolicyLifecycle
+	m.screen = screenPolicyLifecycleForm
+	s.initInputs("Initialize Policy", &m)
+	s.Update(tea.KeyMsg{Type: tea.KeyEsc}, &m)
+	if m.screen != screenPolicyLifecycle {
+		t.Errorf("expected screenPolicyLifecycle on form Esc, got %v", m.screen)
+	}
+}
+
+func TestPolicyLifecycleScreenViewRendering(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyLifecycleScreen
+
+	// Main list view
+	m.screen = screenPolicyLifecycle
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy › Lifecycle") {
+		t.Errorf("expected header in view, got %q", viewStr)
+	}
+
+	// Form view for Increment Version (includes warning banner)
+	m.screen = screenPolicyLifecycleForm
+	s.initInputs("Increment Version", &m)
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Warning: This is an advanced operation") {
+		t.Errorf("expected warning banner in Increment Version view, got %q", viewStr)
+	}
+}
+
+func TestBackendExecInterface(t *testing.T) {
+	be := backendExec{run: func() error { return nil }}
+	if err := be.Run(); err != nil {
+		t.Errorf("expected nil error from backendExec.Run(), got %v", err)
+	}
+
+	beErr := backendExec{run: func() error { return errors.New("exec error") }}
+	if err := beErr.Run(); err == nil || err.Error() != "exec error" {
+		t.Errorf("expected 'exec error' from backendExec.Run(), got %v", err)
+	}
+
+	// Cover setters
+	be.SetStdin(nil)
+	be.SetStdout(nil)
+	be.SetStderr(nil)
+}
+
+func TestHandlePolicyLifecycleCommandReadOnly(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.readOnly = true
+
+	cmd := handlePolicyLifecycleCommand(&m, "Initialize Policy", "targets", "", false)
+	msg := cmd()
+	res, ok := msg.(policyLifecycleResultMsg)
+	if !ok {
+		t.Fatalf("expected policyLifecycleResultMsg, got %T", msg)
+	}
+	if res.err == nil || !strings.Contains(res.err.Error(), "read-only mode") {
+		t.Errorf("expected read-only mode error, got %v", res.err)
+	}
+}

--- a/internal/cmd/tui/screen_policy_principals.go
+++ b/internal/cmd/tui/screen_policy_principals.go
@@ -191,6 +191,7 @@ func (s *policyPrincipalsScreen) Update(msg tea.Msg, m *model) (tea.Model, tea.C
 			switch msg.String() {
 			case "a":
 				s.addChoice = true
+				m.errorMsg = ""
 				return *m, nil
 			case "e":
 				if sel, ok := s.list.SelectedItem().(item); ok {

--- a/internal/cmd/tui/screen_policy_principals_test.go
+++ b/internal/cmd/tui/screen_policy_principals_test.go
@@ -1,0 +1,331 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+	"github.com/gittuf/gittuf/internal/tuf"
+	tufv02 "github.com/gittuf/gittuf/internal/tuf/v02"
+)
+
+func TestPolicyPrincipalsFormScreenInitialization(t *testing.T) {
+	f := &policyPrincipalsFormScreen{}
+
+	// Test initInputs for Add Standalone Key(s)
+	f.initInputs("Add Standalone Key(s)")
+	if len(f.inputs) != 1 {
+		t.Fatalf("expected 1 input for standalone key, got %d", len(f.inputs))
+	}
+	if f.action != "Add Standalone Key(s)" {
+		t.Errorf("expected action 'Add Standalone Key(s)', got %q", f.action)
+	}
+
+	// Test initInputs for Add Person
+	f.initInputs("Add Person")
+	if len(f.inputs) != 4 {
+		t.Fatalf("expected 4 inputs for person, got %d", len(f.inputs))
+	}
+
+	// Test initInputsPrefilled for Person
+	p := &tufv02.Person{
+		PersonID: "alice",
+		PublicKeys: map[string]*tufv02.Key{
+			"key-1": {KeyID: "key-1"},
+		},
+		AssociatedIdentities: map[string]string{
+			"github": "alice123",
+		},
+		Custom: map[string]string{
+			"role": "admin",
+		},
+	}
+
+	f.initInputsPrefilled(p)
+	if f.inputs[0].Value() != "alice" {
+		t.Errorf("expected personID 'alice', got %q", f.inputs[0].Value())
+	}
+	if !strings.Contains(f.inputs[1].Value(), "key-1") {
+		t.Errorf("expected public keys to contain 'key-1', got %q", f.inputs[1].Value())
+	}
+	if !strings.Contains(f.inputs[2].Value(), "github::alice123") {
+		t.Errorf("expected identity 'github::alice123', got %q", f.inputs[2].Value())
+	}
+	if !strings.Contains(f.inputs[3].Value(), "role=admin") {
+		t.Errorf("expected custom metadata 'role=admin', got %q", f.inputs[3].Value())
+	}
+}
+
+func TestPolicyPrincipalsFormScreenFocusCycle(t *testing.T) {
+	f := &policyPrincipalsFormScreen{}
+	f.initInputs("Add Person")
+
+	if f.focusIndex != 0 {
+		t.Errorf("expected focus 0, got %d", f.focusIndex)
+	}
+
+	// Cycle focus down / tab
+	f.cycleFocus("tab")
+	if f.focusIndex != 1 {
+		t.Errorf("expected focus 1, got %d", f.focusIndex)
+	}
+
+	// Cycle focus up / shift+tab
+	f.cycleFocus("shift+tab")
+	if f.focusIndex != 0 {
+		t.Errorf("expected focus 0, got %d", f.focusIndex)
+	}
+
+	// Cycle up (wrap to 3)
+	f.cycleFocus("up")
+	if f.focusIndex != 3 {
+		t.Errorf("expected focus 3, got %d", f.focusIndex)
+	}
+
+	// Cycle down (wrap to 0)
+	f.cycleFocus("down")
+	if f.focusIndex != 0 {
+		t.Errorf("expected focus 0, got %d", f.focusIndex)
+	}
+}
+
+func TestPolicyPrincipalsScreenChoiceAndNavigation(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyPrincipalsScreen
+	m.screen = screenPolicyPrincipals
+
+	// Pressing 'a' toggles addChoice
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}, &m)
+	if !s.addChoice {
+		t.Error("expected addChoice to be true after pressing 'a'")
+	}
+
+	// Test choice '1' (Add Person)
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicyPrincipalsForm {
+		t.Errorf("expected screenPolicyPrincipalsForm, got %v", resModel.screen)
+	}
+	if resModel.policyPrincipalsFormScreen.action != "Add Person" {
+		t.Errorf("expected action 'Add Person', got %q", resModel.policyPrincipalsFormScreen.action)
+	}
+
+	// Reset back to choice menu
+	s.addChoice = true
+	m.screen = screenPolicyPrincipals
+
+	// Test choice '2' (Add Standalone Key)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")}, &m)
+	resModel = updatedModel.(model)
+	if resModel.policyPrincipalsFormScreen.action != "Add Standalone Key(s)" {
+		t.Errorf("expected action 'Add Standalone Key(s)', got %q", resModel.policyPrincipalsFormScreen.action)
+	}
+
+	// Reset back and test esc
+	s.addChoice = true
+	s.Update(tea.KeyMsg{Type: tea.KeyEsc}, &m)
+	if s.addChoice {
+		t.Error("expected addChoice to be false after pressing Esc")
+	}
+}
+
+func TestPolicyPrincipalsScreenDeleteConfirm(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyPrincipalsScreen
+	m.screen = screenPolicyPrincipals
+
+	p := &tufv02.Person{PersonID: "alice"}
+	s.principals = []tuf.Principal{p}
+	s.list = list.New([]list.Item{item{title: "alice"}}, list.NewDefaultDelegate(), 80, 20)
+
+	// Pressing 'd' triggers confirm delete
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, &m)
+	if !s.confirmDelete {
+		t.Error("expected confirmDelete to be true after pressing 'd'")
+	}
+
+	// Cancel delete
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")}, &m)
+	if s.confirmDelete {
+		t.Error("expected confirmDelete to be false after pressing 'n'")
+	}
+}
+
+func TestPolicyPrincipalsFormValidationErrors(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	f := &m.policyPrincipalsFormScreen
+	m.screen = screenPolicyPrincipalsForm
+
+	// 1. Missing Person ID error
+	f.initInputs("Add Person")
+	f.focusIndex = 3
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if !strings.Contains(m.errorMsg, "Principal ID is required") {
+		t.Errorf("expected error for missing principal ID, got %q", m.errorMsg)
+	}
+
+	// 2. Invalid Associated Identity format
+	m.errorMsg = ""
+	f.initInputs("Add Person")
+	f.inputs[0].SetValue("alice")
+	f.inputs[2].SetValue("invalididentityformat")
+	f.focusIndex = 3
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if !strings.Contains(m.errorMsg, "invalid format for associated identity") {
+		t.Errorf("expected error for invalid identity, got %q", m.errorMsg)
+	}
+
+	// 3. Invalid Custom Metadata format
+	m.errorMsg = ""
+	f.initInputs("Add Person")
+	f.inputs[0].SetValue("alice")
+	f.inputs[3].SetValue("invalidmetadataformat")
+	f.focusIndex = 3
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if !strings.Contains(m.errorMsg, "invalid format for custom metadata") {
+		t.Errorf("expected error for invalid custom metadata, got %q", m.errorMsg)
+	}
+
+	// 4. Missing Standalone Public Keys error
+	m.errorMsg = ""
+	f.initInputs("Add Standalone Key(s)")
+	f.focusIndex = 0
+	f.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if !strings.Contains(m.errorMsg, "At least one public key is required") {
+		t.Errorf("expected error for missing standalone key, got %q", m.errorMsg)
+	}
+}
+
+func TestPolicyPrincipalsScreenViewRendering(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyPrincipalsScreen
+	f := &m.policyPrincipalsFormScreen
+	m.screen = screenPolicyPrincipals
+
+	// Test main screen view with empty list
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy › Principals") {
+		t.Errorf("expected header in view, got %q", viewStr)
+	}
+
+	// Test choice popup rendering
+	s.addChoice = true
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Add Principal") {
+		t.Errorf("expected choice popup in view, got %q", viewStr)
+	}
+	s.addChoice = false
+
+	// Test updatePrincipalsList
+	p := &tufv02.Person{
+		PersonID: "alice",
+		PublicKeys: map[string]*tufv02.Key{
+			"key-1": {KeyID: "key-1"},
+		},
+		AssociatedIdentities: map[string]string{
+			"github": "alice123",
+		},
+		Custom: map[string]string{
+			"role": "admin",
+		},
+	}
+	s.principals = []tuf.Principal{p}
+	s.updatePrincipalsList()
+
+	// Test delete confirm overlay
+	s.confirmDelete = true
+	s.deleteTarget = "alice"
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Delete rule \"alice\"?") {
+		t.Errorf("expected delete overlay in view, got %q", viewStr)
+	}
+
+	// Test Form Screen view
+	f.initInputs("Add Person")
+	viewStr = f.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy › Principals › Add Person") {
+		t.Errorf("expected form header in view, got %q", viewStr)
+	}
+}
+
+func TestPolicyPrincipalsScreenReadOnlyAddGuard(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyPrincipalsScreen
+	m.screen = screenPolicyPrincipals
+
+	// Pressing 'a' in read-only mode should not open addChoice popup
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}, &m)
+	if s.addChoice {
+		t.Error("expected addChoice to remain false in read-only mode")
+	}
+}
+
+func TestPolicyPrincipalsScreenEditStandaloneKey(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyPrincipalsScreen
+	m.screen = screenPolicyPrincipals
+
+	key := &tufv02.Key{KeyID: "key-1"}
+	s.principals = []tuf.Principal{key}
+	s.updatePrincipalsList()
+
+	// Pressing 'e' on a standalone key should show error and stay on screenPolicyPrincipals
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")}, &m)
+	if m.screen != screenPolicyPrincipals {
+		t.Errorf("expected screen to remain screenPolicyPrincipals, got %v", m.screen)
+	}
+	if !strings.Contains(m.errorMsg, "Standalone keys cannot be edited") {
+		t.Errorf("expected error message for standalone key edit, got %q", m.errorMsg)
+	}
+
+	// Pressing 'a' should clear the stale errorMsg and open addChoice popup
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}, &m)
+	if !s.addChoice {
+		t.Error("expected addChoice to be true after pressing 'a'")
+	}
+	if m.errorMsg != "" {
+		t.Errorf("expected errorMsg to be cleared after pressing 'a', got %q", m.errorMsg)
+	}
+}

--- a/internal/cmd/tui/screen_policy_rules_test.go
+++ b/internal/cmd/tui/screen_policy_rules_test.go
@@ -1,0 +1,261 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestPolicyRulesScreenInitialization(t *testing.T) {
+	s := &policyRulesScreen{}
+
+	// Test initRuleInputs
+	s.initRuleInputs()
+	if len(s.inputs) != 4 {
+		t.Fatalf("expected 4 input fields, got %d", len(s.inputs))
+	}
+	if s.focusIndex != 0 {
+		t.Errorf("expected focusIndex 0, got %d", s.focusIndex)
+	}
+
+	// Test initRuleInputsPrefilled
+	r := rule{
+		name:      "rule-1",
+		pattern:   "refs/heads/main",
+		key:       "key-1",
+		threshold: 2,
+	}
+	s.initRuleInputsPrefilled(r)
+	if s.inputs[0].Value() != "rule-1" {
+		t.Errorf("expected rule name 'rule-1', got %q", s.inputs[0].Value())
+	}
+	if s.inputs[1].Value() != "refs/heads/main" {
+		t.Errorf("expected pattern 'refs/heads/main', got %q", s.inputs[1].Value())
+	}
+	if s.inputs[2].Value() != "key-1" {
+		t.Errorf("expected key 'key-1', got %q", s.inputs[2].Value())
+	}
+	if s.inputs[3].Value() != "2" {
+		t.Errorf("expected threshold '2', got %q", s.inputs[3].Value())
+	}
+}
+
+func TestPolicyRulesScreenCycleFocus(t *testing.T) {
+	s := &policyRulesScreen{}
+	s.initRuleInputs()
+
+	// Initial focus index 0
+	if s.focusIndex != 0 {
+		t.Errorf("expected initial focus 0, got %d", s.focusIndex)
+	}
+
+	// Tab down
+	s.cycleFocus("tab")
+	if s.focusIndex != 1 {
+		t.Errorf("expected focus 1 after tab, got %d", s.focusIndex)
+	}
+
+	// Tab up / shift+tab
+	s.cycleFocus("shift+tab")
+	if s.focusIndex != 0 {
+		t.Errorf("expected focus 0 after shift+tab, got %d", s.focusIndex)
+	}
+
+	// Up key (wrap to last index 3)
+	s.cycleFocus("up")
+	if s.focusIndex != 3 {
+		t.Errorf("expected focus 3 after up, got %d", s.focusIndex)
+	}
+
+	// Down key (wrap to index 0)
+	s.cycleFocus("down")
+	if s.focusIndex != 0 {
+		t.Errorf("expected focus 0 after down, got %d", s.focusIndex)
+	}
+}
+
+func TestPolicyRulesScreenKeyHandling(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenPolicyRules
+	s := &m.policyRulesScreen
+
+	// Setup dummy rules
+	s.rules = []rule{
+		{name: "rule-a", pattern: "refs/heads/a", key: "key-a", threshold: 1},
+		{name: "rule-b", pattern: "refs/heads/b", key: "key-b", threshold: 1},
+	}
+	s.updateRuleList()
+
+	// Test 'a' key (Add Rule)
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicyAddRule {
+		t.Errorf("expected screenPolicyAddRule after pressing 'a', got %v", resModel.screen)
+	}
+
+	// Reset screen back
+	m.screen = screenPolicyRules
+
+	// Test 'e' key (Edit Rule)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyEditRule {
+		t.Errorf("expected screenPolicyEditRule after pressing 'e', got %v", resModel.screen)
+	}
+
+	// Reset screen back
+	m.screen = screenPolicyRules
+
+	// Test 'd' key (Delete Rule trigger)
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")}, &m)
+	if !s.confirmDelete {
+		t.Error("expected confirmDelete to be true after pressing 'd'")
+	}
+	if s.deleteTarget != "rule-a" {
+		t.Errorf("expected deleteTarget 'rule-a', got %q", s.deleteTarget)
+	}
+
+	// Test cancelling delete confirm (pressing any key except 'y')
+	s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")}, &m)
+	if s.confirmDelete {
+		t.Error("expected confirmDelete to be false after pressing 'n'")
+	}
+}
+
+func TestPolicyRulesScreenReorder(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenPolicyRules
+	s := &m.policyRulesScreen
+
+	s.rules = []rule{
+		{name: "rule-a", pattern: "refs/heads/a", key: "key-a", threshold: 1},
+		{name: "rule-b", pattern: "refs/heads/b", key: "key-b", threshold: 1},
+	}
+	s.updateRuleList()
+
+	// Test handleReorderDown when at top (index 0)
+	s.handleReorderDown(&m)
+	if s.rules[0].name != "rule-b" || s.rules[1].name != "rule-a" {
+		t.Errorf("expected [rule-b, rule-a] after reorder down, got [%s, %s]", s.rules[0].name, s.rules[1].name)
+	}
+
+	// Test handleReorderUp when at index 1
+	s.ruleList.Select(1)
+	s.handleReorderUp(&m)
+	if s.rules[0].name != "rule-a" || s.rules[1].name != "rule-b" {
+		t.Errorf("expected [rule-a, rule-b] after reorder up, got [%s, %s]", s.rules[0].name, s.rules[1].name)
+	}
+}
+
+func TestPolicyRulesScreenFormNavigationAndSubmit(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenPolicyAddRule
+	s := &m.policyRulesScreen
+	s.initRuleInputs()
+
+	// Pressing Enter on field 0 should advance focus to field 1
+	if s.focusIndex != 0 {
+		t.Fatalf("expected focusIndex 0, got %d", s.focusIndex)
+	}
+
+	s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	if s.focusIndex != 1 {
+		t.Errorf("expected focusIndex 1 after Enter on field 0, got %d", s.focusIndex)
+	}
+
+	// Move focus to last field (field 3)
+	s.focusIndex = 3
+
+	// Pressing Enter on last field triggers handlePolicyFormSubmit
+	s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	// Since repoAddRule fails without git repo, error dialog should open
+	if m.errorDialog == nil {
+		t.Error("expected errorDialog to open when repoAddRule fails without git repo")
+	}
+}
+
+func TestPolicyRulesScreenView(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.policyRulesScreen
+
+	// Test View on screenPolicyRules with no rules
+	m.screen = screenPolicyRules
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy › Rules") {
+		t.Errorf("expected view to contain header, got %q", viewStr)
+	}
+
+	// Test View on screenPolicyRules with delete overlay confirm
+	s.confirmDelete = true
+	s.deleteTarget = "test-rule"
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Delete rule \"test-rule\"?") {
+		t.Errorf("expected view to contain delete overlay, got %q", viewStr)
+	}
+	s.confirmDelete = false
+
+	// Test View on screenPolicyAddRule
+	m.screen = screenPolicyAddRule
+	s.initRuleInputs()
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Add Rule") {
+		t.Errorf("expected view to contain 'Add Rule', got %q", viewStr)
+	}
+
+	// Test View on screenPolicyEditRule
+	m.screen = screenPolicyEditRule
+	viewStr = s.View(&m)
+	if !strings.Contains(viewStr, "Edit Rule") {
+		t.Errorf("expected view to contain 'Edit Rule', got %q", viewStr)
+	}
+}
+
+func TestPolicyRulesScreenReadOnlyKeyIgnore(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.readOnly = true
+	m.screen = screenPolicyRules
+	s := &m.policyRulesScreen
+	s.rules = []rule{{name: "rule-a", pattern: "refs/heads/a", key: "key-a", threshold: 1}}
+	s.ruleList = list.New([]list.Item{item{title: "rule-a"}}, list.NewDefaultDelegate(), 80, 20)
+
+	// Pressing 'a' in read-only mode should be ignored
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicyRules {
+		t.Errorf("expected screen to stay screenPolicyRules in readOnly mode, got %v", resModel.screen)
+	}
+}

--- a/internal/cmd/tui/screen_policy_test.go
+++ b/internal/cmd/tui/screen_policy_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
 )
 
 func selectItemByTitle(t *testing.T, l *list.Model, title string) {
@@ -72,9 +73,11 @@ func TestPolicyUINavigationInteractive(t *testing.T) {
 	o := &options{
 		readOnly:  true,
 		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
 	}
 
 	m := initialModel(context.Background(), o)
+	m.screen = screenChoice
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
 
 	// Wait for home screen Policy option

--- a/internal/cmd/tui/screen_policy_test.go
+++ b/internal/cmd/tui/screen_policy_test.go
@@ -1,0 +1,96 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+)
+
+func selectItemByTitle(t *testing.T, l *list.Model, title string) {
+	t.Helper()
+	for i, it := range l.Items() {
+		if item, ok := it.(item); ok && item.title == title {
+			l.Select(i)
+			return
+		}
+	}
+	t.Fatalf("menu item %q not found", title)
+}
+
+func TestPolicyUINavigationMenu(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenPolicy
+
+	// Test View rendering
+	viewStr := m.policyScreen.View(&m)
+	if !strings.Contains(viewStr, "Home › Policy") {
+		t.Errorf("expected view to contain header Home › Policy, got %q", viewStr)
+	}
+
+	// Test selecting "View Rules"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "View Rules")
+	updatedModel, _ := m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicyRules {
+		t.Errorf("expected screenPolicyRules (%v), got %v", screenPolicyRules, resModel.screen)
+	}
+
+	// Test selecting "Manage Principals"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "Manage Principals")
+	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyPrincipals {
+		t.Errorf("expected screenPolicyPrincipals (%v), got %v", screenPolicyPrincipals, resModel.screen)
+	}
+
+	// Test selecting "Manage Lifecycle"
+	m.screen = screenPolicy
+	selectItemByTitle(t, &m.policyScreen.policyScreenList, "Manage Lifecycle")
+	updatedModel, _ = m.policyScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyLifecycle {
+		t.Errorf("expected screenPolicyLifecycle (%v), got %v", screenPolicyLifecycle, resModel.screen)
+	}
+}
+
+func TestPolicyUINavigationInteractive(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+	// Wait for home screen Policy option
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Press Enter to navigate to Policy screen (Policy is 1st item)
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Policy screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Home › Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Quit with 'q' from non-form screen
+	tm.Send(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*10))
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests and bug fixes for the Policy TUI sub-screens (`Policy`, `Policy Rules`, `Policy Principals`, and `Policy Lifecycle`):

- **Policy Main Screen (`screen_policy_test.go`)**: Tests menu rendering and navigation using dynamic title matching (`selectItemByTitle`) and screen state resets between tests.
- **Policy Rules Screen (`screen_policy_rules_test.go`)**: Tests rule listing, add/edit forms, delete confirmation overlays, and reordering actions (`handleReorderUp`/`handleReorderDown`) with explicit swap assertions.
- **Policy Principals Screen (`screen_policy_principals.go` & `screen_policy_principals_test.go`)**: Adds tests for principal listing, add/edit forms, read-only `'a'` guard, standalone key edit error banner, and a fix to clear stale `errorMsg` when opening the add choice popup.
- **Policy Lifecycle Screen (`screen_policy_lifecycle.go` & `screen_policy_lifecycle_test.go`)**: Adds tests for policy lifecycle actions, `tea.Cmd` return assertions, `backendExec` error propagation, read-only guards, and a fix to handle `esc` key navigation from the lifecycle form back to the lifecycle menu.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull request.
- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to draft unit tests and review edge cases. All code has been manually reviewed, tested (`go test`), and verified with `golangci-lint` locally.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).