### PR TITLE
test(cmd): add unit tests for rsl remote reconcile, rsl log, and trustpolicy discard commands

### DIFF
--- a/internal/cmd/rsl/log/log_test.go
+++ b/internal/cmd/rsl/log/log_test.go
@@ -1,0 +1,32 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLog(t *testing.T) {
+	t.Run("invalid repository path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("repository without RSL initialized", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_ = gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "unable to find RSL entry")
+	})
+}

--- a/internal/cmd/rsl/remote/reconcile/reconcile_test.go
+++ b/internal/cmd/rsl/remote/reconcile/reconcile_test.go
@@ -1,0 +1,37 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package reconcile
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReconcile(t *testing.T) {
+	t.Run("missing required argument via cobra", func(t *testing.T) {
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "accepts 1 arg(s), received 0")
+	})
+
+	t.Run("invalid repository path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_, _, _, err := cmd.ExecuteCommandC(New(), "origin")
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("repository without remote", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_ = gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		_, _, _, err := cmd.ExecuteCommandC(New(), "origin")
+		assert.Error(t, err)
+	})
+}

--- a/internal/cmd/trustpolicy/discard/discard_test.go
+++ b/internal/cmd/trustpolicy/discard/discard_test.go
@@ -1,0 +1,32 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package discard
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/cmd"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDiscard(t *testing.T) {
+	t.Run("invalid repository path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.ErrorContains(t, err, "not a git repository")
+	})
+
+	t.Run("repository without staged policy", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		_ = gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		_, _, _, err := cmd.ExecuteCommandC(New())
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

This PR adds unit tests for the rsl remote reconcile, rsl log, and trustpolicy discard commands, achieving 100% statement test coverage across all three packages.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

I used AI for the original draft of the test coverages, but I manually checked the code and made sure it hit all parts that needed to be covered. 

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
