### PR TITLE
test: add unit test for PublicKeys in internal/cmd/common

### DIFF
--- a/internal/cmd/common/common_test.go
+++ b/internal/cmd/common/common_test.go
@@ -1,0 +1,30 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicKeys(t *testing.T) {
+	t.Parallel()
+
+	pk := &PublicKeys{}
+
+	// Test Type()
+	assert.Equal(t, "public-keys", pk.Type())
+
+	// Test Set() and String() with initial value
+	err := pk.Set("key1.pub")
+	require.NoError(t, err)
+	assert.Equal(t, "key1.pub", pk.String())
+
+	// Test Set() appending a second value and String() formatting with comma separation
+	err = pk.Set("key2.pub")
+	require.NoError(t, err)
+	assert.Equal(t, "key1.pub, key2.pub", pk.String())
+}


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

Adds unit test coverage for the `PublicKeys` type methods (`Type`, `Set`, and `String`) in `internal/cmd/common/common.go`.

Part of #1252

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

I used AI to assist in the draft code, but manually tested its accuracy to make sure the tests work. 

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
