### PR TITLE
policy: Fix prioritization of global rule's exhaustive verifier

### DIFF
--- a/internal/policy/helpers_test.go
+++ b/internal/policy/helpers_test.go
@@ -548,6 +548,101 @@ func createTestStateWithGlobalConstraintBlockForcePushes(t *testing.T) *State {
 	return state
 }
 
+// createTestStateWithBranchProtectionAndGlobalConstraintThreshold creates a
+// policy state with both a branch protection rule (with threshold 2) and a
+// global constraint (of threshold 1), both targeting main. An additional
+// principal is added that is in the policy file, but not authorized for main. A
+// branch protection rule and global rule (both with threshold 1) are also added
+// for the feature branch.
+
+func createTestStateWithBranchProtectionAndGlobalConstraintThreshold(t *testing.T) *State {
+	t.Helper()
+
+	signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
+	key := tufv01.NewKeyFromSSLibKey(signer.MetadataKey())
+
+	rootMetadata, err := InitializeRootMetadata(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rootMetadata.AddPrimaryRuleFilePrincipal(key); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rootMetadata.AddGlobalRule(tufv01.NewGlobalRuleThreshold("threshold-1-main", []string{"git:refs/heads/main"}, 1)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := rootMetadata.AddGlobalRule(tufv01.NewGlobalRuleThreshold("threshold-1-feature", []string{"git:refs/heads/feature"}, 1)); err != nil {
+		t.Fatal(err)
+	}
+
+	rootEnv, err := dsse.CreateEnvelope(rootMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootEnv, err = dsse.SignEnvelope(context.Background(), rootEnv, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gpgKeyR, err := gpg.LoadGPGKeyFromBytes(gpgPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpgKey := tufv01.NewKeyFromSSLibKey(gpgKeyR)
+
+	gpg2KeyR, err := gpg.LoadGPGKeyFromBytes(gpgUnauthorizedPubKeyBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gpg2Key := tufv01.NewKeyFromSSLibKey(gpg2KeyR)
+
+	targetsMetadata := InitializeTargetsMetadata()
+	if err := targetsMetadata.AddPrincipal(gpgKey); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := targetsMetadata.AddPrincipal(key); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := targetsMetadata.AddPrincipal(gpg2Key); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := targetsMetadata.AddRule("protect-main", []string{gpgKey.KeyID, key.KeyID}, []string{"git:refs/heads/main"}, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := targetsMetadata.AddRule("protect-feature", []string{gpgKey.KeyID}, []string{"git:refs/heads/feature"}, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	targetsEnv, err := dsse.CreateEnvelope(targetsMetadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetsEnv, err = dsse.SignEnvelope(context.Background(), targetsEnv, signer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	state := &State{
+		Metadata: &StateMetadata{
+			RootEnvelope:    rootEnv,
+			TargetsEnvelope: targetsEnv,
+		},
+	}
+
+	if err := state.preprocess(); err != nil {
+		t.Fatal(err)
+	}
+
+	return state
+}
+
 func createTestStateWithPolicyUsingPersons(t *testing.T) *State {
 	t.Helper()
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -67,13 +67,14 @@ type State struct {
 
 	GitHubApps map[string]tuf.GitHubApp
 
-	repository     gitstore.Storer
-	loadedEntry    rsl.ReferenceUpdaterEntry
-	verifiersCache map[string][]*SignatureVerifier
-	ruleNames      *set.Set[string]
-	allPrincipals  map[string]tuf.Principal
-	hasFileRule    bool
-	globalRules    map[string][]tuf.GlobalRule
+	repository          gitstore.Storer
+	loadedEntry         rsl.ReferenceUpdaterEntry
+	verifiersCache      map[string][]*SignatureVerifier
+	globalRulesVerifier *SignatureVerifier
+	ruleNames           *set.Set[string]
+	allPrincipals       map[string]tuf.Principal
+	hasFileRule         bool
+	globalRules         map[string][]tuf.GlobalRule
 }
 
 type StateMetadata struct {
@@ -409,7 +410,12 @@ func LoadFirstState(ctx context.Context, repo gitstore.Storer, opts ...policyopt
 
 // FindVerifiersForPath identifies the trusted set of verifiers for the
 // specified path. While walking the delegation graph for the path, signatures
-// for delegated metadata files are verified using the verifier context.
+// for delegated metadata files are verified using the verifier context. An
+// empty set is returned when no rule protects the path.
+//
+// The returned verifiers only reflect the rules protecting the path. Global
+// rules are not delegations of trust and are verified separately, see
+// getVerifierForGlobalRules.
 func (s *State) FindVerifiersForPath(path string) ([]*SignatureVerifier, error) {
 	if s.verifiersCache == nil {
 		slog.Debug("Initializing path cache in policy...")
@@ -420,34 +426,54 @@ func (s *State) FindVerifiersForPath(path string) ([]*SignatureVerifier, error) 
 		return verifiers, nil
 	}
 
-	allVerifiers := []*SignatureVerifier{}
-
-	if len(s.globalRules) != 0 {
-		slog.Debug("Global constraints found, including exhaustive verifier...")
-		// This has to go first so it's prioritized during verification
-		// At least one global rule exists, return an exhaustive verifier
-		verifier := &SignatureVerifier{
-			repository: s.repository,
-			name:       tuf.ExhaustiveVerifierName,
-			principals: []tuf.Principal{}, // we'll add all principals below
-
-			// threshold doesn't matter since we set verifyExhaustively to true
-			threshold:          1,
-			verifyExhaustively: true, // very important!
-		}
-
-		for _, principal := range s.allPrincipals {
-			verifier.principals = append(verifier.principals, principal)
-		}
-
-		allVerifiers = append(allVerifiers, verifier)
-	}
-
-	specificVerifiers, err := s.findVerifiersForPathIfProtected(path)
+	verifiers, err := s.findVerifiersForPathIfProtected(path)
 	if err != nil {
 		return nil, err
 	}
-	allVerifiers = append(allVerifiers, specificVerifiers...)
+
+	// add to cache
+	s.verifiersCache[path] = verifiers
+	// return verifiers
+	return verifiers, nil
+}
+
+// getVerifierForGlobalRules returns a verifier that trusts every principal
+// declared in the policy. Global rules are not delegations of trust: they
+// constrain a namespace irrespective of who is trusted for it, so they are
+// evaluated against every principal that signed rather than only the principals
+// trusted by the rules protecting the namespace. Accordingly, the returned
+// verifier MUST NOT be used to decide whether the rules protecting a namespace
+// are met, as it accepts principals who are not trusted for that namespace. It
+// is only used to enumerate the principals the global rules are evaluated
+// against.
+//
+// nil is returned when the policy declares no global rules.
+func (s *State) getVerifierForGlobalRules() *SignatureVerifier {
+	if len(s.globalRules) == 0 {
+		return nil
+	}
+
+	if s.globalRulesVerifier != nil {
+		return s.globalRulesVerifier
+	}
+
+	slog.Debug("Global constraints found, creating exhaustive verifier...")
+
+	// Unlike the verifiers for rules, this verifier is not specific to a path:
+	// it trusts every principal for every path, so it's built once per state.
+	verifier := &SignatureVerifier{
+		repository: s.repository,
+		name:       tuf.ExhaustiveVerifierName,
+		principals: []tuf.Principal{}, // we'll add all principals below
+
+		// threshold doesn't matter since we set verifyExhaustively to true
+		threshold:          1,
+		verifyExhaustively: true, // very important!
+	}
+
+	for _, principal := range s.allPrincipals {
+		verifier.principals = append(verifier.principals, principal)
+	}
 
 	// Note: we could loop through all global constraints and create a
 	// verifier with all principals but targeting a specific constraint (or
@@ -458,10 +484,8 @@ func (s *State) FindVerifiersForPath(path string) ([]*SignatureVerifier, error) 
 	// would also want to verify every applicable global constraint for
 	// safety, so we would be doing extra work for no reason.
 
-	// add to cache
-	s.verifiersCache[path] = allVerifiers
-	// return verifiers
-	return allVerifiers, nil
+	s.globalRulesVerifier = verifier
+	return verifier
 }
 
 func (s *State) findVerifiersForPathIfProtected(path string) ([]*SignatureVerifier, error) {

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -294,7 +294,9 @@ func (v *PolicyVerifier) verifyMergeable(ctx context.Context, targetRef string, 
 			return false, err
 		}
 
-		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
+		// these will be set after one successful verification of the commit to
+		// avoid repeated signature verification
+		verifiedUsing := ""
 		for _, path := range paths {
 			// If we've already verified and identified commit signature, we can
 			// just check if that verifier is trusted for the new path. If not
@@ -893,7 +895,9 @@ func verifyEntry(ctx context.Context, repo gitstore.Storer, policy *State, attes
 			return err
 		}
 
-		verifiedUsing := "" // this will be set after one successful verification of the commit to avoid repeated signature verification
+		// these will be set after one successful verification of the commit to
+		// avoid repeated signature verification
+		verifiedUsing := ""
 		for _, path := range paths {
 			// If we've already verified and identified commit signature, we
 			// can just check if that verifier is trusted for the new path.
@@ -1088,8 +1092,11 @@ func getCommits(repo gitstore.Storer, entry *rsl.ReferenceEntry) ([]githash.Hash
 type verifyGitObjectAndAttestationsOptions struct {
 	approverPrincipalIDs *set.Set[string]
 	verifyMergeable      bool
-	trustedVerifier      string
-	tagObjectID          githash.Hash
+	// trustedVerifier is the name of the verifier that has already been used to
+	// verify in the past. If the newly discovered set of verifiers includes the
+	// trusted verifier, then we can skip verifying the signature again.
+	trustedVerifier string
+	tagObjectID     githash.Hash
 }
 
 type verifyGitObjectAndAttestationsOption func(o *verifyGitObjectAndAttestationsOptions)
@@ -1113,7 +1120,8 @@ func withVerifyMergeable() verifyGitObjectAndAttestationsOption {
 
 // withTrustedVerifier is used to specify the name of a verifier that has
 // already been used to verify in the past. If the newly discovered set of
-// verifiers includes the trusted verifier, then we can return early.
+// verifiers includes the trusted verifier, then we can skip verifying the
+// signature again.
 func withTrustedVerifier(name string) verifyGitObjectAndAttestationsOption {
 	return func(o *verifyGitObjectAndAttestationsOptions) {
 		o.trustedVerifier = name
@@ -1140,61 +1148,107 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 		return "", false, err
 	}
 
-	if len(verifiers) == 0 {
+	// Global rules apply to the target irrespective of the rules protecting it,
+	// so they must be verified even when no rule protects the target.
+	globalRulesVerifier := policy.getVerifierForGlobalRules()
+
+	if len(verifiers) == 0 && globalRulesVerifier == nil {
 		// This target is not protected by gittuf policy
 		return "", false, nil
 	}
 
+	var (
+		verifiedUsing                  string
+		rslSignatureNeededForThreshold bool
+		rulesAlreadyVerified           bool
+	)
+
 	if options.trustedVerifier != "" {
 		for _, verifier := range verifiers {
 			if verifier.Name() == options.trustedVerifier {
-				return options.trustedVerifier, false, nil
-			}
-		}
-	}
-
-	appNames := []string{}
-	for appName, appEntry := range policy.GitHubApps {
-		if appEntry.IsTrusted() {
-			appNames = append(appNames, appName)
-		}
-	}
-	verifiedUsing, acceptedPrincipalIDs, rslSignatureNeededForThreshold, err := verifyGitObjectAndAttestationsUsingVerifiers(ctx, verifiers, gitID, authorizationAttestation, appNames, options.approverPrincipalIDs, options.verifyMergeable)
-	if err != nil {
-		return "", false, err
-	}
-
-	if !options.tagObjectID.IsZero() {
-		// Verify tag object's signature as well
-		tagObjVerified := false
-		for _, verifier := range verifiers {
-			// explicitly not looking at the attestation
-			// that applies to the _push_
-			// thus, we also set threshold to 1
-			verifier.threshold = 1
-
-			_, err := verifier.Verify(ctx, options.tagObjectID, nil)
-			if err == nil {
-				// Signature verification succeeded
-				tagObjVerified = true
-				// TODO: should we check if a different verifier / signer was
-				// matched for the tag object compared with the RSL entry?
+				// The trusted verifier also protects this target, so its
+				// signature verification carries over and the rules protecting
+				// the target are met. We must not return here, the global rules
+				// below still apply to the target.
+				//
+				// rslSignatureNeededForThreshold is left false because the
+				// trustedVerifier is only meant to be used for file path rules,
+				// where RSL signature doesn't matter anyway.
+				verifiedUsing = options.trustedVerifier
+				rulesAlreadyVerified = true
 				break
-			} else if !errors.Is(err, ErrVerifierConditionsUnmet) {
-				// Unexpected error
-				return "", false, err
 			}
-			// Haven't found a valid verifier, continue with next verifier
-		}
-
-		if !tagObjVerified {
-			return "", false, fmt.Errorf("verifying tag object's signature failed")
 		}
 	}
 
-	verifiedPrincipalIDs := 0
-	if acceptedPrincipalIDs != nil {
-		verifiedPrincipalIDs = acceptedPrincipalIDs.Len()
+	// Verify the rules protecting the target. When no rule protects it, there
+	// is nothing to meet here and only the global rules below apply. Similarly,
+	// if we established above that the verifier that applied to this Git object
+	// + attestation(s) is trusted for the namespace under verification this
+	// time, we don't need to verify the rules again.
+	//
+	// TODO: in the long run, we should:
+	// a) structure the outcome as a report rather than an increasingly complex
+	// set of return values
+	// b) cache the report against Git object + attestation(s) context to avoid
+	// relying on callsites passing in information correctly and at the right
+	// times
+	if !rulesAlreadyVerified && len(verifiers) != 0 {
+		appNames := []string{}
+		for appName, appEntry := range policy.GitHubApps {
+			if appEntry.IsTrusted() {
+				appNames = append(appNames, appName)
+			}
+		}
+
+		verifiedUsing, _, rslSignatureNeededForThreshold, err = verifyGitObjectAndAttestationsUsingVerifiers(ctx, verifiers, gitID, authorizationAttestation, appNames, options.approverPrincipalIDs, options.verifyMergeable)
+		if err != nil {
+			return "", false, err
+		}
+
+		if !options.tagObjectID.IsZero() {
+			// Verify tag object's signature as well
+			tagObjVerified := false
+			for _, verifier := range verifiers {
+				// explicitly not looking at the attestation
+				// that applies to the _push_
+				// thus, we also set threshold to 1
+				verifier.threshold = 1
+
+				_, err := verifier.Verify(ctx, options.tagObjectID, nil)
+				if err == nil {
+					// Signature verification succeeded
+					tagObjVerified = true
+					// TODO: should we check if a different verifier / signer was
+					// matched for the tag object compared with the RSL entry?
+					break
+				} else if !errors.Is(err, ErrVerifierConditionsUnmet) {
+					// Unexpected error
+					return "", false, err
+				}
+				// Haven't found a valid verifier, continue with next verifier
+			}
+
+			if !tagObjVerified {
+				return "", false, fmt.Errorf("verifying tag object's signature failed")
+			}
+		}
+	}
+
+	// Global rules are not delegations of trust: they constrain the target
+	// irrespective of who is trusted for it. They are therefore verified
+	// independently of the rules above, against every principal declared in the
+	// policy that signed rather than only those trusted by those rules.
+	verifiedGlobalRulesPrincipalIDs := 0
+	if globalRulesVerifier != nil {
+		globalRulesPrincipalIDs, err := globalRulesVerifier.Verify(ctx, gitID, authorizationAttestation)
+		if err != nil {
+			return "", false, err
+		}
+
+		if globalRulesPrincipalIDs != nil {
+			verifiedGlobalRulesPrincipalIDs = globalRulesPrincipalIDs.Len()
+		}
 	}
 
 	for controllerName, globalRules := range policy.globalRules {
@@ -1222,10 +1276,10 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 					slog.Debug("Reducing required global threshold by 1 (verifying if change is mergeable and RSL signature is required)...")
 					requiredThreshold--
 				}
-				if verifiedPrincipalIDs < requiredThreshold {
+				if verifiedGlobalRulesPrincipalIDs < requiredThreshold {
 					// Check if the verifiedPrincipalIDs meets the required global
 					// threshold
-					slog.Debug(fmt.Sprintf("Global rule '%s' not met, required threshold '%d', only have '%d'", rule.GetName(), rule.GetThreshold(), verifiedPrincipalIDs))
+					slog.Debug(fmt.Sprintf("Global rule '%s' not met, required threshold '%d', only have '%d'", rule.GetName(), rule.GetThreshold(), verifiedGlobalRulesPrincipalIDs))
 					return "", false, ErrVerifierConditionsUnmet
 				}
 

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gittuf/gittuf/internal/cache"
 	"github.com/gittuf/gittuf/internal/common"
 	"github.com/gittuf/gittuf/internal/common/set"
-	"github.com/gittuf/gittuf/internal/dev"
 	"github.com/gittuf/gittuf/internal/propagation"
 	"github.com/gittuf/gittuf/internal/signerverifier/dsse"
 	"github.com/gittuf/gittuf/internal/signerverifier/ssh"
@@ -2935,8 +2934,6 @@ func TestVerifyEntry(t *testing.T) {
 	})
 
 	t.Run("successful verification using persons", func(t *testing.T) {
-		t.Setenv(dev.DevModeKey, "1")
-
 		repo, state := createTestRepository(t, createTestStateWithPolicyUsingPersons)
 
 		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
@@ -3063,8 +3060,6 @@ func TestVerifyEntry(t *testing.T) {
 	})
 
 	t.Run("successful verification with higher threshold but using GitHub approval", func(t *testing.T) {
-		t.Setenv(dev.DevModeKey, "1")
-
 		repo, state := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrust)
 
 		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
@@ -3120,8 +3115,6 @@ func TestVerifyEntry(t *testing.T) {
 	})
 
 	t.Run("unsuccessful verification with higher threshold but using GitHub approval due to invalid app key", func(t *testing.T) {
-		t.Setenv(dev.DevModeKey, "1")
-
 		repo, state := createTestRepository(t, createTestStateWithThresholdPolicyAndGitHubAppTrust)
 
 		currentAttestations, err := attestations.LoadCurrentAttestations(repo)
@@ -3780,6 +3773,39 @@ func TestVerifyEntry(t *testing.T) {
 		entry.ID = entryID
 
 		err = verifyEntry(testCtx, networkRepository, networkState, currentAttestations, entry)
+		assert.ErrorIs(t, err, ErrVerificationFailed)
+	})
+
+	t.Run("both global and policy rule declared, global rule threshold less than policy rule", func(t *testing.T) {
+		// Test that an authorized keyholder for main cannot alone satisfy the
+		// branch protection rule
+		repo, state := createTestRepository(t, createTestStateWithBranchProtectionAndGlobalConstraintThreshold)
+
+		rslTip, err := repo.GetReference(rsl.Ref)
+		require.NoError(t, err)
+
+		commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgKeyBytes)
+		entry := rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID := common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgKeyBytes)
+		entry.ID = entryID
+
+		err = verifyEntry(testCtx, repo, state, nil, entry)
+		assert.ErrorIs(t, err, ErrVerificationFailed)
+
+		// Test that a keyholder not authorized for main but still added to
+		// policy cannot satisfy the branch protection rule
+		err = repo.DeleteReference(refName)
+		require.Nil(t, err)
+
+		err = repo.SetReference(rsl.Ref, rslTip)
+		require.Nil(t, err)
+
+		commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo, refName, 1, gpgUnauthorizedKeyBytes)
+		entry = rsl.NewReferenceEntry(refName, commitIDs[0])
+		entryID = common.CreateTestRSLReferenceEntryCommit(t, repo, entry, gpgUnauthorizedKeyBytes)
+		entry.ID = entryID
+
+		err = verifyEntry(testCtx, repo, state, nil, entry)
 		assert.ErrorIs(t, err, ErrVerificationFailed)
 	})
 }


### PR DESCRIPTION
## Description

<!-- Enter a description of what your pull request does. -->

Global rules were being incorrectly prioritized ahead of policy rules. This commit fixes it and decouples global rules verification from policy rules verification.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [ ] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

<!-- If you used generative AI, you must briefly describe how you used it, e.g.
you copied output directly from an LLM, you used AI to draft code/documentation
but made significant manual edits, etc.-->

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
