### PR TITLE
rsl: report unknown entry types with upgrade guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## Unreleased
+
+### Added
+
+- A clear upgrade message when the RSL contains an entry type or the policy
+  metadata uses a schema version this client does not implement
+
 ## v0.16.0
 
 This release adds support for SHA-256 Git repositories and reworks gittuf's

--- a/internal/cmd/root/upgrade.go
+++ b/internal/cmd/root/upgrade.go
@@ -1,0 +1,27 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import (
+	"errors"
+
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/rsl"
+)
+
+var upgradeRequiredErrors = []error{
+	rsl.ErrUnknownRSLEntryType,
+	tuf.ErrUnknownRootMetadataVersion,
+	tuf.ErrUnknownTargetsMetadataVersion,
+}
+
+func IsUpgradeRequiredError(err error) bool {
+	for _, target := range upgradeRequiredErrors {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/cmd/root/upgrade_test.go
+++ b/internal/cmd/root/upgrade_test.go
@@ -1,0 +1,39 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/rsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUpgradeRequiredError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"nil":                              {err: nil, expected: false},
+		"unrelated error":                  {err: errors.New("something else"), expected: false},
+		"unknown RSL entry type":           {err: rsl.ErrUnknownRSLEntryType, expected: true},
+		"unknown root metadata version":    {err: tuf.ErrUnknownRootMetadataVersion, expected: true},
+		"unknown targets metadata version": {err: tuf.ErrUnknownTargetsMetadataVersion, expected: true},
+		"wrapped":                          {err: fmt.Errorf("loading RSL: %w", rsl.ErrUnknownRSLEntryType), expected: true},
+		"invalid RSL entry is not enough":  {err: rsl.ErrInvalidRSLEntry, expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, IsUpgradeRequiredError(test.err))
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/cmd/profile"
 	"github.com/gittuf/gittuf/internal/cmd/root"
+	"github.com/gittuf/gittuf/internal/version"
 )
 
 func main() {
@@ -29,6 +30,9 @@ func main() {
 
 	rootCmd := root.New()
 	if err := rootCmd.Execute(); err != nil {
+		if root.IsUpgradeRequiredError(err) {
+			fmt.Fprintf(os.Stderr, "This client is gittuf %s.\n", version.GetVersion())
+		}
 		// We can ignore the linter here (deferred functions are not executed
 		// when os.Exit is invoked) because if we do have an error, we don't
 		// have a panic, which is what the deferred function is looking for.

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -54,6 +54,7 @@ var (
 	ErrInvalidGetLatestReferenceUpdaterEntryOptions = errors.New("invalid options presented for getting latest reference updater entry (are both before or until conditions set or is the before number less than the until number?)")
 	ErrCannotUseEntryNumberFilter                   = errors.New("current RSL entries are not numbered, cannot use number range options")
 	ErrInvalidUntilEntryNumberCondition             = errors.New("cannot meet until entry number condition")
+	ErrUnknownRSLEntryType                          = fmt.Errorf("%w: RSL entry is of an unknown type", ErrInvalidRSLEntry)
 )
 
 // commitEntry commits an RSL entry: an empty-tree commit on Ref carrying the
@@ -1102,31 +1103,44 @@ func ParseEntryText(id githash.Hash, text string) (Entry, error) {
 	return parseRSLEntryText(id, text)
 }
 
+const unknownEntryTypeGuidance = "This repository may use a gittuf feature newer than this client. Upgrade gittuf to the latest release and retry. If this client is already the latest release, the entry may be corrupt or malicious and should be reported to the repository owners."
+
+const maxHeaderInError = 80
+
+func newUnknownEntryTypeError(id githash.Hash, text string) error {
+	header, _, _ := strings.Cut(text, "\n")
+	if len(header) > maxHeaderInError {
+		header = header[:maxHeaderInError] + "..."
+	}
+	return fmt.Errorf("%w: entry %s has header %q. %s", ErrUnknownRSLEntryType, id.String(), header, unknownEntryTypeGuidance)
+}
+
 func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
+	header, _, _ := strings.Cut(text, "\n")
 	// Each parser returns a concrete pointer type. Assign to a local and return
 	// an explicit nil interface on error: returning the typed nil pointer
 	// directly would yield a non-nil Entry wrapping a nil pointer.
-	switch {
-	case strings.HasPrefix(text, ReferenceEntryHeader):
+	switch header {
+	case ReferenceEntryHeader:
 		entry, err := parseReferenceEntryText(id, text)
 		if err != nil {
 			return nil, err
 		}
 		return entry, nil
-	case strings.HasPrefix(text, AnnotationEntryHeader):
+	case AnnotationEntryHeader:
 		entry, err := parseAnnotationEntryText(id, text)
 		if err != nil {
 			return nil, err
 		}
 		return entry, nil
-	case strings.HasPrefix(text, PropagationEntryHeader):
+	case PropagationEntryHeader:
 		entry, err := parsePropagationEntryText(id, text)
 		if err != nil {
 			return nil, err
 		}
 		return entry, nil
 	default:
-		return nil, ErrInvalidRSLEntry
+		return nil, newUnknownEntryTypeError(id, text)
 	}
 }
 

--- a/pkg/rsl/rsl_test.go
+++ b/pkg/rsl/rsl_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/pkg/githash"
@@ -654,4 +655,32 @@ func BenchmarkParseRSLEntryText(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestParseRSLEntryTextUnknownHeader(t *testing.T) {
+	t.Parallel()
+
+	for _, header := range []string{
+		"RSL Future Entry",
+		ReferenceEntryHeader + " v2",
+		AnnotationEntryHeader + " v2",
+		PropagationEntryHeader + " v2",
+	} {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
+
+			entry, err := parseRSLEntryText(githash.ZeroHash, header+"\n\nsomething: else")
+			assert.Nil(t, entry)
+			assert.ErrorIs(t, err, ErrUnknownRSLEntryType)
+			assert.ErrorIs(t, err, ErrInvalidRSLEntry)
+			assert.ErrorContains(t, err, fmt.Sprintf("%q", header))
+			assert.ErrorContains(t, err, "Upgrade gittuf to the latest release")
+		})
+	}
+
+	longHeader := "RSL " + strings.Repeat("x", 200) + " Entry"
+	_, err := parseRSLEntryText(githash.ZeroHash, longHeader+"\n\nsomething: else")
+	assert.ErrorIs(t, err, ErrUnknownRSLEntryType)
+	assert.ErrorContains(t, err, longHeader[:maxHeaderInError]+"...")
+	assert.NotContains(t, err.Error(), longHeader)
 }


### PR DESCRIPTION
## Description

An RSL entry whose header the client does not recognize used to fail with the generic invalid entry error, leaving the user unable to tell a corrupt entry from a repository written by a newer gittuf. Introduce ErrUnknownRSLEntryType, which wraps ErrInvalidRSLEntry so existing callers keep matching, and include the entry ID, a bounded prefix of the header and a request to upgrade in the message.

The CLI now recognizes this error and the existing unknown metadata schema version errors as upgrade required, and prints the running client version after them so a bug report or upgrade decision has the version at hand.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Creating tests and formulating commit message.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
