### PR TITLE
cmd: Make keys not required for person

### DIFF
--- a/internal/cmd/policy/addperson/addperson.go
+++ b/internal/cmd/policy/addperson/addperson.go
@@ -47,7 +47,6 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		[]string{},
 		"authorized public key for the person (path to SSH public key, \"gpg:<fingerprint>\" for GPG, or \"fulcio:<identity>::<issuer>\" for Sigstore)",
 	)
-	cmd.MarkFlagRequired("public-key") //nolint:errcheck
 
 	cmd.Flags().StringArrayVar(
 		&o.associatedIdentities,


### PR DESCRIPTION
## Description

This drops the requirement that `Person` has a key specified when being defined in gittuf metadata.

## AI Usage

- [X] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

## Contributor Checklist

- [X] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [X] I fully understand the content I am submitting.
- [X] The changes introduced are documented and have tests included if
  applicable.
- [X] My changes do not infringe on copyright/trademarks/etc.
- [X] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [X] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
