### PR TITLE
test: add unit tests for persistent options packages

### DIFF
--- a/internal/cmd/attest/persistent/persistent_test.go
+++ b/internal/cmd/attest/persistent/persistent_test.go
@@ -1,0 +1,26 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistent
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddPersistentFlags(t *testing.T) {
+	o := &Options{}
+	cmd := &cobra.Command{Use: "test"}
+	o.AddPersistentFlags(cmd)
+
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("signing-key"))
+	assert.NotNil(t, cmd.PersistentFlags().ShorthandLookup("k"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("create-rsl-entry"))
+
+	err := cmd.ParseFlags([]string{"-k", "test-key", "--create-rsl-entry"})
+	assert.Nil(t, err)
+	assert.Equal(t, "test-key", o.SigningKey)
+	assert.True(t, o.WithRSLEntry)
+}

--- a/internal/cmd/policy/persistent/persistent_test.go
+++ b/internal/cmd/policy/persistent/persistent_test.go
@@ -1,0 +1,26 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistent
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddPersistentFlags(t *testing.T) {
+	o := &Options{}
+	cmd := &cobra.Command{Use: "test"}
+	o.AddPersistentFlags(cmd)
+
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("signing-key"))
+	assert.NotNil(t, cmd.PersistentFlags().ShorthandLookup("k"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("create-rsl-entry"))
+
+	err := cmd.ParseFlags([]string{"-k", "test-key", "--create-rsl-entry"})
+	assert.Nil(t, err)
+	assert.Equal(t, "test-key", o.SigningKey)
+	assert.True(t, o.WithRSLEntry)
+}

--- a/internal/cmd/trust/persistent/persistent_test.go
+++ b/internal/cmd/trust/persistent/persistent_test.go
@@ -1,0 +1,26 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package persistent
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddPersistentFlags(t *testing.T) {
+	o := &Options{}
+	cmd := &cobra.Command{Use: "test"}
+	o.AddPersistentFlags(cmd)
+
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("signing-key"))
+	assert.NotNil(t, cmd.PersistentFlags().ShorthandLookup("k"))
+	assert.NotNil(t, cmd.PersistentFlags().Lookup("create-rsl-entry"))
+
+	err := cmd.ParseFlags([]string{"-k", "test-key", "--create-rsl-entry"})
+	assert.Nil(t, err)
+	assert.Equal(t, "test-key", o.SigningKey)
+	assert.True(t, o.WithRSLEntry)
+}


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->
Adds unit test coverage for the persistent options helpers across three packages.
## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

Used AI for the drafting of the code but manually checked its accuracy for the test coverages. 

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
