### PR TITLE
perf: add experimental go-git storage backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         go-version: ['1.26', '1.27']
+        storer: [binary, go-git]
     runs-on: ${{ matrix.os }}
+    env:
+      GITTUF_STORER: ${{ matrix.storer }}
     steps:
     - name: Checkout code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/docs/cli/gittuf.md
+++ b/docs/cli/gittuf.md
@@ -14,6 +14,8 @@ gittuf is a security layer for Git repositories, powered by TUF. The CLI provide
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_add-hooks.md
+++ b/docs/cli/gittuf_add-hooks.md
@@ -24,6 +24,8 @@ gittuf add-hooks [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest.md
+++ b/docs/cli/gittuf_attest.md
@@ -21,6 +21,8 @@ The 'attest' command provides tools for attesting to code contributions. It incl
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_apply.md
+++ b/docs/cli/gittuf_attest_apply.md
@@ -26,6 +26,8 @@ gittuf attest apply [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_authorize.md
+++ b/docs/cli/gittuf_attest_authorize.md
@@ -27,6 +27,8 @@ gittuf attest authorize [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github.md
+++ b/docs/cli/gittuf_attest_github.md
@@ -21,6 +21,8 @@ The 'github' command provides tools to create attestations for actions and entit
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_dismiss-approval.md
+++ b/docs/cli/gittuf_attest_github_dismiss-approval.md
@@ -28,6 +28,8 @@ gittuf attest github dismiss-approval [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_pull-request.md
+++ b/docs/cli/gittuf_attest_github_pull-request.md
@@ -30,6 +30,8 @@ gittuf attest github pull-request [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_attest_github_record-approval.md
+++ b/docs/cli/gittuf_attest_github_record-approval.md
@@ -30,6 +30,8 @@ gittuf attest github record-approval [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign attestations (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_cache.md
+++ b/docs/cli/gittuf_cache.md
@@ -19,6 +19,8 @@ The 'cache' command group contains subcommands to manage gittuf's local persiste
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_cache_delete.md
+++ b/docs/cli/gittuf_cache_delete.md
@@ -23,6 +23,8 @@ gittuf cache delete [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_cache_init.md
+++ b/docs/cli/gittuf_cache_init.md
@@ -23,6 +23,8 @@ gittuf cache init [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_clone.md
+++ b/docs/cli/gittuf_clone.md
@@ -26,6 +26,8 @@ gittuf clone [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy.md
+++ b/docs/cli/gittuf_policy.md
@@ -21,6 +21,8 @@ The 'policy' command provides a suite of tools for managing gittuf policy config
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_add-key.md
+++ b/docs/cli/gittuf_policy_add-key.md
@@ -27,6 +27,8 @@ gittuf policy add-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_add-person.md
+++ b/docs/cli/gittuf_policy_add-person.md
@@ -30,6 +30,8 @@ gittuf policy add-person [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_add-rule.md
+++ b/docs/cli/gittuf_policy_add-rule.md
@@ -30,6 +30,8 @@ gittuf policy add-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_apply.md
+++ b/docs/cli/gittuf_policy_apply.md
@@ -26,6 +26,8 @@ gittuf policy apply [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_discard.md
+++ b/docs/cli/gittuf_policy_discard.md
@@ -25,6 +25,8 @@ gittuf policy discard [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_increment-version.md
+++ b/docs/cli/gittuf_policy_increment-version.md
@@ -26,6 +26,8 @@ gittuf policy increment-version [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_init.md
+++ b/docs/cli/gittuf_policy_init.md
@@ -26,6 +26,8 @@ gittuf policy init [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_inspect.md
+++ b/docs/cli/gittuf_policy_inspect.md
@@ -27,6 +27,8 @@ gittuf policy inspect [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_list-principals.md
+++ b/docs/cli/gittuf_policy_list-principals.md
@@ -27,6 +27,8 @@ gittuf policy list-principals [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_list-rules.md
+++ b/docs/cli/gittuf_policy_list-rules.md
@@ -26,6 +26,8 @@ gittuf policy list-rules [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote.md
+++ b/docs/cli/gittuf_policy_remote.md
@@ -21,6 +21,8 @@ The 'remote' subcommand provides tools for pulling and pushing gittuf policy to 
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote_pull.md
+++ b/docs/cli/gittuf_policy_remote_pull.md
@@ -25,6 +25,8 @@ gittuf policy remote pull <remote> [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remote_push.md
+++ b/docs/cli/gittuf_policy_remote_push.md
@@ -25,6 +25,8 @@ gittuf policy remote push <remote> [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-key.md
+++ b/docs/cli/gittuf_policy_remove-key.md
@@ -27,6 +27,8 @@ gittuf policy remove-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-person.md
+++ b/docs/cli/gittuf_policy_remove-person.md
@@ -27,6 +27,8 @@ gittuf policy remove-person [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_remove-rule.md
+++ b/docs/cli/gittuf_policy_remove-rule.md
@@ -27,6 +27,8 @@ gittuf policy remove-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_reorder-rules.md
+++ b/docs/cli/gittuf_policy_reorder-rules.md
@@ -26,6 +26,8 @@ gittuf policy reorder-rules [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_sign.md
+++ b/docs/cli/gittuf_policy_sign.md
@@ -26,6 +26,8 @@ gittuf policy sign [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_stage.md
+++ b/docs/cli/gittuf_policy_stage.md
@@ -26,6 +26,8 @@ gittuf policy stage [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_update-person.md
+++ b/docs/cli/gittuf_policy_update-person.md
@@ -30,6 +30,8 @@ gittuf policy update-person [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_policy_update-rule.md
+++ b/docs/cli/gittuf_policy_update-rule.md
@@ -30,6 +30,8 @@ gittuf policy update-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign policy metadata (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl.md
+++ b/docs/cli/gittuf_rsl.md
@@ -19,6 +19,8 @@ The 'rsl' subcommand provides tools for managing the repository's Reference Stat
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_annotate.md
+++ b/docs/cli/gittuf_rsl_annotate.md
@@ -27,6 +27,8 @@ gittuf rsl annotate [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_log.md
+++ b/docs/cli/gittuf_rsl_log.md
@@ -24,6 +24,8 @@ gittuf rsl log [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_propagate.md
+++ b/docs/cli/gittuf_rsl_propagate.md
@@ -23,6 +23,8 @@ gittuf rsl propagate [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_record.md
+++ b/docs/cli/gittuf_rsl_record.md
@@ -27,6 +27,8 @@ gittuf rsl record [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_remote.md
+++ b/docs/cli/gittuf_rsl_remote.md
@@ -19,6 +19,8 @@ The 'remote' command provides tools for managing RSL interactions with remote re
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_remote_pull.md
+++ b/docs/cli/gittuf_rsl_remote_pull.md
@@ -23,6 +23,8 @@ gittuf rsl remote pull <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_remote_push.md
+++ b/docs/cli/gittuf_rsl_remote_push.md
@@ -23,6 +23,8 @@ gittuf rsl remote push <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_remote_reconcile.md
+++ b/docs/cli/gittuf_rsl_remote_reconcile.md
@@ -23,6 +23,8 @@ gittuf rsl remote reconcile <remote> [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_rsl_skip-rewritten.md
+++ b/docs/cli/gittuf_rsl_skip-rewritten.md
@@ -23,6 +23,8 @@ gittuf rsl skip-rewritten [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_sync.md
+++ b/docs/cli/gittuf_sync.md
@@ -24,6 +24,8 @@ gittuf sync [remoteName] [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust.md
+++ b/docs/cli/gittuf_trust.md
@@ -21,6 +21,8 @@ The 'trust' command provides tools to manage gittuf's root of trust, including s
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-controller-repository.md
+++ b/docs/cli/gittuf_trust_add-controller-repository.md
@@ -28,6 +28,8 @@ gittuf trust add-controller-repository [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-github-app.md
+++ b/docs/cli/gittuf_trust_add-github-app.md
@@ -27,6 +27,8 @@ gittuf trust add-github-app [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-global-rule.md
+++ b/docs/cli/gittuf_trust_add-global-rule.md
@@ -29,6 +29,8 @@ gittuf trust add-global-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-hook.md
+++ b/docs/cli/gittuf_trust_add-hook.md
@@ -32,6 +32,8 @@ gittuf trust add-hook [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-network-repository.md
+++ b/docs/cli/gittuf_trust_add-network-repository.md
@@ -28,6 +28,8 @@ gittuf trust add-network-repository [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-policy-key.md
+++ b/docs/cli/gittuf_trust_add-policy-key.md
@@ -26,6 +26,8 @@ gittuf trust add-policy-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-propagation-directive.md
+++ b/docs/cli/gittuf_trust_add-propagation-directive.md
@@ -31,6 +31,8 @@ gittuf trust add-propagation-directive [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_add-root-key.md
+++ b/docs/cli/gittuf_trust_add-root-key.md
@@ -26,6 +26,8 @@ gittuf trust add-root-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_apply.md
+++ b/docs/cli/gittuf_trust_apply.md
@@ -26,6 +26,8 @@ gittuf trust apply [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_disable-github-app-approvals.md
+++ b/docs/cli/gittuf_trust_disable-github-app-approvals.md
@@ -26,6 +26,8 @@ gittuf trust disable-github-app-approvals [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_enable-github-app-approvals.md
+++ b/docs/cli/gittuf_trust_enable-github-app-approvals.md
@@ -26,6 +26,8 @@ gittuf trust enable-github-app-approvals [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_increment-version.md
+++ b/docs/cli/gittuf_trust_increment-version.md
@@ -25,6 +25,8 @@ gittuf trust increment-version [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_init.md
+++ b/docs/cli/gittuf_trust_init.md
@@ -26,6 +26,8 @@ gittuf trust init [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_inspect-root.md
+++ b/docs/cli/gittuf_trust_inspect-root.md
@@ -26,6 +26,8 @@ gittuf trust inspect-root [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-global-rules.md
+++ b/docs/cli/gittuf_trust_list-global-rules.md
@@ -26,6 +26,8 @@ gittuf trust list-global-rules [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-hooks.md
+++ b/docs/cli/gittuf_trust_list-hooks.md
@@ -26,6 +26,8 @@ gittuf trust list-hooks [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_list-propagation-directives.md
+++ b/docs/cli/gittuf_trust_list-propagation-directives.md
@@ -26,6 +26,8 @@ gittuf trust list-propagation-directives [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_make-controller.md
+++ b/docs/cli/gittuf_trust_make-controller.md
@@ -25,6 +25,8 @@ gittuf trust make-controller [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote.md
+++ b/docs/cli/gittuf_trust_remote.md
@@ -21,6 +21,8 @@ The 'remote' subcommand provides tools for pulling and pushing gittuf policy to 
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote_pull.md
+++ b/docs/cli/gittuf_trust_remote_pull.md
@@ -25,6 +25,8 @@ gittuf trust remote pull <remote> [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remote_push.md
+++ b/docs/cli/gittuf_trust_remote_push.md
@@ -25,6 +25,8 @@ gittuf trust remote push <remote> [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-github-app.md
+++ b/docs/cli/gittuf_trust_remove-github-app.md
@@ -26,6 +26,8 @@ gittuf trust remove-github-app [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-global-rule.md
+++ b/docs/cli/gittuf_trust_remove-global-rule.md
@@ -26,6 +26,8 @@ gittuf trust remove-global-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-hook.md
+++ b/docs/cli/gittuf_trust_remove-hook.md
@@ -28,6 +28,8 @@ gittuf trust remove-hook [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-policy-key.md
+++ b/docs/cli/gittuf_trust_remove-policy-key.md
@@ -26,6 +26,8 @@ gittuf trust remove-policy-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-propagation-directive.md
+++ b/docs/cli/gittuf_trust_remove-propagation-directive.md
@@ -26,6 +26,8 @@ gittuf trust remove-propagation-directive [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_remove-root-key.md
+++ b/docs/cli/gittuf_trust_remove-root-key.md
@@ -26,6 +26,8 @@ gittuf trust remove-root-key [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_set-repository-location.md
+++ b/docs/cli/gittuf_trust_set-repository-location.md
@@ -26,6 +26,8 @@ gittuf trust set-repository-location [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_sign.md
+++ b/docs/cli/gittuf_trust_sign.md
@@ -25,6 +25,8 @@ gittuf trust sign [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_stage.md
+++ b/docs/cli/gittuf_trust_stage.md
@@ -26,6 +26,8 @@ gittuf trust stage [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-global-rule.md
+++ b/docs/cli/gittuf_trust_update-global-rule.md
@@ -29,6 +29,8 @@ gittuf trust update-global-rule [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-hook.md
+++ b/docs/cli/gittuf_trust_update-hook.md
@@ -32,6 +32,8 @@ gittuf trust update-hook [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-policy-threshold.md
+++ b/docs/cli/gittuf_trust_update-policy-threshold.md
@@ -26,6 +26,8 @@ gittuf trust update-policy-threshold [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-propagation-directive.md
+++ b/docs/cli/gittuf_trust_update-propagation-directive.md
@@ -31,6 +31,8 @@ gittuf trust update-propagation-directive [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_trust_update-root-threshold.md
+++ b/docs/cli/gittuf_trust_update-root-threshold.md
@@ -26,6 +26,8 @@ gittuf trust update-root-threshold [flags]
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
   -k, --signing-key string           signing key to use to sign root of trust (path to SSH key, "gpg:<fingerprint>" for GPG, "fulcio:" for Sigstore)
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_tui.md
+++ b/docs/cli/gittuf_tui.md
@@ -28,6 +28,8 @@ gittuf tui [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_verify-mergeable.md
+++ b/docs/cli/gittuf_verify-mergeable.md
@@ -26,6 +26,8 @@ gittuf verify-mergeable [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_verify-network.md
+++ b/docs/cli/gittuf_verify-network.md
@@ -23,6 +23,8 @@ gittuf verify-network [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_verify-ref.md
+++ b/docs/cli/gittuf_verify-ref.md
@@ -22,6 +22,8 @@ gittuf verify-ref [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/docs/cli/gittuf_version.md
+++ b/docs/cli/gittuf_version.md
@@ -23,6 +23,8 @@ gittuf version [flags]
       --profile                      enable CPU and memory profiling
       --profile-CPU-file string      file to store CPU profile (default "cpu.prof")
       --profile-memory-file string   file to store memory profile (default "memory.prof")
+      --storer string                Git storage backend to use, one of binary or go-git (experimental, overrides GITTUF_STORER) (default "binary")
+      --storer-trace                 report Git storage backend call counts, timings and git fork counts to stderr on exit
       --verbose                      enable verbose logging
 ```
 

--- a/experimental/gittuf/attestations_test.go
+++ b/experimental/gittuf/attestations_test.go
@@ -31,12 +31,12 @@ func TestApplyAttestations(t *testing.T) {
 	remoteName := "origin"
 	testDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, testDir, false)
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
 	fromRef := "refs/heads/main"
 	targetTagRef := "refs/tags/v1"
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -86,7 +86,7 @@ func TestApplyAttestations(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -116,7 +116,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		}
 		defer os.Chdir(pwd) //nolint:errcheck
 
-		repo := &Repository{r: r}
+		repo := &Repository{r: newStorer(r)}
 
 		targetRef := "main"
 		absTargetRef := "refs/heads/main"
@@ -124,7 +124,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		absFeatureRef := "refs/heads/feature"
 
 		// Create common base for main and feature branches
-		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -237,13 +237,13 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 		}
 		defer os.Chdir(pwd) //nolint:errcheck
 
-		repo := &Repository{r: r}
+		repo := &Repository{r: newStorer(r)}
 
 		fromRef := "refs/heads/main"
 		targetTagRef := "refs/tags/v1"
 
 		// Create common base for main and feature branches
-		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -305,7 +305,7 @@ func TestAddAndRemoveReferenceAuthorization(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
 
@@ -334,7 +334,7 @@ func TestAddGitHubPullRequestAttestationForCommit(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -355,7 +355,7 @@ func TestAddGitHubPullRequestAttestationForNumber(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -376,7 +376,7 @@ func TestAddGitHubPullRequestApprover(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
 
@@ -399,7 +399,7 @@ func TestDismissGitHubPullRequestApprover(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
 
@@ -435,12 +435,12 @@ func TestAddReferenceAuthorizationForNewTagZeroHashFormat(t *testing.T) {
 			}
 			defer os.Chdir(pwd) //nolint:errcheck
 
-			repo := &Repository{r: r}
+			repo := &Repository{r: newStorer(r)}
 
 			fromRef := "refs/heads/main"
 			targetTagRef := "refs/tags/v1"
 
-			treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+			treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 			emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 			if err != nil {
 				t.Fatal(err)

--- a/experimental/gittuf/helpers_test.go
+++ b/experimental/gittuf/helpers_test.go
@@ -51,7 +51,7 @@ func createTestRepositoryWithRoot(t *testing.T, location string, opts ...gitinte
 		repo = gitinterface.CreateTestGitRepository(t, location, false, opts...)
 	}
 
-	r := &Repository{r: repo}
+	r := &Repository{r: newStorer(repo)}
 
 	if err := r.InitializeRoot(testCtx, signer, false); err != nil {
 		t.Fatal(err)

--- a/experimental/gittuf/hook.go
+++ b/experimental/gittuf/hook.go
@@ -251,7 +251,7 @@ func (r *Repository) executeHook(ctx context.Context, hook tuf.Hook, parameters 
 	var hookContents string
 	hookBlobID := hook.GetBlobID()
 
-	environment, err := luasandbox.NewLuaEnvironment(ctx, r.r, luasandboxopts.WithLuaTimeout(hook.GetTimeout()))
+	environment, err := luasandbox.NewLuaEnvironment(ctx, r.r.Repository, luasandboxopts.WithLuaTimeout(hook.GetTimeout()))
 	if err != nil {
 		return -1, err
 	}

--- a/experimental/gittuf/hook_test.go
+++ b/experimental/gittuf/hook_test.go
@@ -23,7 +23,7 @@ func TestUpdatePrePushHook(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		err := r.UpdateGitHook(HookPrePush, []byte("some content"), false)
 		require.NoError(t, err)
@@ -38,7 +38,7 @@ func TestUpdatePrePushHook(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		hookFile := filepath.Join(repo.GetGitDir(), "hooks", "pre-push")
 		err := os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec
@@ -55,7 +55,7 @@ func TestUpdatePrePushHook(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		hookFile := filepath.Join(repo.GetGitDir(), "hooks", "pre-push")
 		err := os.WriteFile(hookFile, []byte("existing hook script"), 0o700) // nolint:gosec
@@ -85,7 +85,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		_, err := r.InvokeHooksForStage(testCtx, nil, tuf.HookStagePreCommit)
 		assert.ErrorIs(t, err, sslibdsse.ErrNoSigners)
@@ -95,7 +95,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		hookStage := tuf.HookStagePreCommit
 		hookName := "test-hook"
@@ -126,7 +126,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 		tmpDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		hookStage := tuf.HookStagePreCommit
 		hookName := "test-hook"
@@ -176,7 +176,7 @@ func TestInvokeHooksForStage(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				r := &Repository{r: repo}
+				r := &Repository{r: newStorer(repo)}
 
 				hookStage := tuf.HookStagePrePush
 				hookName := "test-hook"

--- a/experimental/gittuf/keys.go
+++ b/experimental/gittuf/keys.go
@@ -160,14 +160,14 @@ func LoadSigner(repo *Repository, key string) (sslibdsse.SignerVerifier, error) 
 	case strings.HasPrefix(key, GPGKeyPrefix):
 		keyID := strings.TrimPrefix(key, GPGKeyPrefix)
 
-		opts, err := getGPGOptions(repo.GetGitRepository())
+		opts, err := getGPGOptions(repo.GetStorer())
 		if err != nil {
 			return nil, err
 		}
 
 		return gpg.NewSignerFromKeyID(keyID, opts...)
 	case strings.HasPrefix(key, FulcioPrefix):
-		opts, err := getSigstoreOptions(repo.GetGitRepository())
+		opts, err := getSigstoreOptions(repo.GetStorer())
 		if err != nil {
 			return nil, err
 		}

--- a/experimental/gittuf/keys_test.go
+++ b/experimental/gittuf/keys_test.go
@@ -64,7 +64,7 @@ func TestLoadSigner(t *testing.T) {
 		t.Run("no signing method specified", func(t *testing.T) {
 			// Test no configuration, this means GPG
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
 				t.Fatal(err)
@@ -80,7 +80,7 @@ func TestLoadSigner(t *testing.T) {
 
 		t.Run("method specified but no signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
 				t.Fatal(err)
@@ -95,7 +95,7 @@ func TestLoadSigner(t *testing.T) {
 
 		t.Run("no method specified but signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
 				t.Fatal(err)
@@ -114,7 +114,7 @@ func TestLoadSigner(t *testing.T) {
 
 		t.Run("method and signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
 				t.Fatal(err)
@@ -137,7 +137,7 @@ func TestLoadSigner(t *testing.T) {
 			// Test misconfiguration of SSH
 			tmpDir := t.TempDir()
 			// CreateTestGitRepository sets up the repository to use ssh by default
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("user.signingkey", ""); err != nil {
 				t.Fatal(err)
@@ -151,7 +151,7 @@ func TestLoadSigner(t *testing.T) {
 			// Test a working SSH key configured
 			tmpDir := t.TempDir()
 			// CreateTestGitRepository sets up the repository to use ssh by default
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			signer, err := LoadSigner(repo, "")
 			assert.Nil(t, err)
@@ -185,7 +185,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 		t.Run("no signing method specified", func(t *testing.T) {
 			// Test no configuration, this means GPG
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
 				t.Fatal(err)
@@ -201,7 +201,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 
 		t.Run("method specified but no signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
 				t.Fatal(err)
@@ -216,7 +216,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 
 		t.Run("no method specified but signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", ""); err != nil {
 				t.Fatal(err)
@@ -235,7 +235,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 
 		t.Run("method and signing key specified", func(t *testing.T) {
 			tmpDir := t.TempDir()
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("gpg.format", "gpg"); err != nil {
 				t.Fatal(err)
@@ -258,7 +258,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 			// Test misconfiguration of SSH
 			tmpDir := t.TempDir()
 			// CreateTestGitRepository sets up the repository to use ssh by default
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			if err := repo.r.SetGitConfig("user.signingkey", ""); err != nil {
 				t.Fatal(err)
@@ -272,7 +272,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 			// Test a working SSH key configured
 			tmpDir := t.TempDir()
 			// CreateTestGitRepository sets up the repository to use ssh by default
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			signer, err := LoadSignerFromGitConfig(repo)
 			assert.Nil(t, err)
@@ -291,7 +291,7 @@ func TestLoadSignerFromGitConfig(t *testing.T) {
 		t.Run("non-sigstore program", func(t *testing.T) {
 			tmpDir := t.TempDir()
 
-			repo := &Repository{r: gitinterface.CreateTestGitRepository(t, tmpDir, false)}
+			repo := &Repository{r: newStorer(gitinterface.CreateTestGitRepository(t, tmpDir, false))}
 
 			require.NoError(t, repo.r.SetGitConfig("gpg.format", "x509"))
 			require.NoError(t, repo.r.SetGitConfig("user.signingkey", ""))

--- a/experimental/gittuf/policy_test.go
+++ b/experimental/gittuf/policy_test.go
@@ -82,7 +82,7 @@ func TestPullPolicy(t *testing.T) {
 
 		localTmpDir := t.TempDir()
 		localRepoR := gitinterface.CreateTestGitRepository(t, localTmpDir, false)
-		localRepo := &Repository{r: localRepoR}
+		localRepo := &Repository{r: newStorer(localRepoR)}
 
 		if err := localRepo.r.CreateRemote(remoteName, remoteTmpDir); err != nil {
 			t.Fatal(err)
@@ -106,7 +106,7 @@ func TestPullPolicy(t *testing.T) {
 
 		localTmpDir := t.TempDir()
 		localRepoR := gitinterface.CreateTestGitRepository(t, localTmpDir, false)
-		localRepo := &Repository{r: localRepoR}
+		localRepo := &Repository{r: newStorer(localRepoR)}
 
 		if err := rsl.NewReferenceEntry(policy.PolicyRef, gitinterface.ZeroHash).Commit(localRepo.r, false); err != nil {
 			t.Fatal(err)
@@ -132,7 +132,7 @@ func TestHasPolicy(t *testing.T) {
 	t.Run("policy does not exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		repo := &Repository{r: r}
+		repo := &Repository{r: newStorer(r)}
 
 		hasPolicy, err := repo.HasPolicy()
 		assert.Nil(t, err)
@@ -189,7 +189,7 @@ func TestApplyPolicy(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -224,7 +224,7 @@ func TestDiscardPolicy(t *testing.T) {
 	t.Run("discard with no policy references", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		repo := &Repository{r: r}
+		repo := &Repository{r: newStorer(r)}
 
 		err := repo.DiscardPolicy()
 		assert.Nil(t, err)
@@ -396,7 +396,7 @@ func TestStagePolicy(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")

--- a/experimental/gittuf/repository.go
+++ b/experimental/gittuf/repository.go
@@ -9,8 +9,10 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/gittuf/gittuf/internal/gogitstore"
 	"github.com/gittuf/gittuf/internal/tuf"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
 )
 
 const (
@@ -28,11 +30,39 @@ func InDebugMode() bool {
 }
 
 type Repository struct {
-	r *gitinterface.Repository
+	r *gogitstore.Storer
 }
 
+// GetGitRepository returns the git binary backend. Use GetStorer instead for
+// anything taking a gitstore.Storer, so it uses the selected backend.
 func (r *Repository) GetGitRepository() *gitinterface.Repository {
+	return r.r.Repository
+}
+
+// GetStorer returns the repository's storage backend.
+func (r *Repository) GetStorer() gitstore.Storer {
 	return r.r
+}
+
+// newStorer wraps repo with the selected backend, attaching a trace if one was
+// requested.
+func newStorer(repo *gitinterface.Repository) *gogitstore.Storer {
+	backend := storer.resolve()
+	enableGoGit := backend == StorerBackendGoGit
+
+	if !storer.tracing() {
+		return gogitstore.New(repo, enableGoGit)
+	}
+
+	trace := gogitstore.NewTrace()
+
+	activeTrace.mu.Lock()
+	activeTrace.trace = trace
+	activeTrace.repo = repo
+	activeTrace.backend = backend
+	activeTrace.mu.Unlock()
+
+	return gogitstore.NewWithTrace(repo, enableGoGit, trace)
 }
 
 func LoadRepository(repositoryPath string) (*Repository, error) {
@@ -54,7 +84,7 @@ func LoadRepository(repositoryPath string) (*Repository, error) {
 	}
 
 	return &Repository{
-		r: repo,
+		r: newStorer(repo),
 	}, nil
 }
 

--- a/experimental/gittuf/repository_test.go
+++ b/experimental/gittuf/repository_test.go
@@ -68,7 +68,7 @@ func TestUnauthorizedKey(t *testing.T) {
 	rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 	targetsSigner := setupSSHKeysForSigning(t, targetsKeyBytes, targetsPubKeyBytes)
 
-	r := &Repository{r: repo}
+	r := &Repository{r: newStorer(repo)}
 	if err := r.InitializeRoot(testCtx, rootSigner, false); err != nil {
 		t.Fatal(err)
 	}
@@ -90,7 +90,7 @@ func TestGetGitRepository(t *testing.T) {
 	tmpDir := t.TempDir()
 	repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
 
-	r := &Repository{r: repo}
+	r := &Repository{r: newStorer(repo)}
 	result := r.GetGitRepository()
 	assert.Equal(t, repo, result)
 }

--- a/experimental/gittuf/root_test.go
+++ b/experimental/gittuf/root_test.go
@@ -61,7 +61,7 @@ func TestInitializeRoot(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
@@ -92,7 +92,7 @@ func TestInitializeRoot(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		// Make a test GPG keyring in tempdir to use for tests
 		gpg.SetupTestGPGHomeDir(t, artifacts.GPGKey1Private)
@@ -145,7 +145,7 @@ func TestInitializeRoot(t *testing.T) {
 	t.Run("fails when root staged but not applied (policy-staging has root)", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
 		err := r.InitializeRoot(testCtx, signer, false)
@@ -158,7 +158,7 @@ func TestInitializeRoot(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 		signer := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
 		// Test signCommit
@@ -195,7 +195,7 @@ func TestSetRepositoryLocation(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 		rootSigner := setupSSHKeysForSigning(t, rootKeyBytes, rootPubKeyBytes)
 
 		// Test signCommit
@@ -253,7 +253,7 @@ func TestAddRootKey(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -359,7 +359,7 @@ func TestRemoveRootKey(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		r := &Repository{r: repo}
+		r := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -417,7 +417,7 @@ func TestAddTopLevelTargetsKey(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -502,7 +502,7 @@ func TestRemoveTopLevelTargetsKey(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -560,7 +560,7 @@ func TestAddGitHubApp(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -666,7 +666,7 @@ func TestRemoveGitHubApp(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -757,7 +757,7 @@ func TestTrustGitHubApp(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -862,7 +862,7 @@ func TestUntrustGitHubApp(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -977,7 +977,7 @@ func TestUpdateRootThreshold(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -1066,7 +1066,7 @@ func TestUpdateTopLevelTargetsThreshold(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -1121,7 +1121,7 @@ func TestSignRoot(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -1184,7 +1184,7 @@ func TestAddGlobalRuleThreshold(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -1251,7 +1251,7 @@ func TestAddGlobalRuleBlockForcePushes(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err = repo.SetGitConfig("user.signingkey", "")
@@ -1389,7 +1389,7 @@ func TestRemoveGlobalRule(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -1756,7 +1756,7 @@ func TestUpdateGlobalRule(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -1894,7 +1894,7 @@ func TestAddPropagationDirective(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2015,7 +2015,7 @@ func TestUpdatePropagationDirective(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2166,7 +2166,7 @@ func TestRemovePropagationDirective(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2700,7 +2700,7 @@ func TestIncrementRootVersion(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2812,7 +2812,7 @@ func TestEnableController(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2863,7 +2863,7 @@ func TestDisableController(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2913,7 +2913,7 @@ func TestAddControllerRepository(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -2975,7 +2975,7 @@ func TestAddNetworkRepository(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -908,7 +908,7 @@ func (r *Repository) PropagateChangesFromUpstreamRepositories(ctx context.Contex
 			return fmt.Errorf("unable to fetch upstream repository '%s': %w", upstreamRepositoryURL, err)
 		}
 
-		if err := propagation.PropagateChangesFromUpstreamRepository(r.r, upstreamRepository, directives, sign); err != nil {
+		if err := propagation.PropagateChangesFromUpstreamRepository(r.r.Repository, upstreamRepository, directives, sign); err != nil {
 			// TODO: atomic? abort?
 			return err
 		}

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -30,9 +30,9 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	tempDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -142,7 +142,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 
 		remoteTmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, remoteTmpDir, true)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -162,7 +162,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		blobID, err := localR.WriteBlob([]byte("test"))
 		if err != nil {
@@ -196,7 +196,7 @@ func TestRecordRSLEntryForReference(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -227,9 +227,9 @@ func TestRecordRSLEntryForReferenceAtTarget(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			r := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-			repo := &Repository{r: r}
+			repo := &Repository{r: newStorer(r)}
 
-			treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+			treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 			emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 			if err != nil {
 				t.Fatal(err)
@@ -303,12 +303,12 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	tempDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
 
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
 	err := repo.RecordRSLAnnotation(testCtx, []string{gitinterface.ZeroHash.String()}, false, "test annotation", false, rslopts.WithAnnotateLocalOnly())
 	assert.ErrorIs(t, err, rsl.ErrRSLEntryNotFound)
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {
 		t.Fatal(err)
@@ -360,7 +360,7 @@ func TestRecordRSLAnnotation(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -381,7 +381,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("remote has updates for local", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -405,7 +405,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -438,7 +438,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("remote uses gittuf transport prefix", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -468,7 +468,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if err := localR.AddRemote(remoteName, gittufTransportPrefix+tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		// Simulate more remote actions
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
@@ -507,7 +507,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("remote has no updates for local", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -531,7 +531,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		originalRSLTip, err := localRepo.r.GetReference(rsl.Ref)
 		if err != nil {
@@ -552,7 +552,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("local is ahead of remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -578,7 +578,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		// Simulate local actions
 		if _, err := localR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
@@ -617,7 +617,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("remote and local have diverged", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -643,7 +643,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		// Simulate remote actions
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
@@ -711,7 +711,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("remote and local have diverged but modify same ref", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -737,7 +737,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		// Simulate remote actions
 		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
@@ -784,7 +784,7 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -804,7 +804,7 @@ func TestSync(t *testing.T) {
 	t.Run("local and remote are identical", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, true)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -829,7 +829,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -841,7 +841,7 @@ func TestSync(t *testing.T) {
 	t.Run("remote uses gittuf transport prefix", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, true)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -870,7 +870,7 @@ func TestSync(t *testing.T) {
 		if err := localR.AddRemote(remoteName, gittufTransportPrefix+tmpDir); err != nil {
 			t.Fatal(err)
 		}
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		divergedRefs, err := localRepo.Sync(testCtx, remoteName, false, false)
 		assert.Nil(t, err)
@@ -890,7 +890,7 @@ func TestSync(t *testing.T) {
 	t.Run("local is strictly ahead of remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, true)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -915,7 +915,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -950,7 +950,7 @@ func TestSync(t *testing.T) {
 	t.Run("local is strictly behind remote", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -975,7 +975,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -1010,7 +1010,7 @@ func TestSync(t *testing.T) {
 	t.Run("local RSL has diverged, not allowed to overwrite", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -1035,7 +1035,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -1063,7 +1063,7 @@ func TestSync(t *testing.T) {
 	t.Run("local ref (not RSL) has diverged, not allowed to overwrite", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -1088,7 +1088,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -1113,7 +1113,7 @@ func TestSync(t *testing.T) {
 	t.Run("local RSL has diverged, allowed to overwrite", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -1138,7 +1138,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -1170,7 +1170,7 @@ func TestSync(t *testing.T) {
 	t.Run("local ref (not RSL) has diverged, allowed to overwrite", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
-		remoteRepo := &Repository{r: remoteR}
+		remoteRepo := &Repository{r: newStorer(remoteR)}
 
 		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
@@ -1195,7 +1195,7 @@ func TestSync(t *testing.T) {
 		}
 		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
 		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
-		localRepo := &Repository{r: localR}
+		localRepo := &Repository{r: newStorer(localR)}
 
 		assertLocalAndRemoteRefsMatch(t, localR, remoteR, rsl.Ref)
 
@@ -1271,7 +1271,7 @@ func TestPullRSL(t *testing.T) {
 
 		localTmpDir := t.TempDir()
 		localRepoR := gitinterface.CreateTestGitRepository(t, localTmpDir, false)
-		localRepo := &Repository{r: localRepoR}
+		localRepo := &Repository{r: newStorer(localRepoR)}
 		if err := localRepo.r.CreateRemote(remoteName, remoteTmpDir); err != nil {
 			t.Fatal(err)
 		}
@@ -1292,7 +1292,7 @@ func TestPullRSL(t *testing.T) {
 
 		localTmpDir := t.TempDir()
 		localRepoR := gitinterface.CreateTestGitRepository(t, localTmpDir, false)
-		localRepo := &Repository{r: localRepoR}
+		localRepo := &Repository{r: newStorer(localRepoR)}
 		if err := localRepo.r.CreateRemote(remoteName, remoteTmpDir); err != nil {
 			t.Fatal(err)
 		}
@@ -1342,7 +1342,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r)
+		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r.Repository)
 		upstreamRootTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("b", blobBID),
@@ -1376,7 +1376,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r)
+		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r.Repository)
 		downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("foo/b", blobBID),
@@ -1481,7 +1481,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r)
+		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r.Repository)
 		upstreamRootTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("b", blobBID),
@@ -1525,7 +1525,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r)
+		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r.Repository)
 		downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("foo/b", blobBID),
@@ -1646,7 +1646,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r)
+		upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo.r.Repository)
 		upstreamRootTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("b", blobBID),
@@ -1690,7 +1690,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r)
+		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r.Repository)
 		downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("foo/b", blobBID),
@@ -1831,7 +1831,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		upstreamTreeBuilder1 := gitinterface.NewTreeBuilder(upstreamRepo1.r)
+		upstreamTreeBuilder1 := gitinterface.NewTreeBuilder(upstreamRepo1.r.Repository)
 		upstreamRootTree1ID, err := upstreamTreeBuilder1.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("b", blobBID),
@@ -1860,7 +1860,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		upstreamTreeBuilder2 := gitinterface.NewTreeBuilder(upstreamRepo2.r)
+		upstreamTreeBuilder2 := gitinterface.NewTreeBuilder(upstreamRepo2.r.Repository)
 		upstreamRootTree2ID, err := upstreamTreeBuilder2.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("c", blobCID),
 			gitinterface.NewEntryBlob("d", blobDID),
@@ -1896,7 +1896,7 @@ func TestPropagateChangesFromUpstreamRepositories(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r)
+		downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo.r.Repository)
 		downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
 			gitinterface.NewEntryBlob("a", blobAID),
 			gitinterface.NewEntryBlob("foo/b", blobBID),
@@ -2175,9 +2175,9 @@ func TestRecordRSLEntryForReferenceWithSigningKeyBytes(t *testing.T) {
 	// CommitUsingSpecificKey takes.
 	tempDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	require.NoError(t, err)
 	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
@@ -2212,9 +2212,9 @@ func TestRecordRSLAnnotationWithSigningKeyBytes(t *testing.T) {
 	// Mirror the entry test for annotations.
 	tempDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	require.NoError(t, err)
 	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)
@@ -2263,9 +2263,9 @@ func TestRecordRSLEntryForReferenceSigningKeyBytesIgnoredWhenUnsigned(t *testing
 	// the existing flag rather than letting key presence silently override it.
 	tempDir := t.TempDir()
 	r := gitinterface.CreateTestGitRepository(t, tempDir, false)
-	repo := &Repository{r: r}
+	repo := &Repository{r: newStorer(r)}
 
-	treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+	treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	require.NoError(t, err)
 	_, err = repo.r.Commit(emptyTreeHash, "refs/heads/main", "Initial commit\n", false)

--- a/experimental/gittuf/storer.go
+++ b/experimental/gittuf/storer.go
@@ -1,0 +1,149 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gittuf
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+)
+
+// StorerBackendEnvKey selects the backend from the environment, for scripts
+// and benchmarks that cannot pass --storer.
+const StorerBackendEnvKey = "GITTUF_STORER"
+
+// StorerBackend names a Git storage backend.
+type StorerBackend string
+
+const (
+	// StorerBackendBinary invokes the git binary. It is the default and the
+	// only backend gittuf makes compatibility guarantees for.
+	StorerBackendBinary StorerBackend = "binary"
+
+	// StorerBackendGoGit reads objects in-process, delegating writes and
+	// merges to the git binary. Experimental.
+	StorerBackendGoGit StorerBackend = "go-git"
+)
+
+// ErrUnknownStorerBackend is returned for an unrecognised backend name.
+var ErrUnknownStorerBackend = errors.New("unknown Git storage backend")
+
+const experimentalStorerWarning = "the go-git storage backend is EXPERIMENTAL: results are not covered by gittuf's compatibility guarantees and may differ from the default backend; unset --storer/" + StorerBackendEnvKey + " to disable"
+
+// ParseStorerBackend reads a backend name. An empty name selects the default.
+func ParseStorerBackend(value string) (StorerBackend, error) {
+	switch backend := StorerBackend(value); backend {
+	case "":
+		return StorerBackendBinary, nil
+	case StorerBackendBinary, StorerBackendGoGit:
+		return backend, nil
+	default:
+		return StorerBackendBinary, fmt.Errorf("%w: %s", ErrUnknownStorerBackend, value)
+	}
+}
+
+// storerSelection holds the process-wide backend and tracing settings.
+type storerSelection struct {
+	mu      sync.Mutex
+	backend StorerBackend
+	isSet   bool
+	warned  bool
+	trace   bool
+
+	// warn and debugf are fields so tests can capture their output.
+	warn   func(message string)
+	debugf func(message string)
+}
+
+// storer is the process wide selection, set by the CLI before any command
+// body runs.
+var storer = &storerSelection{
+	warn:   func(message string) { slog.Warn(message) },
+	debugf: func(message string) { slog.Debug(message) },
+}
+
+func (s *storerSelection) set(backend StorerBackend) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.backend = backend
+	s.isSet = true
+}
+
+// resolve prefers an explicit setting over the environment. A bad environment
+// value is ignored rather than fatal, so it cannot block reading a repository.
+func (s *storerSelection) resolve() StorerBackend {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	backend := s.backend
+	if !s.isSet {
+		backend, _ = ParseStorerBackend(os.Getenv(StorerBackendEnvKey))
+	}
+
+	if backend != StorerBackendBinary && !s.warned {
+		s.warned = true
+		s.warn(experimentalStorerWarning)
+	}
+
+	if s.debugf != nil {
+		s.debugf(fmt.Sprintf("Using '%s' Git storage backend", backend))
+	}
+
+	return backend
+}
+
+// SetStorerBackend selects the backend for subsequently loaded repositories.
+func SetStorerBackend(backend StorerBackend) {
+	storer.set(backend)
+}
+
+// StorerBackendInUse returns the backend this process will use.
+func StorerBackendInUse() StorerBackend {
+	return storer.resolve()
+}
+
+func (s *storerSelection) setTrace(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.trace = enabled
+}
+
+func (s *storerSelection) tracing() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.trace
+}
+
+// SetStorerTrace enables per method counts and timings, read back with
+// StorerTraceReport.
+func SetStorerTrace(enabled bool) {
+	storer.setTrace(enabled)
+}
+
+// activeTrace holds the trace for the last loaded repository.
+var activeTrace struct {
+	mu      sync.Mutex
+	trace   *gogitstore.Trace
+	repo    *gitinterface.Repository
+	backend StorerBackend
+}
+
+// StorerTraceReport reports false when tracing is off or no repository was
+// loaded.
+func StorerTraceReport() (string, bool) {
+	activeTrace.mu.Lock()
+	defer activeTrace.mu.Unlock()
+
+	if activeTrace.trace == nil || activeTrace.repo == nil {
+		return "", false
+	}
+
+	return activeTrace.trace.Report(string(activeTrace.backend), activeTrace.repo.GitInvocationCount()), true
+}

--- a/experimental/gittuf/storer_test.go
+++ b/experimental/gittuf/storer_test.go
@@ -1,0 +1,183 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gittuf
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/policy"
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListPrincipalsBackendEquivalenceAndForks(t *testing.T) {
+	resetStorerForTest(t)
+	SetStorerBackend(StorerBackendBinary)
+	repo := createTestRepositoryWithPolicyWithFileRule(t, "")
+	binary := repo.GetGitRepository()
+	before := binary.GitInvocationCount()
+	want, err := repo.ListPrincipals(t.Context(), policy.PolicyRef, tuf.TargetsRoleName)
+	require.NoError(t, err)
+	binaryForks := binary.GitInvocationCount() - before
+
+	SetStorerBackend(StorerBackendGoGit)
+	fast := &Repository{r: newStorer(binary)}
+	before = binary.GitInvocationCount()
+	got, err := fast.ListPrincipals(t.Context(), policy.PolicyRef, tuf.TargetsRoleName)
+	require.NoError(t, err)
+	fastForks := binary.GitInvocationCount() - before
+
+	assert.Equal(t, want, got)
+	assert.Less(t, fastForks, binaryForks)
+}
+
+// resetStorerForTest restores the process wide selection afterwards.
+func resetStorerForTest(t *testing.T) {
+	t.Helper()
+
+	previous := storer
+	t.Cleanup(func() {
+		storer = previous
+		activeTrace.mu.Lock()
+		activeTrace.trace, activeTrace.repo = nil, nil
+		activeTrace.mu.Unlock()
+	})
+	storer = &storerSelection{warn: func(string) {}, debugf: func(string) {}}
+}
+
+func TestParseStorerBackend(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value       string
+		expected    StorerBackend
+		expectedErr bool
+	}{
+		"binary":                   {value: "binary", expected: StorerBackendBinary},
+		"go-git":                   {value: "go-git", expected: StorerBackendGoGit},
+		"empty defaults to binary": {value: "", expected: StorerBackendBinary},
+		"unknown":                  {value: "libgit2", expectedErr: true},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			backend, err := ParseStorerBackend(test.value)
+			if test.expectedErr {
+				assert.ErrorIs(t, err, ErrUnknownStorerBackend)
+				return
+			}
+			require.Nil(t, err)
+			assert.Equal(t, test.expected, backend)
+		})
+	}
+}
+
+func TestStorerSelection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("warns once when go-git is selected", func(t *testing.T) {
+		t.Parallel()
+
+		warnings := []string{}
+		selection := &storerSelection{warn: func(message string) { warnings = append(warnings, message) }}
+		selection.set(StorerBackendGoGit)
+
+		assert.Equal(t, StorerBackendGoGit, selection.resolve())
+		assert.Equal(t, StorerBackendGoGit, selection.resolve())
+		assert.Equal(t, StorerBackendGoGit, selection.resolve())
+
+		require.Len(t, warnings, 1)
+		assert.Contains(t, warnings[0], "EXPERIMENTAL")
+	})
+}
+
+func TestStorerSelectionFromEnvironment(t *testing.T) {
+	t.Run("defaults to the git binary and does not warn", func(t *testing.T) {
+		t.Setenv(StorerBackendEnvKey, "")
+
+		warnings := []string{}
+		selection := &storerSelection{warn: func(message string) { warnings = append(warnings, message) }}
+
+		assert.Equal(t, StorerBackendBinary, selection.resolve())
+		assert.Empty(t, warnings)
+	})
+
+	t.Run("environment selects the backend when nothing was set", func(t *testing.T) {
+		selection := &storerSelection{warn: func(string) {}}
+		t.Setenv(StorerBackendEnvKey, "go-git")
+
+		assert.Equal(t, StorerBackendGoGit, selection.resolve())
+	})
+
+	t.Run("an explicit setting beats the environment", func(t *testing.T) {
+		selection := &storerSelection{warn: func(string) {}}
+		t.Setenv(StorerBackendEnvKey, "go-git")
+		selection.set(StorerBackendBinary)
+
+		assert.Equal(t, StorerBackendBinary, selection.resolve())
+	})
+
+	t.Run("an unparseable environment value falls back to the git binary", func(t *testing.T) {
+		selection := &storerSelection{warn: func(string) {}}
+		t.Setenv(StorerBackendEnvKey, "libgit2")
+
+		assert.Equal(t, StorerBackendBinary, selection.resolve())
+	})
+}
+
+func TestStorerSelectionLogsResolvedBackend(t *testing.T) {
+	t.Parallel()
+
+	messages := []string{}
+	selection := &storerSelection{
+		warn:   func(string) {},
+		debugf: func(message string) { messages = append(messages, message) },
+	}
+	selection.set(StorerBackendGoGit)
+
+	require.Equal(t, StorerBackendGoGit, selection.resolve())
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0], string(StorerBackendGoGit))
+}
+
+func TestStorerTraceReport(t *testing.T) {
+	t.Run("absent unless tracing was enabled", func(t *testing.T) {
+		t.Setenv(StorerBackendEnvKey, "")
+		resetStorerForTest(t)
+
+		repo := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+		storer := newStorer(repo)
+
+		_, err := storer.WriteBlob([]byte("contents"))
+		require.Nil(t, err)
+
+		_, has := StorerTraceReport()
+		assert.False(t, has)
+	})
+
+	t.Run("reports storer calls and git forks once enabled", func(t *testing.T) {
+		t.Setenv(StorerBackendEnvKey, "")
+		resetStorerForTest(t)
+		SetStorerBackend(StorerBackendGoGit)
+		SetStorerTrace(true)
+
+		repo := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+		storer := newStorer(repo)
+
+		blobID, err := storer.WriteBlob([]byte("contents"))
+		require.Nil(t, err)
+		_, err = storer.ReadBlob(blobID)
+		require.Nil(t, err)
+
+		report, has := StorerTraceReport()
+		require.True(t, has)
+		assert.Contains(t, report, "ReadBlob")
+		assert.Contains(t, report, string(StorerBackendGoGit))
+		assert.Contains(t, report, "git forks")
+	})
+}

--- a/experimental/gittuf/sync.go
+++ b/experimental/gittuf/sync.go
@@ -67,7 +67,7 @@ func Clone(ctx context.Context, remoteURL, dir, initialBranch string, expectedRo
 		return nil, errors.Join(ErrCloningRepository, err)
 	}
 
-	repository := &Repository{r: r}
+	repository := &Repository{r: newStorer(r)}
 
 	if len(expectedRootKeys) > 0 {
 		slog.Debug("Verifying if root keys are expected root keys...")

--- a/experimental/gittuf/sync_test.go
+++ b/experimental/gittuf/sync_test.go
@@ -26,7 +26,7 @@ func TestClone(t *testing.T) {
 	targetsPubKey := tufv01.NewKeyFromSSLibKey(targetsSigner.MetadataKey())
 
 	remoteR := gitinterface.CreateTestGitRepository(t, remoteTmpDir, true)
-	remoteRepo := &Repository{r: remoteR}
+	remoteRepo := &Repository{r: newStorer(remoteR)}
 	treeBuilder := gitinterface.NewTreeBuilder(remoteR)
 	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
 	if err != nil {

--- a/experimental/gittuf/targets_test.go
+++ b/experimental/gittuf/targets_test.go
@@ -62,7 +62,7 @@ func TestInitializeTargets(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -143,7 +143,7 @@ func TestAddDelegation(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -199,7 +199,7 @@ func TestUpdateDelegation(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -260,7 +260,7 @@ func TestReorderDelegations(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -330,7 +330,7 @@ func TestRemoveDelegation(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -385,7 +385,7 @@ func TestAddPrincipalToTargets(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -456,7 +456,7 @@ func TestUpdatePrincipalInTargets(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -517,7 +517,7 @@ func TestRemovePrincipalFromTargets(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -558,7 +558,7 @@ func TestSignTargets(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")
@@ -605,7 +605,7 @@ func TestIncrementTargetsVersion(t *testing.T) {
 	t.Run("miscellaneous error checking", func(t *testing.T) {
 		tempDir := t.TempDir()
 		repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
-		nr := &Repository{r: repo}
+		nr := &Repository{r: newStorer(repo)}
 
 		// Test signCommit
 		err := repo.SetGitConfig("user.signingkey", "")

--- a/experimental/gittuf/verify_test.go
+++ b/experimental/gittuf/verify_test.go
@@ -42,7 +42,7 @@ func TestVerifyRefRecordedWithGitSigning(t *testing.T) {
 			refName := "refs/heads/main"
 
 			// Commits are signed with the repository's Git signing key.
-			common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, rsaKeyBytes)
+			common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, rsaKeyBytes)
 
 			// Record the RSL entry through the Git-signed workflow.
 			if err := repo.RecordRSLEntryForReference(testCtx, refName, true, rslopts.WithRecordLocalOnly()); err != nil {
@@ -66,7 +66,7 @@ func testVerifyRef(t *testing.T, objectFormat gitinterface.ObjectFormat) {
 	refName := "refs/heads/main"
 	remoteRefName := "refs/heads/not-main"
 
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgKeyBytes)
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	entryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 	entry.ID = entryID
@@ -136,7 +136,7 @@ func testVerifyRef(t *testing.T, objectFormat gitinterface.ObjectFormat) {
 	}
 
 	// Add another commit
-	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgKeyBytes)
 	err := repo.VerifyRef(testCtx, refName, verifyopts.WithLatestOnly())
 	assert.ErrorIs(t, err, ErrRefStateDoesNotMatchRSL)
 	err = repo.VerifyRef(testCtx, refName, verifyopts.WithLatestOnly())
@@ -161,7 +161,7 @@ func testVerifyRefFromEntry(t *testing.T, objectFormat gitinterface.ObjectFormat
 	remoteRefName := "refs/heads/not-main"
 
 	// Policy violation
-	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgUnauthorizedKeyBytes)
+	commitIDs := common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgUnauthorizedKeyBytes)
 	// Violation for refName
 	entry := rsl.NewReferenceEntry(refName, commitIDs[0])
 	violatingEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgUnauthorizedKeyBytes)
@@ -170,7 +170,7 @@ func testVerifyRefFromEntry(t *testing.T, objectFormat gitinterface.ObjectFormat
 	violatingRemoteRefNameEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgUnauthorizedKeyBytes)
 
 	// No policy violation for refName
-	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgKeyBytes)
 	// refName
 	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
 	goodEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
@@ -179,7 +179,7 @@ func testVerifyRefFromEntry(t *testing.T, objectFormat gitinterface.ObjectFormat
 	goodRemoteRefNameEntryID := common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 
 	// No policy violation for refName (what we verify)
-	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	commitIDs = common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgKeyBytes)
 	entry = rsl.NewReferenceEntry(refName, commitIDs[0])
 	common.CreateTestRSLReferenceEntryCommit(t, repo.r, entry, gpgKeyBytes)
 	// No policy violation for remoteRefName (what we verify)
@@ -237,7 +237,7 @@ func testVerifyRefFromEntry(t *testing.T, objectFormat gitinterface.ObjectFormat
 	}
 
 	// Add another commit
-	common.AddNTestCommitsToSpecifiedRef(t, repo.r, refName, 1, gpgKeyBytes)
+	common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, refName, 1, gpgKeyBytes)
 
 	// Verifying from only good entry tells us ref does not match RSL
 	err := repo.VerifyRefFromEntry(testCtx, refName, goodEntryID.String())
@@ -255,7 +255,7 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("not mergeable without approval", func(t *testing.T) {
 		repo := createTestRepositoryWithPolicy(t, "")
 
-		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -271,7 +271,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := repo.r.SetReference(featureRef, baseCommitID); err != nil {
 			t.Fatal(err)
 		}
-		common.AddNTestCommitsToSpecifiedRef(t, repo.r, featureRef, 1, gpgUnauthorizedKeyBytes)
+		common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, featureRef, 1, gpgUnauthorizedKeyBytes)
 		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
@@ -284,7 +284,7 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("mergeable with approval", func(t *testing.T) {
 		repo := createTestRepositoryWithPolicy(t, "")
 
-		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -300,7 +300,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := repo.r.SetReference(featureRef, baseCommitID); err != nil {
 			t.Fatal(err)
 		}
-		common.AddNTestCommitsToSpecifiedRef(t, repo.r, featureRef, 1, gpgUnauthorizedKeyBytes)
+		common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, featureRef, 1, gpgUnauthorizedKeyBytes)
 		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}
@@ -329,7 +329,7 @@ func TestVerifyMergeable(t *testing.T) {
 			t.Run(string(objectFormat), func(t *testing.T) {
 				repo := createTestRepositoryWithPolicy(t, "", gitinterface.WithObjectFormat(objectFormat))
 
-				treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+				treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 				emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 				if err != nil {
 					t.Fatal(err)
@@ -337,7 +337,7 @@ func TestVerifyMergeable(t *testing.T) {
 				if _, err := repo.r.Commit(emptyTreeID, featureRef, "Initial commit\n", false); err != nil {
 					t.Fatal(err)
 				}
-				common.AddNTestCommitsToSpecifiedRef(t, repo.r, featureRef, 1, gpgUnauthorizedKeyBytes)
+				common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, featureRef, 1, gpgUnauthorizedKeyBytes)
 				if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 					t.Fatal(err)
 				}
@@ -362,7 +362,7 @@ func TestVerifyMergeable(t *testing.T) {
 	t.Run("mergeable with approval and feature RSL bypass", func(t *testing.T) {
 		repo := createTestRepositoryWithPolicy(t, "")
 
-		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r.Repository)
 		emptyTreeID, err := treeBuilder.WriteTreeFromEntries(nil)
 		if err != nil {
 			t.Fatal(err)
@@ -378,7 +378,7 @@ func TestVerifyMergeable(t *testing.T) {
 		if err := repo.r.SetReference(featureRef, baseCommitID); err != nil {
 			t.Fatal(err)
 		}
-		common.AddNTestCommitsToSpecifiedRef(t, repo.r, featureRef, 1, gpgUnauthorizedKeyBytes)
+		common.AddNTestCommitsToSpecifiedRef(t, repo.r.Repository, featureRef, 1, gpgUnauthorizedKeyBytes)
 		if err := repo.RecordRSLEntryForReference(testCtx, featureRef, false, rslopts.WithRecordLocalOnly()); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmd/policy/inspect/inspect.go
+++ b/internal/cmd/policy/inspect/inspect.go
@@ -50,9 +50,9 @@ func (o *options) Run(cmd *cobra.Command, _ []string) error {
 			return err
 		}
 
-		state, err = policy.LoadStateFromCommit(repo.GetGitRepository(), commitID)
+		state, err = policy.LoadStateFromCommit(repo.GetStorer(), commitID)
 	} else {
-		state, err = policy.LoadCurrentState(cmd.Context(), repo.GetGitRepository(), policy.PolicyStagingRef, policyopts.BypassRSL())
+		state, err = policy.LoadCurrentState(cmd.Context(), repo.GetStorer(), policy.PolicyStagingRef, policyopts.BypassRSL())
 	}
 	if err != nil {
 		return err

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -4,6 +4,8 @@
 package root
 
 import (
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 
@@ -34,6 +36,8 @@ type options struct {
 	profile           bool
 	cpuProfileFile    string
 	memoryProfileFile string
+	storer            string
+	storerTrace       bool
 }
 
 func (o *options) AddFlags(cmd *cobra.Command) {
@@ -71,9 +75,28 @@ func (o *options) AddFlags(cmd *cobra.Command) {
 		"memory.prof",
 		"file to store memory profile",
 	)
+
+	cmd.PersistentFlags().StringVar(
+		&o.storer,
+		"storer",
+		string(gittuf.StorerBackendBinary),
+		fmt.Sprintf("Git storage backend to use, one of %s or %s (experimental, overrides %s)", gittuf.StorerBackendBinary, gittuf.StorerBackendGoGit, gittuf.StorerBackendEnvKey),
+	)
+
+	cmd.PersistentFlags().BoolVar(
+		&o.storerTrace,
+		"storer-trace",
+		false,
+		"report Git storage backend call counts, timings and git fork counts to stderr on exit",
+	)
 }
 
-func (o *options) PreRunE(_ *cobra.Command, _ []string) error {
+func (o *options) PreRunE(cmd *cobra.Command, _ []string) error {
+	if err := o.selectStorerBackend(cmd); err != nil {
+		return err
+	}
+	gittuf.SetStorerTrace(o.storerTrace)
+
 	// Check if colored output must be disabled
 	output := os.Stdout
 	isTerminal := isatty.IsTerminal(output.Fd()) || isatty.IsCygwinTerminal(output.Fd())
@@ -126,4 +149,50 @@ func New() *cobra.Command {
 	cmd.AddCommand(tui.New(&persistent.Options{}))
 
 	return cmd
+}
+
+// selectStorerBackend gives an explicit flag precedence over the environment.
+func (o *options) selectStorerBackend(cmd *cobra.Command) error {
+	backend, err := gittuf.ParseStorerBackend(o.storer)
+	if err != nil {
+		return err
+	}
+
+	// Include flags inherited from the root command.
+	var passed bool
+	if cmd != nil {
+		if flag := cmd.Flag("storer"); flag != nil {
+			passed = flag.Changed
+		}
+	}
+
+	if !passed {
+		if fromEnv, err := gittuf.ParseStorerBackend(os.Getenv(gittuf.StorerBackendEnvKey)); err == nil {
+			backend = fromEnv
+		}
+	}
+
+	gittuf.SetStorerBackend(backend)
+
+	return nil
+}
+
+// storerTraceReported keeps the trace to one emission. It is reported from
+// main's deferred cleanup and again before a non-zero exit, both on the main
+// goroutine.
+var storerTraceReported bool
+
+// ReportStorerTrace writes the storer trace if one was requested. Only the
+// first call writes.
+func ReportStorerTrace(w io.Writer) {
+	if storerTraceReported {
+		return
+	}
+	storerTraceReported = true
+
+	report, has := gittuf.StorerTraceReport()
+	if !has {
+		return
+	}
+	fmt.Fprint(w, report)
 }

--- a/internal/cmd/root/root_test.go
+++ b/internal/cmd/root/root_test.go
@@ -1,0 +1,119 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/gittuf/gittuf/experimental/gittuf"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPreRunEStorerBackend(t *testing.T) {
+	t.Run("rejects an unknown backend", func(t *testing.T) {
+		o := &options{storer: "libgit2"}
+
+		err := o.PreRunE(nil, nil)
+		assert.ErrorIs(t, err, gittuf.ErrUnknownStorerBackend)
+	})
+
+	t.Run("accepts the git binary backend", func(t *testing.T) {
+		o := &options{storer: string(gittuf.StorerBackendBinary)}
+
+		require.Nil(t, o.PreRunE(nil, nil))
+	})
+
+	t.Run("accepts the go-git backend", func(t *testing.T) {
+		o := &options{storer: string(gittuf.StorerBackendGoGit)}
+
+		require.Nil(t, o.PreRunE(nil, nil))
+	})
+}
+
+func TestStorerFlagIsRegistered(t *testing.T) {
+	flag := New().PersistentFlags().Lookup("storer")
+
+	require.NotNil(t, flag)
+	assert.Equal(t, string(gittuf.StorerBackendBinary), flag.DefValue)
+	assert.Contains(t, flag.Usage, "experimental")
+}
+
+func TestStorerTraceFlagIsRegistered(t *testing.T) {
+	flag := New().PersistentFlags().Lookup("storer-trace")
+
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestReportStorerTraceIsSilentWhenDisabled(t *testing.T) {
+	o := &options{storer: string(gittuf.StorerBackendBinary), storerTrace: false}
+	require.Nil(t, o.PreRunE(nil, nil))
+
+	out := &bytes.Buffer{}
+	ReportStorerTrace(out)
+	assert.Empty(t, out.String())
+}
+
+func TestPreRunEStorerBackendPrecedence(t *testing.T) {
+	newCmd := func(o *options) *cobra.Command {
+		cmd := &cobra.Command{Use: "test"}
+		o.AddFlags(cmd)
+		return cmd
+	}
+
+	t.Run("the environment applies when the flag was not passed", func(t *testing.T) {
+		t.Setenv(gittuf.StorerBackendEnvKey, "go-git")
+
+		o := &options{}
+		cmd := newCmd(o)
+		require.Nil(t, o.PreRunE(cmd, nil))
+
+		assert.Equal(t, gittuf.StorerBackendGoGit, gittuf.StorerBackendInUse())
+	})
+
+	t.Run("an explicitly passed flag beats the environment", func(t *testing.T) {
+		t.Setenv(gittuf.StorerBackendEnvKey, "go-git")
+
+		o := &options{}
+		cmd := newCmd(o)
+		require.Nil(t, cmd.PersistentFlags().Set("storer", "binary"))
+		require.Nil(t, o.PreRunE(cmd, nil))
+
+		assert.Equal(t, gittuf.StorerBackendBinary, gittuf.StorerBackendInUse())
+	})
+
+	t.Run("the flag applies when the environment is unset", func(t *testing.T) {
+		t.Setenv(gittuf.StorerBackendEnvKey, "")
+
+		o := &options{}
+		cmd := newCmd(o)
+		require.Nil(t, cmd.PersistentFlags().Set("storer", "go-git"))
+		require.Nil(t, o.PreRunE(cmd, nil))
+
+		assert.Equal(t, gittuf.StorerBackendGoGit, gittuf.StorerBackendInUse())
+	})
+
+	t.Run("an unparseable environment value falls back to the flag", func(t *testing.T) {
+		t.Setenv(gittuf.StorerBackendEnvKey, "libgit2")
+
+		o := &options{}
+		cmd := newCmd(o)
+		require.Nil(t, o.PreRunE(cmd, nil))
+
+		assert.Equal(t, gittuf.StorerBackendBinary, gittuf.StorerBackendInUse())
+	})
+
+	t.Run("an unparseable flag is an error", func(t *testing.T) {
+		t.Setenv(gittuf.StorerBackendEnvKey, "")
+
+		o := &options{}
+		cmd := newCmd(o)
+		require.Nil(t, cmd.PersistentFlags().Set("storer", "libgit2"))
+
+		assert.ErrorIs(t, o.PreRunE(cmd, nil), gittuf.ErrUnknownStorerBackend)
+	})
+}

--- a/internal/gogitstore/delegated.go
+++ b/internal/gogitstore/delegated.go
@@ -1,0 +1,44 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore
+
+import (
+	"time"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+)
+
+// These overrides trace operations delegated to Git.
+
+func (s *Storer) EmptyTree() (githash.Hash, error) {
+	defer s.record("EmptyTree", time.Now(), true)
+	return s.Repository.EmptyTree()
+}
+
+func (s *Storer) LookupConfig(key gitstore.ConfigKey) (string, bool, error) {
+	defer s.record("LookupConfig", time.Now(), true)
+	return s.Repository.LookupConfig(key)
+}
+
+func (s *Storer) GetCommitsBetweenRange(commitNewID, commitOldID githash.Hash) ([]githash.Hash, error) {
+	defer s.record("GetCommitsBetweenRange", time.Now(), true)
+	return s.Repository.GetCommitsBetweenRange(commitNewID, commitOldID)
+}
+
+func (s *Storer) GetFilePathsChangedByCommit(commitID githash.Hash) ([]string, error) {
+	defer s.record("GetFilePathsChangedByCommit", time.Now(), true)
+	return s.Repository.GetFilePathsChangedByCommit(commitID)
+}
+
+func (s *Storer) GetMergeTree(commitAID, commitBID githash.Hash) (githash.Hash, error) {
+	defer s.record("GetMergeTree", time.Now(), true)
+	return s.Repository.GetMergeTree(commitAID, commitBID)
+}
+
+// KnowsCommit delegates to Git to respect shallow-history boundaries.
+func (s *Storer) KnowsCommit(testCommitID, ancestorCommitID githash.Hash) (bool, error) {
+	defer s.record("KnowsCommit", time.Now(), true)
+	return s.Repository.KnowsCommit(testCommitID, ancestorCommitID)
+}

--- a/internal/gogitstore/equivalence_test.go
+++ b/internal/gogitstore/equivalence_test.go
@@ -1,0 +1,356 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore_test
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// git runs a command for fixtures gitinterface has no API for, such as a tree
+// holding a submodule gitlink.
+func git(t *testing.T, repo *gitinterface.Repository, stdin string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"--git-dir", repo.GetGitDir()}, args...)...) //nolint:gosec
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	out, err := cmd.Output()
+	require.Nil(t, err, "git %s", strings.Join(args, " "))
+
+	return strings.TrimSpace(string(out))
+}
+
+func TestGetEntriesInTree(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+
+			blobID, err := binary.WriteBlob([]byte("contents"))
+			require.Nil(t, err)
+			treeID, err := binary.WriteTree([]gitstore.TreeEntry{
+				{Path: "root.json", ID: blobID, Kind: gitstore.KindBlob},
+				{Path: "nested/targets.json", ID: blobID, Kind: gitstore.KindBlob},
+			})
+			require.Nil(t, err)
+
+			t.Run("blobs and subtrees", func(t *testing.T) {
+				want, err := binary.GetEntriesInTree(treeID)
+				require.Nil(t, err)
+
+				got, err := fast.GetEntriesInTree(treeID)
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+
+				kinds := map[string]gitstore.EntryKind{}
+				for _, entry := range got {
+					kinds[entry.Path] = entry.Kind
+				}
+				assert.Equal(t, gitstore.KindBlob, kinds["root.json"])
+				assert.Equal(t, gitstore.KindSubtree, kinds["nested"])
+			})
+
+			t.Run("empty tree yields nil, not an empty slice", func(t *testing.T) {
+				emptyTree, err := binary.EmptyTree()
+				require.Nil(t, err)
+
+				want, err := binary.GetEntriesInTree(emptyTree)
+				require.Nil(t, err)
+				require.Nil(t, want)
+
+				got, err := fast.GetEntriesInTree(emptyTree)
+				require.Nil(t, err)
+				assert.Nil(t, got)
+			})
+
+			t.Run("submodule gitlink is reported as a blob", func(t *testing.T) {
+				commitID, err := binary.Commit(treeID, "refs/heads/sub", "sub\n", false)
+				require.Nil(t, err)
+
+				gitlinkTree := git(t, binary,
+					fmt.Sprintf("160000 commit %s\tsubmodule\n", commitID.String()),
+					"mktree")
+				gitlinkTreeID, err := githash.NewHash(gitlinkTree)
+				require.Nil(t, err)
+
+				want, err := binary.GetEntriesInTree(gitlinkTreeID)
+				require.Nil(t, err)
+				require.Len(t, want, 1)
+				require.Equal(t, gitstore.KindBlob, want[0].Kind)
+
+				got, err := fast.GetEntriesInTree(gitlinkTreeID)
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+		})
+	}
+}
+
+func TestGetAllFilesInTree(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+
+			blobID, err := binary.WriteBlob([]byte("contents"))
+			require.Nil(t, err)
+			treeID, err := binary.WriteTree([]gitstore.TreeEntry{
+				{Path: "root.json", ID: blobID, Kind: gitstore.KindBlob},
+				{Path: "a/b/c/deep.json", ID: blobID, Kind: gitstore.KindBlob},
+			})
+			require.Nil(t, err)
+
+			t.Run("flattens nested trees", func(t *testing.T) {
+				want, err := binary.GetAllFilesInTree(treeID)
+				require.Nil(t, err)
+
+				got, err := fast.GetAllFilesInTree(treeID)
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+				assert.Contains(t, got, "a/b/c/deep.json")
+			})
+
+			t.Run("empty tree yields nil, not an empty map", func(t *testing.T) {
+				emptyTree, err := binary.EmptyTree()
+				require.Nil(t, err)
+
+				want, err := binary.GetAllFilesInTree(emptyTree)
+				require.Nil(t, err)
+				require.Nil(t, want)
+
+				got, err := fast.GetAllFilesInTree(emptyTree)
+				require.Nil(t, err)
+				assert.Nil(t, got)
+			})
+
+			t.Run("submodule gitlink is included as a leaf", func(t *testing.T) {
+				commitID, err := binary.Commit(treeID, "refs/heads/sub2", "sub\n", false)
+				require.Nil(t, err)
+
+				gitlinkTree := git(t, binary,
+					fmt.Sprintf("160000 commit %s\tsubmodule\n", commitID.String()),
+					"mktree")
+				gitlinkTreeID, err := githash.NewHash(gitlinkTree)
+				require.Nil(t, err)
+
+				want, err := binary.GetAllFilesInTree(gitlinkTreeID)
+				require.Nil(t, err)
+				require.Contains(t, want, "submodule")
+
+				got, err := fast.GetAllFilesInTree(gitlinkTreeID)
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+		})
+	}
+}
+
+func TestGetPathIDInTree(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+
+			blobID, err := binary.WriteBlob([]byte("contents"))
+			require.Nil(t, err)
+			treeID, err := binary.WriteTree([]gitstore.TreeEntry{
+				{Path: "root.json", ID: blobID, Kind: gitstore.KindBlob},
+				{Path: "a/b/deep.json", ID: blobID, Kind: gitstore.KindBlob},
+			})
+			require.Nil(t, err)
+
+			for _, treePath := range []string{"root.json", "a", "a/", "a/b", "a/b/deep.json"} {
+				t.Run(treePath, func(t *testing.T) {
+					want, err := binary.GetPathIDInTree(treeID, treePath)
+					require.Nil(t, err)
+
+					got, err := fast.GetPathIDInTree(treeID, treePath)
+					require.Nil(t, err)
+					assert.Equal(t, want, got)
+				})
+			}
+
+			t.Run("missing path", func(t *testing.T) {
+				_, wantErr := binary.GetPathIDInTree(treeID, "a/absent.json")
+				require.ErrorIs(t, wantErr, gitinterface.ErrTreeDoesNotHavePath)
+
+				_, gotErr := fast.GetPathIDInTree(treeID, "a/absent.json")
+				assert.ErrorIs(t, gotErr, gitinterface.ErrTreeDoesNotHavePath)
+			})
+		})
+	}
+}
+
+func TestGetReference(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 2)
+
+			t.Run("full reference name", func(t *testing.T) {
+				want, err := binary.GetReference("refs/heads/main")
+				require.Nil(t, err)
+				require.Equal(t, ids[1], want)
+
+				got, err := fast.GetReference("refs/heads/main")
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+
+			t.Run("missing reference reports the zero hash", func(t *testing.T) {
+				want, wantErr := binary.GetReference("refs/heads/absent")
+				require.ErrorIs(t, wantErr, gitstore.ErrReferenceNotFound)
+
+				got, gotErr := fast.GetReference("refs/heads/absent")
+				assert.ErrorIs(t, gotErr, gitstore.ErrReferenceNotFound)
+				assert.Equal(t, want, got)
+				assert.True(t, got.IsZero())
+			})
+
+			t.Run("packed refs are visible", func(t *testing.T) {
+				git(t, binary, "", "pack-refs", "--all")
+
+				got, err := fast.GetReference("refs/heads/main")
+				require.Nil(t, err)
+				assert.Equal(t, ids[1], got)
+			})
+
+			// rev-parse takes revision expressions go-git cannot resolve, so
+			// these must fall through to the git binary.
+			t.Run("revision expressions are delegated", func(t *testing.T) {
+				for _, revision := range []string{"main", ids[1].String(), "refs/heads/main^{commit}", "refs/heads/main~1", "refs/heads/main@{0}"} {
+					want, err := binary.GetReference(revision)
+					require.Nil(t, err)
+
+					got, err := fast.GetReference(revision)
+					require.Nil(t, err, "revision %s", revision)
+					assert.Equal(t, want, got)
+				}
+			})
+		})
+	}
+}
+
+func TestGetTagTarget(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 1)
+
+			tagID, err := binary.TagUsingSpecificKey(ids[0], "v1", "release\n", artifacts.SSHRSAPrivate)
+			require.Nil(t, err)
+
+			want, err := binary.GetTagTarget(tagID)
+			require.Nil(t, err)
+			require.Equal(t, ids[0], want)
+
+			got, err := fast.GetTagTarget(tagID)
+			require.Nil(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestGetObjectSignature(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+
+			treeID, err := binary.EmptyTree()
+			require.Nil(t, err)
+
+			signedID, err := binary.Commit(treeID, "refs/heads/signed", "signed\n", true)
+			require.Nil(t, err)
+			unsignedID, err := binary.Commit(treeID, "refs/heads/unsigned", "unsigned\n", false)
+			require.Nil(t, err)
+			tagID, err := binary.TagUsingSpecificKey(signedID, "v1", "release\n", artifacts.SSHRSAPrivate)
+			require.Nil(t, err)
+
+			cases := map[string]githash.Hash{
+				"signed commit":   signedID,
+				"unsigned commit": unsignedID,
+				"signed tag":      tagID,
+			}
+
+			for name, objectID := range cases {
+				t.Run(name, func(t *testing.T) {
+					wantPayload, wantSignature, err := binary.GetObjectSignature(objectID)
+					require.Nil(t, err)
+
+					gotPayload, gotSignature, err := fast.GetObjectSignature(objectID)
+					require.Nil(t, err)
+					assert.Equal(t, wantPayload, gotPayload)
+					assert.Equal(t, wantSignature, gotSignature)
+				})
+			}
+
+			t.Run("signed commit actually carries a signature", func(t *testing.T) {
+				_, signature, err := fast.GetObjectSignature(signedID)
+				require.Nil(t, err)
+				assert.NotEmpty(t, signature)
+			})
+
+			t.Run("blob is neither commit nor tag", func(t *testing.T) {
+				blobID, err := binary.WriteBlob([]byte("contents"))
+				require.Nil(t, err)
+
+				_, _, wantErr := binary.GetObjectSignature(blobID)
+				require.ErrorIs(t, wantErr, gitinterface.ErrNotCommitOrTag)
+
+				_, _, gotErr := fast.GetObjectSignature(blobID)
+				assert.ErrorIs(t, gotErr, gitinterface.ErrNotCommitOrTag)
+			})
+		})
+	}
+}
+
+func TestDisabledBackendDelegates(t *testing.T) {
+	t.Parallel()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+	disabled := gogitstore.New(binary, false)
+
+	blobID, err := binary.WriteBlob([]byte("contents"))
+	require.Nil(t, err)
+
+	want, err := binary.ReadBlob(blobID)
+	require.Nil(t, err)
+
+	got, err := disabled.ReadBlob(blobID)
+	require.Nil(t, err)
+	assert.Equal(t, want, got)
+}

--- a/internal/gogitstore/forks_test.go
+++ b/internal/gogitstore/forks_test.go
@@ -1,0 +1,151 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countGitForks puts a shim ahead of git on PATH and reports how many times it
+// ran. PATH is process global, so callers must not use t.Parallel.
+func countGitForks(t *testing.T) func() int {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("the git shim used to count forks is a POSIX shell script")
+	}
+
+	realGit, err := exec.LookPath("git")
+	require.Nil(t, err)
+
+	shimDir := t.TempDir()
+	logPath := filepath.Join(shimDir, "invocations")
+	shim := fmt.Sprintf("#!/bin/sh\necho invoked >> %q\nexec %q \"$@\"\n", logPath, realGit)
+	require.Nil(t, os.WriteFile(filepath.Join(shimDir, "git"), []byte(shim), 0o700)) //nolint:gosec // the shim stands in for the git binary, so it has to be executable
+
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	return func() int {
+		contents, err := os.ReadFile(logPath)
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.Nil(t, err)
+		return bytes.Count(contents, []byte("\n"))
+	}
+}
+
+type readFixture struct {
+	repo     *gitinterface.Repository
+	blobID   githash.Hash
+	treeID   githash.Hash
+	commitID githash.Hash
+	signedID githash.Hash
+	tagID    githash.Hash
+	refName  string
+}
+
+func newReadFixture(t *testing.T) *readFixture {
+	t.Helper()
+
+	repo := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+
+	blobID, err := repo.WriteBlob([]byte("policy metadata"))
+	require.Nil(t, err)
+
+	treeID, err := repo.WriteTree([]gitstore.TreeEntry{
+		{Path: "root.json", ID: blobID, Kind: gitstore.KindBlob},
+		{Path: "nested/targets.json", ID: blobID, Kind: gitstore.KindBlob},
+	})
+	require.Nil(t, err)
+
+	refName := "refs/heads/main"
+	_, err = repo.Commit(treeID, refName, "first\n", false)
+	require.Nil(t, err)
+	commitID, err := repo.Commit(treeID, refName, "second\n", false)
+	require.Nil(t, err)
+
+	signedID, err := repo.Commit(treeID, "refs/heads/signed", "signed\n", true)
+	require.Nil(t, err)
+
+	tagID, err := repo.TagUsingSpecificKey(commitID, "v1", "release\n", artifacts.SSHRSAPrivate)
+	require.Nil(t, err)
+
+	return &readFixture{
+		repo: repo, blobID: blobID, treeID: treeID, commitID: commitID,
+		signedID: signedID, tagID: tagID,
+		refName: refName,
+	}
+}
+
+func TestReadsDoNotForkGit(t *testing.T) {
+	f := newReadFixture(t)
+
+	reads := map[string]func(s *gogitstore.Storer) error{
+		"ReadBlob": func(s *gogitstore.Storer) error {
+			_, err := s.ReadBlob(f.blobID)
+			return err
+		},
+		"GetCommitMessage": func(s *gogitstore.Storer) error {
+			_, err := s.GetCommitMessage(f.commitID)
+			return err
+		},
+		"GetCommitParentIDs": func(s *gogitstore.Storer) error {
+			_, err := s.GetCommitParentIDs(f.commitID)
+			return err
+		},
+		"GetCommitTreeID": func(s *gogitstore.Storer) error {
+			_, err := s.GetCommitTreeID(f.commitID)
+			return err
+		},
+		"GetEntriesInTree": func(s *gogitstore.Storer) error {
+			_, err := s.GetEntriesInTree(f.treeID)
+			return err
+		},
+		"GetAllFilesInTree": func(s *gogitstore.Storer) error {
+			_, err := s.GetAllFilesInTree(f.treeID)
+			return err
+		},
+		"GetPathIDInTree": func(s *gogitstore.Storer) error {
+			_, err := s.GetPathIDInTree(f.treeID, "root.json")
+			return err
+		},
+		"GetReference": func(s *gogitstore.Storer) error {
+			_, err := s.GetReference(f.refName)
+			return err
+		},
+		"GetTagTarget": func(s *gogitstore.Storer) error {
+			_, err := s.GetTagTarget(f.tagID)
+			return err
+		},
+		"GetObjectSignature": func(s *gogitstore.Storer) error {
+			_, _, err := s.GetObjectSignature(f.signedID)
+			return err
+		},
+	}
+
+	for name, read := range reads {
+		t.Run(name, func(t *testing.T) {
+			fast := gogitstore.New(f.repo, true)
+
+			forks := countGitForks(t)
+			require.Nil(t, read(fast))
+			assert.Zero(t, forks(), "%s forked the git binary", name)
+		})
+	}
+}

--- a/internal/gogitstore/gogitstore.go
+++ b/internal/gogitstore/gogitstore.go
@@ -1,0 +1,529 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package gogitstore provides experimental in-process Git reads.
+package gogitstore
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+	gogit "github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing"
+	"github.com/go-git/go-git/v6/plumbing/filemode"
+	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/storage/memory"
+)
+
+// ErrInvalidHash is returned when a hash is not a valid go-git object ID.
+var ErrInvalidHash = errors.New("hash is not a valid Git object ID")
+
+// Git resolves the empty tree even when it is absent from the object database.
+const (
+	emptyTreeSHA1   = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	emptyTreeSHA256 = "6ef19b41225c5369f1c104d45d8d85efa9b057b53b14b4b9b939dd74decc5321"
+)
+
+var _ gitstore.Storer = (*Storer)(nil)
+
+// Storer caches a go-git handle and delegates other operations to Git.
+type Storer struct {
+	*gitinterface.Repository
+
+	mu      sync.Mutex
+	gogit   *gogit.Repository
+	enabled bool
+
+	trace *Trace
+}
+
+// New wraps repo. With enableGoGit false every method delegates, leaving
+// behaviour identical to gitinterface.
+func New(repo *gitinterface.Repository, enableGoGit bool) *Storer {
+	return &Storer{Repository: repo, enabled: enableGoGit}
+}
+
+// NewWithTrace is New with tracing attached.
+func NewWithTrace(repo *gitinterface.Repository, enableGoGit bool, trace *Trace) *Storer {
+	return &Storer{Repository: repo, enabled: enableGoGit, trace: trace}
+}
+
+// record logs one call. Callers defer it, so start is evaluated on entry.
+func (s *Storer) record(method string, start time.Time, delegated bool) {
+	if s.trace == nil {
+		return
+	}
+	s.trace.record(method, start, delegated)
+}
+
+// fast returns the cached go-git handle, opening it if needed. A nil handle
+// and nil error mean the backend is off and the caller should delegate.
+func (s *Storer) fast() (*gogit.Repository, error) {
+	if !s.enabled {
+		return nil, nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.gogit != nil {
+		return s.gogit, nil
+	}
+
+	repo, err := s.GetGoGitRepository()
+	if err != nil {
+		return nil, err
+	}
+	s.gogit = repo
+
+	slog.Debug("Opened in-process go-git repository handle")
+	if s.trace != nil {
+		s.trace.recordHandleOpen()
+	}
+
+	return repo, nil
+}
+
+// invalidate drops the cached handle. go-git looks objects up in a packfile
+// index it caches on open, so it would miss a packfile written afterwards.
+func (s *Storer) invalidate() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.gogit = nil
+}
+
+func (s *Storer) ReadBlob(blobID githash.Hash) ([]byte, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("ReadBlob", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.ReadBlob(blobID)
+	}
+
+	id, err := toGoGit(blobID)
+	if err != nil {
+		return nil, err
+	}
+
+	// BlobObject already fails on a non-blob, so no separate type check.
+	blob, err := repo.BlobObject(id)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read blob '%s': %w", blobID.String(), err)
+	}
+
+	reader, err := blob.Reader()
+	if err != nil {
+		return nil, fmt.Errorf("unable to read blob '%s': %w", blobID.String(), err)
+	}
+	defer reader.Close() //nolint:errcheck
+
+	return io.ReadAll(reader)
+}
+
+func (s *Storer) GetCommitMessage(commitID githash.Hash) (string, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return "", err
+	}
+	defer s.record("GetCommitMessage", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetCommitMessage(commitID)
+	}
+
+	commit, err := s.commit(repo, commitID)
+	if err != nil {
+		return "", fmt.Errorf("unable to identify message for commit '%s': %w", commitID.String(), err)
+	}
+
+	// Match gitinterface whitespace trimming.
+	return strings.TrimSpace(commit.Message), nil
+}
+
+func (s *Storer) GetCommitTreeID(commitID githash.Hash) (githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetCommitTreeID", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetCommitTreeID(commitID)
+	}
+
+	commit, err := s.commit(repo, commitID)
+	if err != nil {
+		return s.ZeroHash(), fmt.Errorf("unable to identify tree for commit '%s': %w", commitID.String(), err)
+	}
+
+	return fromGoGit(commit.TreeHash)
+}
+
+// GetCommitParentIDs returns nil for a commit with no parents, as gitinterface
+// does.
+func (s *Storer) GetCommitParentIDs(commitID githash.Hash) ([]githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetCommitParentIDs", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetCommitParentIDs(commitID)
+	}
+
+	commit, err := s.commit(repo, commitID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to identify parents for commit '%s': %w", commitID.String(), err)
+	}
+
+	shallow, err := repo.Storer.Shallow()
+	if err != nil {
+		return nil, err
+	}
+	for _, boundary := range shallow {
+		if boundary == commit.Hash {
+			return nil, nil
+		}
+	}
+
+	if len(commit.ParentHashes) == 0 {
+		return nil, nil
+	}
+
+	parentIDs := make([]githash.Hash, 0, len(commit.ParentHashes))
+	for _, parentHash := range commit.ParentHashes {
+		parentID, err := fromGoGit(parentHash)
+		if err != nil {
+			return nil, fmt.Errorf("invalid parent commit ID '%s': %w", parentHash.String(), err)
+		}
+		parentIDs = append(parentIDs, parentID)
+	}
+
+	return parentIDs, nil
+}
+
+// GetEntriesInTree returns nil for an empty tree, as gitinterface does.
+func (s *Storer) GetEntriesInTree(treeID githash.Hash) ([]gitstore.TreeEntry, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetEntriesInTree", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetEntriesInTree(treeID)
+	}
+
+	tree, err := s.tree(repo, treeID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to enumerate items in tree '%s': %w", treeID.String(), err)
+	}
+
+	if len(tree.Entries) == 0 {
+		return nil, nil
+	}
+
+	entries := make([]gitstore.TreeEntry, 0, len(tree.Entries))
+	for _, entry := range tree.Entries {
+		id, err := fromGoGit(entry.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Git ID '%s' for path '%s': %w", entry.Hash.String(), entry.Name, err)
+		}
+
+		// ls-tree only reports trees as "tree". Everything else, including
+		// submodule gitlinks, counts as a blob.
+		kind := gitstore.KindBlob
+		if entry.Mode == filemode.Dir {
+			kind = gitstore.KindSubtree
+		}
+
+		entries = append(entries, gitstore.TreeEntry{Path: entry.Name, ID: id, Kind: kind})
+	}
+
+	return entries, nil
+}
+
+// GetAllFilesInTree returns nil for an empty tree, as gitinterface does.
+func (s *Storer) GetAllFilesInTree(treeID githash.Hash) (map[string]githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetAllFilesInTree", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetAllFilesInTree(treeID)
+	}
+
+	files := map[string]githash.Hash{}
+	if err := s.collectFiles(repo, treeID, "", files); err != nil {
+		return nil, fmt.Errorf("unable to enumerate all files in tree: %w", err)
+	}
+
+	if len(files) == 0 {
+		return nil, nil
+	}
+
+	return files, nil
+}
+
+// collectFiles records every non-tree entry. Submodule gitlinks are leaves,
+// matching ls-tree -r.
+func (s *Storer) collectFiles(repo *gogit.Repository, treeID githash.Hash, prefix string, files map[string]githash.Hash) error {
+	tree, err := s.tree(repo, treeID)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range tree.Entries {
+		path := entry.Name
+		if prefix != "" {
+			path = prefix + "/" + entry.Name
+		}
+
+		id, err := fromGoGit(entry.Hash)
+		if err != nil {
+			return fmt.Errorf("invalid Git ID '%s' for path '%s': %w", entry.Hash.String(), path, err)
+		}
+
+		if entry.Mode == filemode.Dir {
+			if err := s.collectFiles(repo, id, path, files); err != nil {
+				return err
+			}
+			continue
+		}
+
+		files[path] = id
+	}
+
+	return nil
+}
+
+// GetPathIDInTree resolves a slash separated path. An intermediate path
+// returns that subtree's ID.
+func (s *Storer) GetPathIDInTree(treeID githash.Hash, treePath string) (githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetPathIDInTree", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetPathIDInTree(treeID, treePath)
+	}
+
+	components := strings.Split(strings.TrimSuffix(treePath, "/"), "/")
+
+	currentTreeID := treeID
+	for len(components) != 0 {
+		entries, err := s.GetEntriesInTree(currentTreeID)
+		if err != nil {
+			return nil, err
+		}
+
+		entryID, has := findEntryID(entries, components[0])
+		if !has {
+			return nil, fmt.Errorf("%w: %s", gitinterface.ErrTreeDoesNotHavePath, treePath)
+		}
+
+		currentTreeID = entryID
+		components = components[1:]
+	}
+
+	return currentTreeID, nil
+}
+
+func findEntryID(entries []gitstore.TreeEntry, name string) (githash.Hash, bool) {
+	for _, entry := range entries {
+		if entry.Path == name {
+			return entry.ID, true
+		}
+	}
+	return nil, false
+}
+
+// GetReference delegates anything that is not a full reference name.
+// gitinterface uses rev-parse, which also accepts revision expressions such as
+// short branch names and object IDs.
+func (s *Storer) GetReference(refName string) (githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	delegated := repo == nil || !isFullReferenceName(refName)
+	defer s.record("GetReference", time.Now(), delegated)
+
+	if delegated {
+		return s.Repository.GetReference(refName)
+	}
+
+	reference, err := repo.Reference(plumbing.ReferenceName(refName), true)
+	if err != nil {
+		if errors.Is(err, plumbing.ErrReferenceNotFound) {
+			return s.ZeroHash(), gitstore.ErrReferenceNotFound
+		}
+		return s.ZeroHash(), fmt.Errorf("unable to read reference '%s': %w", refName, err)
+	}
+
+	return fromGoGit(reference.Hash())
+}
+
+func isFullReferenceName(refName string) bool {
+	return refName == "HEAD" || (strings.HasPrefix(refName, "refs/") && plumbing.ReferenceName(refName).Validate() == nil)
+}
+
+// GetTagTarget peels chained tags down to a commit. gitinterface uses
+// rev-list -n 1, which does the same, not the tag's immediate target.
+func (s *Storer) GetTagTarget(tagID githash.Hash) (githash.Hash, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, err
+	}
+	defer s.record("GetTagTarget", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetTagTarget(tagID)
+	}
+
+	id, err := toGoGit(tagID)
+	if err != nil {
+		return s.ZeroHash(), err
+	}
+
+	for {
+		tag, err := repo.TagObject(id)
+		if err != nil {
+			break
+		}
+		id = tag.Target
+	}
+
+	commit, err := repo.CommitObject(id)
+	if err != nil {
+		return s.ZeroHash(), fmt.Errorf("unable to resolve tag's target ID: %w", err)
+	}
+
+	return fromGoGit(commit.Hash)
+}
+
+// GetObjectSignature is already go-git in gitinterface. Overriding it reuses
+// the cached handle and drops the two cat-file calls used to find the type.
+func (s *Storer) GetObjectSignature(objectID githash.Hash) ([]byte, []byte, error) {
+	repo, err := s.fast()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer s.record("GetObjectSignature", time.Now(), repo == nil)
+
+	if repo == nil {
+		return s.Repository.GetObjectSignature(objectID)
+	}
+
+	id, err := toGoGit(objectID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	obj, err := repo.Object(plumbing.AnyObject, id)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to load object '%s': %w", objectID.String(), err)
+	}
+
+	switch obj := obj.(type) {
+	case *object.Commit:
+		payload, err := encodeWithoutSignature(obj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to encode commit contents: %w", err)
+		}
+
+		// SHA-256 commits sign under gpgsig-sha256, which go-git keeps apart
+		// from the SHA-1 gpgsig header.
+		signature := obj.Signature
+		if objectID.IsSHA256() {
+			signature = obj.SignatureSHA256
+		}
+
+		return payload, []byte(signature), nil
+
+	case *object.Tag:
+		payload, err := encodeWithoutSignature(obj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to encode tag contents: %w", err)
+		}
+
+		// Tag signatures are appended to the payload in both object formats.
+		return payload, []byte(obj.Signature), nil
+	}
+
+	return nil, nil, gitinterface.ErrNotCommitOrTag
+}
+
+// signatureless is implemented by go-git commits and tags, which can re-encode
+// themselves as the bytes their signature covered.
+type signatureless interface {
+	EncodeWithoutSignature(o plumbing.EncodedObject) error
+}
+
+func encodeWithoutSignature(obj signatureless) ([]byte, error) {
+	encoded := memory.NewStorage().NewEncodedObject()
+	if err := obj.EncodeWithoutSignature(encoded); err != nil {
+		return nil, err
+	}
+
+	reader, err := encoded.Reader()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close() //nolint:errcheck
+
+	return io.ReadAll(reader)
+}
+
+func (s *Storer) commit(repo *gogit.Repository, commitID githash.Hash) (*object.Commit, error) {
+	id, err := toGoGit(commitID)
+	if err != nil {
+		return nil, err
+	}
+	return repo.CommitObject(id)
+}
+
+func (s *Storer) tree(repo *gogit.Repository, treeID githash.Hash) (*object.Tree, error) {
+	if isEmptyTree(treeID) {
+		return &object.Tree{}, nil
+	}
+
+	id, err := toGoGit(treeID)
+	if err != nil {
+		return nil, err
+	}
+	return repo.TreeObject(id)
+}
+
+func isEmptyTree(treeID githash.Hash) bool {
+	id := treeID.String()
+	return id == emptyTreeSHA1 || id == emptyTreeSHA256
+}
+
+func toGoGit(h githash.Hash) (plumbing.Hash, error) {
+	id, ok := plumbing.FromHex(h.String())
+	if !ok {
+		return plumbing.ZeroHash, fmt.Errorf("%w: %s", ErrInvalidHash, h.String())
+	}
+	return id, nil
+}
+
+func fromGoGit(id plumbing.Hash) (githash.Hash, error) {
+	return githash.NewHash(id.String())
+}

--- a/internal/gogitstore/gogitstore_test.go
+++ b/internal/gogitstore/gogitstore_test.go
@@ -1,0 +1,207 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var objectFormats = []gitinterface.ObjectFormat{
+	gitinterface.ObjectFormatSHA1,
+	gitinterface.ObjectFormatSHA256,
+}
+
+// newBackends returns both backends over the same repository.
+func newBackends(t *testing.T, objectFormat gitinterface.ObjectFormat) (*gitinterface.Repository, *gogitstore.Storer) {
+	t.Helper()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false, gitinterface.WithObjectFormat(objectFormat))
+	return binary, gogitstore.New(binary, true)
+}
+
+func TestReadBlob(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+
+			blobID, err := binary.WriteBlob([]byte("hello there"))
+			require.Nil(t, err)
+
+			want, err := binary.ReadBlob(blobID)
+			require.Nil(t, err)
+
+			got, err := fast.ReadBlob(blobID)
+			require.Nil(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func commitChain(t *testing.T, repo *gitinterface.Repository, refName string, n int) []githash.Hash {
+	t.Helper()
+
+	treeID, err := repo.EmptyTree()
+	require.Nil(t, err)
+
+	ids := make([]githash.Hash, 0, n)
+	for i := range n {
+		id, err := repo.Commit(treeID, refName, fmt.Sprintf("commit %d\n", i), false)
+		require.Nil(t, err)
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+func TestGetCommitMessage(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 1)
+
+			want, err := binary.GetCommitMessage(ids[0])
+			require.Nil(t, err)
+
+			got, err := fast.GetCommitMessage(ids[0])
+			require.Nil(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestGetCommitParentIDs(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 2)
+
+			t.Run("commit with a parent", func(t *testing.T) {
+				want, err := binary.GetCommitParentIDs(ids[1])
+				require.Nil(t, err)
+
+				got, err := fast.GetCommitParentIDs(ids[1])
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+
+			t.Run("initial commit has no parents", func(t *testing.T) {
+				want, err := binary.GetCommitParentIDs(ids[0])
+				require.Nil(t, err)
+
+				got, err := fast.GetCommitParentIDs(ids[0])
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+		})
+	}
+}
+
+func TestGetCommitTreeID(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 1)
+
+			want, err := binary.GetCommitTreeID(ids[0])
+			require.Nil(t, err)
+
+			got, err := fast.GetCommitTreeID(ids[0])
+			require.Nil(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestKnowsCommit(t *testing.T) {
+	t.Parallel()
+
+	for _, objectFormat := range objectFormats {
+		t.Run(string(objectFormat), func(t *testing.T) {
+			t.Parallel()
+
+			binary, fast := newBackends(t, objectFormat)
+			ids := commitChain(t, binary, "refs/heads/main", 3)
+
+			t.Run("ancestor", func(t *testing.T) {
+				want, err := binary.KnowsCommit(ids[2], ids[0])
+				require.Nil(t, err)
+				require.True(t, want)
+
+				got, err := fast.KnowsCommit(ids[2], ids[0])
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+
+			t.Run("not an ancestor", func(t *testing.T) {
+				want, err := binary.KnowsCommit(ids[0], ids[2])
+				require.Nil(t, err)
+				require.False(t, want)
+
+				got, err := fast.KnowsCommit(ids[0], ids[2])
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+
+			t.Run("commit knows itself", func(t *testing.T) {
+				want, err := binary.KnowsCommit(ids[1], ids[1])
+				require.Nil(t, err)
+
+				got, err := fast.KnowsCommit(ids[1], ids[1])
+				require.Nil(t, err)
+				assert.Equal(t, want, got)
+			})
+		})
+	}
+}
+
+func TestShallowHistory(t *testing.T) {
+	t.Parallel()
+	for _, format := range objectFormats {
+		t.Run(string(format), func(t *testing.T) {
+			t.Parallel()
+			binary, fast := newBackends(t, format)
+			ids := commitChain(t, binary, "refs/heads/main", 3)
+			require.NoError(t, os.WriteFile(filepath.Join(binary.GetGitDir(), "shallow"), []byte(ids[1].String()+"\n"), 0o600))
+			for _, pair := range [][2]int{{2, 1}, {2, 0}, {1, 0}, {1, 1}} {
+				want, err := binary.KnowsCommit(ids[pair[0]], ids[pair[1]])
+				require.NoError(t, err)
+				got, err := fast.KnowsCommit(ids[pair[0]], ids[pair[1]])
+				require.NoError(t, err)
+				assert.Equal(t, want, got)
+			}
+			for _, id := range ids {
+				want, err := binary.GetCommitParentIDs(id)
+				require.NoError(t, err)
+				got, err := fast.GetCommitParentIDs(id)
+				require.NoError(t, err)
+				assert.Equal(t, want, got)
+			}
+		})
+	}
+}

--- a/internal/gogitstore/invalidation_test.go
+++ b/internal/gogitstore/invalidation_test.go
@@ -1,0 +1,75 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchInvalidatesCachedHandle(t *testing.T) {
+	t.Parallel()
+	for _, format := range objectFormats {
+		t.Run(string(format), func(t *testing.T) {
+			t.Parallel()
+			for name, fetch := range map[string]func(*gogitstore.Storer, githash.Hash) error{
+				"Fetch": func(s *gogitstore.Storer, _ githash.Hash) error {
+					return s.Fetch("origin", []string{"refs/gittuf/remote-only"}, true)
+				},
+				"FetchRefSpec": func(s *gogitstore.Storer, _ githash.Hash) error {
+					return s.FetchRefSpec("origin", []string{"refs/gittuf/remote-only:refs/gittuf/remote-only"})
+				},
+				"FetchObject": func(s *gogitstore.Storer, id githash.Hash) error { return s.FetchObject("origin", id) },
+			} {
+				t.Run(name, func(t *testing.T) {
+					t.Parallel()
+					remoteDir := t.TempDir()
+					remote := gitinterface.CreateTestGitRepository(t, remoteDir, true, gitinterface.WithObjectFormat(format))
+					tree, err := remote.EmptyTree()
+					require.NoError(t, err)
+					remoteID, err := remote.Commit(tree, "refs/gittuf/remote-only", "remote", false)
+					require.NoError(t, err)
+					local, fast := newBackends(t, format)
+					// Keep fetched objects packed to exercise the cached pack index.
+					git(t, local, "", "config", "fetch.unpackLimit", "1")
+					localID := commitChain(t, local, "refs/heads/local", 2)[1]
+					_, err = fast.GetCommitMessage(localID)
+					require.NoError(t, err)
+					require.NoError(t, fast.AddRemote("origin", remoteDir))
+					require.NoError(t, fetch(fast, remoteID))
+					packs, err := filepath.Glob(filepath.Join(local.GetGitDir(), "objects", "pack", "*.pack"))
+					require.NoError(t, err)
+					require.NotEmpty(t, packs)
+					message, err := fast.GetCommitMessage(remoteID)
+					require.NoError(t, err)
+					assert.Equal(t, "remote", message)
+				})
+			}
+		})
+	}
+}
+
+func TestWriteThenReadThroughWrapper(t *testing.T) {
+	t.Parallel()
+
+	local := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+	fast := gogitstore.New(local, true)
+
+	existing := commitChain(t, local, "refs/heads/main", 1)
+	_, err := fast.GetCommitMessage(existing[0])
+	require.Nil(t, err)
+
+	blobID, err := fast.WriteBlob([]byte("written after the handle was opened"))
+	require.Nil(t, err)
+
+	contents, err := fast.ReadBlob(blobID)
+	require.Nil(t, err)
+	assert.Equal(t, []byte("written after the handle was opened"), contents)
+}

--- a/internal/gogitstore/mutations.go
+++ b/internal/gogitstore/mutations.go
@@ -1,0 +1,86 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore
+
+import (
+	"time"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+)
+
+// Mutations invalidate the cached handle so subsequent reads see new packfiles.
+
+func (s *Storer) WriteBlob(contents []byte) (githash.Hash, error) {
+	defer s.record("WriteBlob", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.WriteBlob(contents)
+}
+
+func (s *Storer) WriteTree(entries []gitstore.TreeEntry) (githash.Hash, error) {
+	defer s.record("WriteTree", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.WriteTree(entries)
+}
+
+func (s *Storer) Commit(treeID githash.Hash, targetRef, message string, sign bool) (githash.Hash, error) {
+	defer s.record("Commit", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.Commit(treeID, targetRef, message, sign)
+}
+
+func (s *Storer) CommitUsingSpecificKey(treeID githash.Hash, targetRef, message string, signingKeyPEMBytes []byte) (githash.Hash, error) {
+	defer s.record("CommitUsingSpecificKey", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.CommitUsingSpecificKey(treeID, targetRef, message, signingKeyPEMBytes)
+}
+
+func (s *Storer) TagUsingSpecificKey(target githash.Hash, name, message string, signingKeyPEMBytes []byte) (githash.Hash, error) {
+	defer s.record("TagUsingSpecificKey", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.TagUsingSpecificKey(target, name, message, signingKeyPEMBytes)
+}
+
+func (s *Storer) SetReference(refName string, gitID githash.Hash) error {
+	defer s.record("SetReference", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.SetReference(refName, gitID)
+}
+
+func (s *Storer) DeleteReference(refName string) error {
+	defer s.record("DeleteReference", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.DeleteReference(refName)
+}
+
+func (s *Storer) ResetDueToError(cause error, refName string, commitID githash.Hash) error {
+	defer s.record("ResetDueToError", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.ResetDueToError(cause, refName, commitID)
+}
+
+func (s *Storer) Fetch(remoteName string, refs []string, fastForwardOnly bool, opts ...gitinterface.FetchOption) error {
+	defer s.record("Fetch", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.Fetch(remoteName, refs, fastForwardOnly, opts...)
+}
+
+func (s *Storer) FetchRefSpec(remoteName string, refSpecs []string, opts ...gitinterface.FetchOption) error {
+	defer s.record("FetchRefSpec", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.FetchRefSpec(remoteName, refSpecs, opts...)
+}
+
+func (s *Storer) FetchObject(remoteName string, objectID githash.Hash) error {
+	defer s.record("FetchObject", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.FetchObject(remoteName, objectID)
+}
+
+func (s *Storer) Push(remoteName string, refs []string) error {
+	defer s.record("Push", time.Now(), true)
+	defer s.invalidate()
+	return s.Repository.Push(remoteName, refs)
+}

--- a/internal/gogitstore/trace.go
+++ b/internal/gogitstore/trace.go
@@ -1,0 +1,112 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MethodStat records calls and elapsed time for a Storer method.
+type MethodStat struct {
+	Calls     int
+	Delegated int
+	Total     time.Duration
+}
+
+// Trace records Storer call counts and timings.
+type Trace struct {
+	mu          sync.Mutex
+	methods     map[string]*MethodStat
+	handleOpens int
+}
+
+// NewTrace returns a trace ready to attach to a Storer.
+func NewTrace() *Trace {
+	return &Trace{methods: map[string]*MethodStat{}}
+}
+
+// record logs one call. Callers defer it, so start is evaluated on entry.
+func (t *Trace) record(method string, start time.Time, delegated bool) {
+	elapsed := time.Since(start)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	stat, has := t.methods[method]
+	if !has {
+		stat = &MethodStat{}
+		t.methods[method] = stat
+	}
+
+	stat.Calls++
+	stat.Total += elapsed
+	if delegated {
+		stat.Delegated++
+	}
+}
+
+func (t *Trace) recordHandleOpen() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.handleOpens++
+}
+
+// Stat returns the zero value for a method that was never called.
+func (t *Trace) Stat(method string) MethodStat {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if stat, has := t.methods[method]; has {
+		return *stat
+	}
+	return MethodStat{}
+}
+
+// HandleOpens returns the number of go-git handle opens.
+func (t *Trace) HandleOpens() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.handleOpens
+}
+
+// Report renders the trace as a table, slowest method first. gitInvocations
+// comes from gitinterface, which the Storer cannot count itself.
+func (t *Trace) Report(backend string, gitInvocations uint64) string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	names := make([]string, 0, len(t.methods))
+	for name := range t.methods {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if t.methods[names[i]].Total != t.methods[names[j]].Total {
+			return t.methods[names[i]].Total > t.methods[names[j]].Total
+		}
+		return names[i] < names[j]
+	})
+
+	report := &strings.Builder{}
+	fmt.Fprintf(report, "storer trace (%s)\n", backend)
+	fmt.Fprintf(report, "  %-24s %7s %7s %10s\n", "method", "calls", "deleg", "total")
+
+	totals := MethodStat{}
+	for _, name := range names {
+		stat := t.methods[name]
+		fmt.Fprintf(report, "  %-24s %7d %7d %10s\n", name, stat.Calls, stat.Delegated, stat.Total.Round(time.Microsecond))
+
+		totals.Calls += stat.Calls
+		totals.Delegated += stat.Delegated
+		totals.Total += stat.Total
+	}
+
+	fmt.Fprintf(report, "  %-24s %7d %7d %10s\n", "all", totals.Calls, totals.Delegated, totals.Total.Round(time.Microsecond))
+	fmt.Fprintf(report, "  git forks: %d   go-git handle opens: %d\n", gitInvocations, t.handleOpens)
+
+	return report.String()
+}

--- a/internal/gogitstore/trace_test.go
+++ b/internal/gogitstore/trace_test.go
@@ -1,0 +1,145 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gogitstore_test
+
+import (
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/gogitstore"
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTraceRecordsCalls(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T) (*gogitstore.Storer, *gogitstore.Trace, githash.Hash) {
+		t.Helper()
+
+		binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+		trace := gogitstore.NewTrace()
+		blobID, err := binary.WriteBlob([]byte("contents"))
+		require.Nil(t, err)
+
+		return gogitstore.NewWithTrace(binary, true, trace), trace, blobID
+	}
+
+	t.Run("in-process read", func(t *testing.T) {
+		t.Parallel()
+
+		fast, trace, blobID := setup(t)
+
+		_, err := fast.ReadBlob(blobID)
+		require.Nil(t, err)
+
+		stat := trace.Stat("ReadBlob")
+		assert.Equal(t, 1, stat.Calls)
+		assert.Equal(t, 0, stat.Delegated)
+		assert.Positive(t, stat.Total)
+	})
+
+	t.Run("a method with no go-git implementation counts as delegated", func(t *testing.T) {
+		t.Parallel()
+
+		fast, trace, _ := setup(t)
+
+		_, _, err := fast.LookupConfig(gitstore.ConfigUserName)
+		require.Nil(t, err)
+
+		stat := trace.Stat("LookupConfig")
+		assert.Equal(t, 1, stat.Calls)
+		assert.Equal(t, 1, stat.Delegated)
+	})
+
+	t.Run("repeated calls accumulate", func(t *testing.T) {
+		t.Parallel()
+
+		fast, trace, blobID := setup(t)
+
+		for range 4 {
+			_, err := fast.ReadBlob(blobID)
+			require.Nil(t, err)
+		}
+
+		assert.Equal(t, 4, trace.Stat("ReadBlob").Calls)
+	})
+}
+
+func TestTraceWithBackendDisabled(t *testing.T) {
+	t.Parallel()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+	trace := gogitstore.NewTrace()
+	disabled := gogitstore.NewWithTrace(binary, false, trace)
+
+	blobID, err := binary.WriteBlob([]byte("contents"))
+	require.Nil(t, err)
+	_, err = disabled.ReadBlob(blobID)
+	require.Nil(t, err)
+
+	stat := trace.Stat("ReadBlob")
+	assert.Equal(t, 1, stat.Calls)
+	assert.Equal(t, 1, stat.Delegated)
+	assert.Zero(t, trace.HandleOpens(), "the go-git handle must never open when the backend is off")
+}
+
+func TestTraceCountsHandleOpens(t *testing.T) {
+	t.Parallel()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+	trace := gogitstore.NewTrace()
+	fast := gogitstore.NewWithTrace(binary, true, trace)
+
+	blobID, err := binary.WriteBlob([]byte("contents"))
+	require.Nil(t, err)
+
+	for range 3 {
+		_, err := fast.ReadBlob(blobID)
+		require.Nil(t, err)
+	}
+	assert.Equal(t, 1, trace.HandleOpens(), "the handle is cached across reads")
+
+	_, err = fast.WriteBlob([]byte("more contents"))
+	require.Nil(t, err)
+	_, err = fast.ReadBlob(blobID)
+	require.Nil(t, err)
+
+	assert.Equal(t, 2, trace.HandleOpens())
+}
+
+func TestTraceReport(t *testing.T) {
+	t.Parallel()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+	trace := gogitstore.NewTrace()
+	fast := gogitstore.NewWithTrace(binary, true, trace)
+
+	blobID, err := binary.WriteBlob([]byte("contents"))
+	require.Nil(t, err)
+	_, err = fast.ReadBlob(blobID)
+	require.Nil(t, err)
+
+	report := trace.Report("go-git", 7)
+
+	assert.Contains(t, report, "go-git")
+	assert.Contains(t, report, "ReadBlob")
+	assert.NotContains(t, report, "fast")
+	assert.Contains(t, report, "git forks")
+	assert.Contains(t, report, "7")
+}
+
+func TestGitInvocationCountRises(t *testing.T) {
+	t.Parallel()
+
+	binary := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+
+	before := binary.GitInvocationCount()
+	_, err := binary.WriteBlob([]byte("contents"))
+	require.Nil(t, err)
+
+	assert.Greater(t, binary.GitInvocationCount(), before)
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "unexpected profiling error: %s\n", err.Error())
 		}
 
+		root.ReportStorerTrace(os.Stderr)
+
 		if r := recover(); r != nil {
 			fmt.Fprintf(os.Stderr, "unexpected error: %s\n\n", fmt.Sprint(r))
 			debug.PrintStack()
@@ -29,6 +31,10 @@ func main() {
 
 	rootCmd := root.New()
 	if err := rootCmd.Execute(); err != nil {
+		// Deferred functions do not run under os.Exit, so report here too. It
+		// emits at most once.
+		root.ReportStorerTrace(os.Stderr)
+
 		// We can ignore the linter here (deferred functions are not executed
 		// when os.Exit is invoked) because if we do have an error, we don't
 		// have a panic, which is what the deferred function is looking for.

--- a/pkg/gitinterface/repository.go
+++ b/pkg/gitinterface/repository.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/go-git/go-git/v6"
 	gogitconfig "github.com/go-git/go-git/v6/config"
@@ -37,6 +38,16 @@ type Repository struct {
 	gitDirPath   string
 	objectFormat ObjectFormat
 	clock        clockwork.Clock
+
+	// gitInvocations counts spawns of the git binary, which dominate the cost
+	// of read heavy commands.
+	gitInvocations atomic.Uint64
+}
+
+// GitInvocationCount returns how often the git binary was spawned for this
+// repository.
+func (r *Repository) GitInvocationCount() uint64 {
+	return r.gitInvocations.Load()
 }
 
 // GetObjectFormat returns the hash algorithm the repository uses for its object
@@ -303,6 +314,8 @@ func (e *executor) execute() (io.Reader, io.Reader, error) {
 	if e.r.gitDirPath != "" && !e.unsetGitDir {
 		e.args = append([]string{"--git-dir", e.r.gitDirPath}, e.args...)
 	}
+	e.r.gitInvocations.Add(1)
+
 	cmd := exec.Command(binary, e.args...) //nolint:gosec
 	cmd.Env = e.env
 	cmd.Env = append(cmd.Env, "LC_ALL=C")                 // force git to the C (and thus english) locale


### PR DESCRIPTION
## Description

Add experimental go-git storage backend and tracing capabilities at a storer level. The performance impact is substantial (`10s` to `155ms` on this repo) but for the time being it will be kept as opt-in and experimental.

Existing Git binary based storer against the gittuf repository:
```
$ ./dist/gittuf policy list-principals --storer-trace=true
...
storer trace (binary)
  method                     calls   deleg      total
  GetCommitMessage            2058    2058  5.371359s
  GetCommitParentIDs          2058    2058  4.901626s
  ReadBlob                       6       6   12.254ms
  LookupConfig                   8       8   10.514ms
  GetCommitTreeID                3       3    6.904ms
  GetEntriesInTree               6       6    6.408ms
  GetReference                   4       4    4.139ms
  KnowsCommit                    1       1    2.767ms
  all                         4144    4144  10.31597s
  git forks: 8273   go-git handle opens: 0
```

Now changing to the new experimental storer:
```
$ ./dist/gittuf policy list-principals --storer-trace=true --storer=go-git
time=2026-09-11T13:55:41.254+01:00 level=WARN msg="the go-git storage backend is EXPERIMENTAL: results are not covered by gittuf's compatibility guarantees and may differ from the default backend; unset --storer/GITTUF_STORER to disable"
...
storer trace (go-git)
  method                     calls   deleg      total
  GetCommitMessage            2058       0  103.951ms
  GetCommitParentIDs          2058       0   31.792ms
  LookupConfig                   8       8   12.515ms
  KnowsCommit                    1       1    5.643ms
  ReadBlob                       6       0      841µs
  GetCommitTreeID                3       0      349µs
  GetReference                   4       0      223µs
  GetEntriesInTree               6       0      149µs
  all                         4144       9  155.463ms
  git forks: 13   go-git handle opens: 1
```

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Most of the implementation, wiring up and testing.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
