### PR TITLE
test: add unit test for push command in internal/cmd/rsl/remote/push

### DIFF
--- a/internal/cmd/rsl/remote/push/push_test.go
+++ b/internal/cmd/rsl/remote/push/push_test.go
@@ -1,0 +1,37 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package push
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPush(t *testing.T) {
+	t.Run("missing required argument via cobra", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid repository path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_, _, _, err := cmd.ExecuteCommandC(New(), "origin")
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("repository initialized without remote", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_ = gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		_, _, _, err := cmd.ExecuteCommandC(New(), "origin")
+		assert.ErrorContains(t, err, "unable to push RSL")
+	})
+}


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->
Adds unit test coverage for `internal/cmd/rsl/remote/push`, verifying command initialization (`New()`) and options execution (`Run()`) across valid and invalid repository path scenarios.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

I used AI to assist in the draft code, but manually tested its accuracy to make sure the tests work. 



## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
