### PR TITLE
test: enable GPG key tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,14 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
         cache: true
+    - name: Use Git for Windows' bundled gpg (Windows)
+      if: runner.os == 'Windows'
+      shell: powershell
+      # Appended to the end of PATH (via GITHUB_ENV) rather than the front
+      # (via GITHUB_PATH), so this only fills in gpg, which isn't on PATH
+      # otherwise, without shadowing tools like ssh-keygen that already
+      # resolve to the Windows OpenSSH build earlier in PATH.
+      run: echo "PATH=$env:PATH;C:\Program Files\Git\usr\bin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - name: Test
       run: go test -race -timeout 40m ./...
   test-freebsd:

--- a/internal/signerverifier/gpg/gpg.go
+++ b/internal/signerverifier/gpg/gpg.go
@@ -155,13 +155,57 @@ func getPublicKeyForKeyID(keyID, program string) (*signerverifier.SSLibKey, erro
 	return LoadGPGKeyFromBytes(output)
 }
 
+// msysPath converts a native Windows path (e.g. `C:\Users\foo`) into the
+// POSIX-style form MSYS tools such as Git for Windows' bundled gpg expect
+// for absolute paths (e.g. `/c/Users/foo`). See the MSYS2 documentation on
+// path conversion: https://www.msys2.org/docs/filesystem-paths/
+//
+// This intentionally doesn't use filepath.ToSlash: that only rewrites the
+// separator native to the OS the code is compiled for, so on a non-Windows
+// host (as when this package's tests run on Linux/macOS CI runners) it
+// leaves Windows-style backslashes untouched instead of converting them.
+func msysPath(path string) string {
+	path = strings.ReplaceAll(path, `\`, "/")
+	if len(path) >= 2 && path[1] == ':' {
+		path = "/" + strings.ToLower(path[:1]) + path[2:]
+	}
+	return path
+}
+
+// gpgIsMSYSBuild reports whether the `gpg` binary that will actually be
+// invoked is an MSYS build, such as the one bundled with Git for Windows.
+// This matters because MSYS gpg only recognizes POSIX-style absolute paths
+// (e.g. `/c/Users/...`): given a native Windows path, it doesn't treat it as
+// absolute and silently resolves it relative to gpg's working directory
+// instead. A non-MSYS (e.g. Gpg4win) install, on the other hand, expects the
+// native Windows path as-is, so callers must not assume one or the other
+// merely from being on Windows.
+func gpgIsMSYSBuild() bool {
+	path, err := exec.LookPath("gpg")
+	if err != nil {
+		return false
+	}
+
+	return isMSYSGPGPath(path)
+}
+
+// isMSYSGPGPath reports whether path (as resolved by exec.LookPath("gpg"))
+// points at an MSYS build of gpg, such as the one bundled with Git for
+// Windows under `Git\usr\bin` or `Git\mingw64\bin`. See
+// https://www.msys2.org/docs/environments/ for background on the usr/bin
+// vs. mingw64/bin MSYS2 environments Git for Windows is built from.
+//
+// As in msysPath, this doesn't use filepath.ToSlash, since that would only
+// normalize separators when compiled for Windows and this needs to work
+// when the package's tests run on any OS.
+func isMSYSGPGPath(path string) bool {
+	path = strings.ToLower(strings.ReplaceAll(path, `\`, "/"))
+	return strings.Contains(path, "/git/usr/bin/gpg") || strings.Contains(path, "/git/mingw64/bin/gpg")
+}
+
 // SetupTestGPGHomeDir is a test helper used only to prepare a temporary GPG
 // home dir with the specified keys added in.
 func SetupTestGPGHomeDir(t *testing.T, privateKeyBytes ...[]byte) {
-	if runtime.GOOS == "windows" {
-		t.Skip("TODO: test gpg keys for metadata on Windows")
-	}
-
 	// We use os.MkdirTemp because t.TempDir can result in a path
 	// that's too long for socket files, used for gpg-agent.
 	tmpGpgHomeDir, err := os.MkdirTemp("", "gittuf-gpg-")
@@ -170,7 +214,11 @@ func SetupTestGPGHomeDir(t *testing.T, privateKeyBytes ...[]byte) {
 		os.RemoveAll(tmpGpgHomeDir) //nolint:errcheck
 	})
 
-	t.Setenv("GNUPGHOME", tmpGpgHomeDir)
+	gnupgHome := tmpGpgHomeDir
+	if runtime.GOOS == "windows" && gpgIsMSYSBuild() {
+		gnupgHome = msysPath(tmpGpgHomeDir)
+	}
+	t.Setenv("GNUPGHOME", gnupgHome)
 
 	gpgAgentConfPath := filepath.Join(tmpGpgHomeDir, "gpg-agent.conf")
 	if err := os.WriteFile(gpgAgentConfPath, artifacts.GPGAgentConf, 0o600); err != nil {

--- a/internal/signerverifier/gpg/gpg_test.go
+++ b/internal/signerverifier/gpg/gpg_test.go
@@ -90,6 +90,86 @@ func TestLoadGPGKeyFromBytes(t *testing.T) {
 	})
 }
 
+func TestMSYSPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "Windows path with backslashes",
+			path: `C:\Users\foo\AppData\Local\Temp\gittuf-gpg-123`,
+			want: "/c/Users/foo/AppData/Local/Temp/gittuf-gpg-123",
+		},
+		{
+			name: "Windows path with forward slashes",
+			path: "C:/Users/foo/AppData/Local/Temp/gittuf-gpg-123",
+			want: "/c/Users/foo/AppData/Local/Temp/gittuf-gpg-123",
+		},
+		{
+			name: "uppercase drive letter is lowercased",
+			path: `D:\gittuf-gpg-123`,
+			want: "/d/gittuf-gpg-123",
+		},
+		{
+			name: "already POSIX-style path is unchanged",
+			path: "/tmp/gittuf-gpg-123",
+			want: "/tmp/gittuf-gpg-123",
+		},
+		{
+			name: "relative path without a drive letter is unchanged",
+			path: "gittuf-gpg-123",
+			want: "gittuf-gpg-123",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, msysPath(test.path))
+		})
+	}
+}
+
+func TestIsMSYSGPGPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "Git for Windows usr/bin build",
+			path: `C:\Program Files\Git\usr\bin\gpg.exe`,
+			want: true,
+		},
+		{
+			name: "Git for Windows mingw64 build",
+			path: `C:\Program Files\Git\mingw64\bin\gpg.exe`,
+			want: true,
+		},
+		{
+			name: "native Gpg4win install",
+			path: `C:\Program Files\GnuPG\bin\gpg.exe`,
+			want: false,
+		},
+		{
+			name: "Linux system gpg is not mistaken for an MSYS build",
+			path: "/usr/bin/gpg",
+			want: false,
+		},
+		{
+			name: "macOS Homebrew gpg",
+			path: "/opt/homebrew/bin/gpg",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, isMSYSGPGPath(test.path))
+		})
+	}
+}
+
 func TestNewVerifierFromKey(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		pubKey, err := LoadGPGKeyFromBytes(artifacts.GPGKey1Public)


### PR DESCRIPTION
## Description

`SetupTestGPGHomeDir` (`internal/signerverifier/gpg/gpg.go`) unconditionally skipped on Windows, which disabled `TestGPG` in this package as well as the GPG-signing paths exercised via this helper in `experimental/gittuf/verify_test.go`, `experimental/gittuf/root_test.go`, and `experimental/gittuf/keys_test.go` on every Windows CI run.

## Root cause

GnuPG isn't installed on the `windows-latest` GitHub Actions runner image, so `gpg` wasn't found on `PATH` for the `Test` step at all.

Installing it via `choco install gnupg` (my first attempt) turned out to be unreliable: the actual CI run got stuck on package installation and timed out after 45 minutes.

Git for Windows (always present on the runner) already ships its own MSYS build of `gpg` under `Git\usr\bin`. Using that avoids the network install entirely, but surfaces a second, more subtle issue: that MSYS build only recognizes POSIX-style absolute paths (e.g. `/c/Users/...`). Given a native Windows path (what `os.MkdirTemp` returns on Windows, e.g. `C:\Users\...`), it doesn't treat it as absolute and silently resolves it relative to gpg's working directory instead, so `GNUPGHOME` has to be rewritten to POSIX form for that build specifically.

Rewriting it unconditionally on Windows isn't correct either: a native (non-MSYS) GnuPG install, such as Gpg4win, expects the native Windows path as-is and fails to find the same directory if it's rewritten. I hit this directly testing locally, since I have Gpg4win installed and it resolves ahead of Git's bundled build on my machine's `PATH`.

## Fix

1. Add Git's `usr\bin` to `PATH` on the Windows CI runner, appended via `GITHUB_ENV` rather than prepended via `GITHUB_PATH`, so it only fills in `gpg` (otherwise missing) without shadowing tools like `ssh-keygen` that already resolve to the Windows OpenSSH build earlier in `PATH`.
2. In `SetupTestGPGHomeDir`, detect via `exec.LookPath("gpg")` whether the resolved binary is an MSYS build (Git's `usr\bin` or `mingw64\bin`) and only rewrite `GNUPGHOME` to POSIX form in that case, leaving native installs untouched.
3. Remove the `runtime.GOOS == "windows"` skip.

## Testing

- `go build ./...`: passes
- `go vet ./...`: passes
- `go test ./internal/signerverifier/gpg/...`: passes on Windows under both configurations I could reproduce locally:
  - Native GnuPG (Gpg4win) resolved first on `PATH` (my machine's default)
  - MSYS-only `PATH` (Git's `usr\bin` only, no native GnuPG), matching what the CI runner will actually have
- Added `TestMsysPath` and `TestIsMSYSGPGPath` covering the path-rewriting and build-detection logic directly, including the case that caught the bug above (a native, non-MSYS `gpg` on `PATH`).
- Confirmed this doesn't mask a pre-existing, unrelated Windows test failure: `TestVerifyRef` et al. in `experimental/gittuf` fail locally on unmodified `main` too (an `ssh-keygen -Y sign` environment issue, unrelated to GPG), so this PR doesn't touch or regress that.
- The first push of this PR already confirmed real Windows CI hits the `choco` hang described above; this push replaces that approach.

Fixes #1579

## AI Usage

- [x] I did use generative AI in some form in making the content of this pull request. I have described my use of AI below.

Used Claude Code to investigate the root cause end to end (reproducing the `choco install gnupg` CI hang, then the MSYS-vs-native `gpg` path-handling difference), and to draft the code and CI changes. I reviewed and tested the change locally on Windows under both PATH configurations before pushing.

## Contributor Checklist

- [x] I have manually reviewed all content submitted to gittuf in this pull request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a DCO Signoff.
- [x] By submitting this pull request, I agree to follow the gittuf Code of Conduct.
