### PR TITLE
gitinterface: resolve worktrees for detached git dirs and linked worktrees

### DIFF
--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -84,7 +84,10 @@ func (r *Repository) ensureNoCompatObjectFormat() error {
 			if !filepath.IsAbs(commonDirPath) {
 				commonDirPath = filepath.Join(r.gitDirPath, commonDirPath)
 			}
-			configPath = filepath.Join(commonDirPath, "config")
+			commonConfigPath := filepath.Join(commonDirPath, "config")
+			if fileInfo, err := os.Stat(commonConfigPath); err == nil && fileInfo.Mode().IsRegular() {
+				configPath = commonConfigPath
+			}
 		}
 	}
 
@@ -199,13 +202,12 @@ func (r *Repository) GetGitDir() string {
 
 // IsBare returns true if the repository is a bare repository, i.e. it has no
 // worktree. Bareness is determined by Git itself; if Git cannot be consulted,
-// we fall back to inspecting the GIT_DIR name.
+// we fall back to checking for the sentinel files Git writes on bare
+// repositories.
 func (r *Repository) IsBare() bool {
 	stdOut, err := r.executor("rev-parse", "--is-bare-repository").executeString()
 	if err != nil {
-		// TODO: this may not work when the repo is cloned with GIT_DIR set
-		// elsewhere. We don't support this at the moment, so it's probably okay?
-		return !strings.HasSuffix(r.gitDirPath, ".git")
+		return isBareGitDir(r.gitDirPath)
 	}
 	return stdOut == "true"
 }
@@ -215,15 +217,13 @@ func (r *Repository) IsBare() bool {
 // ErrNoWorktree if the repository is bare or if the worktree cannot be
 // determined.
 //
-// Resolution relies on Git's own records so that repositories with a detached
-// GIT_DIR (--separate-git-dir) and linked worktrees (`git worktree add`) are
-// handled correctly:
+// Resolves:
 //  1. linked worktrees record the location of their `.git` file in
-//     `$GIT_DIR/gitdir`
-//  2. `core.worktree` may be set explicitly in some configurations
-//  3. the worktree may have been discovered while loading the repository,
-//     which is the only reliable source for repositories with a detached
-//     GIT_DIR that do not set core.worktree
+//     `$GIT_DIR/gitdir`; the link is verified in both directions
+//  2. the worktree discovered while loading the repository, which is the only
+//     reliable source for repositories with a detached GIT_DIR
+//  3. `core.worktree` from the repository-local configuration, set explicitly
+//     for repositories like submodules
 //  4. otherwise, a `$GIT_DIR` named `.git` implies its parent directory is
 //     the worktree
 //
@@ -241,17 +241,23 @@ func (r *Repository) GetWorktree() (string, error) {
 				worktree = filepath.Join(r.gitDirPath, worktree)
 			}
 			worktree = resolvePath(worktree)
-			// Git records the location of the worktree's `.git` entry here;
-			// if it does not exist, the record is stale or malformed.
+			// Git records the location of the worktree's `.git` entry here.
+			// Verify the link in the other direction too: the `.git` file it
+			// points at must reference this GIT_DIR, so a stale pointer that
+			// now belongs to a different repository is rejected.
 			if isUsableWorktree(r.gitDirPath, worktree) {
-				if _, err := os.Stat(filepath.Join(worktree, ".git")); err == nil {
+				if gitDirBelongsTo(worktree, r.gitDirPath) {
 					return worktree, nil
 				}
 			}
 		}
 	}
 
-	if worktree, err := r.executor("config", "--get", "core.worktree").executeString(); err == nil && worktree != "" {
+	if r.worktreePath != "" {
+		return resolvePath(r.worktreePath), nil
+	}
+
+	if worktree, err := r.executor("config", "--local", "--get", "core.worktree").executeString(); err == nil && worktree != "" {
 		if !filepath.IsAbs(worktree) {
 			// Git interprets relative core.worktree values relative to the
 			// GIT_DIR.
@@ -263,10 +269,6 @@ func (r *Repository) GetWorktree() (string, error) {
 		}
 	}
 
-	if r.worktreePath != "" {
-		return resolvePath(r.worktreePath), nil
-	}
-
 	if filepath.Base(r.gitDirPath) == ".git" {
 		return resolvePath(filepath.Dir(r.gitDirPath)), nil
 	}
@@ -274,11 +276,42 @@ func (r *Repository) GetWorktree() (string, error) {
 	return "", fmt.Errorf("%w: unable to determine worktree for '%s'", ErrNoWorktree, r.gitDirPath)
 }
 
+// gitDirBelongsTo returns true if the `.git` entry at the specified worktree
+// resolves to the supplied GIT_DIR. A conventional `.git` directory matches
+// only when its resolved path is the GIT_DIR; a `.git` file matches when its
+// `gitdir:` pointer resolves to the GIT_DIR.
+func gitDirBelongsTo(worktree, gitDirPath string) bool {
+	resolvedGitDir := resolvePath(gitDirPath)
+	gitEntryPath := filepath.Join(worktree, ".git")
+	fileInfo, err := os.Stat(gitEntryPath)
+	if err != nil {
+		return false
+	}
+	if fileInfo.IsDir() {
+		return filepath.Clean(resolvePath(gitEntryPath)) == filepath.Clean(resolvedGitDir)
+	}
+	gitFileContents, err := os.ReadFile(gitEntryPath)
+	if err != nil {
+		return false
+	}
+	link, has := strings.CutPrefix(strings.TrimSpace(string(gitFileContents)), "gitdir:")
+	if !has {
+		return false
+	}
+	link = strings.TrimSpace(link)
+	if !filepath.IsAbs(link) {
+		link = filepath.Join(worktree, link)
+	}
+	return filepath.Clean(resolvePath(link)) == filepath.Clean(resolvedGitDir)
+}
+
 // isUsableWorktree returns true if the candidate path is an existing directory
 // other than the repository's Git directory.
 func isUsableWorktree(gitDirPath, candidate string) bool {
 	fileInfo, err := os.Stat(candidate)
-	return err == nil && fileInfo.IsDir() && filepath.Clean(candidate) != filepath.Clean(gitDirPath)
+	return err == nil &&
+		fileInfo.IsDir() &&
+		filepath.Clean(resolvePath(candidate)) != filepath.Clean(resolvePath(gitDirPath))
 }
 
 // LoadRepository returns a Repository instance using the current working

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -85,13 +85,13 @@ func (r *Repository) ensureNoCompatObjectFormat() error {
 				commonDirPath = filepath.Join(r.gitDirPath, commonDirPath)
 			}
 			commonConfigPath := filepath.Join(commonDirPath, "config")
-			if fileInfo, err := os.Stat(commonConfigPath); err == nil && fileInfo.Mode().IsRegular() {
+			if fileInfo, err := os.Stat(commonConfigPath); err == nil && fileInfo.Mode().IsRegular() { //nolint:gosec // the path comes from the repository's own commondir and is verified to be a regular file here
 				configPath = commonConfigPath
 			}
 		}
 	}
 
-	configFile, err := os.Open(configPath)
+	configFile, err := os.Open(configPath) //nolint:gosec // opens either the repository's own config or an existing regular file at the commondir location
 	if err != nil {
 		return fmt.Errorf("unable to read repository config: %w", err)
 	}
@@ -265,7 +265,11 @@ func (r *Repository) GetWorktree() (string, error) {
 		}
 		worktree = resolvePath(worktree)
 		if isUsableWorktree(r.gitDirPath, worktree) {
-			return worktree, nil
+			// The worktree must belong to this repository, so core.worktree
+			// cannot redirect resolution to an unrelated directory.
+			if gitDirBelongsTo(worktree, r.gitDirPath) {
+				return worktree, nil
+			}
 		}
 	}
 
@@ -282,15 +286,15 @@ func (r *Repository) GetWorktree() (string, error) {
 // `gitdir:` pointer resolves to the GIT_DIR.
 func gitDirBelongsTo(worktree, gitDirPath string) bool {
 	resolvedGitDir := resolvePath(gitDirPath)
-	gitEntryPath := filepath.Join(worktree, ".git")
-	fileInfo, err := os.Stat(gitEntryPath)
+	gitEntryPath := filepath.Join(worktree, ".git") //nolint:gosec // worktree is resolved and validated before being passed in here
+	fileInfo, err := os.Stat(gitEntryPath)          //nolint:gosec // gitEntryPath is on the already-validated worktree path
 	if err != nil {
 		return false
 	}
 	if fileInfo.IsDir() {
 		return filepath.Clean(resolvePath(gitEntryPath)) == filepath.Clean(resolvedGitDir)
 	}
-	gitFileContents, err := os.ReadFile(gitEntryPath)
+	gitFileContents, err := os.ReadFile(gitEntryPath) //nolint:gosec // gitEntryPath is on the already-validated worktree path
 	if err != nil {
 		return false
 	}
@@ -308,7 +312,7 @@ func gitDirBelongsTo(worktree, gitDirPath string) bool {
 // isUsableWorktree returns true if the candidate path is an existing directory
 // other than the repository's Git directory.
 func isUsableWorktree(gitDirPath, candidate string) bool {
-	fileInfo, err := os.Stat(candidate)
+	fileInfo, err := os.Stat(candidate) //nolint:gosec // candidate is a worktree path validated against the repository before use
 	return err == nil &&
 		fileInfo.IsDir() &&
 		filepath.Clean(resolvePath(candidate)) != filepath.Clean(resolvePath(gitDirPath))

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -29,12 +29,16 @@ var (
 	ErrRepositoryPathNotSpecified    = errors.New("repository path not specified")
 	ErrUnknownObjectFormat           = errors.New("unknown object format")
 	ErrCompatObjectFormatUnsupported = errors.New("gittuf does not support repositories with extensions.compatObjectFormat enabled")
+	ErrNoWorktree                    = errors.New("repository has no worktree")
 )
 
 // Repository is a lightweight wrapper around a Git repository. It stores the
-// location of the repository's GIT_DIR.
+// location of the repository's GIT_DIR. If the repository has a worktree and
+// it was discovered while loading the repository, its location is also
+// recorded.
 type Repository struct {
 	gitDirPath   string
+	worktreePath string
 	objectFormat ObjectFormat
 	clock        clockwork.Clock
 }
@@ -70,6 +74,20 @@ func (r *Repository) readObjectFormat() (ObjectFormat, error) {
 // support refuse to open such repositories at all.
 func (r *Repository) ensureNoCompatObjectFormat() error {
 	configPath := filepath.Join(r.gitDirPath, "config")
+
+	// Linked worktrees do not have their own config file: configuration lives
+	// in the repository's common Git directory, whose location is recorded in
+	// $GIT_DIR/commondir.
+	if contents, err := os.ReadFile(filepath.Join(r.gitDirPath, "commondir")); err == nil {
+		commonDirPath := strings.TrimSpace(string(contents))
+		if commonDirPath != "" {
+			if !filepath.IsAbs(commonDirPath) {
+				commonDirPath = filepath.Join(r.gitDirPath, commonDirPath)
+			}
+			configPath = filepath.Join(commonDirPath, "config")
+		}
+	}
+
 	configFile, err := os.Open(configPath)
 	if err != nil {
 		return fmt.Errorf("unable to read repository config: %w", err)
@@ -88,35 +106,35 @@ func (r *Repository) ensureNoCompatObjectFormat() error {
 	return nil
 }
 
-func findGitDirPath(startPath string) (string, bool, error) {
+func findGitDirPath(startPath string) (string, string, bool, error) {
 	currentPath, err := filepath.Abs(startPath)
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
 
 	for {
 		gitDirPath := filepath.Join(currentPath, ".git")
 		if fileInfo, err := os.Stat(gitDirPath); err == nil {
 			if fileInfo.IsDir() {
-				return gitDirPath, true, nil
+				return gitDirPath, currentPath, true, nil
 			}
 
 			resolvedGitDirPath, err := readGitDirFile(gitDirPath, currentPath)
 			if err != nil {
-				return "", false, err
+				return "", "", false, err
 			}
-			return resolvedGitDirPath, true, nil
+			return resolvedGitDirPath, currentPath, true, nil
 		} else if !os.IsNotExist(err) {
-			return "", false, err
+			return "", "", false, err
 		}
 
 		if isBareGitDir(currentPath) {
-			return currentPath, true, nil
+			return currentPath, "", true, nil
 		}
 
 		parentPath := filepath.Dir(currentPath)
 		if parentPath == currentPath {
-			return "", false, nil
+			return "", "", false, nil
 		}
 		currentPath = parentPath
 	}
@@ -150,6 +168,20 @@ func isBareGitDir(path string) bool {
 	return true
 }
 
+// resolvePath returns the absolute, symlink-resolved form of the specified
+// path. If the path cannot be resolved, the absolute path is returned.
+func resolvePath(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	resolvedPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return absPath
+	}
+	return resolvedPath
+}
+
 // GetGoGitRepository returns the go-git representation of a repository. We use
 // this in certain signing and verifying workflows.
 func (r *Repository) GetGoGitRepository() (*git.Repository, error) {
@@ -165,11 +197,88 @@ func (r *Repository) GetGitDir() string {
 	return r.gitDirPath
 }
 
-// IsBare returns true if the repository is a bare repository.
+// IsBare returns true if the repository is a bare repository, i.e. it has no
+// worktree. Bareness is determined by Git itself; if Git cannot be consulted,
+// we fall back to inspecting the GIT_DIR name.
 func (r *Repository) IsBare() bool {
-	// TODO: this may not work when the repo is cloned with GIT_DIR set
-	// elsewhere. We don't support this at the moment, so it's probably okay?
-	return !strings.HasSuffix(r.gitDirPath, ".git")
+	stdOut, err := r.executor("rev-parse", "--is-bare-repository").executeString()
+	if err != nil {
+		// TODO: this may not work when the repo is cloned with GIT_DIR set
+		// elsewhere. We don't support this at the moment, so it's probably okay?
+		return !strings.HasSuffix(r.gitDirPath, ".git")
+	}
+	return stdOut == "true"
+}
+
+// GetWorktree returns the absolute path of the repository's worktree, i.e.
+// the directory containing the checked out files. It returns an error wrapping
+// ErrNoWorktree if the repository is bare or if the worktree cannot be
+// determined.
+//
+// Resolution relies on Git's own records so that repositories with a detached
+// GIT_DIR (--separate-git-dir) and linked worktrees (`git worktree add`) are
+// handled correctly:
+//  1. linked worktrees record the location of their `.git` file in
+//     `$GIT_DIR/gitdir`
+//  2. `core.worktree` may be set explicitly in some configurations
+//  3. the worktree may have been discovered while loading the repository,
+//     which is the only reliable source for repositories with a detached
+//     GIT_DIR that do not set core.worktree
+//  4. otherwise, a `$GIT_DIR` named `.git` implies its parent directory is
+//     the worktree
+//
+// Callers can test for ErrNoWorktree with errors.Is.
+func (r *Repository) GetWorktree() (string, error) {
+	if r.IsBare() {
+		return "", ErrNoWorktree
+	}
+
+	if contents, err := os.ReadFile(filepath.Join(r.gitDirPath, "gitdir")); err == nil {
+		gitDirFilePath := strings.TrimSpace(string(contents))
+		if gitDirFilePath != "" {
+			worktree := filepath.Dir(gitDirFilePath)
+			if !filepath.IsAbs(worktree) {
+				worktree = filepath.Join(r.gitDirPath, worktree)
+			}
+			worktree = resolvePath(worktree)
+			// Git records the location of the worktree's `.git` entry here;
+			// if it does not exist, the record is stale or malformed.
+			if isUsableWorktree(r.gitDirPath, worktree) {
+				if _, err := os.Stat(filepath.Join(worktree, ".git")); err == nil {
+					return worktree, nil
+				}
+			}
+		}
+	}
+
+	if worktree, err := r.executor("config", "--get", "core.worktree").executeString(); err == nil && worktree != "" {
+		if !filepath.IsAbs(worktree) {
+			// Git interprets relative core.worktree values relative to the
+			// GIT_DIR.
+			worktree = filepath.Join(r.gitDirPath, worktree)
+		}
+		worktree = resolvePath(worktree)
+		if isUsableWorktree(r.gitDirPath, worktree) {
+			return worktree, nil
+		}
+	}
+
+	if r.worktreePath != "" {
+		return resolvePath(r.worktreePath), nil
+	}
+
+	if filepath.Base(r.gitDirPath) == ".git" {
+		return resolvePath(filepath.Dir(r.gitDirPath)), nil
+	}
+
+	return "", fmt.Errorf("%w: unable to determine worktree for '%s'", ErrNoWorktree, r.gitDirPath)
+}
+
+// isUsableWorktree returns true if the candidate path is an existing directory
+// other than the repository's Git directory.
+func isUsableWorktree(gitDirPath, candidate string) bool {
+	fileInfo, err := os.Stat(candidate)
+	return err == nil && fileInfo.IsDir() && filepath.Clean(candidate) != filepath.Clean(gitDirPath)
 }
 
 // LoadRepository returns a Repository instance using the current working
@@ -186,12 +295,13 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 
 	repo := &Repository{clock: clockwork.NewRealClock()}
 
-	gitDirPath, has, err := findGitDirPath(repositoryPath)
+	gitDirPath, worktreePath, has, err := findGitDirPath(repositoryPath)
 	if err != nil {
 		return nil, err
 	}
 	if has {
 		repo.gitDirPath = gitDirPath
+		repo.worktreePath = worktreePath
 		if err := repo.ensureNoCompatObjectFormat(); err != nil {
 			return nil, err
 		}
@@ -218,6 +328,27 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 	}
 	slog.Debug(fmt.Sprintf("Setting git directory for repository to '%s'...", absPath))
 	repo.gitDirPath = absPath
+
+	// Capture the worktree using the same invocation context that resolved
+	// the Git directory so that the two remain consistent even when
+	// environment variables like GIT_DIR influence discovery. Note that
+	// `--show-toplevel` must run without an explicit `--git-dir`: with one,
+	// Git regards the working directory itself as the top level. For bare
+	// repositories this fails and no worktree is recorded.
+	stdOut, stdErr, err = repo.executor("rev-parse", "--show-toplevel").withoutGitDir().withDir(repositoryPath).execute()
+	if err == nil {
+		if worktreeContents, readErr := io.ReadAll(stdOut); readErr == nil {
+			if worktree := strings.TrimSpace(string(worktreeContents)); worktree != "" {
+				slog.Debug(fmt.Sprintf("Setting worktree for repository to '%s'...", worktree))
+				repo.worktreePath = worktree
+			}
+		}
+	} else {
+		errContents, readErr := io.ReadAll(stdErr)
+		if readErr == nil {
+			slog.Debug(fmt.Sprintf("Repository '%s' does not have a worktree: %s", absPath, strings.TrimSpace(string(errContents))))
+		}
+	}
 
 	objectFormat, err := repo.readObjectFormat()
 	if err != nil {

--- a/pkg/gitinterface/repository_test.go
+++ b/pkg/gitinterface/repository_test.go
@@ -71,7 +71,7 @@ func TestRepository(t *testing.T) {
 
 	t.Run("invalid path", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if _, has, err := findGitDirPath(tmpDir); err == nil && has {
+		if _, _, has, err := findGitDirPath(tmpDir); err == nil && has {
 			tmpDir = filepath.Join(tmpDir, "invalid-repository")
 			require.Nil(t, os.Mkdir(tmpDir, 0o700))
 			require.Nil(t, os.WriteFile(filepath.Join(tmpDir, ".git"), []byte("not a gitdir file"), 0o600))
@@ -127,20 +127,22 @@ func TestFindGitDirPath(t *testing.T) {
 		nestedDir := filepath.Join(tmpDir, "nested", "dir")
 		require.Nil(t, os.MkdirAll(nestedDir, 0o700))
 
-		gitDirPath, has, err := findGitDirPath(nestedDir)
+		gitDirPath, worktreePath, has, err := findGitDirPath(nestedDir)
 		require.Nil(t, err)
 		assert.True(t, has)
 		assert.Equal(t, filepath.Join(tmpDir, ".git"), gitDirPath)
+		assert.Equal(t, tmpDir, worktreePath)
 	})
 
 	t.Run("bare git directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		_ = CreateTestGitRepository(t, tmpDir, true)
 
-		gitDirPath, has, err := findGitDirPath(tmpDir)
+		gitDirPath, worktreePath, has, err := findGitDirPath(tmpDir)
 		require.Nil(t, err)
 		assert.True(t, has)
 		assert.Equal(t, tmpDir, gitDirPath)
+		assert.Empty(t, worktreePath)
 	})
 
 	t.Run("gitdir file", func(t *testing.T) {
@@ -151,31 +153,32 @@ func TestFindGitDirPath(t *testing.T) {
 		gitDirPath := filepath.Join(tmpDir, "actual.git")
 		require.Nil(t, os.WriteFile(filepath.Join(worktreePath, ".git"), []byte("gitdir: ../actual.git\n"), 0o600))
 
-		gotGitDirPath, has, err := findGitDirPath(worktreePath)
+		gotGitDirPath, gotWorktreePath, has, err := findGitDirPath(worktreePath)
 		require.Nil(t, err)
 		assert.True(t, has)
 		assert.Equal(t, gitDirPath, gotGitDirPath)
+		assert.Equal(t, worktreePath, gotWorktreePath)
 	})
 
 	t.Run("invalid gitdir file", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		require.Nil(t, os.WriteFile(filepath.Join(tmpDir, ".git"), []byte("not a gitdir file"), 0o600))
 
-		_, has, err := findGitDirPath(tmpDir)
+		_, _, has, err := findGitDirPath(tmpDir)
 		assert.False(t, has)
 		assert.ErrorContains(t, err, "invalid gitdir file")
 	})
 
 	t.Run("no git directory", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		if _, has, err := findGitDirPath(tmpDir); err == nil && has {
+		if _, _, has, err := findGitDirPath(tmpDir); err == nil && has {
 			tmpDir = "/dev"
-			if _, has, err := findGitDirPath(tmpDir); err != nil || has {
+			if _, _, has, err := findGitDirPath(tmpDir); err != nil || has {
 				t.Skip("unable to find a filesystem path outside a Git repository")
 			}
 		}
 
-		_, has, err := findGitDirPath(tmpDir)
+		_, _, has, err := findGitDirPath(tmpDir)
 		require.Nil(t, err)
 		assert.False(t, has)
 	})

--- a/pkg/gitinterface/status.go
+++ b/pkg/gitinterface/status.go
@@ -95,9 +95,9 @@ func (f *FileStatus) Untracked() bool {
 }
 
 func (r *Repository) Status() (map[string]FileStatus, error) {
-	worktree := r.gitDirPath
-	if !r.IsBare() {
-		worktree = strings.TrimSuffix(worktree, ".git") // TODO: this doesn't support detached git dir
+	worktree, err := r.GetWorktree()
+	if err != nil {
+		return nil, fmt.Errorf("unable to check status of repository: %w", err)
 	}
 
 	output, err := r.executor("status", "--porcelain=1", "-z", "--untracked-files=all", "--ignored").withDir(worktree).executeString()

--- a/pkg/gitinterface/tree.go
+++ b/pkg/gitinterface/tree.go
@@ -319,10 +319,10 @@ func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, u
 			return nil, err
 		}
 		if head == localRef {
-			if _, err := r.executor("restore", "--staged", localPath).withDir(worktree).executeString(); err != nil {
+			if _, err := r.executor("restore", "--staged", "--", localPath).withDir(worktree).executeString(); err != nil {
 				return nil, err
 			}
-			if _, err := r.executor("restore", localPath).withDir(worktree).executeString(); err != nil {
+			if _, err := r.executor("restore", "--", localPath).withDir(worktree).executeString(); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/gitinterface/tree.go
+++ b/pkg/gitinterface/tree.go
@@ -307,14 +307,18 @@ func (r *Repository) CreateSubtreeFromUpstreamRepository(upstream *Repository, u
 		return nil, err
 	}
 
-	if !r.IsBare() {
+	worktree, err := r.GetWorktree()
+	if err != nil {
+		// bare repositories have no worktree to update
+		if !errors.Is(err, ErrNoWorktree) {
+			return nil, err
+		}
+	} else {
 		head, err := r.GetSymbolicReferenceTarget("HEAD")
 		if err != nil {
 			return nil, err
 		}
 		if head == localRef {
-			worktree := strings.TrimSuffix(r.gitDirPath, ".git") // TODO: this doesn't support detached git dir
-
 			if _, err := r.executor("restore", "--staged", localPath).withDir(worktree).executeString(); err != nil {
 				return nil, err
 			}

--- a/pkg/gitinterface/utils.go
+++ b/pkg/gitinterface/utils.go
@@ -46,9 +46,9 @@ func RemoteRef(refName, remoteName string) string {
 func (r *Repository) RestoreWorktree(t *testing.T) {
 	t.Helper()
 
-	worktree := r.gitDirPath
-	if !r.IsBare() {
-		worktree = strings.TrimSuffix(worktree, ".git") // TODO: this doesn't support detached git dir
+	worktree, err := r.GetWorktree()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	if _, err := r.executor("restore", "--staged", ".").withDir(worktree).executeString(); err != nil {

--- a/pkg/gitinterface/worktree_test.go
+++ b/pkg/gitinterface/worktree_test.go
@@ -1,0 +1,257 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gitinterface
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mustRunGit runs a Git command directly for test setup scenarios that have no
+// Repository instance yet (e.g. `git init --separate-git-dir`) and fails the
+// test with the command's output if it does not succeed. Ambient GIT_* environment
+// variables are filtered out to keep the suite hermetic.
+func mustRunGit(t *testing.T, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(binary, args...) //nolint:gosec
+	env := []string{}
+	for _, entry := range os.Environ() {
+		if !strings.HasPrefix(entry, "GIT_DIR=") && !strings.HasPrefix(entry, "GIT_WORK_TREE=") {
+			env = append(env, entry)
+		}
+	}
+	cmd.Env = env
+
+	output, err := cmd.CombinedOutput()
+	require.Nil(t, err, "git %v failed: %s", args, string(output))
+}
+
+func evalTestPath(t *testing.T, path string) string {
+	t.Helper()
+
+	resolved, err := filepath.EvalSymlinks(path)
+	require.Nil(t, err)
+	return resolved
+}
+
+func TestGetWorktree(t *testing.T) {
+	t.Run("standard layout", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false)
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+
+	t.Run("standard layout, SHA-256", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, false, WithSHA256Format())
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+
+	t.Run("loaded from subdirectory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		CreateTestGitRepository(t, tmpDir, false)
+
+		subDir := filepath.Join(tmpDir, "subdir")
+		require.Nil(t, os.Mkdir(subDir, 0o755))
+
+		repo, err := LoadRepository(subDir)
+		require.Nil(t, err)
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+
+	t.Run("detached git dir", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		worktreeDir := filepath.Join(tmpDir, "worktree")
+		gitDirPath := filepath.Join(tmpDir, "storage.git")
+
+		mustRunGit(t, "init", "--separate-git-dir", gitDirPath, worktreeDir)
+
+		repo, err := LoadRepository(worktreeDir)
+		require.Nil(t, err)
+
+		// the legacy TrimSuffix approach resolves to <tmp>/storage, which does
+		// not exist; GetWorktree must resolve to the actual worktree instead
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, worktreeDir), worktree)
+	})
+
+	t.Run("explicit relative core.worktree", func(t *testing.T) {
+		// Git interprets relative core.worktree values relative to the
+		// GIT_DIR; submodules are configured this way
+		tmpDir := t.TempDir()
+		worktreeDir := filepath.Join(tmpDir, "worktree")
+		gitDirPath := filepath.Join(tmpDir, "modules", "repo.git")
+		require.Nil(t, os.MkdirAll(filepath.Dir(gitDirPath), 0o755))
+
+		mustRunGit(t, "init", "--separate-git-dir", gitDirPath, worktreeDir)
+
+		repo, err := LoadRepository(worktreeDir)
+		require.Nil(t, err)
+
+		// replace the absolute value Git recorded with an equivalent relative
+		// one, as `git submodule add` does
+		setRelativeWorktree := repo.executor("config", "core.worktree", "../worktree")
+		_, _, err = setRelativeWorktree.execute()
+		require.Nil(t, err)
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, worktreeDir), worktree)
+	})
+
+	t.Run("stale linked worktree record", func(t *testing.T) {
+		// a $GIT_DIR/gitdir entry that points nowhere must not be trusted
+		tmpDir := t.TempDir()
+		gitDirPath := filepath.Join(tmpDir, ".git")
+		mustRunGit(t, "init", tmpDir)
+
+		repo := &Repository{gitDirPath: gitDirPath}
+		require.Nil(t, os.WriteFile(filepath.Join(gitDirPath, "gitdir"), []byte("/does/not/exist/.git\n"), 0o600))
+
+		// fall back to the standard layout instead of trusting the record
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+
+	t.Run("linked worktree", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mainRepoPath := filepath.Join(tmpDir, "main")
+		linkedRepoPath := filepath.Join(tmpDir, "linked")
+		repo := CreateTestGitRepository(t, mainRepoPath, false)
+
+		// `git worktree add` requires at least one commit
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		_, err := repo.executor("add", ".").executeString()
+		require.Nil(t, err)
+		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
+		require.Nil(t, err)
+
+		_, err = repo.executor("worktree", "add", linkedRepoPath, "-b", "feature").executeString()
+		require.Nil(t, err)
+
+		linkedRepo, err := LoadRepository(linkedRepoPath)
+		require.Nil(t, err)
+
+		// linked worktrees do not have a GIT_DIR ending in .git, so IsBare
+		// must not classify them as bare
+		assert.False(t, linkedRepo.IsBare())
+
+		worktree, err := linkedRepo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, linkedRepoPath), worktree)
+
+		// the main repository still resolves to its own worktree
+		worktree, err = repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, mainRepoPath), worktree)
+	})
+
+	t.Run("linked worktree, SHA-256", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mainRepoPath := filepath.Join(tmpDir, "main")
+		linkedRepoPath := filepath.Join(tmpDir, "linked")
+		repo := CreateTestGitRepository(t, mainRepoPath, false, WithSHA256Format())
+
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		_, err := repo.executor("add", ".").executeString()
+		require.Nil(t, err)
+		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
+		require.Nil(t, err)
+
+		_, err = repo.executor("worktree", "add", linkedRepoPath, "-b", "feature").executeString()
+		require.Nil(t, err)
+
+		// loading a linked worktree reads the repository config from the
+		// common Git directory via commondir
+		linkedRepo, err := LoadRepository(linkedRepoPath)
+		require.Nil(t, err)
+		assert.Equal(t, ObjectFormatSHA256, linkedRepo.GetObjectFormat())
+
+		worktree, err := linkedRepo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, linkedRepoPath), worktree)
+	})
+
+	t.Run("status in linked worktree", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		mainRepoPath := filepath.Join(tmpDir, "main")
+		linkedRepoPath := filepath.Join(tmpDir, "linked")
+		repo := CreateTestGitRepository(t, mainRepoPath, false)
+
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		_, err := repo.executor("add", ".").executeString()
+		require.Nil(t, err)
+		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
+		require.Nil(t, err)
+
+		_, err = repo.executor("worktree", "add", linkedRepoPath, "-b", "feature").executeString()
+		require.Nil(t, err)
+
+		untrackedFile := filepath.Join(linkedRepoPath, "untracked.txt")
+		require.Nil(t, os.WriteFile(untrackedFile, []byte("test"), 0o644))
+
+		linkedRepo, err := LoadRepository(linkedRepoPath)
+		require.Nil(t, err)
+
+		statuses, err := linkedRepo.Status()
+		require.Nil(t, err)
+		assert.Len(t, statuses, 1)
+		status, has := statuses["untracked.txt"]
+		require.True(t, has)
+		assert.True(t, status.Untracked())
+	})
+
+	t.Run("bare repository", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := CreateTestGitRepository(t, tmpDir, true)
+
+		assert.True(t, repo.IsBare())
+
+		_, err := repo.GetWorktree()
+		assert.ErrorIs(t, err, ErrNoWorktree)
+	})
+
+	t.Run("bare repository named with .git suffix", func(t *testing.T) {
+		// the name-based heuristic misclassified these as non-bare
+		tmpDir := t.TempDir()
+		bareDirPath := filepath.Join(tmpDir, "bare.git")
+		repo := setupRepository(t, bareDirPath, true, ObjectFormatSHA1)
+
+		assert.True(t, repo.IsBare())
+
+		_, err := repo.GetWorktree()
+		assert.ErrorIs(t, err, ErrNoWorktree)
+	})
+
+	t.Run("fallback without LoadRepository", func(t *testing.T) {
+		// repositories constructed directly only carry their GIT_DIR, so
+		// resolution falls back to Git's standard layout
+		tmpDir := t.TempDir()
+		mustRunGit(t, "init", tmpDir)
+
+		repo := &Repository{gitDirPath: filepath.Join(tmpDir, ".git")}
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+}

--- a/pkg/gitinterface/worktree_test.go
+++ b/pkg/gitinterface/worktree_test.go
@@ -24,7 +24,8 @@ func mustRunGit(t *testing.T, args ...string) {
 	cmd := exec.Command(binary, args...) //nolint:gosec
 	env := []string{}
 	for _, entry := range os.Environ() {
-		if !strings.HasPrefix(entry, "GIT_DIR=") && !strings.HasPrefix(entry, "GIT_WORK_TREE=") {
+		key := strings.ToUpper(strings.SplitN(entry, "=", 2)[0])
+		if key != "GIT_DIR" && key != "GIT_WORK_TREE" {
 			env = append(env, entry)
 		}
 	}
@@ -44,6 +45,8 @@ func evalTestPath(t *testing.T, path string) string {
 
 func TestGetWorktree(t *testing.T) {
 	t.Run("standard layout", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		repo := CreateTestGitRepository(t, tmpDir, false)
 
@@ -62,6 +65,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("loaded from subdirectory", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		CreateTestGitRepository(t, tmpDir, false)
 
@@ -77,6 +82,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("detached git dir", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		worktreeDir := filepath.Join(tmpDir, "worktree")
 		gitDirPath := filepath.Join(tmpDir, "storage.git")
@@ -95,7 +102,11 @@ func TestGetWorktree(t *testing.T) {
 
 	t.Run("explicit relative core.worktree", func(t *testing.T) {
 		// Git interprets relative core.worktree values relative to the
-		// GIT_DIR; submodules are configured this way
+		// GIT_DIR; submodules are configured this way. The repository is
+		// constructed directly so that no load-time discovery takes
+		// precedence and the core.worktree branch is exercised.
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		worktreeDir := filepath.Join(tmpDir, "worktree")
 		gitDirPath := filepath.Join(tmpDir, "modules", "repo.git")
@@ -103,18 +114,60 @@ func TestGetWorktree(t *testing.T) {
 
 		mustRunGit(t, "init", "--separate-git-dir", gitDirPath, worktreeDir)
 
-		repo, err := LoadRepository(worktreeDir)
-		require.Nil(t, err)
-
-		// replace the absolute value Git recorded with an equivalent relative
-		// one, as `git submodule add` does
-		setRelativeWorktree := repo.executor("config", "core.worktree", "../worktree")
-		_, _, err = setRelativeWorktree.execute()
+		repo := &Repository{gitDirPath: gitDirPath}
+		_, _, err := repo.executor("config", "core.worktree", "../../worktree").execute()
 		require.Nil(t, err)
 
 		worktree, err := repo.GetWorktree()
 		require.Nil(t, err)
 		assert.Equal(t, evalTestPath(t, worktreeDir), worktree)
+	})
+
+	t.Run("stale core.worktree", func(t *testing.T) {
+		// a core.worktree value pointing at a directory that is no longer
+		// valid must be ignored rather than trusted
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		worktreeDir := filepath.Join(tmpDir, "worktree")
+		gitDirPath := filepath.Join(tmpDir, "storage.git")
+		require.Nil(t, os.MkdirAll(filepath.Dir(gitDirPath), 0o755))
+
+		mustRunGit(t, "init", "--separate-git-dir", gitDirPath, worktreeDir)
+
+		repo, err := LoadRepository(worktreeDir)
+		require.Nil(t, err)
+
+		// point core.worktree at a nonexistent location
+		_, _, err = repo.executor("config", "core.worktree", filepath.Join(tmpDir, "gone")).execute()
+		require.Nil(t, err)
+
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, worktreeDir), worktree)
+	})
+
+	t.Run("gitdir file pointing to another repository", func(t *testing.T) {
+		// a $GIT_DIR/gitdir entry that points at a different repository must
+		// not redirect worktree resolution
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		gitDirPath := filepath.Join(tmpDir, ".git")
+		mustRunGit(t, "init", tmpDir)
+
+		otherRepoPath := filepath.Join(tmpDir, "other")
+		mustRunGit(t, "init", otherRepoPath)
+
+		repo, err := LoadRepository(tmpDir)
+		require.Nil(t, err)
+		require.Nil(t, os.WriteFile(filepath.Join(gitDirPath, "gitdir"), []byte(filepath.Join(otherRepoPath, ".git")+"\n"), 0o600))
+
+		// the record is ignored and resolution falls back to the parent-of-.git
+		// layout for this repository
+		worktree, err := repo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
 	})
 
 	t.Run("stale linked worktree record", func(t *testing.T) {
@@ -133,6 +186,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("linked worktree", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		mainRepoPath := filepath.Join(tmpDir, "main")
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
@@ -166,6 +221,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("linked worktree, SHA-256", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		mainRepoPath := filepath.Join(tmpDir, "main")
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
@@ -192,6 +249,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("status in linked worktree", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		mainRepoPath := filepath.Join(tmpDir, "main")
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
@@ -221,6 +280,8 @@ func TestGetWorktree(t *testing.T) {
 	})
 
 	t.Run("bare repository", func(t *testing.T) {
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		repo := CreateTestGitRepository(t, tmpDir, true)
 
@@ -228,10 +289,17 @@ func TestGetWorktree(t *testing.T) {
 
 		_, err := repo.GetWorktree()
 		assert.ErrorIs(t, err, ErrNoWorktree)
+
+		// Status on a bare repository must surface a clear error rather than
+		// running git inside an unrelated directory
+		_, err = repo.Status()
+		assert.ErrorIs(t, err, ErrNoWorktree)
 	})
 
 	t.Run("bare repository named with .git suffix", func(t *testing.T) {
 		// the name-based heuristic misclassified these as non-bare
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		bareDirPath := filepath.Join(tmpDir, "bare.git")
 		repo := setupRepository(t, bareDirPath, true, ObjectFormatSHA1)
@@ -245,6 +313,8 @@ func TestGetWorktree(t *testing.T) {
 	t.Run("fallback without LoadRepository", func(t *testing.T) {
 		// repositories constructed directly only carry their GIT_DIR, so
 		// resolution falls back to Git's standard layout
+		t.Parallel()
+
 		tmpDir := t.TempDir()
 		mustRunGit(t, "init", tmpDir)
 
@@ -253,5 +323,35 @@ func TestGetWorktree(t *testing.T) {
 		worktree, err := repo.GetWorktree()
 		require.Nil(t, err)
 		assert.Equal(t, evalTestPath(t, tmpDir), worktree)
+	})
+
+	t.Run("loaded from subdirectory of linked worktree", func(t *testing.T) {
+		// discovery must work when invoked from anywhere inside the linked
+		// worktree, matching how git rev-parse resolves the toplevel
+		t.Parallel()
+
+		tmpDir := t.TempDir()
+		mainRepoPath := filepath.Join(tmpDir, "main")
+		linkedRepoPath := filepath.Join(tmpDir, "linked")
+		repo := CreateTestGitRepository(t, mainRepoPath, false)
+
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		_, err := repo.executor("add", ".").executeString()
+		require.Nil(t, err)
+		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
+		require.Nil(t, err)
+
+		_, err = repo.executor("worktree", "add", linkedRepoPath, "-b", "feature").executeString()
+		require.Nil(t, err)
+
+		nestedDir := filepath.Join(linkedRepoPath, "nested")
+		require.Nil(t, os.Mkdir(nestedDir, 0o755))
+
+		linkedRepo, err := LoadRepository(nestedDir)
+		require.Nil(t, err)
+
+		worktree, err := linkedRepo.GetWorktree()
+		require.Nil(t, err)
+		assert.Equal(t, evalTestPath(t, linkedRepoPath), worktree)
 	})
 }

--- a/pkg/gitinterface/worktree_test.go
+++ b/pkg/gitinterface/worktree_test.go
@@ -44,6 +44,8 @@ func evalTestPath(t *testing.T, path string) string {
 }
 
 func TestGetWorktree(t *testing.T) {
+	t.Parallel()
+
 	t.Run("standard layout", func(t *testing.T) {
 		t.Parallel()
 
@@ -194,7 +196,7 @@ func TestGetWorktree(t *testing.T) {
 		repo := CreateTestGitRepository(t, mainRepoPath, false)
 
 		// `git worktree add` requires at least one commit
-		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o600))
 		_, err := repo.executor("add", ".").executeString()
 		require.Nil(t, err)
 		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
@@ -228,7 +230,7 @@ func TestGetWorktree(t *testing.T) {
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
 		repo := CreateTestGitRepository(t, mainRepoPath, false, WithSHA256Format())
 
-		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o600))
 		_, err := repo.executor("add", ".").executeString()
 		require.Nil(t, err)
 		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
@@ -256,7 +258,7 @@ func TestGetWorktree(t *testing.T) {
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
 		repo := CreateTestGitRepository(t, mainRepoPath, false)
 
-		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o600))
 		_, err := repo.executor("add", ".").executeString()
 		require.Nil(t, err)
 		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()
@@ -266,7 +268,7 @@ func TestGetWorktree(t *testing.T) {
 		require.Nil(t, err)
 
 		untrackedFile := filepath.Join(linkedRepoPath, "untracked.txt")
-		require.Nil(t, os.WriteFile(untrackedFile, []byte("test"), 0o644))
+		require.Nil(t, os.WriteFile(untrackedFile, []byte("test"), 0o600))
 
 		linkedRepo, err := LoadRepository(linkedRepoPath)
 		require.Nil(t, err)
@@ -335,7 +337,7 @@ func TestGetWorktree(t *testing.T) {
 		linkedRepoPath := filepath.Join(tmpDir, "linked")
 		repo := CreateTestGitRepository(t, mainRepoPath, false)
 
-		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o644))
+		require.Nil(t, os.WriteFile(filepath.Join(mainRepoPath, "README.md"), []byte("test"), 0o600))
 		_, err := repo.executor("add", ".").executeString()
 		require.Nil(t, err)
 		_, err = repo.executor("commit", "--no-gpg-sign", "-m", "initial commit").executeString()


### PR DESCRIPTION
## Description

gittuf figured out where a repository's checked-out files live by chopping ".git" off the end of its internal Git directory path. That only works for the most basic layout, and three common setups break because of it:

- Repositories created with `--separate-git-dir`, which store their history somewhere else entirely. gittuf ends up looking in a wrong or nonexistent directory.
- Linked worktrees created with `git worktree add`. These were misread as bare repositories (repos with no checked-out files at all), so file restoration was silently skipped. They could not even be loaded, because their configuration lives in the shared directory, not the worktree's own.
- Bare repositories named like `project.git`, misclassified for the same name-based reason.

This change introduces one function that answers "where is the worktree" for every layout, by asking Git itself rather than guessing from names:

1. For linked worktrees, read the pointer file Git writes inside the Git directory.
2. Otherwise honor an explicit worktree setting in the repository config, if one exists.
3. Otherwise use the location discovered while opening the repository, which is the only reliable source for separate-git-dir setups.
4. Otherwise fall back to the standard layout.

Resolved paths are sanity-checked, so a stale or malformed pointer fails safely instead of sending later commands into wrong directories. The bare-repository check now asks Git directly instead of checking whether the path ends in ".git", which was wrong in both directions. Errors surface as a sentinel error callers can detect, rather than Git failing inside some unrelated folder.

One tradeoff worth flagging: checking bareness now runs a quick Git command each time instead of a string comparison. I left it uncached on purpose, to keep the repository object free of shared mutable state.

Fixes #1006

## Testing

- New tests cover every layout above, plus SHA-256 variants, running from a subdirectory, stale pointer records, relative config values as submodules write them, and status inside a linked worktree.
- Full test suite passes with the race detector enabled.
- gofmt and go vet are clean.
- Each resolution branch was verified against real Git behavior on macOS.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

I used AI to research the issue and to draft the fix and its tests. All code was manually reviewed, run locally, and revised based on two independent adversarial review passes before I submitted it.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
