### PR TITLE
test :- add unit tests and fixes for verify, home, help, view and core TUI engine

### DIFF
--- a/internal/cmd/tui/screen_help_test.go
+++ b/internal/cmd/tui/screen_help_test.go
@@ -1,0 +1,70 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestHelpScreenUpdateAndNavigation(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.helpScreen
+
+	// Store previous screen as screenPolicy
+	s.previousScreen = screenPolicy
+	m.screen = screenHelp
+
+	// Test pressing 'h' to return to previous screen
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicy {
+		t.Errorf("expected screen to return to screenPolicy on 'h', got %v", resModel.screen)
+	}
+
+	// Test pressing 'esc' to return to previous screen
+	s.previousScreen = screenChoice
+	m.screen = screenHelp
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyEsc}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenChoice {
+		t.Errorf("expected screen to return to screenChoice on 'esc', got %v", resModel.screen)
+	}
+}
+
+func TestHelpScreenViewRendering(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.width = 80
+	m.height = 24
+	s := &m.helpScreen
+
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Help") {
+		t.Errorf("expected view to contain 'Help', got %q", viewStr)
+	}
+	if !strings.Contains(viewStr, "Navigate") {
+		t.Errorf("expected view to contain navigation help, got %q", viewStr)
+	}
+
+	// Test small screen dimensions (boxWidth/boxHeight < 0 branch)
+	m.width = 1
+	m.height = 1
+	s.View(&m)
+}

--- a/internal/cmd/tui/screen_home_test.go
+++ b/internal/cmd/tui/screen_home_test.go
@@ -1,0 +1,66 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestHomeScreenMenuSelections(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.homeScreen
+	m.screen = screenChoice
+
+	// 1. Select Policy
+	s.choiceList = list.New([]list.Item{item{title: "Policy"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ := s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenPolicy {
+		t.Errorf("expected screenPolicy, got %v", resModel.screen)
+	}
+
+	// 2. Select Trust
+	s.choiceList = list.New([]list.Item{item{title: "Trust"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenTrust {
+		t.Errorf("expected screenTrust, got %v", resModel.screen)
+	}
+
+	// 3. Select Verify
+	s.choiceList = list.New([]list.Item{item{title: "Verify"}}, list.NewDefaultDelegate(), 80, 20)
+	updatedModel, _ = s.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel = updatedModel.(model)
+	if resModel.screen != screenVerify {
+		t.Errorf("expected screenVerify, got %v", resModel.screen)
+	}
+}
+
+func TestHomeScreenViewRendering(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	s := &m.homeScreen
+
+	viewStr := s.View(&m)
+	if !strings.Contains(viewStr, "Home") {
+		t.Errorf("expected view to contain 'Home', got %q", viewStr)
+	}
+}

--- a/internal/cmd/tui/screen_verify_forms_test.go
+++ b/internal/cmd/tui/screen_verify_forms_test.go
@@ -1,0 +1,170 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestVerifyRefScreenValidation(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenVerifyRefForm
+	m.verifyRefScreen.reset()
+
+	// Initially no error message
+	if m.errorMsg != "" {
+		t.Fatalf("expected empty errorMsg, got %q", m.errorMsg)
+	}
+
+	// Submit empty form (press Enter)
+	updatedModel, _ := m.verifyRefScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+	resModel := updatedModel.(model)
+
+	if resModel.errorMsg != "Target reference is required" {
+		t.Errorf("expected errorMsg %q, got %q", "Target reference is required", resModel.errorMsg)
+	}
+}
+
+func TestVerifyMergeableScreenValidation(t *testing.T) {
+	t.Run("Empty Submission", func(t *testing.T) {
+		o := &options{
+			readOnly:  true,
+			targetRef: "policy",
+		}
+
+		m := initialModel(context.Background(), o)
+		m.screen = screenVerifyMergeableForm
+		m.verifyMergeableScreen.reset()
+
+		// Submit empty form (press Enter)
+		updatedModel, _ := m.verifyMergeableScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+		resModel := updatedModel.(model)
+
+		if resModel.errorMsg != "Both Feature Branch and Base Branch are required" {
+			t.Errorf("expected errorMsg %q, got %q", "Both Feature Branch and Base Branch are required", resModel.errorMsg)
+		}
+	})
+
+	t.Run("Partial Submission", func(t *testing.T) {
+		o := &options{
+			readOnly:  true,
+			targetRef: "policy",
+		}
+
+		m := initialModel(context.Background(), o)
+		m.screen = screenVerifyMergeableForm
+		m.verifyMergeableScreen.reset()
+
+		// Fill only feature branch field
+		m.verifyMergeableScreen.form.inputs[0].SetValue("feature-branch")
+
+		// Submit partial form (press Enter)
+		updatedModel, _ := m.verifyMergeableScreen.Update(tea.KeyMsg{Type: tea.KeyEnter}, &m)
+		resModel := updatedModel.(model)
+
+		if resModel.errorMsg != "Both Feature Branch and Base Branch are required" {
+			t.Errorf("expected errorMsg %q, got %q", "Both Feature Branch and Base Branch are required", resModel.errorMsg)
+		}
+	})
+}
+
+func TestVerifyRefScreenViewAndKeyHandling(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenVerifyRefForm
+	m.verifyRefScreen.reset()
+
+	// Test View rendering
+	viewStr := m.verifyRefScreen.View(&m)
+	if !strings.Contains(viewStr, "Verify a specific reference against gittuf policies") {
+		t.Errorf("expected view to contain header, got %q", viewStr)
+	}
+
+	// Test Update key handling (tab clears footer)
+	m.footer = "some footer"
+	m.verifyRefScreen.Update(tea.KeyMsg{Type: tea.KeyTab}, &m)
+	if m.footer != "" {
+		t.Errorf("expected footer to be cleared on tab, got %q", m.footer)
+	}
+}
+
+func TestVerifyMergeableScreenViewAndKeyHandling(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenVerifyMergeableForm
+	m.verifyMergeableScreen.reset()
+
+	// Test View rendering
+	viewStr := m.verifyMergeableScreen.View(&m)
+	if !strings.Contains(viewStr, "Verify if a feature branch can be merged") {
+		t.Errorf("expected view to contain header, got %q", viewStr)
+	}
+
+	// Test Update key handling (down clears footer and cycles focus)
+	m.footer = "some footer"
+	m.verifyMergeableScreen.Update(tea.KeyMsg{Type: tea.KeyDown}, &m)
+	if m.footer != "" {
+		t.Errorf("expected footer to be cleared on down, got %q", m.footer)
+	}
+}
+
+func TestFormComponentCycleFocus(t *testing.T) {
+	fields := []inputField{
+		{"Field 1", "P1: "},
+		{"Field 2", "P2: "},
+	}
+
+	form := newFormComponent(fields)
+
+	if form.focusIndex != 0 {
+		t.Errorf("expected initial focusIndex 0, got %d", form.focusIndex)
+	}
+
+	// Cycle down / tab
+	form.cycleFocus("tab")
+	if form.focusIndex != 1 {
+		t.Errorf("expected focusIndex 1 after tab, got %d", form.focusIndex)
+	}
+
+	// Cycle down again (should wrap to 0)
+	form.cycleFocus("tab")
+	if form.focusIndex != 0 {
+		t.Errorf("expected focusIndex 0 after wrapping tab, got %d", form.focusIndex)
+	}
+
+	// Cycle up / shift+tab (should wrap to 1)
+	form.cycleFocus("shift+tab")
+	if form.focusIndex != 1 {
+		t.Errorf("expected focusIndex 1 after shift+tab, got %d", form.focusIndex)
+	}
+
+	// Cycle up again (should go to 0)
+	form.cycleFocus("up")
+	if form.focusIndex != 0 {
+		t.Errorf("expected focusIndex 0 after up, got %d", form.focusIndex)
+	}
+
+	// Test form View() rendering
+	formView := form.View()
+	if formView == "" {
+		t.Error("expected non-empty form View()")
+	}
+}

--- a/internal/cmd/tui/screen_verify_test.go
+++ b/internal/cmd/tui/screen_verify_test.go
@@ -1,0 +1,67 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/exp/teatest"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestVerifyUINavigation(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.screen = screenChoice
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(80, 24))
+
+	// Wait for home screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Policy")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	var verifyIndex int
+	for i, it := range m.homeScreen.choiceList.Items() {
+		if it.(item).title == "Verify" {
+			verifyIndex = i
+			break
+		}
+	}
+
+	for i := 0; i < verifyIndex; i++ {
+		tm.Send(tea.KeyMsg{Type: tea.KeyDown})
+		time.Sleep(time.Millisecond * 50)
+	}
+
+	// Enter Verify screen
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Verify menu screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		return strings.Contains(string(out), "Home › Verify")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Enter Verify Reference form
+	tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Wait for Verify Reference form screen
+	teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
+		s := string(out)
+		return strings.Contains(s, "Verify Reference") || strings.Contains(s, "Target Ref")
+	}, teatest.WithCheckInterval(time.Millisecond*50), teatest.WithDuration(time.Second*10))
+
+	// Send ctrl+c to quit (since 'q' is captured by form text inputs)
+	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlC})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(time.Second*10))
+}

--- a/internal/cmd/tui/update_test.go
+++ b/internal/cmd/tui/update_test.go
@@ -1,0 +1,254 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestUpdateInitDoneMsg(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	// 1. Success initDoneMsg
+	msgSuccess := initDoneMsg{
+		readOnly: false,
+		footer:   "Ready",
+		rules: []rule{
+			{name: "rule-1"},
+		},
+		globalRules: []globalRule{
+			{ruleName: "global-1"},
+		},
+	}
+
+	updatedModel, _ := m.Update(msgSuccess)
+	resModel := updatedModel.(model)
+	if resModel.screen != screenChoice {
+		t.Errorf("expected screenChoice after initDoneMsg, got %v", resModel.screen)
+	}
+	if resModel.footer != "Ready" {
+		t.Errorf("expected footer 'Ready', got %q", resModel.footer)
+	}
+
+	// 2. Error initDoneMsg
+	msgErr := initDoneMsg{
+		err: fmt.Errorf("git repo error"),
+	}
+	updatedModel, _ = m.Update(msgErr)
+	resModel = updatedModel.(model)
+	if !strings.Contains(resModel.errorMsg, "Initialization failed: git repo error") {
+		t.Errorf("expected initialization failure errorMsg, got %q", resModel.errorMsg)
+	}
+}
+
+func TestUpdatePolicyLifecycleResultMsg(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	// 1. Success message
+	msgSuccess := policyLifecycleResultMsg{
+		action: "Initialize Policy",
+		msg:    "Successfully initialized policy",
+		err:    nil,
+	}
+	updatedModel, _ := m.Update(msgSuccess)
+	resModel := updatedModel.(model)
+	if resModel.footer != "Successfully initialized policy" {
+		t.Errorf("expected footer update on success, got %q", resModel.footer)
+	}
+
+	// 2. Error message
+	msgError := policyLifecycleResultMsg{
+		action: "Initialize Policy",
+		err:    fmt.Errorf("already initialized"),
+	}
+	updatedModel, _ = m.Update(msgError)
+	resModel = updatedModel.(model)
+	if resModel.errorDialog == nil {
+		t.Error("expected errorDialog on lifecycle error, got nil")
+	}
+}
+
+func TestUpdateWindowSizeAndSpinner(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	// WindowSizeMsg
+	wsMsg := tea.WindowSizeMsg{Width: 100, Height: 40}
+	updatedModel, _ := m.Update(wsMsg)
+	resModel := updatedModel.(model)
+	if resModel.width != 100 || resModel.height != 40 {
+		t.Errorf("expected width 100 height 40, got %dx%d", resModel.width, resModel.height)
+	}
+
+	// Small WindowSizeMsg (testing <= 4 width and <= 6 height branches)
+	wsSmallMsg := tea.WindowSizeMsg{Width: 2, Height: 4}
+	updatedModel, _ = m.Update(wsSmallMsg)
+	resModel = updatedModel.(model)
+	if resModel.logViewport.Width != 2 || resModel.logViewport.Height != 4 {
+		t.Errorf("expected viewport width 2 height 4, got %dx%d", resModel.logViewport.Width, resModel.logViewport.Height)
+	}
+
+	// Spinner TickMsg while loading
+	m.screen = screenLoading
+	spMsg := spinner.TickMsg{}
+	m.Update(spMsg)
+}
+
+func TestUpdateGlobalKeybindings(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	// 1. Ctrl+C quits
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd == nil {
+		t.Error("expected quit cmd on ctrl+c, got nil")
+	}
+
+	// 2. 'h' toggles help screen
+	m.screen = screenChoice
+	updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	resModel := updatedModel.(model)
+	if resModel.screen != screenHelp {
+		t.Errorf("expected screenHelp after pressing 'h', got %v", resModel.screen)
+	}
+
+	// Pressing 'h' again toggles back
+	updatedModel, _ = resModel.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")})
+	resModel = updatedModel.(model)
+	if resModel.screen != screenChoice {
+		t.Errorf("expected screenChoice after pressing 'h' again, got %v", resModel.screen)
+	}
+
+	// 3. 'q' quits from non-form screens
+	m.screen = screenPolicy
+	_, cmd = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("expected quit cmd on 'q' from non-form screen, got nil")
+	}
+
+	// 4. 'q' ignored as quit command in form screens (types 'q' into text input instead)
+	m.screen = screenPolicyAddRule
+	m.policyRulesScreen.initRuleInputs()
+	updatedModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	resModel = updatedModel.(model)
+	if resModel.screen != screenPolicyAddRule {
+		t.Errorf("expected screen to stay screenPolicyAddRule when typing 'q', got %v", resModel.screen)
+	}
+}
+
+func TestUpdateEscNavigationAcrossScreens(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	escScreens := []struct {
+		name     string
+		start    screen
+		expected screen
+	}{
+		{"screenPolicy to screenChoice", screenPolicy, screenChoice},
+		{"screenTrust to screenChoice", screenTrust, screenChoice},
+		{"screenVerify to screenChoice", screenVerify, screenChoice},
+		{"screenPolicyLifecycle to screenPolicy", screenPolicyLifecycle, screenPolicy},
+		{"screenPolicyLifecycleForm to screenPolicyLifecycle", screenPolicyLifecycleForm, screenPolicyLifecycle},
+		{"screenPolicyAddRule to screenPolicyRules", screenPolicyAddRule, screenPolicyRules},
+		{"screenPolicyEditRule to screenPolicyRules", screenPolicyEditRule, screenPolicyRules},
+		{"screenVerifyRefForm to screenVerify", screenVerifyRefForm, screenVerify},
+		{"screenVerifyMergeableForm to screenVerify", screenVerifyMergeableForm, screenVerify},
+	}
+
+	for _, tc := range escScreens {
+		t.Run(tc.name, func(t *testing.T) {
+			m.screen = tc.start
+			updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+			resModel := updatedModel.(model)
+			if resModel.screen != tc.expected {
+				t.Errorf("expected %v after Esc, got %v", tc.expected, resModel.screen)
+			}
+		})
+	}
+}
+
+func TestUpdateErrorDialogKeyHandling(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.openErrorDialog("Test Title", "Test Message")
+
+	// 1. 'q' in error dialog quits
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	if cmd == nil {
+		t.Error("expected quit cmd when pressing 'q' in error dialog, got nil")
+	}
+
+	// 2. 'enter' in error dialog dismisses dialog
+	updatedModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	resModel := updatedModel.(model)
+	if resModel.errorDialog != nil {
+		t.Error("expected errorDialog to be dismissed after Enter, got non-nil")
+	}
+}
+
+func TestLogStreamingHelpers(t *testing.T) {
+	// Test splitAndTrim
+	parts := splitAndTrim("  a , b,c  ")
+	if len(parts) != 3 || parts[0] != "a" || parts[1] != "b" || parts[2] != "c" {
+		t.Errorf("unexpected splitAndTrim result: %v", parts)
+	}
+
+	// Test collectLogsCmd and drainLogChannel
+	scanner := bufio.NewScanner(strings.NewReader("line1\nline2\n"))
+	ch := make(chan string, 10)
+	cmd := collectLogsCmd(scanner, ch)
+	cmd() // execute goroutine logic synchronously
+
+	lines := drainLogChannel(ch)
+	if len(lines) != 2 || lines[0] != "line1" || lines[1] != "line2" {
+		t.Errorf("unexpected drained lines: %v", lines)
+	}
+
+	// Test logFlushTick
+	tickCmd := logFlushTick(ch)
+	if tickCmd == nil {
+		t.Error("expected non-nil tea.Cmd from logFlushTick")
+	}
+}

--- a/internal/cmd/tui/view_test.go
+++ b/internal/cmd/tui/view_test.go
@@ -1,0 +1,204 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package tui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/gittuf/gittuf/internal/cmd/policy/persistent"
+)
+
+func TestViewHelperFunctions(t *testing.T) {
+	// Test renderWithMargin
+	marginStr := renderWithMargin("content")
+	if !strings.Contains(marginStr, "content") {
+		t.Errorf("expected margin content, got %q", marginStr)
+	}
+
+	// Test renderFooter
+	footerStr := renderFooter("footer-text")
+	if !strings.Contains(footerStr, "footer-text") {
+		t.Errorf("expected footer text, got %q", footerStr)
+	}
+
+	// Test renderErrorMsg
+	if renderErrorMsg("") != "" {
+		t.Error("expected empty string for empty errorMsg")
+	}
+	errMsg := renderErrorMsg("some error")
+	if !strings.Contains(errMsg, "some error") {
+		t.Errorf("expected error message formatted, got %q", errMsg)
+	}
+
+	// Test renderDeleteOverlay
+	delOverlay := renderDeleteOverlay("test-target")
+	if !strings.Contains(delOverlay, "Delete rule \"test-target\"?") {
+		t.Errorf("expected delete overlay string, got %q", delOverlay)
+	}
+
+	// Test renderActionHints for readOnly vs edit mode
+	hintsReadOnly := renderActionHints(true)
+	if !strings.Contains(hintsReadOnly, "help") || strings.Contains(hintsReadOnly, "add") {
+		t.Errorf("unexpected readOnly action hints: %q", hintsReadOnly)
+	}
+
+	hintsEdit := renderActionHints(false)
+	if !strings.Contains(hintsEdit, "add") || !strings.Contains(hintsEdit, "edit") {
+		t.Errorf("unexpected edit mode action hints: %q", hintsEdit)
+	}
+}
+
+func TestRenderFooterBoxVariants(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.readOnly = true
+	m.showHelp = true
+	m.signerError = "signer unavailable"
+
+	// Read-only mode with showHelp and signerError
+	boxStr := renderFooterBox(m)
+	if !strings.Contains(boxStr, "Read-only mode") || !strings.Contains(boxStr, "signer unavailable") {
+		t.Errorf("expected read-only help box with signer error, got %q", boxStr)
+	}
+
+	// Read-only mode without showHelp but with signerError
+	m.showHelp = false
+	boxStr = renderFooterBox(m)
+	if !strings.Contains(boxStr, "Notice: signer") {
+		t.Errorf("expected signer notice in footer, got %q", boxStr)
+	}
+}
+
+func TestRenderErrorAndPopupDialog(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.width = 100
+
+	// When no error dialog present
+	if renderErrorDialog(m) != "" || renderPopupDialog(m) != "" {
+		t.Error("expected empty string when no error dialog is present")
+	}
+
+	// Open error dialog
+	m.openErrorDialog("Fatal Error", "Something went wrong")
+
+	dialogStr := renderPopupDialog(m)
+	if !strings.Contains(dialogStr, "Fatal Error") || !strings.Contains(dialogStr, "Something went wrong") {
+		t.Errorf("expected dialog with title and message, got %q", dialogStr)
+	}
+
+	// Test small width error dialog boundary
+	m.width = 10
+	dialogSmallStr := renderErrorDialog(m)
+	if !strings.Contains(dialogSmallStr, "Fatal Error") {
+		t.Errorf("expected small dialog, got %q", dialogSmallStr)
+	}
+}
+
+func TestRenderStatusBar(t *testing.T) {
+	// Width 0 fallback (defaults to 80)
+	barStr := renderStatusBar("TestScreen", false, 0)
+	if !strings.Contains(barStr, "TestScreen") || !strings.Contains(barStr, "Edit Mode") {
+		t.Errorf("expected status bar with Edit Mode, got %q", barStr)
+	}
+
+	// Read-only status bar
+	barReadOnly := renderStatusBar("TestScreen", true, 100)
+	if !strings.Contains(barReadOnly, "Read-only") {
+		t.Errorf("expected status bar with Read-only, got %q", barReadOnly)
+	}
+}
+
+func TestRenderListOrEmpty(t *testing.T) {
+	o := &options{
+		readOnly:  true,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+	m.readOnly = true
+	m.signerError = "key error"
+	m.width = 80
+	m.height = 24
+
+	l := list.New([]list.Item{item{title: "item-1"}}, list.NewDefaultDelegate(), 80, 20)
+
+	// Non-empty list returns l.View()
+	viewStr := m.renderListOrEmpty(l, 1, "No items")
+	if !strings.Contains(viewStr, "item-1") {
+		t.Errorf("expected item-1 in list view, got %q", viewStr)
+	}
+
+	// Empty list returns placeholder
+	emptyView := m.renderListOrEmpty(l, 0, "No items found")
+	if !strings.Contains(emptyView, "No items found") {
+		t.Errorf("expected empty state text, got %q", emptyView)
+	}
+}
+
+func TestModelViewScreenStates(t *testing.T) {
+	o := &options{
+		readOnly:  false,
+		targetRef: "policy",
+		p:         &persistent.Options{SigningKey: "dummy-key"},
+	}
+
+	m := initialModel(context.Background(), o)
+
+	// Width/Height == 0 returns spinner loading
+	m.width = 0
+	m.height = 0
+	viewStr := m.View()
+	if !strings.Contains(viewStr, "Loading TUI...") {
+		t.Errorf("expected Loading TUI... when width/height 0, got %q", viewStr)
+	}
+
+	m.width = 80
+	m.height = 24
+
+	// screenLoading without error
+	m.screen = screenLoading
+	viewStr = m.View()
+	if !strings.Contains(viewStr, "Loading, please wait...") {
+		t.Errorf("expected loading message, got %q", viewStr)
+	}
+
+	// screenLoading with error
+	m.errorMsg = "Failed to load repo"
+	viewStr = m.View()
+	if !strings.Contains(viewStr, "Failed to load repo") {
+		t.Errorf("expected errorMsg in loading screen, got %q", viewStr)
+	}
+	m.errorMsg = ""
+
+	// Verifying mode
+	m.verifying = true
+	m.loadingMsg = "Verifying repository..."
+	viewStr = m.View()
+	if !strings.Contains(viewStr, "Verifying repository...") {
+		t.Errorf("expected verifying message, got %q", viewStr)
+	}
+	m.verifying = false
+
+	// Default unknown screen
+	m.screen = screen(999)
+	viewStr = m.View()
+	if !strings.Contains(viewStr, "Unknown screen") {
+		t.Errorf("expected 'Unknown screen' for unknown screen enum, got %q", viewStr)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds comprehensive unit tests and core engine fixes for the Verify, Home, Help, View, and Update components of the TUI:

- **Core TUI Model (`model.go`)**: Fixes `initialModel` to propagate `readOnly: o.readOnly` so the model struct accurately reflects read-only mode upon initialization.
- **Verify Screens (`screen_verify_test.go` & `screen_verify_forms_test.go`)**: Tests main Verify menu view rendering, dynamic menu selection index calculation, Verify Ref and Verify Mergeable forms, focus cycling, inline validation, and partial submissions.
- **Home Screen (`screen_home_test.go`)**: Tests home screen menu selection dispatching logic.
- **Help Screen (`screen_help_test.go`)**: Tests generic help screen view rendering and keybinding displays.
- **View Module (`view_test.go`)**: Tests view rendering across screen states, header/footer formatting, error dialog overlays, and status bar rendering.
- **Update Loop & Common Engine (`update_test.go`)**: Tests main TUI update loop, global keybindings (`h`, `q`, `esc`), error dialog dismissals, log channel streaming helpers (`splitAndTrim`, `drainLogChannel`), and descriptive subtest names for `TestUpdateEscNavigationAcrossScreens`.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull request.
- [x] I **did** use generative AI in some form in making the content of this pull request. I have described my use of AI below.

AI was used to draft unit tests and review edge cases. All code has been manually reviewed, tested (`go test`), and verified with `golangci-lint` locally.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).