### PR TITLE
feat(tui): connecting new error screen to trust menus

### DIFF
--- a/internal/cmd/tui/screen_trust_github_app.go
+++ b/internal/cmd/tui/screen_trust_github_app.go
@@ -4,7 +4,6 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -227,7 +226,18 @@ func (s *trustGitHubAppScreen) handleFormSubmit(m *model) (tea.Model, tea.Cmd) {
 	}
 
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error updating GitHub App settings: %v", err)
+		title := "Update GitHub App Settings Failed"
+		switch s.selectedAction {
+		case trustGitHubAppActionAdd:
+			title = "Add GitHub App Failed"
+		case trustGitHubAppActionRemove:
+			title = "Remove GitHub App Failed"
+		case trustGitHubAppActionEnableApprovals:
+			title = "Enable App Approvals Failed"
+		case trustGitHubAppActionDisableApprovals:
+			title = "Disable App Approvals Failed"
+		}
+		m.openErrorDialog(title, err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/screen_trust_hooks.go
+++ b/internal/cmd/tui/screen_trust_hooks.go
@@ -4,8 +4,6 @@
 package tui
 
 import (
-	"fmt"
-
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -158,7 +156,7 @@ func runSelectedHookAction(s *trustHookScreen, m *model) {
 	case trustListHooksAction:
 		trustHooks, err := repoListHooks(m.ctx, m.options)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error listing hooks: %v", err)
+			m.openErrorDialog("List Hooks Failed", err.Error())
 			return
 		}
 

--- a/internal/cmd/tui/screen_trust_keys_thresholds.go
+++ b/internal/cmd/tui/screen_trust_keys_thresholds.go
@@ -171,7 +171,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 
 		err = repoAddRootKey(m.ctx, m.options, value)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error adding root key: %v", err)
+			m.openErrorDialog("Add Root Key Failed", err.Error())
 			return *m, nil
 		}
 
@@ -191,7 +191,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 
 		err = repoRemoveRootKey(m.ctx, m.options, value)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error removing root key: %v", err)
+			m.openErrorDialog("Remove Root Key Failed", err.Error())
 			return *m, nil
 		}
 
@@ -211,7 +211,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 
 		err = repoAddPolicyKey(m.ctx, m.options, value)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error adding policy key: %v", err)
+			m.openErrorDialog("Add Policy Key Failed", err.Error())
 			return *m, nil
 		}
 
@@ -231,7 +231,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 
 		err = repoRemovePolicyKey(m.ctx, m.options, value)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error removing policy key: %v", err)
+			m.openErrorDialog("Remove Policy Key Failed", err.Error())
 			return *m, nil
 		}
 
@@ -255,7 +255,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 		}
 		err = repoUpdateRootThreshold(m.ctx, m.options, threshold)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error updating root threshold: %v", err)
+			m.openErrorDialog("Update Root Threshold Failed", err.Error())
 			return *m, nil
 		}
 
@@ -280,7 +280,7 @@ func (s *trustKeysThresholdsScreen) handleFormSubmit(m *model) (tea.Model, tea.C
 		}
 		err = repoUpdatePolicyThreshold(m.ctx, m.options, threshold)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error updating policy threshold: %v", err)
+			m.openErrorDialog("Update Policy Threshold Failed", err.Error())
 			return *m, nil
 		}
 

--- a/internal/cmd/tui/screen_trust_lifecycle.go
+++ b/internal/cmd/tui/screen_trust_lifecycle.go
@@ -4,8 +4,6 @@
 package tui
 
 import (
-	"fmt"
-
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -80,7 +78,7 @@ func runSelectedLifecycleAction(s *trustLifecycleScreen, m *model) {
 	case trustLifecycleActionStage:
 		err = repoStageTrustChanges(m.ctx, m.options)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error staging trust changes: %v", err)
+			m.openErrorDialog("Stage Trust Changes Failed", err.Error())
 			return
 		}
 
@@ -91,7 +89,7 @@ func runSelectedLifecycleAction(s *trustLifecycleScreen, m *model) {
 	case trustLifecycleActionSign:
 		err = repoSignTrustChanges(m.ctx, m.options)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error signing trust changes: %v", err)
+			m.openErrorDialog("Sign Trust Changes Failed", err.Error())
 			return
 		}
 
@@ -102,7 +100,7 @@ func runSelectedLifecycleAction(s *trustLifecycleScreen, m *model) {
 	case trustLifecycleActionApply:
 		err = repoApplyTrustChanges(m.ctx, m.options)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error applying trust changes: %v", err)
+			m.openErrorDialog("Apply Trust Changes Failed", err.Error())
 			return
 		}
 

--- a/internal/cmd/tui/screen_trust_propagation.go
+++ b/internal/cmd/tui/screen_trust_propagation.go
@@ -4,7 +4,6 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -175,7 +174,7 @@ func runSelectedPropagationAction(s *trustPropagationScreen, m *model) {
 	case trustListDirectivesAction:
 		directives, err := repoListPropagationDirectives(m.ctx, m.options)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error listing directives: %v", err)
+			m.openErrorDialog("List Directives Failed", err.Error())
 			return
 		}
 
@@ -242,7 +241,11 @@ func (s *trustPropagationScreen) handlePropagationFormSubmit(m *model) (tea.Mode
 			m.footer = "Propagation directive updated!"
 		}
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error saving directive: %v", err)
+			title := "Update Directive Failed"
+			if s.selectedAction == trustAddDirectiveAction {
+				title = "Add Directive Failed"
+			}
+			m.openErrorDialog(title, err.Error())
 			return *m, nil
 		}
 	case trustRemoveDirectiveAction:
@@ -252,7 +255,7 @@ func (s *trustPropagationScreen) handlePropagationFormSubmit(m *model) (tea.Mode
 			return *m, nil
 		}
 		if err := repoRemovePropagationDirective(m.ctx, m.options, name); err != nil {
-			m.errorMsg = fmt.Sprintf("Error removing directive: %v", err)
+			m.openErrorDialog("Remove Directive Failed", err.Error())
 			return *m, nil
 		}
 		m.footer = "Propagation directive removed!"

--- a/internal/cmd/tui/screen_trust_repo_network.go
+++ b/internal/cmd/tui/screen_trust_repo_network.go
@@ -4,7 +4,6 @@
 package tui
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -231,7 +230,18 @@ func (s *trustRepoNetworkScreen) handleFormSubmit(m *model) (tea.Model, tea.Cmd)
 	}
 
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error updating repo/network settings: %v", err)
+		title := "Update Repo/Network Settings Failed"
+		switch s.selectedAction {
+		case trustRepoNetworkActionAddControllerRepository:
+			title = "Add Controller Repository Failed"
+		case trustRepoNetworkActionAddNetworkRepository:
+			title = "Add Network Repository Failed"
+		case trustRepoNetworkActionSetRepositoryLocation:
+			title = "Set Repository Location Failed"
+		case trustRepoNetworkActionMakeController:
+			title = "Make Controller Failed"
+		}
+		m.openErrorDialog(title, err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/trusthelpers.go
+++ b/internal/cmd/tui/trusthelpers.go
@@ -547,14 +547,14 @@ func (s *trustHookScreen) handleHookFormSubmit(m *model) (tea.Model, tea.Cmd) {
 	case trustAddHookAction:
 		err = repoAddHook(m.ctx, m.options, hookName, s.isPreCommit, s.isPrePush, timeout, environment, principalIDs)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error adding hook: %v", err)
+			m.openErrorDialog("Add Hook Failed", err.Error())
 			return *m, nil
 		}
 		m.footer = "Hook added!"
 	case trustUpdateHookAction:
 		err = repoUpdateHook(m.ctx, m.options, hookName, s.isPreCommit, s.isPrePush, timeout, environment, principalIDs)
 		if err != nil {
-			m.errorMsg = fmt.Sprintf("Error adding hook: %v", err)
+			m.openErrorDialog("Update Hook Failed", err.Error())
 			return *m, nil
 		}
 		m.footer = "Hook updated!"
@@ -586,7 +586,7 @@ func (s *trustHookScreen) handleRemoveHookSubmit(m *model) (tea.Model, tea.Cmd) 
 
 	err := repoRemoveHook(m.ctx, m.options, value, s.isPreCommit, s.isPrePush)
 	if err != nil {
-		m.errorMsg = fmt.Sprintf("Error removing hook: %v", err)
+		m.openErrorDialog("Remove Hook Failed", err.Error())
 		return *m, nil
 	}
 

--- a/internal/cmd/tui/tui_test.go
+++ b/internal/cmd/tui/tui_test.go
@@ -172,13 +172,17 @@ func TestTUI(t *testing.T) {
 		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-			return strings.Contains(string(out), "Error listing hooks")
+			content := string(out)
+			return strings.Contains(content, "List Hooks Failed") &&
+				strings.Contains(content, "Press Enter or Esc to close.")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 
 		tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
 
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-			return strings.Contains(string(out), "Home › Trust")
+			content := string(out)
+			return strings.Contains(content, "Trust Hooks") &&
+				strings.Contains(content, "List Hooks")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 	})
 
@@ -207,13 +211,17 @@ func TestTUI(t *testing.T) {
 		tm.Send(tea.KeyMsg{Type: tea.KeyEnter})
 
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-			return strings.Contains(string(out), "Error listing directives")
+			content := string(out)
+			return strings.Contains(content, "List Directives Failed") &&
+				strings.Contains(content, "Press Enter or Esc to close.")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 
 		tm.Send(tea.KeyMsg{Type: tea.KeyEsc})
 
 		teatest.WaitFor(t, tm.Output(), func(out []byte) bool {
-			return strings.Contains(string(out), "Home › Trust")
+			content := string(out)
+			return strings.Contains(content, "Trust Propagation") &&
+				strings.Contains(content, "List Directives")
 		}, teatest.WithCheckInterval(time.Millisecond*100), teatest.WithDuration(time.Second*15))
 	})
 }
@@ -434,4 +442,46 @@ func TestTrustMenuRoutesToWriteScreens(t *testing.T) {
 			assert.Equal(t, tt.screen, typed.screen)
 		})
 	}
+}
+
+func TestTrustPropagationBackendErrorUsesErrorDialog(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenTrustUpdatePropagationForm
+	m.trustPropagationScreen.selectedAction = trustUpdateDirectiveAction
+	m.trustPropagationScreen.inputs = initInputs([]inputField{
+		{placeholder: "Directive name", prompt: "Name: "},
+		{placeholder: "Upstream repository", prompt: "From Repository: "},
+		{placeholder: "Upstream reference", prompt: "From Reference: "},
+		{placeholder: "Upstream path", prompt: "From Path: "},
+		{placeholder: "Downstream reference", prompt: "Into Reference: "},
+		{placeholder: "Downstream path", prompt: "Into Path: "},
+	})
+	m.trustPropagationScreen.inputs[0].SetValue("demo")
+	m.trustPropagationScreen.inputs[1].SetValue("repo")
+	m.trustPropagationScreen.inputs[2].SetValue("main")
+	m.trustPropagationScreen.inputs[4].SetValue("refs/heads/main")
+	m.trustPropagationScreen.inputs[5].SetValue("policy")
+
+	updated, _ := m.trustPropagationScreen.handlePropagationFormSubmit(&m)
+	typed := updated.(model)
+
+	require.NotNil(t, typed.errorDialog)
+	assert.Equal(t, "Update Directive Failed", typed.errorDialog.title)
+	assert.NotEmpty(t, typed.errorDialog.message)
+	assert.Empty(t, typed.errorMsg)
+}
+
+func TestTrustKeyValidationStaysInline(t *testing.T) {
+	m := initialModel(context.Background(), &options{readOnly: false, targetRef: "policy"})
+	m.screen = screenTrustKeyForm
+	m.trustKeysScreen.selectedAction = trustKeysActionAddRootKey
+	m.trustKeysScreen.inputs = initInputs([]inputField{
+		{placeholder: "Path to public key or key ref", prompt: "Key: "},
+	})
+
+	updated, _ := m.trustKeysScreen.handleFormSubmit(&m)
+	typed := updated.(model)
+
+	assert.Nil(t, typed.errorDialog)
+	assert.Equal(t, "Key input is required", typed.errorMsg)
 }


### PR DESCRIPTION
## Description

This PR addes the new error popup window into the trust tui screens so the errors can be shown in the modal instead of inline footer text

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

used generative Ai to generate test case
<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
