### PR TITLE
rsl: add bulk reference entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ This file tracks the changes introduced by gittuf versions.
 
 ### Added
 
+- RSL bulk reference entries recording several reference updates under one
+  signature
+- `ref` qualifiers on RSL annotation entries so a skip can target one update
+  inside a bulk entry
 - A clear upgrade message when the RSL contains an entry type or the policy
   metadata uses a schema version this client does not implement
+- `make test-compat` covering v0.8.1, v0.14.1 and v0.16.0
 
 ## v0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file tracks the changes introduced by gittuf versions.
 
+## Unreleased
+
+### Added
+
+- A clear upgrade message when the RSL contains an entry type or the policy
+  metadata uses a schema version this client does not implement
+
 ## v0.16.0
 
 This release adds support for SHA-256 Git repositories and reworks gittuf's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file tracks the changes introduced by gittuf versions.
 ### Added
 
 - RSL bulk reference entries recording several reference updates under one
-  signature
+  signature, with support for custom fields
 - `ref` qualifiers on RSL annotation entries so a skip can target one update
   inside a bulk entry
 - A clear upgrade message when the RSL contains an entry type or the policy

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
+GO ?= go
+
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 
 LDFLAGS=-buildid= -X github.com/gittuf/gittuf/internal/version.gitVersion=$(GIT_VERSION)
 
-.PHONY : build test install fmt
+.PHONY : build test test-compat install fmt
 
 default : install
 
 build : test
 ifeq ($(OS),Windows_NT)
 	set CGO_ENABLED=0
-	go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
-	go build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
+	$(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
 	set CGO_ENABLED=
 else
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
+	CGO_ENABLED=0 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/gittuf .
+	CGO_ENABLED=0 $(GO) build -trimpath -ldflags "$(LDFLAGS)" -o dist/git-remote-gittuf ./internal/git-remote-gittuf
 endif
 
 install : test just-install
@@ -24,19 +26,22 @@ install : test just-install
 just-install :
 ifeq ($(OS),Windows_NT)
 	set CGO_ENABLED=0
-	go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
-	go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
+	$(GO) install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
+	$(GO) install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
 	set CGO_ENABLED=
 else
-	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
-	CGO_ENABLED=0 go install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
+	CGO_ENABLED=0 $(GO) install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf
+	CGO_ENABLED=0 $(GO) install -trimpath -ldflags "$(LDFLAGS)" github.com/gittuf/gittuf/internal/git-remote-gittuf
 endif
 
 test :
-	go test -race -timeout 20m -v ./...
+	$(GO) test -race -timeout 20m -v ./...
+
+test-compat :
+	GO=$(GO) ./scripts/test-compat.sh
 
 fmt :
-	go fmt ./...
+	$(GO) fmt ./...
 
 generate :
-	go generate ./...
+	$(GO) generate ./...

--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -362,6 +362,7 @@ RSL Bulk Reference Entry
 <ref 2>: <target ID 2>
 
 number: <number>
+custom.<namespace>/<name>: <value>
 ```
 
 The following rules are enforced by the parser, and therefore by every
@@ -378,6 +379,10 @@ verifier.
 * The `number` field is mandatory for this entry type, unlike for the other
   entry types where it is optional. It always follows exactly one blank line
   after the last update line.
+* Custom fields, described below, follow the `number` line. Unlike the other
+  entry types, which ignore keys they do not recognize, any other key after
+  the `number` line is rejected, so a client fails closed on a field it does
+  not implement.
 * The entry commit uses the empty tree, like every other RSL entry, and the
   signature on that commit covers all the updates the entry lists.
 

--- a/docs/design-document.md
+++ b/docs/design-document.md
@@ -330,6 +330,7 @@ entries. Annotations have the following schema.
 RSL Annotation Entry
 
 entryID: <RSL entry ID 1>
+ref: <ref name>
 entryID: <RSL entry ID 2>
 ...
 skip: <true/false>
@@ -339,6 +340,62 @@ custom.<namespace>/<name>: <value>
 <message>
 ------END MESSAGE------
 ```
+
+The `ref` lines after an `entryID` are optional qualifiers. An entry ID with no
+qualifier is referred to as a whole, while an entry ID with qualifiers is
+referred to only for the listed reference updates. Qualifiers are only valid
+against RSL bulk reference entries, and they allow an annotation to skip one
+reference update inside a bulk entry while leaving the other updates in that
+entry in force.
+
+##### RSL Bulk Reference Entries
+
+A bulk reference entry records several reference updates under one signature.
+It exists so that a push touching several references costs one RSL entry and
+one signature rather than one of each per reference. It has the following
+structure.
+
+```
+RSL Bulk Reference Entry
+
+<ref 1>: <target ID 1>
+<ref 2>: <target ID 2>
+
+number: <number>
+```
+
+The following rules are enforced by the parser, and therefore by every
+verifier.
+
+* The body is one line per reference update, in the order the updates were
+  recorded. The reference name is the key and the target ID is the value.
+  Git reference names cannot contain a colon, so splitting each line on its
+  first colon is unambiguous.
+* Reference names must be fully qualified and must be unique within one entry.
+  A duplicate reference is rejected.
+* No reference may be in the `refs/gittuf/` namespace. Policy,
+  policy-staging and attestations updates keep their own single entries.
+* The `number` field is mandatory for this entry type, unlike for the other
+  entry types where it is optional. It always follows exactly one blank line
+  after the last update line.
+* The entry commit uses the empty tree, like every other RSL entry, and the
+  signature on that commit covers all the updates the entry lists.
+
+The blank line before the mandatory `number` line is load bearing for
+compatibility with clients that do not implement this entry type. gittuf
+v0.9.0 through v0.16.0 reject an entry whose header they do not recognize.
+Clients up to v0.8.1 instead parse any unknown header with the reference entry
+parser, which rejects a body line that has no colon in it. The blank line is
+such a line, so those clients fail closed rather than silently reading an
+entry with an empty reference name.
+
+gittuf reads a bulk reference entry as one per-reference view of the update for
+each line. All the views of one entry share the entry's ID and number, so a
+bulk entry counts as one entry for RSL numbering and for the RSL's hash chain.
+A writer never records a bulk entry for a single update, which is written as a
+plain RSL reference entry instead. The parser nonetheless accepts a
+single-update bulk entry, so that a future writer may record one without
+breaking clients shipped before that change.
 
 RSL entries may carry application-defined custom fields after their standard
 fields (for annotation entries, before the message block), each a
@@ -456,6 +513,27 @@ number: 6
 -----BEGIN MESSAGE-----
 U2tpcHBpbmcgUlNMIGVudHJ5
 -----END MESSAGE-----
+```
+
+The commit object for a bulk reference entry recording two references is as
+follows:
+
+```bash
+~/tmp/repo $ git cat-file -p 8f4b0c1d2e3a4b5c6d7e8f90a1b2c3d4e5f60718
+tree 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+parent cccfb6f27b2a71c33e9a55bc82f084e2445aa398
+author Jane Doe <jane.doe@example.com> 1729515000 -0400
+committer Jane Doe <jane.doe@example.com> 1729515000 -0400
+gpgsig -----BEGIN SSH SIGNATURE-----
+ ...
+ -----END SSH SIGNATURE-----
+
+RSL Bulk Reference Entry
+
+refs/heads/feature: 4a2f1b9c7e5d3a8b6c4f2e1d0b9a8c7f6e5d4c3b
+refs/heads/release: 9e37b2f8b9d5b0e1cc2f2c2a6a4b1f9c7b5e0d31
+
+number: 7
 ```
 
 #### Attestations for Authorization Records

--- a/docs/gaps/7/README.md
+++ b/docs/gaps/7/README.md
@@ -93,10 +93,15 @@ Git ref that points to a blob.
 
 ### Supported Types
 
-All three RSL entry types carry custom fields: reference entries, annotation
-entries, and propagation entries. The key grammar, value alphabet, and length
-and count limits are identical across them and are enforced by a single shared
-implementation.
+Every RSL entry type carries custom fields: reference entries, bulk reference
+entries, annotation entries, and propagation entries. The key grammar, value
+alphabet, and length and count limits are identical across them and are
+enforced by a single shared implementation.
+
+The entry types differ in what they do with a key they do not recognize.
+Reference, annotation, and propagation entries ignore it, as they always have.
+A bulk reference entry rejects it, because that entry type fails closed on
+anything a client does not implement.
 
 Nothing outside the RSL carries custom fields, including policy metadata and
 the commits that record it. The RSL is where an application's context about a
@@ -300,8 +305,10 @@ what makes the rule "a field a canonical writer could not have produced is
 never surfaced by a read" checkable, and leaves the validation package free of
 any assumption that custom fields are carried as commit message lines.
 
-In the RSL package, `ReferenceEntry`, `AnnotationEntry`, and
-`PropagationEntry` each carry a `CustomFields` map. The keyed read lives on a
+In the RSL package, `ReferenceEntry`, `BulkReferenceEntry`, `AnnotationEntry`,
+and `PropagationEntry` each carry a `CustomFields` map. The per-ref views a
+bulk entry expands into share the entry's map, so a field set on a bulk entry
+is readable from every update it records. The keyed read lives on a
 `CustomFieldEntry` interface rather than on `Entry`, so adding it does not
 break existing implementations of `Entry`: they continue to satisfy `Entry`,
 and simply do not satisfy `CustomFieldEntry`. Callers holding an `Entry` reach

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -573,7 +573,7 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 		case *rsl.ReferenceEntry:
 			err = rsl.NewReferenceEntry(entry.RefName, entry.TargetID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
 		case *rsl.BulkReferenceEntry:
-			err = rsl.NewBulkReferenceEntry(slices.Clone(entry.Updates)).Commit(r.r, sign)
+			err = rsl.NewBulkReferenceEntry(slices.Clone(entry.Updates), rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
 		case *rsl.PropagationEntry:
 			err = rsl.NewPropagationEntry(entry.RefName, entry.TargetID, entry.UpstreamRepository, entry.UpstreamEntryID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
 		case *rsl.AnnotationEntry:

--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"strings"
 
 	rslopts "github.com/gittuf/gittuf/experimental/gittuf/options/rsl"
@@ -66,30 +67,7 @@ func (r *Repository) RecordRSLEntryForReference(ctx context.Context, refName str
 		}
 	}
 
-	slog.Debug("Identifying absolute reference path...")
-	refName, err := r.r.AbsoluteReference(refName)
-	if err != nil {
-		return err
-	}
-
-	// Track localRefName to check the expected tip as we may override refName
-	localRefName := refName
-
-	if options.RefNameOverride != "" {
-		// dst differs from src
-		// Eg: git push <remote> <src>:<dst>
-		slog.Debug("Name of reference overridden to match remote reference name, identifying absolute reference path...")
-		refNameOverride, err := r.r.AbsoluteReference(options.RefNameOverride)
-		if err != nil {
-			return err
-		}
-
-		refName = refNameOverride
-	}
-
-	// The tip of the ref is always from the localRefName
-	slog.Debug(fmt.Sprintf("Loading current state of '%s'...", localRefName))
-	refTip, err := r.r.GetReference(localRefName)
+	refName, refTip, err := r.resolveReferenceUpdate(refName, options.RefNameOverride)
 	if err != nil {
 		return err
 	}
@@ -127,6 +105,166 @@ func (r *Repository) RecordRSLEntryForReference(ctx context.Context, refName str
 
 	_, err = r.Sync(ctx, options.RemoteName, false, signCommit)
 	return err
+}
+
+// ReferenceUpdateRequest names one local reference to record, optionally
+// under a different name, as during git push <src>:<dst>.
+type ReferenceUpdateRequest struct {
+	RefName         string
+	RefNameOverride string
+}
+
+// resolvedReferenceUpdate is a request after ref resolution and duplicate
+// filtering.
+type resolvedReferenceUpdate struct {
+	refName string
+	tip     githash.Hash
+}
+
+// RecordRSLEntryForReferences records the current state of several
+// references. When more than one update remains after duplicate filtering,
+// one BulkReferenceEntry is recorded, so either every update is recorded by
+// that single entry or none of them is. A single remaining update is
+// recorded as one ReferenceEntry, exactly as RecordRSLEntryForReference
+// does.
+func (r *Repository) RecordRSLEntryForReferences(ctx context.Context, updates []ReferenceUpdateRequest, signCommit bool, opts ...rslopts.RecordOption) error {
+	options := &rslopts.RecordOptions{}
+	for _, fn := range opts {
+		fn(options)
+	}
+
+	if signCommit && options.SigningKeyBytes == nil {
+		slog.Debug("Checking if Git signing is configured...")
+		if err := r.r.CanSign(); err != nil {
+			return err
+		}
+	}
+
+	if options.RemoteName == "" && !options.LocalOnly {
+		return ErrRemoteNotSpecified
+	} else if options.RemoteName != "" && options.LocalOnly {
+		return ErrCannotUseRemoteAndLocalOnly
+	}
+
+	if !options.LocalOnly {
+		if _, err := r.Sync(ctx, options.RemoteName, false, signCommit); err != nil {
+			return err
+		}
+	}
+
+	// A bulk entry must not list the same reference twice, so requests that
+	// resolve to the same recorded reference are collapsed into the first
+	// position with the last tip given.
+	seen := make(map[string]int, len(updates))
+	resolved := make([]resolvedReferenceUpdate, 0, len(updates))
+	for _, update := range updates {
+		refName, tip, err := r.resolveReferenceUpdate(update.RefName, update.RefNameOverride)
+		if err != nil {
+			return err
+		}
+
+		if i, isSeen := seen[refName]; isSeen {
+			slog.Debug(fmt.Sprintf("Reference '%s' is named more than once, using the last target...", refName))
+			resolved[i].tip = tip
+			continue
+		}
+
+		seen[refName] = len(resolved)
+		resolved = append(resolved, resolvedReferenceUpdate{refName: refName, tip: tip})
+	}
+
+	if !options.SkipCheckForDuplicate {
+		slog.Debug("Checking if latest entry for each reference has same target...")
+		remaining := make([]resolvedReferenceUpdate, 0, len(resolved))
+		for _, update := range resolved {
+			isDuplicate, err := r.isDuplicateEntry(update.refName, update.tip)
+			if err != nil {
+				return err
+			}
+			if isDuplicate {
+				slog.Debug(fmt.Sprintf("The latest entry for '%s' has the same target, skipping...", update.refName))
+				continue
+			}
+
+			remaining = append(remaining, update)
+		}
+		resolved = remaining
+	} else {
+		slog.Debug("Not checking if latest entry for each reference has same target")
+	}
+
+	if len(resolved) == 0 {
+		return nil
+	}
+
+	// TODO: once policy verification is in place, the signing key used by
+	// signCommit must be verified for each refName in the delegation tree.
+
+	if len(resolved) > 1 {
+		slog.Debug("Creating RSL bulk reference entry...")
+		rslUpdates := make([]rsl.ReferenceUpdate, 0, len(resolved))
+		for _, update := range resolved {
+			rslUpdates = append(rslUpdates, rsl.ReferenceUpdate{RefName: update.refName, TargetID: update.tip})
+		}
+		entry := rsl.NewBulkReferenceEntry(rslUpdates)
+		if signCommit && options.SigningKeyBytes != nil {
+			if err := entry.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
+				return err
+			}
+		} else if err := entry.Commit(r.r, signCommit); err != nil {
+			return err
+		}
+	} else {
+		for _, update := range resolved {
+			slog.Debug(fmt.Sprintf("Creating RSL reference entry for '%s'...", update.refName))
+			entry := rsl.NewReferenceEntry(update.refName, update.tip)
+			if signCommit && options.SigningKeyBytes != nil {
+				if err := entry.CommitUsingSpecificKey(r.r, options.SigningKeyBytes); err != nil {
+					return err
+				}
+			} else if err := entry.Commit(r.r, signCommit); err != nil {
+				return err
+			}
+		}
+	}
+
+	if options.LocalOnly {
+		return nil
+	}
+
+	_, err := r.Sync(ctx, options.RemoteName, false, signCommit)
+	return err
+}
+
+// resolveReferenceUpdate resolves the local ref to record and its tip. The
+// tip is always read from the local ref. The recorded name is the override
+// when one is given.
+func (r *Repository) resolveReferenceUpdate(refName, refNameOverride string) (string, githash.Hash, error) {
+	slog.Debug("Identifying absolute reference path...")
+	localRefName, err := r.r.AbsoluteReference(refName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	recordedRefName := localRefName
+	if refNameOverride != "" {
+		// dst differs from src
+		// Eg: git push <remote> <src>:<dst>
+		slog.Debug("Name of reference overridden to match remote reference name, identifying absolute reference path...")
+		recordedRefName, err = r.r.AbsoluteReference(refNameOverride)
+		if err != nil {
+			return "", nil, err
+		}
+	}
+
+	// The tip of the ref is always from the localRefName
+	slog.Debug(fmt.Sprintf("Loading current state of '%s'...", localRefName))
+	tip, err := r.r.GetReference(localRefName)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return recordedRefName, tip, nil
 }
 
 // RecordRSLEntryForReferenceAtTarget is a special version of
@@ -240,13 +378,41 @@ func (r *Repository) RecordRSLAnnotation(ctx context.Context, rslEntryIDs []stri
 	return err
 }
 
+// rewriteAnnotationTargets maps an annotation's targets and qualifiers
+// through the entries a replay wrote. A target that was not replayed keeps
+// its ID and its qualifiers. A replayed target is mapped to the ID of the
+// entry the replay wrote, with its qualifiers rekeyed to that ID.
+func rewriteAnnotationTargets(entry *rsl.AnnotationEntry, replayedIDs map[string]githash.Hash) ([]githash.Hash, map[string][]string) {
+	newIDs := make([]githash.Hash, 0, len(entry.RSLEntryIDs))
+	newRefs := map[string][]string{}
+
+	for _, id := range entry.RSLEntryIDs {
+		refs, qualified := entry.Refs[id.String()]
+
+		newID, wasReplayed := replayedIDs[id.String()]
+		if !wasReplayed {
+			newID = id
+		}
+
+		newIDs = append(newIDs, newID)
+		if qualified {
+			newRefs[newID.String()] = refs
+		}
+	}
+
+	return newIDs, newRefs
+}
+
 // ReconcileLocalRSLWithRemote checks the local RSL against the specified remote
 // and reconciles the local RSL if needed. If the local RSL doesn't exist or is
 // strictly behind the remote RSL, then the local RSL is updated to match the
 // remote RSL. If the local RSL is ahead of the remote RSL, nothing is updated.
 // Finally, if the local and remote RSLs have diverged, then the local only RSL
 // entries are reapplied over the latest entries in the remote if the local only
-// RSL entries and remote only entries are for different Git references.
+// RSL entries and remote only entries are for different Git references. A
+// local only bulk reference entry is replayed as a bulk reference entry.
+// Replayed entries receive new IDs, so an annotation that referred to a
+// replayed entry is rewritten to the new ID.
 func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName string, sign bool) error {
 	if sign {
 		slog.Debug("Checking if Git signing is configured...")
@@ -364,16 +530,16 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 	localUpdatedRefs := set.NewSet[string]()
 	for _, entry := range localOnlyEntries {
 		slog.Debug(fmt.Sprintf("Identified local only entry that must be reapplied '%s'", entry.GetID().String()))
-		if entry, isRefEntry := entry.(*rsl.ReferenceEntry); isRefEntry {
-			localUpdatedRefs.Add(entry.RefName)
+		if err := addUpdatedRefs(localUpdatedRefs, entry); err != nil {
+			return fmt.Errorf("unable to inspect local only entry '%s': %w", entry.GetID().String(), err)
 		}
 	}
 
 	remoteUpdatedRefs := set.NewSet[string]()
 	for _, entry := range remoteOnlyEntries {
 		slog.Debug(fmt.Sprintf("Identified remote only entry '%s'", entry.GetID().String()))
-		if entry, isRefEntry := entry.(*rsl.ReferenceEntry); isRefEntry {
-			remoteUpdatedRefs.Add(entry.RefName)
+		if err := addUpdatedRefs(remoteUpdatedRefs, entry); err != nil {
+			return fmt.Errorf("unable to inspect remote only entry '%s': %w", entry.GetID().String(), err)
 		}
 	}
 
@@ -389,35 +555,43 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 		return fmt.Errorf("unable to update local RSL: %w", err)
 	}
 
-	// Apply local only entries on top of the new local RSL
-	// localOnlyEntries is in reverse order
+	// Apply local only entries on top of the new local RSL. localOnlyEntries
+	// is in reverse order. Replayed entries receive new IDs, so annotations
+	// that referred to replayed entries are rewritten to the new IDs.
+	replayedIDs := map[string]githash.Hash{}
 	for i := len(localOnlyEntries) - 1; i >= 0; i-- {
-		slog.Debug(fmt.Sprintf("Reapplying entry '%s'...", localOnlyEntries[i].GetID().String()))
+		original := localOnlyEntries[i]
+		slog.DebugContext(ctx, fmt.Sprintf("Reapplying entry '%s'...", original.GetID().String()))
 
-		// We create a new object so as to apply anything the
-		// entry may contain that is inferred at commit time
-		// For example, an incrementing number inferred from the
-		// parent entry
+		// We create a new object so as to apply anything the entry may
+		// contain that is inferred at commit time, such as the number.
 		// WithCustomFields copies the fields into the new entry, so the
-		// original entry's map can be passed directly without cloning it first.
-		switch entry := localOnlyEntries[i].(type) {
+		// original entry's map can be passed directly without cloning it
+		// first.
+		var err error
+		switch entry := original.(type) {
 		case *rsl.ReferenceEntry:
-			if err := rsl.NewReferenceEntry(entry.RefName, entry.TargetID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
-				return fmt.Errorf("unable to reapply reference entry '%s': %w", entry.ID.String(), err)
-			}
+			err = rsl.NewReferenceEntry(entry.RefName, entry.TargetID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
+		case *rsl.BulkReferenceEntry:
+			err = rsl.NewBulkReferenceEntry(slices.Clone(entry.Updates)).Commit(r.r, sign)
+		case *rsl.PropagationEntry:
+			err = rsl.NewPropagationEntry(entry.RefName, entry.TargetID, entry.UpstreamRepository, entry.UpstreamEntryID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
 		case *rsl.AnnotationEntry:
-			if err := rsl.NewAnnotationEntry(entry.RSLEntryIDs, entry.Skip, entry.Message, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
-				return fmt.Errorf("unable to reapply annotation entry '%s': %w", entry.ID.String(), err)
-			}
+			newIDs, newRefs := rewriteAnnotationTargets(entry, replayedIDs)
+			err = rsl.NewAnnotationEntryWithQualifiers(newIDs, newRefs, entry.Skip, entry.Message, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign)
+		default:
+			err = fmt.Errorf("%w: cannot reapply entry type %T", rsl.ErrUnknownRSLEntryType, original)
+		}
+		if err != nil {
+			return fmt.Errorf("unable to reapply entry '%s': %w", original.GetID().String(), err)
 		}
 
-		if slog.Default().Enabled(ctx, slog.LevelDebug) {
-			currentTip, err := r.r.GetReference(rsl.Ref)
-			if err != nil {
-				return fmt.Errorf("unable to get current tip of the RSL: %w", err)
-			}
-			slog.Debug("New entry ID for '%s' is '%s'", localOnlyEntries[i].GetID().String(), currentTip.String())
+		currentTip, err := r.r.GetReference(rsl.Ref)
+		if err != nil {
+			return fmt.Errorf("unable to get current tip of the RSL: %w", err)
 		}
+		replayedIDs[original.GetID().String()] = currentTip
+		slog.DebugContext(ctx, fmt.Sprintf("New entry ID for '%s' is '%s'", original.GetID().String(), currentTip.String()))
 	}
 
 	slog.Debug("Updated local RSL!")
@@ -719,6 +893,29 @@ func getRSLEntriesUntil(repo gitstore.Storer, start, until githash.Hash) ([]rsl.
 	return entries, nil
 }
 
+// addUpdatedRefs records every ref that entry updates into refs. It handles
+// the same entry types as the replay switch in ReconcileLocalRSLWithRemote, so
+// an entry type this build does not know cannot silently contribute no refs
+// and slip past the conflict check.
+func addUpdatedRefs(refs *set.Set[string], entry rsl.Entry) error {
+	switch entry := entry.(type) {
+	case *rsl.ReferenceEntry:
+		refs.Add(entry.RefName)
+	case *rsl.PropagationEntry:
+		refs.Add(entry.RefName)
+	case *rsl.BulkReferenceEntry:
+		for _, update := range entry.Updates {
+			refs.Add(update.RefName)
+		}
+	case *rsl.AnnotationEntry:
+		// Annotations refer to prior entries and update no refs of their own.
+	default:
+		return fmt.Errorf("%w: cannot identify the refs updated by entry type %T", rsl.ErrUnknownRSLEntryType, entry)
+	}
+
+	return nil
+}
+
 func getLatestRefTipsFromRSLEntries(entries []rsl.Entry) map[string]githash.Hash {
 	refTips := map[string]githash.Hash{}
 	annotationsMap := map[string][]*rsl.AnnotationEntry{}
@@ -735,6 +932,21 @@ func getLatestRefTipsFromRSLEntries(entries []rsl.Entry) map[string]githash.Hash
 			}
 
 			refTips[entry.GetRefName()] = entry.GetTargetID()
+		case *rsl.BulkReferenceEntry:
+			// The annotations apply to the entry, so they are looked up once
+			// rather than per view.
+			annotations, hasAnnotations := annotationsMap[entry.GetID().String()]
+			for _, view := range entry.ReferenceEntries() {
+				if _, has := refTips[view.RefName]; has {
+					continue
+				}
+
+				if hasAnnotations && view.SkippedBy(annotations) {
+					continue
+				}
+
+				refTips[view.RefName] = view.TargetID
+			}
 		case *rsl.PropagationEntry:
 			if _, has := refTips[entry.GetRefName()]; has {
 				continue

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -2294,3 +2294,419 @@ func TestRecordRSLEntryForReferenceSigningKeyBytesIgnoredWhenUnsigned(t *testing
 	err = gitobject.Verify(testCtx, publicKey, payload, signature)
 	assert.Error(t, err, "entry must not be signed when signCommit=false")
 }
+
+func TestReconcileLocalRSLWithRemoteBulkAndAnnotation(t *testing.T) {
+	remoteName := "origin"
+	refName := "refs/heads/main"
+
+	tmpDir := t.TempDir()
+	remoteRepo := createTestRepositoryWithPolicy(t, tmpDir)
+	remoteR := remoteRepo.r
+
+	treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+	emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+
+	_, err = remoteR.Commit(emptyTreeHash, refName, "Test commit", false)
+	require.NoError(t, err)
+	require.NoError(t, remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()))
+
+	localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+	defer os.RemoveAll(localTmpDir) //nolint:errcheck
+	localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref, policy.PolicyRef}, true)
+	require.NoError(t, err)
+	require.NoError(t, localR.SetGitConfig("user.name", "Jane Doe"))
+	require.NoError(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
+	localRepo := &Repository{r: localR}
+
+	// The entry both RSLs share, recorded before they diverge. It is not
+	// replayed, so annotations that refer to it keep its ID.
+	sharedEntry, err := rsl.GetLatestEntry(localR)
+	require.NoError(t, err)
+	sharedEntryID := sharedEntry.GetID()
+
+	_, err = remoteR.Commit(emptyTreeHash, refName, "Test commit", false)
+	require.NoError(t, err)
+	require.NoError(t, remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()))
+
+	featureID, err := localR.Commit(emptyTreeHash, "refs/heads/feature", "Test commit", false)
+	require.NoError(t, err)
+	releaseID, err := localR.Commit(emptyTreeHash, "refs/heads/release", "Test commit", false)
+	require.NoError(t, err)
+	updates := []rsl.ReferenceUpdate{
+		{RefName: "refs/heads/feature", TargetID: featureID},
+		{RefName: "refs/heads/release", TargetID: releaseID},
+	}
+	require.NoError(t, rsl.NewBulkReferenceEntry(updates).Commit(localR, false))
+	originalBulk, err := rsl.GetLatestEntry(localR)
+	require.NoError(t, err)
+	originalBulkID := originalBulk.GetID()
+
+	downstreamID, err := localR.Commit(emptyTreeHash, "refs/heads/downstream", "Test commit", false)
+	require.NoError(t, err)
+	require.NoError(t, rsl.NewPropagationEntry("refs/heads/downstream", downstreamID, "https://example.com/upstream", sharedEntryID).Commit(localR, false))
+
+	// The annotation refers to the shared entry and to the bulk entry. Only
+	// the bulk entry is replayed, so only its ID is rewritten.
+	require.NoError(t, rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{sharedEntryID, originalBulkID}, map[string][]string{originalBulkID.String(): {"refs/heads/feature"}}, true, "rewritten feature").Commit(localR, false))
+
+	require.NoError(t, localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false))
+
+	tip, err := rsl.GetLatestEntry(localR)
+	require.NoError(t, err)
+	annotation, isAnnotation := tip.(*rsl.AnnotationEntry)
+	require.True(t, isAnnotation)
+
+	replayedPropagationT, err := rsl.GetParentForEntry(localR, tip)
+	require.NoError(t, err)
+	replayedPropagation, isPropagation := replayedPropagationT.(*rsl.PropagationEntry)
+	require.True(t, isPropagation)
+	assert.Equal(t, "refs/heads/downstream", replayedPropagation.RefName)
+	assert.Equal(t, downstreamID, replayedPropagation.TargetID)
+	assert.Equal(t, "https://example.com/upstream", replayedPropagation.UpstreamRepository)
+	assert.Equal(t, sharedEntryID, replayedPropagation.UpstreamEntryID)
+
+	replayedBulkT, err := rsl.GetParentForEntry(localR, replayedPropagation)
+	require.NoError(t, err)
+	replayedBulk, isBulk := replayedBulkT.(*rsl.BulkReferenceEntry)
+	require.True(t, isBulk)
+	assert.NotEqual(t, originalBulkID, replayedBulk.ID)
+	assert.Equal(t, updates, replayedBulk.Updates)
+
+	assert.Equal(t, []githash.Hash{sharedEntryID, replayedBulk.ID}, annotation.RSLEntryIDs)
+	assert.Equal(t, map[string][]string{replayedBulk.ID.String(): {"refs/heads/feature"}}, annotation.Refs)
+	assert.True(t, annotation.Skip)
+
+	remoteTip, err := remoteR.GetReference(rsl.Ref)
+	require.NoError(t, err)
+	parentOfBulk, err := rsl.GetParentForEntry(localR, replayedBulk)
+	require.NoError(t, err)
+	assert.Equal(t, remoteTip, parentOfBulk.GetID())
+}
+
+func TestGetLatestRefTipsFromRSLEntriesWithBulk(t *testing.T) {
+	t.Parallel()
+
+	bulkID, err := gitinterface.NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	require.NoError(t, err)
+	target, err := gitinterface.NewHash("1111111111111111111111111111111111111111")
+	require.NoError(t, err)
+
+	bulk := &rsl.BulkReferenceEntry{ID: bulkID, Updates: []rsl.ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: target},
+		{RefName: "refs/heads/feature", TargetID: target},
+	}}
+
+	t.Run("qualified skip", func(t *testing.T) {
+		t.Parallel()
+
+		annotation := rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{bulkID}, map[string][]string{bulkID.String(): {"refs/heads/feature"}}, true, "")
+
+		// entries are newest first, as getRSLEntriesUntil returns them
+		tips := getLatestRefTipsFromRSLEntries([]rsl.Entry{annotation, bulk})
+		assert.Equal(t, map[string]githash.Hash{"refs/heads/main": target}, tips)
+	})
+
+	t.Run("unqualified skip", func(t *testing.T) {
+		t.Parallel()
+
+		annotation := rsl.NewAnnotationEntry([]githash.Hash{bulkID}, true, "")
+
+		tips := getLatestRefTipsFromRSLEntries([]rsl.Entry{annotation, bulk})
+		assert.Equal(t, map[string]githash.Hash{}, tips)
+	})
+}
+
+func TestRecordRSLEntryForReferences(t *testing.T) {
+	setup := func(t *testing.T) (*Repository, githash.Hash, githash.Hash) {
+		t.Helper()
+		tempDir := t.TempDir()
+		r := gitinterface.CreateTestGitRepository(t, tempDir, false)
+		repo := &Repository{r: r}
+
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+		mainID, err := repo.r.Commit(emptyTreeHash, "refs/heads/main", "main\n", false)
+		require.NoError(t, err)
+		featureID, err := repo.r.Commit(emptyTreeHash, "refs/heads/feature", "feature\n", false)
+		require.NoError(t, err)
+		return repo, mainID, featureID
+	}
+
+	t.Run("more than one update produces one bulk entry", func(t *testing.T) {
+		repo, mainID, featureID := setup(t)
+
+		err := repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{
+			{RefName: "refs/heads/main"},
+			{RefName: "refs/heads/feature"},
+		}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		bulk, isBulk := latest.(*rsl.BulkReferenceEntry)
+		require.True(t, isBulk)
+		assert.Equal(t, []rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainID},
+			{RefName: "refs/heads/feature", TargetID: featureID},
+		}, bulk.Updates)
+	})
+
+	t.Run("overridden ref name is the one recorded", func(t *testing.T) {
+		repo, mainID, featureID := setup(t)
+
+		err := repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{
+			{RefName: "refs/heads/main"},
+			{RefName: "feature", RefNameOverride: "refs/heads/feature-remote"},
+		}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		bulk, isBulk := latest.(*rsl.BulkReferenceEntry)
+		require.True(t, isBulk)
+		assert.Equal(t, []rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainID},
+			{RefName: "refs/heads/feature-remote", TargetID: featureID},
+		}, bulk.Updates)
+	})
+
+	t.Run("single update is never bulk", func(t *testing.T) {
+		repo, mainID, _ := setup(t)
+
+		err := repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{{RefName: "refs/heads/main"}}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		entry, isRef := latest.(*rsl.ReferenceEntry)
+		require.True(t, isRef)
+		assert.Equal(t, mainID, entry.TargetID)
+		assert.False(t, entry.FromBulkEntry())
+	})
+
+	t.Run("repeated recorded ref is collapsed with the last tip", func(t *testing.T) {
+		repo, _, _ := setup(t)
+
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+		laterMainID, err := repo.r.Commit(emptyTreeHash, "refs/heads/main", "main again\n", false)
+		require.NoError(t, err)
+		featureID, err := repo.r.GetReference("refs/heads/feature")
+		require.NoError(t, err)
+
+		err = repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{
+			{RefName: "refs/heads/main"},
+			{RefName: "refs/heads/feature"},
+			{RefName: "main", RefNameOverride: "refs/heads/main"},
+		}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		bulk, isBulk := latest.(*rsl.BulkReferenceEntry)
+		require.True(t, isBulk)
+		assert.Equal(t, []rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: laterMainID},
+			{RefName: "refs/heads/feature", TargetID: featureID},
+		}, bulk.Updates)
+	})
+
+	t.Run("filtering runs after collapsing repeated refs", func(t *testing.T) {
+		repo, mainID, featureID := setup(t)
+
+		// The RSL records main at its first tip, which is also the tip the
+		// first request for main in the batch resolves to.
+		require.NoError(t, repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()))
+		require.NoError(t, repo.r.SetReference("refs/heads/earlier-main", mainID))
+
+		treeBuilder := gitinterface.NewTreeBuilder(repo.r)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+		laterMainID, err := repo.r.Commit(emptyTreeHash, "refs/heads/main", "main again\n", false)
+		require.NoError(t, err)
+
+		err = repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{
+			{RefName: "refs/heads/earlier-main", RefNameOverride: "refs/heads/main"},
+			{RefName: "refs/heads/feature"},
+			{RefName: "refs/heads/main"},
+		}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		bulk, isBulk := latest.(*rsl.BulkReferenceEntry)
+		require.True(t, isBulk)
+		assert.Equal(t, []rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: laterMainID},
+			{RefName: "refs/heads/feature", TargetID: featureID},
+		}, bulk.Updates)
+	})
+
+	t.Run("one remaining update after filtering is not a bulk entry", func(t *testing.T) {
+		repo, mainID, featureID := setup(t)
+
+		require.NoError(t, repo.RecordRSLEntryForReference(testCtx, "refs/heads/main", false, rslopts.WithRecordLocalOnly()))
+
+		err := repo.RecordRSLEntryForReferences(testCtx, []ReferenceUpdateRequest{
+			{RefName: "refs/heads/main"},
+			{RefName: "refs/heads/feature"},
+		}, false, rslopts.WithRecordLocalOnly())
+		require.NoError(t, err)
+
+		latest, err := rsl.GetLatestEntry(repo.r)
+		require.NoError(t, err)
+		entry, isRef := latest.(*rsl.ReferenceEntry)
+		require.True(t, isRef)
+		assert.Equal(t, "refs/heads/feature", entry.RefName)
+		assert.Equal(t, featureID, entry.TargetID)
+		assert.False(t, entry.FromBulkEntry())
+
+		parent, err := rsl.GetParentForEntry(repo.r, latest)
+		require.NoError(t, err)
+		previous, isRef := parent.(*rsl.ReferenceEntry)
+		require.True(t, isRef)
+		assert.Equal(t, "refs/heads/main", previous.RefName)
+		assert.Equal(t, mainID, previous.TargetID)
+	})
+}
+
+func TestReconcileLocalRSLWithRemoteDivergenceDetection(t *testing.T) {
+	t.Parallel()
+
+	remoteName := "origin"
+	refName := "refs/heads/main"
+
+	setup := func(t *testing.T) (*Repository, *Repository, githash.Hash) {
+		t.Helper()
+
+		tmpDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+		remoteRepo := &Repository{r: remoteR}
+
+		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		require.NoError(t, err)
+
+		_, err = remoteR.Commit(emptyTreeHash, refName, "Test commit", false)
+		require.NoError(t, err)
+		require.NoError(t, remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()))
+
+		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+		t.Cleanup(func() {
+			os.RemoveAll(localTmpDir) //nolint:errcheck
+		})
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
+		require.NoError(t, err)
+		require.NoError(t, localR.SetGitConfig("user.name", "Jane Doe"))
+		require.NoError(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
+
+		// The remote records another entry for refName after the clone, so the
+		// two RSLs diverge.
+		_, err = remoteR.Commit(emptyTreeHash, refName, "Test commit", false)
+		require.NoError(t, err)
+		require.NoError(t, remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()))
+
+		return remoteRepo, &Repository{r: localR}, emptyTreeHash
+	}
+
+	t.Run("local propagation entry for the ref the remote also updated", func(t *testing.T) {
+		t.Parallel()
+
+		remoteRepo, localRepo, emptyTreeHash := setup(t)
+
+		sharedEntry, err := rsl.GetLatestEntry(localRepo.r)
+		require.NoError(t, err)
+
+		mainID, err := localRepo.r.Commit(emptyTreeHash, refName, "Test commit", false)
+		require.NoError(t, err)
+		require.NoError(t, rsl.NewPropagationEntry(refName, mainID, "https://example.com/upstream", sharedEntry.GetID()).Commit(localRepo.r, false))
+
+		originalLocalTip, err := localRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		originalRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+
+		err = localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false)
+		assert.ErrorContains(t, err, "changes to the same ref")
+		assert.ErrorContains(t, err, refName)
+
+		currentLocalTip, err := localRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		currentRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		assert.Equal(t, originalLocalTip, currentLocalTip)
+		assert.Equal(t, originalRemoteTip, currentRemoteTip)
+	})
+
+	t.Run("local bulk entry whose second update is for the ref the remote also updated", func(t *testing.T) {
+		t.Parallel()
+
+		remoteRepo, localRepo, emptyTreeHash := setup(t)
+
+		featureID, err := localRepo.r.Commit(emptyTreeHash, "refs/heads/feature", "Test commit", false)
+		require.NoError(t, err)
+		mainID, err := localRepo.r.Commit(emptyTreeHash, refName, "Test commit", false)
+		require.NoError(t, err)
+		require.NoError(t, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/feature", TargetID: featureID},
+			{RefName: refName, TargetID: mainID},
+		}).Commit(localRepo.r, false))
+
+		originalLocalTip, err := localRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		originalRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+
+		err = localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false)
+		assert.ErrorContains(t, err, "changes to the same ref")
+		assert.ErrorContains(t, err, refName)
+
+		currentLocalTip, err := localRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		currentRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		assert.Equal(t, originalLocalTip, currentLocalTip)
+		assert.Equal(t, originalRemoteTip, currentRemoteTip)
+	})
+
+	t.Run("local bulk entry for refs the remote did not update", func(t *testing.T) {
+		t.Parallel()
+
+		remoteRepo, localRepo, emptyTreeHash := setup(t)
+
+		featureID, err := localRepo.r.Commit(emptyTreeHash, "refs/heads/feature", "Test commit", false)
+		require.NoError(t, err)
+		releaseID, err := localRepo.r.Commit(emptyTreeHash, "refs/heads/release", "Test commit", false)
+		require.NoError(t, err)
+		updates := []rsl.ReferenceUpdate{
+			{RefName: "refs/heads/feature", TargetID: featureID},
+			{RefName: "refs/heads/release", TargetID: releaseID},
+		}
+		require.NoError(t, rsl.NewBulkReferenceEntry(updates).Commit(localRepo.r, false))
+
+		originalBulk, err := rsl.GetLatestEntry(localRepo.r)
+		require.NoError(t, err)
+		originalRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+
+		require.NoError(t, localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false))
+
+		tip, err := rsl.GetLatestEntry(localRepo.r)
+		require.NoError(t, err)
+		replayedBulk, isBulk := tip.(*rsl.BulkReferenceEntry)
+		require.True(t, isBulk)
+		assert.NotEqual(t, originalBulk.GetID(), replayedBulk.ID)
+		assert.Equal(t, updates, replayedBulk.Updates)
+
+		parentOfBulk, err := rsl.GetParentForEntry(localRepo.r, replayedBulk)
+		require.NoError(t, err)
+		assert.Equal(t, originalRemoteTip, parentOfBulk.GetID())
+
+		currentRemoteTip, err := remoteRepo.r.GetReference(rsl.Ref)
+		require.NoError(t, err)
+		assert.Equal(t, originalRemoteTip, currentRemoteTip)
+	})
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -105,13 +105,18 @@ func PopulatePersistentCache(repo gitstore.Storer) error {
 	persistent.AddedAttestationsBeforeNumber = iterator.GetNumber()
 
 	for {
-		if iterator, isReferenceEntry := iterator.(*rsl.ReferenceEntry); isReferenceEntry {
-			switch iterator.RefName {
+		switch entry := iterator.(type) {
+		case *rsl.ReferenceEntry:
+			switch entry.RefName {
 			case policyRef:
-				persistent.InsertPolicyEntryNumber(iterator.GetNumber(), iterator.GetID())
+				persistent.InsertPolicyEntryNumber(entry.GetNumber(), entry.GetID())
 			case attestations.Ref:
-				persistent.InsertAttestationEntryNumber(iterator.GetNumber(), iterator.GetID())
+				persistent.InsertAttestationEntryNumber(entry.GetNumber(), entry.GetID())
 			}
+		case *rsl.BulkReferenceEntry:
+			// Bulk reference entries cannot record gittuf namespace refs, so
+			// they never carry policy or attestations updates. Nothing to
+			// index.
 		}
 
 		iterator, err = rsl.GetParentForEntry(repo, iterator)

--- a/internal/cmd/root/upgrade.go
+++ b/internal/cmd/root/upgrade.go
@@ -1,0 +1,27 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import (
+	"errors"
+
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/rsl"
+)
+
+var upgradeRequiredErrors = []error{
+	rsl.ErrUnknownRSLEntryType,
+	tuf.ErrUnknownRootMetadataVersion,
+	tuf.ErrUnknownTargetsMetadataVersion,
+}
+
+func IsUpgradeRequiredError(err error) bool {
+	for _, target := range upgradeRequiredErrors {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/cmd/root/upgrade_test.go
+++ b/internal/cmd/root/upgrade_test.go
@@ -1,0 +1,39 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package root
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/internal/tuf"
+	"github.com/gittuf/gittuf/pkg/rsl"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUpgradeRequiredError(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		err      error
+		expected bool
+	}{
+		"nil":                              {err: nil, expected: false},
+		"unrelated error":                  {err: errors.New("something else"), expected: false},
+		"unknown RSL entry type":           {err: rsl.ErrUnknownRSLEntryType, expected: true},
+		"unknown root metadata version":    {err: tuf.ErrUnknownRootMetadataVersion, expected: true},
+		"unknown targets metadata version": {err: tuf.ErrUnknownTargetsMetadataVersion, expected: true},
+		"wrapped":                          {err: fmt.Errorf("loading RSL: %w", rsl.ErrUnknownRSLEntryType), expected: true},
+		"invalid RSL entry is not enough":  {err: rsl.ErrInvalidRSLEntry, expected: false},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.expected, IsUpgradeRequiredError(test.err))
+		})
+	}
+}

--- a/internal/common/test_helpers.go
+++ b/internal/common/test_helpers.go
@@ -57,6 +57,23 @@ func CreateTestRSLReferenceEntryCommit(t *testing.T, repo gitstore.Storer, entry
 	return entryID
 }
 
+// CreateTestRSLBulkReferenceEntryCommit is a test helper used to create a
+// signed bulk reference entry using the specified key.
+func CreateTestRSLBulkReferenceEntryCommit(t *testing.T, repo gitstore.Storer, entry *rsl.BulkReferenceEntry, signingKeyBytes []byte) githash.Hash {
+	t.Helper()
+
+	if err := entry.CommitUsingSpecificKey(repo, signingKeyBytes); err != nil {
+		t.Fatal(err)
+	}
+
+	entryID, err := repo.GetReference(rsl.Ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return entryID
+}
+
 // CreateTestRSLAnnotationEntryCommit is a test helper used to create a
 // **signed** RSL annotation using the specified GPG key. It is used to
 // substitute for the default RSL annotation creation and signing mechanism

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -75,6 +75,21 @@ func RSLLog(repo gitstore.Storer, writer io.WriteCloser, opts ...Option) error {
 				// unexpectedly closed, such as by killing the pager
 				return nil
 			}
+		case *rsl.BulkReferenceEntry:
+			// The whole entry renders when any update matches the filter,
+			// because the entry is one signed act.
+			if options.refs.Len() != 0 && !bulkTouchesAnyRef(iteratorEntry, options.refs) {
+				slog.Debug(fmt.Sprintf("Skipping bulk reference entry '%s' since none of its refs were requested...", iteratorEntry.ID.String()))
+				break
+			}
+
+			slog.Debug(fmt.Sprintf("Writing bulk reference entry '%s'...", iteratorEntry.ID.String()))
+			if err := writeRSLBulkReferenceEntry(writer, iteratorEntry, annotationsMap[iteratorEntry.ID.String()], hasParent); err != nil {
+				// We return nil here to avoid noisy output when the writer is
+				// unexpectedly closed, such as by killing the pager
+				return nil
+			}
+
 		case *rsl.AnnotationEntry:
 			slog.Debug(fmt.Sprintf("Tracking annotation entry '%s'...", iteratorEntry.ID.String()))
 			for _, targetID := range iteratorEntry.RSLEntryIDs {
@@ -163,6 +178,88 @@ func writeRSLReferenceEntry(writer io.WriteCloser, entry *rsl.ReferenceEntry, an
 	}
 	text = appendCustomFields(text, entry.CustomFields, "  ")
 
+	text += formatAnnotations(annotations, entry.ID.String())
+
+	text += "\n" // single trailing newline by default
+	if hasParent {
+		text += "\n" // extra newline for all intermediate (i.e., not last) entries
+	}
+
+	_, err := writer.Write([]byte(text))
+	return err
+}
+
+// bulkTouchesAnyRef reports whether any of the entry's updates is for one of
+// the requested refs.
+func bulkTouchesAnyRef(entry *rsl.BulkReferenceEntry, refs *set.Set[string]) bool {
+	for _, update := range entry.Updates {
+		if refs.Has(update.RefName) {
+			return true
+		}
+	}
+	return false
+}
+
+// writeRSLBulkReferenceEntry renders a bulk entry as one block listing every
+// update, followed by its annotations. A qualified annotation lists the refs
+// it applies to.
+func writeRSLBulkReferenceEntry(writer io.WriteCloser, entry *rsl.BulkReferenceEntry, annotations []*rsl.AnnotationEntry, hasParent bool) error {
+	/* Output format:
+	   bulk entry <entryID> (skipped)
+
+	     Ref:    <refName>
+	     Target: <targetID>
+
+	     Ref:    <refName>
+	     Target: <targetID>
+
+	     Number: <number>
+
+	       Annotation ID: <annotationID>
+	       Skip:          <yes/no>
+	       Refs:          <ref>, <ref>
+	       Number:        <number>
+	       Message:
+	         <message>
+	*/
+
+	text := colorer(fmt.Sprintf("bulk entry %s", entry.ID.String()), yellow)
+
+	for _, annotation := range annotations {
+		if annotation.Skip && len(annotation.Refs[entry.ID.String()]) == 0 {
+			text += fmt.Sprintf(" %s", colorer("(skipped)", red))
+			break
+		}
+	}
+	text += "\n"
+
+	for i, update := range entry.Updates {
+		if i != 0 {
+			text += "\n"
+		}
+		text += fmt.Sprintf("\n  Ref:    %s", update.RefName)
+		text += fmt.Sprintf("\n  Target: %s", update.TargetID.String())
+	}
+	if entry.Number != 0 {
+		text += "\n"
+		text += fmt.Sprintf("\n  Number: %d", entry.Number)
+	}
+
+	text += formatAnnotations(annotations, entry.ID.String())
+
+	text += "\n"
+	if hasParent {
+		text += "\n"
+	}
+
+	_, err := writer.Write([]byte(text))
+	return err
+}
+
+// formatAnnotations renders the annotation blocks shared by reference and
+// bulk entries. entryID selects which qualifiers to show.
+func formatAnnotations(annotations []*rsl.AnnotationEntry, entryID string) string {
+	text := ""
 	for _, annotation := range annotations {
 		text += "\n\n"
 		text += colorer(fmt.Sprintf("    Annotation ID: %s", annotation.ID.String()), green)
@@ -172,20 +269,16 @@ func writeRSLReferenceEntry(writer io.WriteCloser, entry *rsl.ReferenceEntry, an
 		} else {
 			text += "    Skip:          no"
 		}
+		if refs := annotation.Refs[entryID]; len(refs) != 0 {
+			text += fmt.Sprintf("\n    Refs:          %s", strings.Join(refs, ", "))
+		}
 		if annotation.Number != 0 {
 			text += fmt.Sprintf("\n    Number:        %d", annotation.Number)
 		}
 		text = appendCustomFields(text, annotation.CustomFields, "    ")
 		text += fmt.Sprintf("\n    Message:\n      %s", strings.TrimSpace(annotation.Message))
 	}
-
-	text += "\n" // single trailing newline by default
-	if hasParent {
-		text += "\n" // extra newline for all intermediate (i.e., not last) entries
-	}
-
-	_, err := writer.Write([]byte(text))
-	return err
+	return text
 }
 
 func writeRSLPropagationEntry(writer io.WriteCloser, entry *rsl.PropagationEntry, hasParent bool) error {

--- a/internal/display/rsl.go
+++ b/internal/display/rsl.go
@@ -214,6 +214,8 @@ func writeRSLBulkReferenceEntry(writer io.WriteCloser, entry *rsl.BulkReferenceE
 	     Target: <targetID>
 
 	     Number: <number>
+	     Custom Fields:
+	       <key>: <value>
 
 	       Annotation ID: <annotationID>
 	       Skip:          <yes/no>
@@ -244,6 +246,7 @@ func writeRSLBulkReferenceEntry(writer io.WriteCloser, entry *rsl.BulkReferenceE
 		text += "\n"
 		text += fmt.Sprintf("\n  Number: %d", entry.Number)
 	}
+	text = appendCustomFields(text, entry.CustomFields, "  ")
 
 	text += formatAnnotations(annotations, entry.ID.String())
 

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -865,6 +865,38 @@ func TestWriteRSLBulkReferenceEntry(t *testing.T) {
 		assert.Equal(t, expectedOutput, output.String())
 	})
 
+	t.Run("custom fields", func(t *testing.T) {
+		entry := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}, rsl.WithCustomFields(rsl.CustomFields{
+			"custom.gitforge.com/server-version": "v4.2.0-c0ffee",
+			"custom.gitforge.com/pusher":         "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)",
+		}))
+		entry.ID = gitinterface.ZeroHash
+		entry.Number = 2
+
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+  Number: 2
+  Custom Fields:
+    custom.gitforge.com/pusher: jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)
+    custom.gitforge.com/server-version: v4.2.0-c0ffee
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, entry, nil, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
 	t.Run("qualified skip annotation, has parent", func(t *testing.T) {
 		annotation := rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{gitinterface.ZeroHash}, map[string][]string{gitinterface.ZeroHash.String(): {"refs/heads/feature"}}, true, "rewritten")
 		annotation.ID = gitinterface.ZeroHash

--- a/internal/display/rsl_test.go
+++ b/internal/display/rsl_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gittuf/gittuf/pkg/gitinterface"
 	"github.com/gittuf/gittuf/pkg/rsl"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRSLLog(t *testing.T) {
@@ -742,4 +743,279 @@ func TestWriteRSLPropagationEntryWithCustomFields(t *testing.T) {
 	err := writeRSLPropagationEntry(testWriter, entry, false)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedOutput, output.String())
+}
+
+func TestWriteRSLBulkReferenceEntry(t *testing.T) {
+	// Set colorer to off for tests
+	colorer = colorerOff
+
+	newEntry := func() *rsl.BulkReferenceEntry {
+		entry := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		})
+		entry.ID = gitinterface.ZeroHash
+		return entry
+	}
+
+	t.Run("no parent", func(t *testing.T) {
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, newEntry(), nil, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("has parent", func(t *testing.T) {
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, newEntry(), nil, true)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("with number, no parent", func(t *testing.T) {
+		entry := newEntry()
+		entry.Number = 3
+
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+  Number: 3
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, entry, nil, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("unqualified skip annotation, no parent", func(t *testing.T) {
+		annotation := rsl.NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, true, "rewritten")
+		annotation.ID = gitinterface.ZeroHash
+
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000 (skipped)
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+    Annotation ID: 0000000000000000000000000000000000000000
+    Skip:          yes
+    Message:
+      rewritten
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, newEntry(), []*rsl.AnnotationEntry{annotation}, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("annotation with message but no skip, no parent", func(t *testing.T) {
+		annotation := rsl.NewAnnotationEntry([]githash.Hash{gitinterface.ZeroHash}, false, "just a note")
+		annotation.ID = gitinterface.ZeroHash
+
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+    Annotation ID: 0000000000000000000000000000000000000000
+    Skip:          no
+    Message:
+      just a note
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, newEntry(), []*rsl.AnnotationEntry{annotation}, false)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("qualified skip annotation, has parent", func(t *testing.T) {
+		annotation := rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{gitinterface.ZeroHash}, map[string][]string{gitinterface.ZeroHash.String(): {"refs/heads/feature"}}, true, "rewritten")
+		annotation.ID = gitinterface.ZeroHash
+
+		expectedOutput := `bulk entry 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+    Annotation ID: 0000000000000000000000000000000000000000
+    Skip:          yes
+    Refs:          refs/heads/feature
+    Message:
+      rewritten
+
+`
+
+		output := &bytes.Buffer{}
+		testWriter := &noopwritecloser{writer: output}
+		err := writeRSLBulkReferenceEntry(testWriter, newEntry(), []*rsl.AnnotationEntry{annotation}, true)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, output.String())
+	})
+}
+
+func TestRSLLogBulkEntry(t *testing.T) {
+	// Set colorer to off for tests
+	colorer = colorerOff
+
+	t.Run("unqualified skip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		require.NoError(t, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}).Commit(repo, false))
+		bulk, err := rsl.GetLatestEntry(repo)
+		require.NoError(t, err)
+
+		require.NoError(t, rsl.NewAnnotationEntry([]githash.Hash{bulk.GetID()}, true, "rewritten").Commit(repo, false))
+		annotation, err := rsl.GetLatestEntry(repo)
+		require.NoError(t, err)
+
+		expectedOutput := fmt.Sprintf(`bulk entry %s (skipped)
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+  Number: 1
+
+    Annotation ID: %s
+    Skip:          yes
+    Number:        2
+    Message:
+      rewritten
+`, bulk.GetID().String(), annotation.GetID().String())
+
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		assert.Nil(t, RSLLog(repo, writer))
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("qualified skip", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		require.NoError(t, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}).Commit(repo, false))
+		bulk, err := rsl.GetLatestEntry(repo)
+		require.NoError(t, err)
+
+		require.NoError(t, rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID()}, map[string][]string{bulk.GetID().String(): {"refs/heads/feature"}}, true, "rewritten").Commit(repo, false))
+		annotation, err := rsl.GetLatestEntry(repo)
+		require.NoError(t, err)
+
+		expectedOutput := fmt.Sprintf(`bulk entry %s
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+  Number: 1
+
+    Annotation ID: %s
+    Skip:          yes
+    Refs:          refs/heads/feature
+    Number:        2
+    Message:
+      rewritten
+`, bulk.GetID().String(), annotation.GetID().String())
+
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		assert.Nil(t, RSLLog(repo, writer))
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("with filtering refs", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		require.NoError(t, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}).Commit(repo, false))
+		bulk, err := rsl.GetLatestEntry(repo)
+		require.NoError(t, err)
+
+		// refs/heads/other is not in the entry, refs/heads/main is, so the
+		// whole entry renders.
+		expectedOutput := fmt.Sprintf(`bulk entry %s
+
+  Ref:    refs/heads/main
+  Target: 0000000000000000000000000000000000000000
+
+  Ref:    refs/heads/feature
+  Target: 0000000000000000000000000000000000000000
+
+  Number: 1
+`, bulk.GetID().String())
+
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		assert.Nil(t, RSLLog(repo, writer, WithReferences([]string{"refs/heads/main", "refs/heads/other"})))
+		assert.Equal(t, expectedOutput, output.String())
+	})
+
+	t.Run("with filtering refs, no update matches", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		repo := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+
+		require.NoError(t, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}).Commit(repo, false))
+
+		output := &bytes.Buffer{}
+		writer := &noopwritecloser{writer: output}
+		assert.Nil(t, RSLLog(repo, writer, WithReferences([]string{"refs/heads/other"})))
+		assert.Equal(t, "", output.String())
+	})
 }

--- a/internal/git-remote-gittuf/curl.go
+++ b/internal/git-remote-gittuf/curl.go
@@ -421,6 +421,7 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 			// to pass the response from the server for those refs
 			// back to Git
 			dstRefs := set.NewSet[string]()
+			rslUpdates := []gittuf.ReferenceUpdateRequest{}
 			for _, pushCommand := range pushCommands {
 				// TODO: maybe find another way to determine
 				// whether repo is gittuf enabled
@@ -451,14 +452,21 @@ func handleCurl(ctx context.Context, repo *gittuf.Repository, remoteName, url st
 						// pushed by the user
 
 						// TODO: skipping propagation; invoke it once total instead of per ref
-						if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
-							return nil, false, err
-						}
+						rslUpdates = append(rslUpdates, gittuf.ReferenceUpdateRequest{RefName: srcRef, RefNameOverride: dstRef})
 					}
 				}
 
 				// Write push command to helper
 				if _, err := helperStdIn.Write(pushCommand); err != nil {
+					return nil, false, err
+				}
+			}
+
+			// The RSL entries must exist before the RSL tip is read and
+			// pushed below. Recording all of the updates in one call keeps
+			// the local RSL either fully updated or untouched.
+			if len(rslUpdates) != 0 {
+				if err := repo.RecordRSLEntryForReferences(ctx, rslUpdates, true, rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
 					return nil, false, err
 				}
 			}

--- a/internal/git-remote-gittuf/ssh.go
+++ b/internal/git-remote-gittuf/ssh.go
@@ -538,6 +538,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 			objectFormat := repo.GetGitRepository().GetObjectFormat()
 			pushObjects := set.NewSet[string]()
 			dstRefs := set.NewSet[string]()
+			rslUpdates := []gittuf.ReferenceUpdateRequest{}
 			for i, refSpec := range pushRefSpecs {
 				refSpecSplit := strings.Split(refSpec, ":")
 				if len(refSpecSplit) < 2 {
@@ -560,9 +561,7 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 
 				if !strings.HasPrefix(dstRef, gittufRefPrefix) {
 					// TODO: skipping propagation; invoke it once total instead of per ref
-					if err := repo.RecordRSLEntryForReference(ctx, srcRef, true, rslopts.WithOverrideRefName(dstRef), rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
-						return nil, false, err
-					}
+					rslUpdates = append(rslUpdates, gittuf.ReferenceUpdateRequest{RefName: srcRef, RefNameOverride: dstRef})
 				}
 
 				oldTip := remoteRefTips[dstRef]
@@ -599,6 +598,15 @@ func handleSSH(ctx context.Context, repo *gittuf.Repository, remoteName, url str
 				}
 				if oldTip != zeroHash {
 					pushObjects.Add(fmt.Sprintf("^%s", oldTip)) // this is passed on to git rev-list to enumerate objects, and we're saying don't send the old objects
+				}
+			}
+
+			// The RSL entries must exist before the RSL tip is read and
+			// pushed below. Recording all of the updates in one call keeps
+			// the local RSL either fully updated or untouched.
+			if len(rslUpdates) != 0 {
+				if err := repo.RecordRSLEntryForReferences(ctx, rslUpdates, true, rslopts.WithSkipCheckForDuplicateEntry(), rslopts.WithRecordLocalOnly()); err != nil {
+					return nil, false, err
 				}
 			}
 

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -721,13 +721,13 @@ func (s *State) Verify(ctx context.Context) error {
 				upstreamEntryID = propagationEntry.(*rsl.PropagationEntry).UpstreamEntryID
 			}
 
-			upstreamEntry, err := rsl.GetEntry(controllerRepository, upstreamEntryID)
+			upstreamUpdater, err := rsl.GetReferenceUpdaterEntryForRef(controllerRepository, upstreamEntryID, PolicyRef)
 			if err != nil {
-				return err
+				return fmt.Errorf("%w: upstream entry %s is not a policy reference update: %w", ErrControllerMetadataNotVerified, upstreamEntryID.String(), err)
 			}
 
 			// LoadState does full verification up until the requested entry
-			if _, err := LoadState(ctx, controllerRepository, upstreamEntry.(rsl.ReferenceUpdaterEntry), policyopts.WithInitialRootPrincipals(controllerRepositoryDetail.GetInitialRootPrincipals())); err != nil {
+			if _, err := LoadState(ctx, controllerRepository, upstreamUpdater, policyopts.WithInitialRootPrincipals(controllerRepositoryDetail.GetInitialRootPrincipals())); err != nil {
 				return fmt.Errorf("%w, unable to verify root of trust for controller '%s': %w", ErrControllerMetadataNotVerified, controllerName, err)
 			}
 

--- a/internal/policy/searcher.go
+++ b/internal/policy/searcher.go
@@ -167,7 +167,7 @@ func (c *cacheSearcher) FindFirstPolicyEntry() (rsl.ReferenceUpdaterEntry, error
 		return nil, ErrPolicyNotFound
 	}
 
-	entry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntries[0].GetEntryID())
+	entry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntries[0].GetEntryID(), PolicyRef)
 	if err != nil {
 		return c.searcher.FindFirstPolicyEntry()
 	}
@@ -184,7 +184,7 @@ func (c *cacheSearcher) FindLatestPolicyEntry() (rsl.ReferenceUpdaterEntry, erro
 		return nil, ErrPolicyNotFound
 	}
 
-	entry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntries[len(policyEntries)-1].GetEntryID())
+	entry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntries[len(policyEntries)-1].GetEntryID(), PolicyRef)
 	if err != nil {
 		return c.searcher.FindLatestPolicyEntry()
 	}
@@ -217,7 +217,7 @@ func (c *cacheSearcher) FindPolicyEntryFor(entry rsl.Entry) (rsl.ReferenceUpdate
 		return nil, ErrPolicyNotFound
 	}
 
-	policyEntry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntryIndex.GetEntryID())
+	policyEntry, err := loadRSLReferenceUpdaterEntry(c.repo, policyEntryIndex.GetEntryID(), PolicyRef)
 	if err != nil {
 		return c.searcher.FindPolicyEntryFor(entry)
 	}
@@ -252,7 +252,7 @@ func (c *cacheSearcher) FindPolicyEntriesInRange(firstEntry, lastEntry rsl.Entry
 
 	entries := []rsl.ReferenceUpdaterEntry{}
 	for _, index := range policyIndices {
-		entry, err := loadRSLReferenceUpdaterEntry(c.repo, index.GetEntryID())
+		entry, err := loadRSLReferenceUpdaterEntry(c.repo, index.GetEntryID(), PolicyRef)
 		if err != nil {
 			return c.searcher.FindPolicyEntriesInRange(firstEntry, lastEntry)
 		}
@@ -288,7 +288,7 @@ func (c *cacheSearcher) FindAttestationsEntryFor(entry rsl.Entry) (rsl.Reference
 		return nil, attestations.ErrAttestationsNotFound
 	}
 
-	attestationsEntry, err := loadRSLReferenceUpdaterEntry(c.repo, attestationsEntryIndex.GetEntryID())
+	attestationsEntry, err := loadRSLReferenceUpdaterEntry(c.repo, attestationsEntryIndex.GetEntryID(), attestations.Ref)
 	if err != nil {
 		return c.searcher.FindAttestationsEntryFor(entry)
 	}
@@ -305,7 +305,7 @@ func (c *cacheSearcher) FindLatestAttestationsEntry() (rsl.ReferenceUpdaterEntry
 		return nil, attestations.ErrAttestationsNotFound
 	}
 
-	entry, err := loadRSLReferenceUpdaterEntry(c.repo, attestationsEntries[len(attestationsEntries)-1].GetEntryID())
+	entry, err := loadRSLReferenceUpdaterEntry(c.repo, attestationsEntries[len(attestationsEntries)-1].GetEntryID(), attestations.Ref)
 	if err != nil {
 		return c.searcher.FindLatestAttestationsEntry()
 	}
@@ -320,15 +320,23 @@ func newCacheSearcher(repo gitstore.Storer, persistentCache *cache.Persistent) *
 	}
 }
 
-func loadRSLReferenceUpdaterEntry(repo gitstore.Storer, entryID githash.Hash) (rsl.ReferenceUpdaterEntry, error) {
-	entryT, err := rsl.GetEntry(repo, entryID)
+// loadRSLReferenceUpdaterEntry loads the reference entry for refName at
+// entryID. The ref is required because entryID may be a bulk reference entry
+// carrying several updates.
+func loadRSLReferenceUpdaterEntry(repo gitstore.Storer, entryID githash.Hash, refName string) (rsl.ReferenceUpdaterEntry, error) {
+	entryT, err := rsl.GetReferenceUpdaterEntryForRef(repo, entryID, refName)
 	if err != nil {
 		return nil, err
 	}
 
+	// Every caller asks for the policy or the attestations ref. Bulk
+	// reference entries cannot record refs in the gittuf namespace, so a
+	// match here is always a plain reference entry. The assertion also
+	// excludes propagation entries, which do record gittuf refs, so a
+	// propagated policy update is reported as an error rather than returned.
 	entry, isReferenceEntry := entryT.(*rsl.ReferenceEntry)
 	if !isReferenceEntry {
-		return nil, fmt.Errorf("not reference entry")
+		return nil, fmt.Errorf("%w: entry %s for ref %s is not a reference entry", rsl.ErrInvalidRSLEntry, entryID.String(), refName)
 	}
 
 	return entry, nil

--- a/internal/policy/verify.go
+++ b/internal/policy/verify.go
@@ -41,6 +41,7 @@ var (
 	ErrNetworkRepositoryDoesNotDeclareRequiredController = errors.New("network repository does not declare required controller repository")
 	ErrNetworkRepositoryHasStaleControllerMetadata       = errors.New("network repository has not fetched latest controller metadata")
 	ErrMetadataRollbackDetected                          = errors.New("gittuf policy metadata rollback detected")
+	ErrUnexpectedEntryInVerificationSet                  = errors.New("unexpected entry type in verification set")
 )
 
 // PolicyVerifier implements various gittuf verification workflows.
@@ -99,7 +100,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (gith
 		slog.Debug("Cache is enabled, checking for last verified entry...")
 		entryNumber, entryID := v.persistentCache.GetLastVerifiedEntryForRef(target)
 		if entryNumber != 0 {
-			firstEntry, err = loadRSLReferenceUpdaterEntry(v.repo, entryID)
+			firstEntry, err = loadRSLReferenceUpdaterEntry(v.repo, entryID, target)
 			if err != nil {
 				return gitinterface.ZeroHash, err
 			}
@@ -133,7 +134,7 @@ func (v *PolicyVerifier) VerifyRefFull(ctx context.Context, target string) (gith
 func (v *PolicyVerifier) VerifyRefFromEntry(ctx context.Context, target string, entryID githash.Hash) (githash.Hash, error) {
 	// Load starting point entry
 	slog.Debug("Identifying starting RSL entry...")
-	fromEntryT, err := rsl.GetEntry(v.repo, entryID)
+	fromEntryT, err := rsl.GetReferenceUpdaterEntryForRef(v.repo, entryID, target)
 	if err != nil {
 		return gitinterface.ZeroHash, err
 	}
@@ -586,6 +587,9 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 					return ErrPolicyNotFound
 				}
 				if err := verifyEntry(ctx, v.repo, currentPolicy, currentAttestations, entry); err != nil {
+					// The ref name matters when the entry is a view of a bulk
+					// entry, where several refs share one entry ID.
+					err = fmt.Errorf("%w: update to %s in entry %s", err, entry.GetRefName(), entry.GetID().String())
 					slog.Debug(fmt.Sprintf("Violation found: %s", err.Error()))
 					slog.Debug("Checking if entry has been revoked...")
 					// If the invalid entry is never marked as skipped, we return err
@@ -609,6 +613,9 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 				}
 
 				continue
+
+			default:
+				return fmt.Errorf("%w: %T", ErrUnexpectedEntryInVerificationSet, entry)
 			}
 		}
 
@@ -710,6 +717,9 @@ func (v *PolicyVerifier) VerifyRelativeForRef(ctx context.Context, firstEntry, l
 				if !newEntry.SkippedBy(annotations[newEntry.ID.String()]) {
 					invalidIntermediateEntries = append(invalidIntermediateEntries, newEntry)
 				}
+
+			default:
+				return fmt.Errorf("%w: %T", ErrUnexpectedEntryInVerificationSet, newEntry)
 			}
 		}
 
@@ -1308,7 +1318,12 @@ func verifyGitObjectAndAttestations(ctx context.Context, policy *State, target s
 				// its predecessor entry.
 				// Why? Because the rule type only accepts git:<> as patterns.
 				// If we have another object here, we've gone wrong somewhere.
-				currentEntry, err := rsl.GetEntry(policy.repository, gitID)
+				// target is a rule pattern, so it carries the git scheme
+				// prefix. The rule type only matches git patterns, so the
+				// remainder is the ref name being verified.
+				targetRef := strings.TrimPrefix(target, gitReferenceRuleScheme+":")
+
+				currentEntry, err := rsl.GetReferenceUpdaterEntryForRef(policy.repository, gitID, targetRef)
 				if err != nil {
 					slog.Debug(fmt.Sprintf("unable to load RSL entry for '%s': %v", gitID.String(), err))
 					return "", false, err

--- a/internal/policy/verify_test.go
+++ b/internal/policy/verify_test.go
@@ -4182,3 +4182,273 @@ func getPropagationDirectivesForNetworkRepository(t *testing.T, rootMetadata tuf
 
 	return directives
 }
+
+func TestVerifyRelativeForRefWithBulkEntries(t *testing.T) {
+	t.Run("all updates authorized", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+		mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		featureCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+			{RefName: "refs/heads/feature", TargetID: featureCommits[0]},
+		})
+		bulkID := common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+		mainView, err := rsl.GetReferenceUpdaterEntryForRef(repo, bulkID, "refs/heads/main")
+		require.NoError(t, err)
+
+		verifier := NewPolicyVerifier(repo)
+		assert.NoError(t, verifier.VerifyRelativeForRef(testCtx, mainView, mainView, "refs/heads/main"))
+
+		// refs/heads/feature is not protected by the test policy, so this
+		// assertion pins only that the bulk view for it loads and walks
+		// without error.
+		_, err = verifier.VerifyRef(testCtx, "refs/heads/feature")
+		assert.NoError(t, err)
+	})
+
+	t.Run("one update unauthorized, qualified skip and fix recovers", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+		goodMain := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		first := rsl.NewReferenceEntry("refs/heads/main", goodMain[0])
+		first.ID = common.CreateTestRSLReferenceEntryCommit(t, repo, first, gpgKeyBytes)
+
+		badMain := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgUnauthorizedKeyBytes)
+		feature := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: badMain[0]},
+			{RefName: "refs/heads/feature", TargetID: feature[0]},
+		})
+		bulkID := common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgUnauthorizedKeyBytes)
+
+		verifier := NewPolicyVerifier(repo)
+		_, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.ErrorIs(t, err, ErrVerificationFailed)
+		assert.ErrorContains(t, err, "refs/heads/main")
+
+		annotation := rsl.NewAnnotationEntryWithQualifiers([]githash.Hash{bulkID}, map[string][]string{bulkID.String(): {"refs/heads/main"}}, true, "bad main")
+		common.CreateTestRSLAnnotationEntryCommit(t, repo, annotation, gpgKeyBytes)
+
+		require.NoError(t, repo.SetReference("refs/heads/main", goodMain[0]))
+		fix := rsl.NewReferenceEntry("refs/heads/main", goodMain[0])
+		fix.ID = common.CreateTestRSLReferenceEntryCommit(t, repo, fix, gpgKeyBytes)
+
+		_, err = verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.NoError(t, err)
+
+		// The feature update was never skipped and is unaffected by the
+		// recovery on main. There is no rule protecting feature, so this
+		// assertion pins only that the bulk view for it loads and walks
+		// without error.
+		_, err = verifier.VerifyRefFull(testCtx, "refs/heads/feature")
+		assert.NoError(t, err)
+	})
+
+	t.Run("VerifyRefFromEntry accepts a bulk entry ID", func(t *testing.T) {
+		repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+		mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		featureCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/feature", TargetID: featureCommits[0]},
+			{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+		})
+		bulkID := common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+		verifier := NewPolicyVerifier(repo)
+		_, err := verifier.VerifyRefFromEntry(testCtx, "refs/heads/main", bulkID)
+		assert.NoError(t, err)
+
+		_, err = verifier.VerifyRefFromEntry(testCtx, "refs/heads/nonexistent", bulkID)
+		assert.ErrorIs(t, err, rsl.ErrRSLEntryDoesNotMatchRef)
+	})
+}
+
+func TestVerifyRefFullWithPersistentCacheOverBulkEntries(t *testing.T) {
+	repo, _ := createTestRepository(t, createTestStateWithPolicy)
+
+	// The bulk entry's first update is for feature and its second is for
+	// main, so the cached last-verified entry for main is a bulk entry whose
+	// first update is for another ref.
+	featureCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+	mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+	bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+		{RefName: "refs/heads/feature", TargetID: featureCommits[0]},
+		{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+	})
+	bulkID := common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+	require.NoError(t, cache.PopulatePersistentCache(repo))
+
+	verifier := NewPolicyVerifier(repo)
+	currentTip, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, mainCommits[0], currentTip)
+
+	bulkEntry, err := rsl.GetEntry(repo, bulkID)
+	require.NoError(t, err)
+
+	persistentCache, err := cache.LoadPersistentCache(repo)
+	require.NoError(t, err)
+	entryNumber, entryID := persistentCache.GetLastVerifiedEntryForRef("refs/heads/main")
+	assert.GreaterOrEqual(t, entryNumber, bulkEntry.GetNumber())
+	// The bulk entry is the latest entry for main at this point, so the
+	// cached ID is the bulk entry itself and the resumed walk must resolve it
+	// to the main view.
+	assert.Equal(t, bulkID, entryID)
+
+	// Verification resumes from the cached bulk entry for a later main entry.
+	laterMainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+	later := rsl.NewReferenceEntry("refs/heads/main", laterMainCommits[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo, later, gpgKeyBytes)
+
+	verifier = NewPolicyVerifier(repo)
+	currentTip, err = verifier.VerifyRefFull(testCtx, "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, laterMainCommits[0], currentTip)
+
+	persistentCache, err = cache.LoadPersistentCache(repo)
+	require.NoError(t, err)
+	entryNumber, _ = persistentCache.GetLastVerifiedEntryForRef("refs/heads/main")
+	assert.GreaterOrEqual(t, entryNumber, bulkEntry.GetNumber())
+}
+
+func TestVerifyRefFullWithTagInBulkEntry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("signer authorized for both the branch and the tag", func(t *testing.T) {
+		t.Parallel()
+
+		repo, _ := createTestRepository(t, createTestStateWithTagPolicy)
+
+		mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		tagID := common.CreateTestSignedTag(t, repo, "v1", mainCommits[0], gpgKeyBytes)
+
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+			{RefName: gitinterface.TagReferenceName("v1"), TargetID: tagID},
+		})
+		common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+		verifier := NewPolicyVerifier(repo)
+		currentTip, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.NoError(t, err)
+		assert.Equal(t, mainCommits[0], currentTip)
+
+		verifier = NewPolicyVerifier(repo)
+		currentTip, err = verifier.VerifyRefFull(testCtx, gitinterface.TagReferenceName("v1"))
+		assert.NoError(t, err)
+		assert.Equal(t, tagID, currentTip)
+	})
+
+	t.Run("signer authorized for the branch but not the tag", func(t *testing.T) {
+		t.Parallel()
+
+		repo, _ := createTestRepository(t, createTestStateWithTagPolicyForUnauthorizedTest)
+
+		mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		tagID := common.CreateTestSignedTag(t, repo, "v1", mainCommits[0], gpgKeyBytes)
+
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+			{RefName: gitinterface.TagReferenceName("v1"), TargetID: tagID},
+		})
+		common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+		verifier := NewPolicyVerifier(repo)
+		_, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.NoError(t, err)
+
+		verifier = NewPolicyVerifier(repo)
+		_, err = verifier.VerifyRefFull(testCtx, gitinterface.TagReferenceName("v1"))
+		assert.ErrorIs(t, err, ErrVerificationFailed)
+		assert.ErrorContains(t, err, gitinterface.TagReferenceName("v1"))
+	})
+}
+
+func TestVerifyRefFullWithBulkEntryAndBlockForcePushesGlobalRule(t *testing.T) {
+	t.Parallel()
+
+	repo, _ := createTestRepository(t, createTestStateWithGlobalConstraintBlockForcePushes)
+
+	mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+	first := rsl.NewReferenceEntry("refs/heads/main", mainCommits[0])
+	common.CreateTestRSLReferenceEntryCommit(t, repo, first, gpgKeyBytes)
+
+	// Rewrite main's history so its new tip does not descend from the commit
+	// recorded by the first entry. The key is switched as well so the
+	// rewritten commits cannot collide with the original ones.
+	require.NoError(t, repo.SetReference("refs/heads/main", gitinterface.ZeroHash))
+	rewrittenMainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 2, rootKeyBytes)
+	require.False(t, rewrittenMainCommits[1].Equal(mainCommits[0].Bytes()))
+
+	featureCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+
+	bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: rewrittenMainCommits[1]},
+		{RefName: "refs/heads/feature", TargetID: featureCommits[0]},
+	})
+	common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+
+	verifier := NewPolicyVerifier(repo)
+	_, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+	assert.ErrorIs(t, err, ErrVerificationFailed)
+	assert.ErrorContains(t, err, "refs/heads/main")
+
+	// The global rule only protects main, so the feature update in the same
+	// bulk entry is unaffected.
+	verifier = NewPolicyVerifier(repo)
+	_, err = verifier.VerifyRefFull(testCtx, "refs/heads/feature")
+	assert.NoError(t, err)
+}
+
+func TestVerifyRefFullWithBulkEntryBeforePolicy(t *testing.T) {
+	t.Parallel()
+
+	createBulkEntry := func(t *testing.T, repo *gitinterface.Repository) {
+		t.Helper()
+
+		mainCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/main", 1, gpgKeyBytes)
+		featureCommits := common.AddNTestCommitsToSpecifiedRef(t, repo, "refs/heads/feature", 1, gpgKeyBytes)
+		bulk := rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: mainCommits[0]},
+			{RefName: "refs/heads/feature", TargetID: featureCommits[0]},
+		})
+		common.CreateTestRSLBulkReferenceEntryCommit(t, repo, bulk, gpgKeyBytes)
+	}
+
+	t.Run("no policy entry at all", func(t *testing.T) {
+		t.Parallel()
+
+		repo := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+		createBulkEntry(t, repo)
+
+		verifier := NewPolicyVerifier(repo)
+		_, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+
+		verifier = NewPolicyVerifier(repo)
+		_, err = verifier.VerifyRefFull(testCtx, "refs/heads/feature")
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+	})
+
+	t.Run("policy entry only after the bulk entry", func(t *testing.T) {
+		t.Parallel()
+
+		repo := gitinterface.CreateTestGitRepository(t, t.TempDir(), false)
+		createBulkEntry(t, repo)
+
+		state := createTestStateWithPolicy(t)
+		state.repository = repo
+		require.NoError(t, state.Commit(repo, "Create test state", true, false))
+		require.NoError(t, Apply(testCtx, repo, false))
+
+		verifier := NewPolicyVerifier(repo)
+		_, err := verifier.VerifyRefFull(testCtx, "refs/heads/main")
+		assert.ErrorIs(t, err, ErrPolicyNotFound)
+	})
+}

--- a/internal/propagation/propagation_test.go
+++ b/internal/propagation/propagation_test.go
@@ -6,6 +6,8 @@ package propagation
 import (
 	"testing"
 
+	"github.com/gittuf/gittuf/internal/common"
+	artifacts "github.com/gittuf/gittuf/internal/testartifacts"
 	"github.com/gittuf/gittuf/internal/tuf"
 	tufv01 "github.com/gittuf/gittuf/internal/tuf/v01"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
@@ -248,4 +250,99 @@ func TestPropagateChangesUpstreamPathMissing(t *testing.T) {
 
 	err = PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo, []tuf.PropagationDirective{directive}, false)
 	assert.ErrorIs(t, err, gitinterface.ErrTreeDoesNotHavePath)
+}
+
+func TestPropagateChangesFromUpstreamBulkEntry(t *testing.T) {
+	upstreamRepoLocation := t.TempDir()
+	upstreamRepo := gitinterface.CreateTestGitRepository(t, upstreamRepoLocation, true)
+
+	downstreamRepoLocation := t.TempDir()
+	downstreamRepo := gitinterface.CreateTestGitRepository(t, downstreamRepoLocation, true)
+
+	upstreamBlobID, err := upstreamRepo.WriteBlob([]byte("upstream"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	upstreamTreeBuilder := gitinterface.NewTreeBuilder(upstreamRepo)
+	upstreamRootTreeID, err := upstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+		gitinterface.NewEntryBlob("a", upstreamBlobID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	otherCommitID, err := upstreamRepo.Commit(upstreamRootTreeID, "refs/heads/other", "Other commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upstreamCommitID, err := upstreamRepo.Commit(upstreamRootTreeID, "refs/heads/main", "Upstream commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The propagated ref is the second update in the bulk entry, so the
+	// entry ID recorded downstream does not identify it on its own.
+	bulkEntryID := common.CreateTestRSLBulkReferenceEntryCommit(t, upstreamRepo, rsl.NewBulkReferenceEntry([]rsl.ReferenceUpdate{
+		{RefName: "refs/heads/other", TargetID: otherCommitID},
+		{RefName: "refs/heads/main", TargetID: upstreamCommitID},
+	}), artifacts.SSHRSAPrivate)
+
+	downstreamBlobID, err := downstreamRepo.WriteBlob([]byte("downstream"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	downstreamTreeBuilder := gitinterface.NewTreeBuilder(downstreamRepo)
+	downstreamRootTreeID, err := downstreamTreeBuilder.WriteTreeFromEntries([]gitinterface.TreeEntry{
+		gitinterface.NewEntryBlob("b", downstreamBlobID),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	downstreamCommitID, err := downstreamRepo.Commit(downstreamRootTreeID, "refs/heads/main", "Downstream commit\n", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rsl.NewReferenceEntry("refs/heads/main", downstreamCommitID).Commit(downstreamRepo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	directive := &tufv01.PropagationDirective{
+		UpstreamReference:   "refs/heads/main",
+		UpstreamRepository:  upstreamRepoLocation,
+		DownstreamReference: "refs/heads/main",
+		DownstreamPath:      "upstream",
+	}
+
+	err = PropagateChangesFromUpstreamRepository(downstreamRepo, upstreamRepo, []tuf.PropagationDirective{directive}, false)
+	assert.Nil(t, err)
+
+	latestEntry, err := rsl.GetLatestEntry(downstreamRepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	propagationEntry, isPropagationEntry := latestEntry.(*rsl.PropagationEntry)
+	if !isPropagationEntry {
+		t.Fatal("unexpected entry type in downstream repo")
+	}
+	assert.Equal(t, upstreamRepoLocation, propagationEntry.UpstreamRepository)
+	assert.Equal(t, bulkEntryID, propagationEntry.UpstreamEntryID)
+
+	updater, err := rsl.GetReferenceUpdaterEntryForRef(upstreamRepo, propagationEntry.UpstreamEntryID, "refs/heads/main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "refs/heads/main", updater.GetRefName())
+	assert.Equal(t, upstreamCommitID, updater.GetTargetID())
+
+	propagatedRootTreeID, err := downstreamRepo.GetCommitTreeID(propagationEntry.TargetID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pathTreeID, err := downstreamRepo.GetPathIDInTree(propagatedRootTreeID, "upstream")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, upstreamRootTreeID, pathTreeID)
 }

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gittuf/gittuf/internal/cmd/profile"
 	"github.com/gittuf/gittuf/internal/cmd/root"
+	"github.com/gittuf/gittuf/internal/version"
 )
 
 func main() {
@@ -29,6 +30,9 @@ func main() {
 
 	rootCmd := root.New()
 	if err := rootCmd.Execute(); err != nil {
+		if root.IsUpgradeRequiredError(err) {
+			fmt.Fprintf(os.Stderr, "This client is gittuf %s.\n", version.GetVersion())
+		}
 		// We can ignore the linter here (deferred functions are not executed
 		// when os.Exit is invoked) because if we do have an error, we don't
 		// have a panic, which is what the deferred function is looking for.

--- a/pkg/gitinterface/commit.go
+++ b/pkg/gitinterface/commit.go
@@ -28,10 +28,18 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 		}
 	}
 
+	return r.CommitWithExpectedTip(treeID, targetRef, message, sign, currentGitID)
+}
+
+// CommitWithExpectedTip is Commit with the parent pinned to expectedTip. The
+// commit is created with expectedTip as its parent (none when expectedTip is
+// the zero hash) and targetRef is updated only if it still points at
+// expectedTip. It fails if another writer advanced targetRef in between.
+func (r *Repository) CommitWithExpectedTip(treeID Hash, targetRef, message string, sign bool, expectedTip Hash) (Hash, error) {
 	args := []string{"commit-tree", "-m", message}
 
-	if !currentGitID.IsZero() {
-		args = append(args, "-p", currentGitID.String())
+	if !expectedTip.IsZero() {
+		args = append(args, "-p", expectedTip.String())
 	}
 
 	if sign {
@@ -52,7 +60,7 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 		return ZeroHash, fmt.Errorf("received invalid commit ID: %w", err)
 	}
 
-	return commitID, r.CheckAndSetReference(targetRef, commitID, currentGitID)
+	return commitID, r.CheckAndSetReference(targetRef, commitID, expectedTip)
 }
 
 // CommitUsingSpecificKey creates a new commit in the repository for the
@@ -61,6 +69,22 @@ func (r *Repository) Commit(treeID Hash, targetRef, message string, sign bool) (
 // developer mode. In standard workflows, Commit() must be used instead which
 // infers the signing key from the user's Git config.
 func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message string, signingKeyPEMBytes []byte) (Hash, error) {
+	refTip, err := r.GetReference(targetRef)
+	if err != nil {
+		if !errors.Is(err, ErrReferenceNotFound) {
+			return ZeroHash, err
+		}
+	}
+
+	return r.CommitUsingSpecificKeyWithExpectedTip(treeID, targetRef, message, signingKeyPEMBytes, refTip)
+}
+
+// CommitUsingSpecificKeyWithExpectedTip is CommitUsingSpecificKey with the
+// parent pinned to expectedTip. The commit is created with expectedTip as its
+// parent (none when expectedTip is the zero hash) and targetRef is updated
+// only if it still points at expectedTip. It fails if another writer advanced
+// targetRef in between.
+func (r *Repository) CommitUsingSpecificKeyWithExpectedTip(treeID Hash, targetRef, message string, signingKeyPEMBytes []byte, expectedTip Hash) (Hash, error) {
 	name, _, err := r.LookupConfig(gitstore.ConfigUserName)
 	if err != nil {
 		return ZeroHash, err
@@ -83,15 +107,8 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 		Message:   message,
 	}
 
-	refTip, err := r.GetReference(targetRef)
-	if err != nil {
-		if !errors.Is(err, ErrReferenceNotFound) {
-			return ZeroHash, err
-		}
-	}
-
-	if !refTip.IsZero() {
-		commit.ParentHashes = []plumbing.Hash{plumbing.NewHash(refTip.String())}
+	if !expectedTip.IsZero() {
+		commit.ParentHashes = []plumbing.Hash{plumbing.NewHash(expectedTip.String())}
 	}
 
 	commitContents, err := getCommitBytesWithoutSignature(commit)
@@ -130,7 +147,7 @@ func (r *Repository) CommitUsingSpecificKey(treeID Hash, targetRef, message stri
 		return ZeroHash, err
 	}
 
-	return commitIDHash, r.CheckAndSetReference(targetRef, commitIDHash, refTip)
+	return commitIDHash, r.CheckAndSetReference(targetRef, commitIDHash, expectedTip)
 }
 
 // commitWithParents creates a new commit in the repo but does not update any

--- a/pkg/gitinterface/commit_test.go
+++ b/pkg/gitinterface/commit_test.go
@@ -877,3 +877,47 @@ func TestEnsureIsCommit(t *testing.T) {
 		assert.ErrorContains(t, err, "unable to inspect if object is commit")
 	})
 }
+
+func TestCommitWithExpectedTip(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false)
+
+	treeBuilder := NewTreeBuilder(repo)
+	emptyTree, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+
+	first, err := repo.CommitWithExpectedTip(emptyTree, "refs/heads/main", "first\n", false, ZeroHash)
+	require.NoError(t, err)
+
+	second, err := repo.CommitWithExpectedTip(emptyTree, "refs/heads/main", "second\n", false, first)
+	require.NoError(t, err)
+
+	_, err = repo.CommitWithExpectedTip(emptyTree, "refs/heads/main", "stale\n", false, first)
+	assert.ErrorContains(t, err, "unable to set Git reference")
+
+	tip, err := repo.GetReference("refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, second, tip)
+}
+
+func TestCommitUsingSpecificKeyWithExpectedTip(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := CreateTestGitRepository(t, tempDir, false)
+
+	treeBuilder := NewTreeBuilder(repo)
+	emptyTree, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+
+	first, err := repo.CommitUsingSpecificKeyWithExpectedTip(emptyTree, "refs/heads/main", "first\n", artifacts.SSHRSAPrivate, ZeroHash)
+	require.NoError(t, err)
+
+	second, err := repo.CommitUsingSpecificKeyWithExpectedTip(emptyTree, "refs/heads/main", "second\n", artifacts.SSHRSAPrivate, first)
+	require.NoError(t, err)
+
+	_, err = repo.CommitUsingSpecificKeyWithExpectedTip(emptyTree, "refs/heads/main", "stale\n", artifacts.SSHRSAPrivate, first)
+	assert.ErrorContains(t, err, "unable to set Git reference")
+
+	tip, err := repo.GetReference("refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, second, tip)
+}

--- a/pkg/gitstore/gitstore.go
+++ b/pkg/gitstore/gitstore.go
@@ -114,3 +114,28 @@ type Storer interface {
 	// returns cause, wrapped if the reset itself fails.
 	ResetDueToError(cause error, refName string, commitID githash.Hash) error
 }
+
+// TipPinningStorer is an optional extension of Storer for stores that can
+// pin a commit to the tip the caller observed. Both methods create the commit
+// with expectedTip as its only parent, or with no parent when expectedTip is
+// the zero hash, and update targetRef only if targetRef still points at
+// expectedTip. A zero expectedTip therefore also asserts that targetRef does
+// not exist yet. When targetRef has moved in the meantime the methods return
+// an error and leave targetRef untouched. The commit object itself may already
+// have been written, it is simply unreferenced.
+//
+// *gitinterface.Repository implements this interface.
+//
+// Implementing it is optional. pkg/rsl uses it to write an RSL entry against
+// the tip it read the entry number from. A Storer that does not implement it
+// falls back to Commit and CommitUsingSpecificKey, which read the tip again,
+// so an RSL write can record a stale entry number when another writer appends
+// concurrently. pkg/rsl logs a warning each time it takes that fallback.
+type TipPinningStorer interface {
+	// CommitWithExpectedTip is Commit with the parent pinned to expectedTip.
+	CommitWithExpectedTip(treeID githash.Hash, targetRef, message string, sign bool, expectedTip githash.Hash) (githash.Hash, error)
+
+	// CommitUsingSpecificKeyWithExpectedTip is CommitUsingSpecificKey with
+	// the parent pinned to expectedTip.
+	CommitUsingSpecificKeyWithExpectedTip(treeID githash.Hash, targetRef, message string, signingKeyPEMBytes []byte, expectedTip githash.Hash) (githash.Hash, error)
+}

--- a/pkg/rsl/bulk.go
+++ b/pkg/rsl/bulk.go
@@ -1,0 +1,366 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// This file holds the bulk reference entry: its type, codec, validation,
+// parser, and the folding helpers that expand it into per-ref views.
+
+package rsl
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+)
+
+const BulkReferenceEntryHeader = "RSL Bulk Reference Entry"
+
+var (
+	ErrDuplicateReferenceInBulkEntry = errors.New("bulk reference entry lists the same reference more than once")
+	ErrGittufReferenceInBulkEntry    = errors.New("bulk reference entry cannot record references in the gittuf namespace")
+	ErrCannotCommitView              = errors.New("cannot commit a per-ref view of a bulk reference entry, commit the bulk entry instead")
+)
+
+// ReferenceUpdate is one reference update inside a BulkReferenceEntry.
+type ReferenceUpdate struct {
+	RefName  string
+	TargetID githash.Hash
+}
+
+// BulkReferenceEntry records one or more reference updates under a single
+// signature. It implements Entry. It does not implement ReferenceUpdaterEntry
+// because it has no single ref. Walkers expand it into per-ref views with
+// ReferenceEntries. Refs are unique within an entry and never in the gittuf
+// namespace.
+//
+// On the wire an entry is its header, a blank line, one "<ref>: <targetID>"
+// line per update in listed order, a blank line, and a mandatory number line:
+//
+//	RSL Bulk Reference Entry
+//
+//	refs/heads/main: 9e37b2f8b9d5b0e1cc2f2c2a6a4b1f9c7b5e0d31
+//	refs/heads/feature: 4a2f1b9c7e5d3a8b6c4f2e1d0b9a8c7f6e5d4c3b
+//
+//	number: 5
+type BulkReferenceEntry struct {
+	// ID contains the Git hash for the commit corresponding to the entry.
+	ID githash.Hash
+
+	// Updates lists the reference updates in the order they were recorded.
+	Updates []ReferenceUpdate
+
+	// Number contains a strictly increasing number that hints at entry ordering.
+	Number uint64
+}
+
+var _ Entry = (*BulkReferenceEntry)(nil)
+
+// NewBulkReferenceEntry returns a BulkReferenceEntry for the specified
+// updates. Validation happens when the entry is committed.
+func NewBulkReferenceEntry(updates []ReferenceUpdate) *BulkReferenceEntry {
+	return &BulkReferenceEntry{Updates: updates}
+}
+
+func (e *BulkReferenceEntry) GetID() githash.Hash {
+	return e.ID
+}
+
+func (e *BulkReferenceEntry) GetNumber() uint64 {
+	return e.Number
+}
+
+// ReferenceEntries returns one read-only view per update. Each view carries
+// the bulk entry's ID and Number and reports FromBulkEntry as true. Views
+// cannot be committed.
+func (e *BulkReferenceEntry) ReferenceEntries() []*ReferenceEntry {
+	views := make([]*ReferenceEntry, 0, len(e.Updates))
+	for _, update := range e.Updates {
+		views = append(views, e.referenceEntryForUpdate(update))
+	}
+	return views
+}
+
+func (e *BulkReferenceEntry) referenceEntryForUpdate(update ReferenceUpdate) *ReferenceEntry {
+	return &ReferenceEntry{
+		ID:       e.ID,
+		RefName:  update.RefName,
+		TargetID: update.TargetID,
+		Number:   e.Number,
+		isView:   true,
+	}
+}
+
+// Commit creates a commit object in the RSL for the BulkReferenceEntry. The
+// number is assigned the same way as for the other entry types.
+func (e *BulkReferenceEntry) Commit(storer gitstore.Storer, sign bool) error {
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
+		return err
+	}
+
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
+
+	return commitEntry(storer, message, sign, expectedTip)
+}
+
+// CommitUsingSpecificKey creates a commit object in the RSL for the
+// BulkReferenceEntry, signed with the provided PEM encoded key. Intended for
+// developer mode and tests.
+func (e *BulkReferenceEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingKeyBytes []byte) error {
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
+		return err
+	}
+
+	message, err := e.createCommitMessage(true)
+	if err != nil {
+		return err
+	}
+
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes, expectedTip)
+}
+
+func (e *BulkReferenceEntry) setEntryNumber(storer gitstore.Storer) (githash.Hash, error) {
+	number, tip, err := nextEntryNumber(storer)
+	if err != nil {
+		return tip, err
+	}
+
+	e.Number = number
+	return tip, nil
+}
+
+// createCommitMessage renders the bulk entry's wire format. The number is
+// mandatory for a bulk entry, so the includeNumber parameter that the Entry
+// interface requires is ignored here. The older entry types honour it because
+// they must still be able to render the numberless form they shipped with.
+// Commit and CommitUsingSpecificKey assign the number before they render, so
+// a zero number can only come from misuse and is an error.
+func (e *BulkReferenceEntry) createCommitMessage(bool) (string, error) {
+	if err := validateReferenceUpdates(e.Updates); err != nil {
+		return "", err
+	}
+	if e.Number == 0 {
+		return "", fmt.Errorf("%w: bulk reference entry has no number", ErrInvalidRSLEntry)
+	}
+
+	var message strings.Builder
+	message.WriteString(BulkReferenceEntryHeader)
+	message.WriteString("\n\n")
+	for _, update := range e.Updates {
+		fmt.Fprintf(&message, "%s: %s\n", update.RefName, update.TargetID.String())
+	}
+	fmt.Fprintf(&message, "\n%s: %d", NumberKey, e.Number)
+	return message.String(), nil
+}
+
+// validateReferenceUpdates enforces the bulk entry invariants shared by the
+// writer and the parser: at least one update, fully qualified and trimmed
+// ref names, no gittuf namespace refs, and no duplicate refs.
+func validateReferenceUpdates(updates []ReferenceUpdate) error {
+	if len(updates) == 0 {
+		return fmt.Errorf("%w: bulk reference entry has no updates", ErrInvalidRSLEntry)
+	}
+
+	seen := make(map[string]struct{}, len(updates))
+	for _, update := range updates {
+		if err := validateBulkRefName(update.RefName); err != nil {
+			return err
+		}
+		if _, duplicate := seen[update.RefName]; duplicate {
+			return fmt.Errorf("%w: %s: %w", ErrDuplicateReferenceInBulkEntry, update.RefName, ErrInvalidRSLEntry)
+		}
+		seen[update.RefName] = struct{}{}
+	}
+
+	return nil
+}
+
+func validateBulkRefName(refName string) error {
+	// The single line and whitespace checks are here for the writer's sake.
+	// The parser trims every field value before it validates it, so only a
+	// value built in process can still carry a line break or padding.
+	if err := checkSingleLineField(refName); err != nil {
+		return err
+	}
+	if refName == "" {
+		return fmt.Errorf("%w: reference name is empty", ErrInvalidRSLEntry)
+	}
+	if refName != strings.TrimSpace(refName) {
+		return fmt.Errorf("%w: reference name %q has surrounding whitespace", ErrInvalidRSLEntry, refName)
+	}
+	if !strings.HasPrefix(refName, refPrefix) {
+		return fmt.Errorf("%w: reference name %q is not fully qualified", ErrInvalidRSLEntry, refName)
+	}
+	if strings.HasPrefix(refName, gittufNamespacePrefix) {
+		return fmt.Errorf("%w: %s: %w", ErrGittufReferenceInBulkEntry, refName, ErrInvalidRSLEntry)
+	}
+	return nil
+}
+
+// parseBulkReferenceEntryText parses a bulk reference entry. After the header
+// and its mandatory blank line the body is one or more update lines, exactly
+// one blank line, a number line, and nothing but blank lines after that. An
+// update line is split on its first colon. The key is the reference name and
+// the value is the target ID. Git reference names cannot contain a colon, so
+// the split is unambiguous. Anything else is rejected: there are no unknown
+// keys to skip and no optional fields.
+//
+// The shape is chosen so that older clients fail closed. gittuf v0.9.0 through
+// v0.16.0 reject an unrecognised header outright. gittuf up to v0.8.1 instead
+// routes every non-annotation header into its lenient reference entry parser,
+// which ignores keys it does not know but returns ErrInvalidRSLEntry for any
+// body line without a colon. The blank line before the number is therefore
+// load bearing: without it, those clients would skip every update line as an
+// unknown key and silently accept an entry with an empty ref and a zero
+// target. Making the number mandatory is what guarantees the blank line is
+// always present.
+func parseBulkReferenceEntryText(id githash.Hash, text string) (*BulkReferenceEntry, error) {
+	body, err := entryBody(text, BulkReferenceEntryHeader)
+	if err != nil {
+		return nil, err
+	}
+
+	const (
+		expectUpdate = iota // update lines, then the blank separator
+		expectNumber        // separator seen, the number line must follow
+		done                // number seen, only blank lines may follow
+	)
+
+	entry := &BulkReferenceEntry{ID: id, Updates: make([]ReferenceUpdate, 0, len(body))}
+	state := expectUpdate
+
+	for _, rawLine := range body {
+		line := strings.TrimSpace(rawLine)
+		if line == "" {
+			switch state {
+			case expectUpdate:
+				if len(entry.Updates) == 0 {
+					return nil, fmt.Errorf("%w: bulk reference entry has no updates", ErrInvalidRSLEntry)
+				}
+				state = expectNumber
+			case done:
+				// Trailing blank lines after the number are harmless.
+			default:
+				return nil, fmt.Errorf("%w: unexpected blank line in bulk reference entry", ErrInvalidRSLEntry)
+			}
+			continue
+		}
+
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("%w: bulk reference entry line has no colon", ErrInvalidRSLEntry)
+		}
+		key, value = strings.TrimSpace(key), strings.TrimSpace(value)
+
+		switch state {
+		case expectUpdate:
+			if err := validateBulkRefName(key); err != nil {
+				return nil, err
+			}
+			update := ReferenceUpdate{RefName: key}
+			if err := setHash(&update.TargetID, value); err != nil {
+				return nil, err
+			}
+			entry.Updates = append(entry.Updates, update)
+
+		case expectNumber:
+			if key != NumberKey {
+				return nil, fmt.Errorf("%w: expected %s after the blank line in bulk reference entry", ErrInvalidRSLEntry, NumberKey)
+			}
+			if err := setNumber(&entry.Number, value); err != nil {
+				return nil, err
+			}
+			state = done
+
+		default:
+			return nil, fmt.Errorf("%w: bulk reference entry has a line after its number", ErrInvalidRSLEntry)
+		}
+	}
+
+	if state != done {
+		return nil, fmt.Errorf("%w: bulk reference entry has no number", ErrInvalidRSLEntry)
+	}
+	if err := validateReferenceUpdates(entry.Updates); err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// referenceUpdaters is the single point where the RSL walkers fold an entry
+// into the reference updaters it carries. Reference and propagation entries
+// return themselves. Bulk reference entries return their per-ref views in
+// listed order. Annotations carry no updates and return nil. Any other type
+// is an error so that a future entry type can never be dropped silently by a
+// walker before verification sees it. The returned slice is freshly
+// allocated, so callers may reorder or otherwise mutate it.
+func referenceUpdaters(entry Entry) ([]ReferenceUpdaterEntry, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("%w: nil entry", ErrUnknownRSLEntryType)
+	}
+
+	switch e := entry.(type) {
+	case *ReferenceEntry:
+		return []ReferenceUpdaterEntry{e}, nil
+	case *PropagationEntry:
+		return []ReferenceUpdaterEntry{e}, nil
+	case *BulkReferenceEntry:
+		updaters := make([]ReferenceUpdaterEntry, 0, len(e.Updates))
+		for _, update := range e.Updates {
+			updaters = append(updaters, e.referenceEntryForUpdate(update))
+		}
+		return updaters, nil
+	case *AnnotationEntry:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("%w: entry %s has unhandled type %T", ErrUnknownRSLEntryType, entry.GetID(), entry)
+	}
+}
+
+// referenceUpdatersNewestFirst is referenceUpdaters in reverse listed order.
+// Walkers that iterate the RSL from the tip backwards use it so that the last
+// listed update in a bulk entry is encountered first. Two idioms follow from
+// that. Iterating newest first and breaking on the first match yields the
+// latest matching update in the entry. Iterating listed order with
+// referenceUpdaters and breaking on the first match yields the first.
+func referenceUpdatersNewestFirst(entry Entry) ([]ReferenceUpdaterEntry, error) {
+	updaters, err := referenceUpdaters(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	slices.Reverse(updaters)
+	return updaters, nil
+}
+
+// GetReferenceUpdaterEntryForRef loads the entry with the specified ID and
+// returns the reference updater in it for refName. For a bulk reference
+// entry this is the view for that ref. For a single-ref entry the ref must
+// match. It is the loader to use wherever an (entry ID, ref) pair has been
+// persisted, such as the persistent cache, because an entry ID alone no
+// longer identifies one reference update.
+func GetReferenceUpdaterEntryForRef(storer gitstore.Storer, entryID githash.Hash, refName string) (ReferenceUpdaterEntry, error) {
+	entry, err := GetEntry(storer, entryID)
+	if err != nil {
+		return nil, err
+	}
+
+	updaters, err := referenceUpdaters(entry)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, updater := range updaters {
+		if updater.GetRefName() == refName {
+			return updater, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: entry %s does not update %s", ErrRSLEntryDoesNotMatchRef, entryID.String(), refName)
+}

--- a/pkg/rsl/bulk.go
+++ b/pkg/rsl/bulk.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/gittuf/gittuf/pkg/gitstore"
 )
@@ -45,6 +46,8 @@ type ReferenceUpdate struct {
 //	refs/heads/feature: 4a2f1b9c7e5d3a8b6c4f2e1d0b9a8c7f6e5d4c3b
 //
 //	number: 5
+//
+// Custom fields, when present, follow the number line.
 type BulkReferenceEntry struct {
 	// ID contains the Git hash for the commit corresponding to the entry.
 	ID githash.Hash
@@ -54,14 +57,18 @@ type BulkReferenceEntry struct {
 
 	// Number contains a strictly increasing number that hints at entry ordering.
 	Number uint64
+
+	// CustomFields contains application-defined metadata for the entry.
+	CustomFields CustomFields
 }
 
 var _ Entry = (*BulkReferenceEntry)(nil)
 
 // NewBulkReferenceEntry returns a BulkReferenceEntry for the specified
 // updates. Validation happens when the entry is committed.
-func NewBulkReferenceEntry(updates []ReferenceUpdate) *BulkReferenceEntry {
-	return &BulkReferenceEntry{Updates: updates}
+func NewBulkReferenceEntry(updates []ReferenceUpdate, opts ...EntryOption) *BulkReferenceEntry {
+	options := applyEntryOptions(opts)
+	return &BulkReferenceEntry{Updates: updates, CustomFields: options.customFields}
 }
 
 func (e *BulkReferenceEntry) GetID() githash.Hash {
@@ -70,6 +77,11 @@ func (e *BulkReferenceEntry) GetID() githash.Hash {
 
 func (e *BulkReferenceEntry) GetNumber() uint64 {
 	return e.Number
+}
+
+func (e *BulkReferenceEntry) GetCustomField(key string) (string, bool) {
+	value, has := e.CustomFields[key]
+	return value, has
 }
 
 // ReferenceEntries returns one read-only view per update. Each view carries
@@ -89,7 +101,10 @@ func (e *BulkReferenceEntry) referenceEntryForUpdate(update ReferenceUpdate) *Re
 		RefName:  update.RefName,
 		TargetID: update.TargetID,
 		Number:   e.Number,
-		isView:   true,
+		// The map is shared with the bulk entry rather than copied. A view
+		// is read only, and GetCustomField is the only reader.
+		CustomFields: e.CustomFields,
+		isView:       true,
 	}
 }
 
@@ -136,7 +151,9 @@ func (e *BulkReferenceEntry) setEntryNumber(storer gitstore.Storer) (githash.Has
 	return tip, nil
 }
 
-// createCommitMessage renders the bulk entry's wire format. The number is
+// createCommitMessage renders the bulk entry's wire format. Custom fields, if
+// any, follow the number line, as they do for the other entry types. The
+// number is
 // mandatory for a bulk entry, so the includeNumber parameter that the Entry
 // interface requires is ignored here. The older entry types honour it because
 // they must still be able to render the numberless form they shipped with.
@@ -157,6 +174,15 @@ func (e *BulkReferenceEntry) createCommitMessage(bool) (string, error) {
 		fmt.Fprintf(&message, "%s: %s\n", update.RefName, update.TargetID.String())
 	}
 	fmt.Fprintf(&message, "\n%s: %d", NumberKey, e.Number)
+
+	lines, err := appendCustomFieldLines(nil, e.CustomFields)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range lines {
+		message.WriteString("\n")
+		message.WriteString(line)
+	}
 	return message.String(), nil
 }
 
@@ -280,7 +306,14 @@ func parseBulkReferenceEntryText(id githash.Hash, text string) (*BulkReferenceEn
 			state = done
 
 		default:
-			return nil, fmt.Errorf("%w: bulk reference entry has a line after its number", ErrInvalidRSLEntry)
+			// Only custom fields may follow the number. Unlike the older
+			// entry types, which ignore unknown keys, an unknown key here is
+			// an error: this entry type fails closed on anything a client
+			// does not implement.
+			if !strings.HasPrefix(key, customfields.Prefix) {
+				return nil, fmt.Errorf("%w: bulk reference entry has a line after its number", ErrInvalidRSLEntry)
+			}
+			setCustomField(&entry.CustomFields, key, value)
 		}
 	}
 

--- a/pkg/rsl/bulk_repository_test.go
+++ b/pkg/rsl/bulk_repository_test.go
@@ -137,3 +137,33 @@ func TestGetReferenceUpdaterEntryForRef(t *testing.T) {
 	_, err = GetReferenceUpdaterEntryForRef(repo, unknownID, "refs/heads/main")
 	assert.ErrorIs(t, err, ErrRSLEntryNotFound)
 }
+
+func TestBulkReferenceEntryCommitWithCustomFields(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	fields := CustomFields{
+		"custom.gitforge.com/pusher":         "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)",
+		"custom.gitforge.com/server-version": "v4.2.0-c0ffee",
+	}
+	updates := []ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+	}
+	if err := NewBulkReferenceEntry(updates, WithCustomFields(fields)).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	latest, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	bulk, isBulk := latest.(*BulkReferenceEntry)
+	require.True(t, isBulk)
+	assert.Equal(t, fields, bulk.CustomFields)
+
+	for _, view := range bulk.ReferenceEntries() {
+		value, has := view.GetCustomField("custom.gitforge.com/pusher")
+		assert.True(t, has)
+		assert.Equal(t, "jane (01ARZ3NDEKTSV4RRFFQ69G5FAV)", value)
+	}
+}

--- a/pkg/rsl/bulk_repository_test.go
+++ b/pkg/rsl/bulk_repository_test.go
@@ -1,0 +1,139 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBulkReferenceEntryCommit(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	updates := []ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+	}
+	if err := NewBulkReferenceEntry(updates).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+
+	latest, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	bulk, isBulk := latest.(*BulkReferenceEntry)
+	require.True(t, isBulk)
+	assert.Equal(t, uint64(2), bulk.Number)
+	assert.Equal(t, updates, bulk.Updates)
+
+	views := bulk.ReferenceEntries()
+	require.Len(t, views, 2)
+	for i, view := range views {
+		assert.Equal(t, bulk.ID, view.ID)
+		assert.Equal(t, bulk.Number, view.Number)
+		assert.Equal(t, updates[i].RefName, view.RefName)
+		assert.True(t, view.FromBulkEntry())
+	}
+
+	assert.ErrorIs(t, views[0].Commit(repo, false), ErrCannotCommitView)
+	assert.ErrorIs(t, views[0].CommitUsingSpecificKey(repo, nil), ErrCannotCommitView)
+	assert.ErrorIs(t, views[0].CommitWithoutNumber(repo), ErrCannotCommitView)
+
+	parent, err := GetParentForEntry(repo, views[1])
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), parent.GetNumber())
+
+	commitMessage, err := repo.GetCommitMessage(bulk.ID)
+	require.NoError(t, err)
+	expected := fmt.Sprintf("%s\n\nrefs/heads/main: %s\nrefs/heads/feature: %s\n\n%s: %d", BulkReferenceEntryHeader, gitinterface.ZeroHash.String(), gitinterface.ZeroHash.String(), NumberKey, 2)
+	assert.Equal(t, expected, commitMessage)
+}
+
+func TestBulkReferenceEntryCommitRejectsInvalidUpdates(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	err := NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/gittuf/policy", TargetID: gitinterface.ZeroHash},
+	}).Commit(repo, false)
+	assert.ErrorIs(t, err, ErrGittufReferenceInBulkEntry)
+
+	_, err = GetLatestEntry(repo)
+	assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+}
+
+func TestGetReferenceUpdaterEntryForRef(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	if err := NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+	single, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	if err := NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+	}).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+	bulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	entry, err := GetReferenceUpdaterEntryForRef(repo, single.GetID(), "refs/heads/main")
+	require.NoError(t, err)
+	assert.Equal(t, single, entry)
+
+	_, err = GetReferenceUpdaterEntryForRef(repo, single.GetID(), "refs/heads/feature")
+	assert.ErrorIs(t, err, ErrRSLEntryDoesNotMatchRef)
+
+	entry, err = GetReferenceUpdaterEntryForRef(repo, bulk.GetID(), "refs/heads/feature")
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/feature", entry.GetRefName())
+	assert.Equal(t, bulk.GetID(), entry.GetID())
+	assert.True(t, entry.(*ReferenceEntry).FromBulkEntry())
+
+	_, err = GetReferenceUpdaterEntryForRef(repo, bulk.GetID(), "refs/heads/other")
+	assert.ErrorIs(t, err, ErrRSLEntryDoesNotMatchRef)
+
+	if err := NewAnnotationEntry([]githash.Hash{bulk.GetID()}, false, annotationMessage).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+	annotation, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	_, err = GetReferenceUpdaterEntryForRef(repo, annotation.GetID(), "refs/heads/main")
+	assert.ErrorIs(t, err, ErrRSLEntryDoesNotMatchRef)
+
+	if err := NewPropagationEntry("refs/heads/downstream", gitinterface.ZeroHash, "https://example.com/upstream", gitinterface.ZeroHash).Commit(repo, false); err != nil {
+		t.Fatal(err)
+	}
+	propagation, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	entry, err = GetReferenceUpdaterEntryForRef(repo, propagation.GetID(), "refs/heads/downstream")
+	require.NoError(t, err)
+	assert.Equal(t, propagation, entry)
+
+	_, err = GetReferenceUpdaterEntryForRef(repo, propagation.GetID(), "refs/heads/main")
+	assert.ErrorIs(t, err, ErrRSLEntryDoesNotMatchRef)
+
+	unknownID, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	require.NoError(t, err)
+
+	_, err = GetReferenceUpdaterEntryForRef(repo, unknownID, "refs/heads/main")
+	assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+}

--- a/pkg/rsl/bulk_test.go
+++ b/pkg/rsl/bulk_test.go
@@ -1,0 +1,428 @@
+// Copyright The gittuf Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package rsl
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gittuf/gittuf/pkg/githash"
+	"github.com/gittuf/gittuf/pkg/gitstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBulkReferenceEntryCreateCommitMessage(t *testing.T) {
+	t.Parallel()
+
+	nonZeroHash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero := githash.ZeroHash.String()
+
+	tests := map[string]struct {
+		entry           *BulkReferenceEntry
+		expectedMessage string
+		expectedErrors  []error
+	}{
+		"two updates": {
+			entry: &BulkReferenceEntry{
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/heads/feature", TargetID: nonZeroHash},
+				},
+				Number: 5,
+			},
+			expectedMessage: BulkReferenceEntryHeader + "\n\nrefs/heads/main: " + zero + "\nrefs/heads/feature: " + nonZeroHash.String() + "\n\nnumber: 5",
+		},
+		"single update is allowed by the codec": {
+			entry: &BulkReferenceEntry{
+				Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:  1,
+			},
+			expectedMessage: fmt.Sprintf("%s\n\nrefs/heads/main: %s\n\n%s: %d", BulkReferenceEntryHeader, zero, NumberKey, 1),
+		},
+		"no number": {
+			entry:          NewBulkReferenceEntry([]ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}}),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"no updates": {
+			entry:          NewBulkReferenceEntry(nil),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"duplicate ref": {
+			entry: &BulkReferenceEntry{
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/heads/main", TargetID: nonZeroHash},
+				},
+				Number: 2,
+			},
+			expectedErrors: []error{ErrDuplicateReferenceInBulkEntry, ErrInvalidRSLEntry},
+		},
+		"gittuf ref": {
+			entry: &BulkReferenceEntry{
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/gittuf/policy", TargetID: nonZeroHash},
+				},
+				Number: 2,
+			},
+			expectedErrors: []error{ErrGittufReferenceInBulkEntry, ErrInvalidRSLEntry},
+		},
+		"unqualified ref": {
+			entry:          &BulkReferenceEntry{Updates: []ReferenceUpdate{{RefName: "main", TargetID: githash.ZeroHash}}, Number: 1},
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"ref with surrounding whitespace": {
+			entry:          &BulkReferenceEntry{Updates: []ReferenceUpdate{{RefName: " refs/heads/main", TargetID: githash.ZeroHash}}, Number: 1},
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"ref with line break": {
+			entry:          &BulkReferenceEntry{Updates: []ReferenceUpdate{{RefName: "refs/heads/main\nrefs/heads/other: " + zero, TargetID: githash.ZeroHash}}, Number: 1},
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			message, err := test.entry.createCommitMessage(true)
+			if len(test.expectedErrors) != 0 {
+				for _, expected := range test.expectedErrors {
+					assert.ErrorIs(t, err, expected)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedMessage, message)
+		})
+	}
+}
+
+func TestBulkReferenceEntryCreateCommitMessageIgnoresIncludeNumber(t *testing.T) {
+	t.Parallel()
+
+	entry := &BulkReferenceEntry{
+		Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+		Number:  3,
+	}
+
+	withNumber, err := entry.createCommitMessage(true)
+	require.NoError(t, err)
+	withoutNumber, err := entry.createCommitMessage(false)
+	require.NoError(t, err)
+	assert.Equal(t, withNumber, withoutNumber)
+	assert.Contains(t, withoutNumber, fmt.Sprintf("\n\n%s: 3", NumberKey))
+}
+
+func TestParseBulkReferenceEntryText(t *testing.T) {
+	t.Parallel()
+
+	nonZeroHash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sha256Hash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12345678900987654321fedcba")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero := githash.ZeroHash.String()
+	body := func(lines ...string) string {
+		return BulkReferenceEntryHeader + "\n\n" + strings.Join(lines, "\n")
+	}
+
+	tests := map[string]struct {
+		message        string
+		expectedEntry  *BulkReferenceEntry
+		expectedErrors []error
+	}{
+		"two updates": {
+			message: body("refs/heads/main: "+zero, "refs/heads/feature: "+nonZeroHash.String(), "", "number: 12"),
+			expectedEntry: &BulkReferenceEntry{
+				ID: githash.ZeroHash,
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/heads/feature", TargetID: nonZeroHash},
+				},
+				Number: 12,
+			},
+		},
+		"single update": {
+			message: body("refs/heads/main: "+zero, "", "number: 1"),
+			expectedEntry: &BulkReferenceEntry{
+				ID:      githash.ZeroHash,
+				Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:  1,
+			},
+		},
+		"sha256 target ID": {
+			message: body("refs/heads/main: "+sha256Hash.String(), "", "number: 1"),
+			expectedEntry: &BulkReferenceEntry{
+				ID:      githash.ZeroHash,
+				Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: sha256Hash}},
+				Number:  1,
+			},
+		},
+		"mixed whitespace around keys and values": {
+			message: body("  refs/heads/main  :   "+zero+"  ", "\trefs/tags/v1:\t"+nonZeroHash.String(), "", "  number :  4 "),
+			expectedEntry: &BulkReferenceEntry{
+				ID: githash.ZeroHash,
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/tags/v1", TargetID: nonZeroHash},
+				},
+				Number: 4,
+			},
+		},
+		"trailing blank lines after the number": {
+			message: body("refs/heads/main: "+zero, "", "number: 1", "", ""),
+			expectedEntry: &BulkReferenceEntry{
+				ID:      githash.ZeroHash,
+				Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:  1,
+			},
+		},
+		"missing number": {
+			message:        body("refs/heads/main: " + zero),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"blank separator but no number": {
+			message:        body("refs/heads/main: "+zero, ""),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"no blank line before the number": {
+			message:        body("refs/heads/main: "+zero, "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"number before the separator": {
+			message:        body("number: 1", "", "refs/heads/main: "+zero),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"two number lines": {
+			message:        body("refs/heads/main: "+zero, "", "number: 1", "number: 2"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"update line after the number": {
+			message:        body("refs/heads/main: "+zero, "", "number: 1", "refs/heads/feature: "+zero),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"two blank lines before the number": {
+			message:        body("refs/heads/main: "+zero, "", "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"blank line between update lines": {
+			message:        body("refs/heads/main: "+zero, "", "refs/heads/feature: "+zero, "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"leading blank line in the body": {
+			message:        body("", "refs/heads/main: "+zero, "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"no updates, only a number": {
+			message:        body("number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"line without a colon": {
+			message:        body("refs/heads/main: "+zero, "not a key value line", "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"uppercase number key": {
+			message:        body("refs/heads/main: "+zero, "", "Number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"legacy ref key": {
+			message:        body("ref: refs/heads/main", "targetID: "+zero, "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"duplicate ref": {
+			message:        body("refs/heads/main: "+zero, "refs/heads/main: "+nonZeroHash.String(), "", "number: 1"),
+			expectedErrors: []error{ErrDuplicateReferenceInBulkEntry, ErrInvalidRSLEntry},
+		},
+		"gittuf ref": {
+			message:        body("refs/gittuf/policy: "+zero, "", "number: 1"),
+			expectedErrors: []error{ErrGittufReferenceInBulkEntry, ErrInvalidRSLEntry},
+		},
+		"unqualified ref": {
+			message:        body("main: "+zero, "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"malformed hash": {
+			message: body("refs/heads/main: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", "", "number: 1"),
+			// Hash errors do not wrap ErrInvalidRSLEntry anywhere in the
+			// package, so only the hash sentinel is asserted here.
+			expectedErrors: []error{ErrInvalidHashEncoding},
+		},
+		"non numeric number": {
+			message:        body("refs/heads/main: "+zero, "", "number: five"),
+			expectedErrors: []error{strconv.ErrSyntax},
+		},
+		"header with trailing text": {
+			message:        BulkReferenceEntryHeader + " v2\n\nrefs/heads/main: " + zero + "\n\nnumber: 1",
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"missing blank line after the header": {
+			message:        BulkReferenceEntryHeader + "\nrefs/heads/main: " + zero + "\n\nnumber: 1",
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			entry, err := parseRSLEntryText(githash.ZeroHash, test.message)
+			if len(test.expectedErrors) != 0 {
+				for _, expected := range test.expectedErrors {
+					assert.ErrorIs(t, err, expected)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedEntry, entry)
+		})
+	}
+}
+
+func TestBulkReferenceEntryRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	nonZeroHash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	entry := &BulkReferenceEntry{
+		ID: githash.ZeroHash,
+		Updates: []ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: nonZeroHash},
+		},
+		Number: 7,
+	}
+	message, err := entry.createCommitMessage(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, fmt.Sprintf("%s\n\nrefs/heads/main: %s\nrefs/heads/feature: %s\n\n%s: 7", BulkReferenceEntryHeader, githash.ZeroHash.String(), nonZeroHash.String(), NumberKey), message)
+
+	parsed, err := parseRSLEntryText(githash.ZeroHash, message)
+	assert.NoError(t, err)
+	assert.Equal(t, entry, parsed)
+}
+
+func TestReferenceUpdaters(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		entry            Entry
+		expectedRefNames []string
+		expectedError    error
+	}{
+		"reference entry": {
+			entry:            &ReferenceEntry{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+			expectedRefNames: []string{"refs/heads/main"},
+		},
+		"propagation entry": {
+			entry:            NewPropagationEntry("refs/heads/main", githash.ZeroHash, "https://git.example.com/repo", githash.ZeroHash),
+			expectedRefNames: []string{"refs/heads/main"},
+		},
+		"annotation entry": {
+			entry: &AnnotationEntry{},
+		},
+		"bulk reference entry": {
+			entry: &BulkReferenceEntry{
+				ID: githash.ZeroHash,
+				Updates: []ReferenceUpdate{
+					{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+					{RefName: "refs/heads/feature", TargetID: githash.ZeroHash},
+					{RefName: "refs/tags/v1", TargetID: githash.ZeroHash},
+				},
+			},
+			expectedRefNames: []string{"refs/heads/main", "refs/heads/feature", "refs/tags/v1"},
+		},
+		"unknown entry type": {
+			entry:         &fakeEntry{},
+			expectedError: ErrUnknownRSLEntryType,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			updaters, err := referenceUpdaters(test.entry)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedRefNames, refNames(updaters))
+			}
+
+			newestFirst, err := referenceUpdatersNewestFirst(test.entry)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+				return
+			}
+			assert.NoError(t, err)
+			reversed := slices.Clone(test.expectedRefNames)
+			slices.Reverse(reversed)
+			assert.Equal(t, reversed, refNames(newestFirst))
+		})
+	}
+}
+
+func TestReferenceUpdatersViewsAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	entry := &BulkReferenceEntry{
+		ID: githash.ZeroHash,
+		Updates: []ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: githash.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: githash.ZeroHash},
+		},
+	}
+
+	updaters, err := referenceUpdaters(entry)
+	assert.NoError(t, err)
+	slices.Reverse(updaters)
+
+	again, err := referenceUpdaters(entry)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"refs/heads/main", "refs/heads/feature"}, refNames(again))
+}
+
+func refNames(updaters []ReferenceUpdaterEntry) []string {
+	if updaters == nil {
+		return nil
+	}
+
+	names := make([]string, 0, len(updaters))
+	for _, updater := range updaters {
+		names = append(names, updater.GetRefName())
+	}
+	return names
+}
+
+type fakeEntry struct{}
+
+func (f *fakeEntry) GetID() githash.Hash                      { return githash.ZeroHash }
+func (f *fakeEntry) Commit(gitstore.Storer, bool) error       { return nil }
+func (f *fakeEntry) GetNumber() uint64                        { return 0 }
+func (f *fakeEntry) createCommitMessage(bool) (string, error) { return "", nil }
+
+func FuzzParseBulkReferenceEntryText(f *testing.F) {
+	f.Add("")
+	f.Add(fmt.Sprintf("%s\n\nrefs/heads/main: %s\n\n%s: 1", BulkReferenceEntryHeader, fuzzZeroHash, NumberKey))
+	f.Add(fmt.Sprintf("%s\n\nrefs/heads/main: %s\nrefs/heads/feature: %s\n\n%s: 3", BulkReferenceEntryHeader, fuzzZeroHash, fuzzNonZeroHash, NumberKey))
+	f.Add(fmt.Sprintf("%s\n\nrefs/heads/main: %s\n%s: 3", BulkReferenceEntryHeader, fuzzZeroHash, NumberKey))
+	f.Add(fmt.Sprintf("%s\n\n%s: refs/heads/main\n%s: %s", BulkReferenceEntryHeader, RefKey, TargetIDKey, fuzzZeroHash))
+
+	f.Fuzz(func(_ *testing.T, text string) {
+		_, _ = parseBulkReferenceEntryText(githash.ZeroHash, text)
+	})
+}

--- a/pkg/rsl/bulk_test.go
+++ b/pkg/rsl/bulk_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/gittuf/gittuf/pkg/gitstore"
 	"github.com/stretchr/testify/assert"
@@ -262,6 +263,40 @@ func TestParseBulkReferenceEntryText(t *testing.T) {
 			message:        body("refs/heads/main: "+zero, "", "number: five"),
 			expectedErrors: []error{strconv.ErrSyntax},
 		},
+		"custom fields after the number": {
+			message: body("refs/heads/main: "+zero, "", "number: 1", "custom.example.com/field: value"),
+			expectedEntry: &BulkReferenceEntry{
+				ID:           githash.ZeroHash,
+				Updates:      []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:       1,
+				CustomFields: CustomFields{"custom.example.com/field": "value"},
+			},
+		},
+		"repeated custom field keeps the first value": {
+			message: body("refs/heads/main: "+zero, "", "number: 1", "custom.example.com/field: first", "custom.example.com/field: second"),
+			expectedEntry: &BulkReferenceEntry{
+				ID:           githash.ZeroHash,
+				Updates:      []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:       1,
+				CustomFields: CustomFields{"custom.example.com/field": "first"},
+			},
+		},
+		"malformed custom field is dropped": {
+			message: body("refs/heads/main: "+zero, "", "number: 1", "custom.example.com/Field: value"),
+			expectedEntry: &BulkReferenceEntry{
+				ID:      githash.ZeroHash,
+				Updates: []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}},
+				Number:  1,
+			},
+		},
+		"custom field before the number": {
+			message:        body("refs/heads/main: "+zero, "custom.example.com/field: value", "", "number: 1"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
+		"unknown key after the number": {
+			message:        body("refs/heads/main: "+zero, "", "number: 1", "other: value"),
+			expectedErrors: []error{ErrInvalidRSLEntry},
+		},
 		"header with trailing text": {
 			message:        BulkReferenceEntryHeader + " v2\n\nrefs/heads/main: " + zero + "\n\nnumber: 1",
 			expectedErrors: []error{ErrInvalidRSLEntry},
@@ -424,5 +459,77 @@ func FuzzParseBulkReferenceEntryText(f *testing.F) {
 
 	f.Fuzz(func(_ *testing.T, text string) {
 		_, _ = parseBulkReferenceEntryText(githash.ZeroHash, text)
+	})
+}
+
+func TestBulkReferenceEntryCustomFieldsCodec(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+	updates := []ReferenceUpdate{{RefName: "refs/heads/main", TargetID: githash.ZeroHash}}
+	body := func(lines ...string) string {
+		return BulkReferenceEntryHeader + "\n\n" + strings.Join(lines, "\n")
+	}
+
+	t.Run("fields are sorted and follow the number", func(t *testing.T) {
+		t.Parallel()
+
+		entry := &BulkReferenceEntry{
+			Updates: updates,
+			Number:  4,
+			CustomFields: CustomFields{
+				"custom.example.com/zebra": "last",
+				"custom.example.com/alpha": "first",
+			},
+		}
+
+		message, err := entry.createCommitMessage(true)
+		require.NoError(t, err)
+		assert.Equal(t, body("refs/heads/main: "+zero, "", "number: 4", "custom.example.com/alpha: first", "custom.example.com/zebra: last"), message)
+	})
+
+	t.Run("invalid field is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		entry := &BulkReferenceEntry{
+			Updates:      updates,
+			Number:       1,
+			CustomFields: CustomFields{"custom.example.com/Field": "value"},
+		}
+
+		_, err := entry.createCommitMessage(true)
+		assert.ErrorIs(t, err, customfields.ErrInvalid)
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		t.Parallel()
+
+		entry := &BulkReferenceEntry{
+			ID:           githash.ZeroHash,
+			Updates:      updates,
+			Number:       9,
+			CustomFields: CustomFields{"custom.example.com/field": "value"},
+		}
+
+		message, err := entry.createCommitMessage(true)
+		require.NoError(t, err)
+		parsed, err := parseRSLEntryText(githash.ZeroHash, message)
+		require.NoError(t, err)
+		assert.Equal(t, entry, parsed)
+	})
+
+	t.Run("constructor copies the supplied fields", func(t *testing.T) {
+		t.Parallel()
+
+		fields := CustomFields{"custom.example.com/field": "value"}
+		entry := NewBulkReferenceEntry(updates, WithCustomFields(fields))
+		fields["custom.example.com/field"] = "changed"
+
+		value, has := entry.GetCustomField("custom.example.com/field")
+		assert.True(t, has)
+		assert.Equal(t, "value", value)
+
+		_, has = entry.GetCustomField("custom.example.com/absent")
+		assert.False(t, has)
 	})
 }

--- a/pkg/rsl/cache_test.go
+++ b/pkg/rsl/cache_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestRSLCache(t *testing.T) {
+	// The cache is package level state shared with every other test in the
+	// package, and the assertions below require it to start empty.
+	newRSLCache()
+
 	// Add test entries
 	// Using fake hashes (these are commits in the gittuf repo itself)
 	entry1 := NewReferenceEntry("refs/heads/main", githash.ZeroHash)

--- a/pkg/rsl/repository_test.go
+++ b/pkg/rsl/repository_test.go
@@ -15,9 +15,12 @@ import (
 	"github.com/gittuf/gittuf/pkg/customfields"
 	"github.com/gittuf/gittuf/pkg/githash"
 	"github.com/gittuf/gittuf/pkg/gitinterface"
+	"github.com/gittuf/gittuf/pkg/gitstore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var _ gitstore.TipPinningStorer = (*gitinterface.Repository)(nil)
 
 const annotationMessage = "test annotation"
 
@@ -2460,4 +2463,380 @@ func TestCommitRejectsLineBreakInField(t *testing.T) {
 		err := NewPropagationEntry("refs/heads/main", gitinterface.ZeroHash, "https://example.com/repo\ninjected", gitinterface.ZeroHash).Commit(repo, false)
 		assert.ErrorIs(t, err, ErrInvalidRSLEntry)
 	})
+}
+
+// buildMixedRSL records, in order: main (single), bulk {main, feature},
+// annotation skipping the bulk entry's feature update only, policy (single),
+// bulk {feature, release}. It returns the entries in recording order.
+func buildMixedRSL(t *testing.T, repo *gitinterface.Repository) []Entry {
+	t.Helper()
+
+	entries := []Entry{}
+	record := func(commit func() error) {
+		if err := commit(); err != nil {
+			t.Fatal(err)
+		}
+		latest, err := GetLatestEntry(repo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries = append(entries, latest)
+	}
+
+	record(func() error { return NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false) })
+	record(func() error {
+		return NewBulkReferenceEntry([]ReferenceUpdate{
+			{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+		}).Commit(repo, false)
+	})
+	record(func() error {
+		bulkID := entries[1].GetID()
+		return NewAnnotationEntryWithQualifiers([]githash.Hash{bulkID}, map[string][]string{bulkID.String(): {"refs/heads/feature"}}, true, annotationMessage).Commit(repo, false)
+	})
+	record(func() error {
+		return NewReferenceEntry("refs/gittuf/policy", gitinterface.ZeroHash).Commit(repo, false)
+	})
+	featureTarget, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseTarget, err := NewHash("1234567890abcdef1234567890abcdef12345678")
+	if err != nil {
+		t.Fatal(err)
+	}
+	record(func() error {
+		return NewBulkReferenceEntry([]ReferenceUpdate{
+			{RefName: "refs/heads/feature", TargetID: featureTarget},
+			{RefName: "refs/heads/release", TargetID: releaseTarget},
+		}).Commit(repo, false)
+	})
+
+	return entries
+}
+
+func TestWalkersWithBulkEntries(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+	entries := buildMixedRSL(t, repo)
+	firstBulk := entries[1].(*BulkReferenceEntry)
+	secondBulk := entries[4].(*BulkReferenceEntry)
+
+	t.Run("latest for ref inside bulk", func(t *testing.T) {
+		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/release"))
+		require.NoError(t, err)
+		assert.Equal(t, secondBulk.ID, entry.GetID())
+		assert.Equal(t, "refs/heads/release", entry.GetRefName())
+		assert.Nil(t, annotations)
+	})
+
+	t.Run("latest without filter is last listed update of latest bulk", func(t *testing.T) {
+		entry, _, err := GetLatestReferenceUpdaterEntry(repo)
+		require.NoError(t, err)
+		assert.Equal(t, "refs/heads/release", entry.GetRefName())
+	})
+
+	t.Run("before bulk ID skips all its updates", func(t *testing.T) {
+		entry, _, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/main"), BeforeEntryID(firstBulk.ID))
+		require.NoError(t, err)
+		assert.Equal(t, entries[0].GetID(), entry.GetID())
+	})
+
+	t.Run("until bulk ID excludes all its updates", func(t *testing.T) {
+		_, _, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/main"), UntilEntryID(firstBulk.ID))
+		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+	})
+
+	t.Run("unskipped honours qualified annotation", func(t *testing.T) {
+		entry, annotations, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/feature"), IsUnskipped(), BeforeEntryID(secondBulk.ID))
+		assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+		assert.Nil(t, entry)
+		assert.Nil(t, annotations)
+
+		entry, annotations, err = GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/main"), IsUnskipped(), BeforeEntryID(secondBulk.ID))
+		require.NoError(t, err)
+		assert.Equal(t, firstBulk.ID, entry.GetID())
+		require.Len(t, annotations, 1)
+		assert.False(t, entry.(*ReferenceEntry).SkippedBy(annotations))
+	})
+
+	t.Run("first for ref inside bulk", func(t *testing.T) {
+		entry, _, err := GetFirstReferenceUpdaterEntryForRef(repo, "refs/heads/feature")
+		require.NoError(t, err)
+		assert.Equal(t, firstBulk.ID, entry.GetID())
+		assert.Equal(t, "refs/heads/feature", entry.GetRefName())
+	})
+
+	t.Run("first entry overall is first listed update when first entry is bulk", func(t *testing.T) {
+		otherDir := t.TempDir()
+		otherRepo := gitinterface.CreateTestGitRepository(t, otherDir, false)
+		require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+			{RefName: "refs/heads/a", TargetID: gitinterface.ZeroHash},
+			{RefName: "refs/heads/b", TargetID: gitinterface.ZeroHash},
+		}).Commit(otherRepo, false))
+		entry, _, err := GetFirstEntry(otherRepo)
+		require.NoError(t, err)
+		assert.Equal(t, "refs/heads/a", entry.GetRefName())
+	})
+
+	t.Run("range across bulk entries in listed order", func(t *testing.T) {
+		updaters, annotationMap, err := GetReferenceUpdaterEntriesInRange(repo, entries[0].GetID(), secondBulk.ID)
+		require.NoError(t, err)
+		refs := make([]string, 0, len(updaters))
+		for _, u := range updaters {
+			refs = append(refs, u.GetRefName())
+		}
+		assert.Equal(t, []string{"refs/heads/main", "refs/heads/main", "refs/heads/feature", "refs/gittuf/policy", "refs/heads/feature", "refs/heads/release"}, refs)
+		require.Len(t, annotationMap[firstBulk.ID.String()], 1)
+
+		require.Len(t, updaters, 6)
+		assert.Equal(t, secondBulk.Updates[0].TargetID, updaters[4].GetTargetID())
+		assert.Equal(t, secondBulk.Updates[1].TargetID, updaters[5].GetTargetID())
+		assert.NotEqual(t, updaters[4].GetTargetID(), updaters[5].GetTargetID())
+	})
+
+	t.Run("range with first equal to last on a bulk entry", func(t *testing.T) {
+		updaters, _, err := GetReferenceUpdaterEntriesInRange(repo, secondBulk.ID, secondBulk.ID)
+		require.NoError(t, err)
+		require.Len(t, updaters, 2)
+		assert.Equal(t, "refs/heads/feature", updaters[0].GetRefName())
+		assert.Equal(t, "refs/heads/release", updaters[1].GetRefName())
+	})
+
+	t.Run("range for ref filters views", func(t *testing.T) {
+		updaters, _, err := GetReferenceUpdaterEntriesInRangeForRef(repo, entries[0].GetID(), secondBulk.ID, "refs/heads/feature")
+		require.NoError(t, err)
+		refs := make([]string, 0, len(updaters))
+		for _, u := range updaters {
+			refs = append(refs, u.GetRefName())
+		}
+		assert.Equal(t, []string{"refs/heads/feature", "refs/gittuf/policy", "refs/heads/feature"}, refs)
+	})
+
+	t.Run("non gittuf parent of a view", func(t *testing.T) {
+		policyEntry := entries[3].(*ReferenceEntry)
+		entry, _, err := GetNonGittufParentReferenceUpdaterEntryForEntry(repo, policyEntry)
+		require.NoError(t, err)
+		assert.Equal(t, firstBulk.ID, entry.GetID())
+		assert.Equal(t, "refs/heads/feature", entry.GetRefName())
+	})
+}
+
+func TestRangeWalkerOverAppliesQualifiedAnnotations(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+	}).Commit(repo, false))
+	bulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	require.NoError(t, NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID()}, map[string][]string{bulk.GetID().String(): {"refs/heads/feature"}}, true, annotationMessage).Commit(repo, false))
+	annotation, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	// The annotation map is keyed by entry ID, so the qualified annotation
+	// reaches the view for every ref the bulk entry updates. Narrowing is the
+	// consumer's job, here via SkippedBy.
+	for _, refName := range []string{"refs/heads/main", "refs/heads/feature"} {
+		updaters, annotationMap, err := GetReferenceUpdaterEntriesInRangeForRef(repo, bulk.GetID(), bulk.GetID(), refName)
+		require.NoError(t, err)
+		require.Len(t, updaters, 1)
+		assert.Equal(t, refName, updaters[0].GetRefName())
+
+		annotations := annotationMap[bulk.GetID().String()]
+		require.Len(t, annotations, 1)
+		assert.Equal(t, annotation.GetID(), annotations[0].GetID())
+
+		skipped := updaters[0].(*ReferenceEntry).SkippedBy(annotations)
+		assert.Equal(t, refName == "refs/heads/feature", skipped)
+	}
+
+	entry, _, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/main"), IsUnskipped())
+	require.NoError(t, err)
+	assert.Equal(t, bulk.GetID(), entry.GetID())
+
+	_, _, err = GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/feature"), IsUnskipped())
+	assert.ErrorIs(t, err, ErrRSLEntryNotFound)
+}
+
+func TestAnnotationQualifierValidationOnCommit(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	require.NoError(t, NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false))
+	single, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: gitinterface.ZeroHash},
+		{RefName: "refs/heads/feature", TargetID: gitinterface.ZeroHash},
+	}).Commit(repo, false))
+	bulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{single.GetID()}, map[string][]string{single.GetID().String(): {"refs/heads/main"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID()}, map[string][]string{bulk.GetID().String(): {"refs/heads/other"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID()}, map[string][]string{single.GetID().String(): {"refs/heads/main"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID()}, map[string][]string{bulk.GetID().String(): {"refs/heads/feature"}}, true, "").Commit(repo, false)
+	require.NoError(t, err)
+
+	latest, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+	annotation := latest.(*AnnotationEntry)
+	assert.Equal(t, map[string][]string{bulk.GetID().String(): {"refs/heads/feature"}}, annotation.Refs)
+
+	require.NoError(t, NewPropagationEntry("refs/heads/downstream", gitinterface.ZeroHash, "https://example.com/upstream", gitinterface.ZeroHash).Commit(repo, false))
+	propagation, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{propagation.GetID()}, map[string][]string{propagation.GetID().String(): {"refs/heads/downstream"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{annotation.GetID()}, map[string][]string{annotation.GetID().String(): {"refs/heads/feature"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	// A qualified entry ID listed twice is rejected because the codec emits
+	// the qualifiers once per occurrence.
+	err = NewAnnotationEntryWithQualifiers([]githash.Hash{bulk.GetID(), bulk.GetID()}, map[string][]string{bulk.GetID().String(): {"refs/heads/feature"}}, true, "").Commit(repo, false)
+	assert.ErrorIs(t, err, ErrInvalidAnnotationQualifier)
+
+	// An unqualified entry ID listed twice stays legal.
+	require.NoError(t, NewAnnotationEntry([]githash.Hash{bulk.GetID(), bulk.GetID()}, true, "").Commit(repo, false))
+}
+
+func TestGetFirstReferenceUpdaterEntryForCommitWithBulk(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+	emptyTree, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+
+	mainCommit, err := repo.Commit(emptyTree, "refs/heads/main", "main\n", false)
+	require.NoError(t, err)
+	featureCommit, err := repo.Commit(emptyTree, "refs/heads/feature", "feature\n", false)
+	require.NoError(t, err)
+
+	require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: mainCommit},
+		{RefName: "refs/heads/feature", TargetID: featureCommit},
+	}).Commit(repo, false))
+	firstBulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	// Both refs advance and are recorded together again. Every later
+	// update contains the earlier commits, which is the contiguity the
+	// walker assumes.
+	mainCommit2, err := repo.Commit(emptyTree, "refs/heads/main", "main 2\n", false)
+	require.NoError(t, err)
+	featureCommit2, err := repo.Commit(emptyTree, "refs/heads/feature", "feature 2\n", false)
+	require.NoError(t, err)
+	require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: mainCommit2},
+		{RefName: "refs/heads/feature", TargetID: featureCommit2},
+	}).Commit(repo, false))
+	secondBulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	// featureCommit is reachable only through the feature update of each
+	// bulk entry. The first entry recording it is the first bulk entry.
+	entry, _, err := GetFirstReferenceUpdaterEntryForCommit(repo, featureCommit)
+	require.NoError(t, err)
+	assert.Equal(t, firstBulk.GetID(), entry.GetID())
+	assert.Equal(t, "refs/heads/feature", entry.GetRefName())
+
+	entry, _, err = GetFirstReferenceUpdaterEntryForCommit(repo, mainCommit)
+	require.NoError(t, err)
+	assert.Equal(t, firstBulk.GetID(), entry.GetID())
+	assert.Equal(t, "refs/heads/main", entry.GetRefName())
+
+	entry, _, err = GetFirstReferenceUpdaterEntryForCommit(repo, featureCommit2)
+	require.NoError(t, err)
+	assert.Equal(t, secondBulk.GetID(), entry.GetID())
+	assert.Equal(t, "refs/heads/feature", entry.GetRefName())
+
+	unknown, err := repo.Commit(emptyTree, "refs/heads/unrecorded", "unrecorded\n", false)
+	require.NoError(t, err)
+	_, _, err = GetFirstReferenceUpdaterEntryForCommit(repo, unknown)
+	assert.ErrorIs(t, err, ErrNoRecordOfCommit)
+}
+
+func TestSkipAllInvalidReferenceEntriesForRefWithBulk(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	treeBuilder := gitinterface.NewTreeBuilder(repo)
+	emptyTree, err := treeBuilder.WriteTreeFromEntries(nil)
+	require.NoError(t, err)
+
+	oldMain, err := repo.Commit(emptyTree, "refs/heads/main", "old main\n", false)
+	require.NoError(t, err)
+	feature, err := repo.Commit(emptyTree, "refs/heads/feature", "feature\n", false)
+	require.NoError(t, err)
+
+	require.NoError(t, NewBulkReferenceEntry([]ReferenceUpdate{
+		{RefName: "refs/heads/main", TargetID: oldMain},
+		{RefName: "refs/heads/feature", TargetID: feature},
+	}).Commit(repo, false))
+	bulk, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	// Rewrite main so oldMain is no longer reachable.
+	require.NoError(t, repo.DeleteReference("refs/heads/main"))
+	newMain, err := repo.Commit(emptyTree, "refs/heads/main", "rewritten main\n", false)
+	require.NoError(t, err)
+	require.NoError(t, NewReferenceEntry("refs/heads/main", newMain).Commit(repo, false))
+
+	require.NoError(t, SkipAllInvalidReferenceEntriesForRef(repo, "refs/heads/main", false))
+
+	latest, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+	annotation, isAnnotation := latest.(*AnnotationEntry)
+	require.True(t, isAnnotation)
+	assert.True(t, annotation.Skip)
+	assert.Equal(t, []githash.Hash{bulk.GetID()}, annotation.RSLEntryIDs)
+	assert.Equal(t, map[string][]string{bulk.GetID().String(): {"refs/heads/main"}}, annotation.Refs)
+
+	// The feature update in the same bulk entry stays unskipped.
+	entry, _, err := GetLatestReferenceUpdaterEntry(repo, ForReference("refs/heads/feature"), IsUnskipped())
+	require.NoError(t, err)
+	assert.Equal(t, bulk.GetID(), entry.GetID())
+}
+
+func TestCommitDetectsConcurrentRSLWrite(t *testing.T) {
+	tempDir := t.TempDir()
+	repo := gitinterface.CreateTestGitRepository(t, tempDir, false)
+
+	require.NoError(t, NewReferenceEntry("refs/heads/main", gitinterface.ZeroHash).Commit(repo, false))
+	first, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+
+	// The interleaving this pins is unreachable through the public API, so
+	// the test drives setEntryNumber and commitEntry directly.
+	entry := NewReferenceEntry("refs/heads/feature", gitinterface.ZeroHash)
+	observedTip, err := entry.setEntryNumber(repo)
+	require.NoError(t, err)
+	assert.Equal(t, first.GetID(), observedTip)
+
+	// Another writer advances the RSL between numbering and commit.
+	require.NoError(t, NewReferenceEntry("refs/heads/other", gitinterface.ZeroHash).Commit(repo, false))
+
+	message, err := entry.createCommitMessage(true)
+	require.NoError(t, err)
+	err = commitEntry(repo, message, false, observedTip)
+	assert.ErrorContains(t, err, "unable to set Git reference")
+
+	latest, err := GetLatestEntry(repo)
+	require.NoError(t, err)
+	assert.Equal(t, "refs/heads/other", latest.(*ReferenceEntry).RefName)
+	assert.Equal(t, uint64(2), latest.GetNumber())
 }

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -42,6 +43,7 @@ const (
 	UpstreamEntryIDKey     = "upstreamEntryID"
 
 	remoteTrackerRef       = "refs/remotes/%s/gittuf/reference-state-log"
+	refPrefix              = "refs/"
 	gittufNamespacePrefix  = "refs/gittuf/"
 	gittufPolicyStagingRef = "refs/gittuf/policy-staging"
 )
@@ -56,28 +58,75 @@ var (
 	ErrCannotUseEntryNumberFilter                   = errors.New("current RSL entries are not numbered, cannot use number range options")
 	ErrInvalidUntilEntryNumberCondition             = errors.New("cannot meet until entry number condition")
 	ErrUnknownRSLEntryType                          = fmt.Errorf("%w: RSL entry is of an unknown type", ErrInvalidRSLEntry)
+	// ErrInvalidAnnotationQualifier is returned only when committing an
+	// annotation, as the parser cannot validate qualifiers without a storer.
+	ErrInvalidAnnotationQualifier = errors.New("annotation ref qualifier does not match a reference update in the target bulk entry")
 )
+
+// nextEntryNumber returns the number to assign to a new entry: one more than
+// the latest entry's number, or 1 when the RSL is empty. The numbering starts
+// from 1 as 0 is used to signal the lack of numbering. It also returns the RSL
+// tip it observed, which is the zero hash when the RSL is empty. Callers pass
+// the tip to the commit helpers so the write is rejected if another writer
+// advanced the RSL in the meantime.
+func nextEntryNumber(storer gitstore.Storer) (uint64, githash.Hash, error) {
+	latestEntry, err := GetLatestEntry(storer)
+	if err != nil {
+		if errors.Is(err, ErrRSLEntryNotFound) {
+			return 1, storer.ZeroHash(), nil
+		}
+		return 0, storer.ZeroHash(), err
+	}
+
+	return latestEntry.GetNumber() + 1, latestEntry.GetID(), nil
+}
+
+// currentTip returns the RSL's tip, or the zero hash when the RSL does not
+// exist yet.
+func currentTip(storer gitstore.Storer) (githash.Hash, error) {
+	tip, err := storer.GetReference(Ref)
+	if err != nil {
+		if errors.Is(err, ErrReferenceNotFound) {
+			return storer.ZeroHash(), nil
+		}
+		return storer.ZeroHash(), err
+	}
+
+	return tip, nil
+}
 
 // commitEntry commits an RSL entry: an empty-tree commit on Ref carrying the
 // entry in its message. This is the storage shape of every RSL entry.
-func commitEntry(storer gitstore.Storer, message string, sign bool) error {
+func commitEntry(storer gitstore.Storer, message string, sign bool, expectedTip githash.Hash) error {
 	emptyTreeID, err := storer.EmptyTree()
 	if err != nil {
 		return err
 	}
 
+	if pinning, ok := storer.(gitstore.TipPinningStorer); ok {
+		_, err = pinning.CommitWithExpectedTip(emptyTreeID, Ref, message, sign, expectedTip)
+		return err
+	}
+
+	slog.Warn("Storer does not support tip-pinned commits, an RSL write may record a stale entry number under concurrent writers")
 	_, err = storer.Commit(emptyTreeID, Ref, message, sign)
 	return err
 }
 
 // commitEntryUsingSpecificKey is commitEntry signing with the provided PEM
 // encoded key. It is intended for gittuf's developer mode and tests.
-func commitEntryUsingSpecificKey(storer gitstore.Storer, message string, signingKeyBytes []byte) error {
+func commitEntryUsingSpecificKey(storer gitstore.Storer, message string, signingKeyBytes []byte, expectedTip githash.Hash) error {
 	emptyTreeID, err := storer.EmptyTree()
 	if err != nil {
 		return err
 	}
 
+	if pinning, ok := storer.(gitstore.TipPinningStorer); ok {
+		_, err = pinning.CommitUsingSpecificKeyWithExpectedTip(emptyTreeID, Ref, message, signingKeyBytes, expectedTip)
+		return err
+	}
+
+	slog.Warn("Storer does not support tip-pinned commits, an RSL write may record a stale entry number under concurrent writers")
 	_, err = storer.CommitUsingSpecificKey(emptyTreeID, Ref, message, signingKeyBytes)
 	return err
 }
@@ -108,6 +157,13 @@ type ReferenceUpdaterEntry interface {
 
 // ReferenceEntry represents a record of a reference state in the RSL. It
 // implements the Entry interface.
+//
+// A *ReferenceEntry may also be a read-only per-ref view of a
+// BulkReferenceEntry. A view carries the bulk entry's ID and Number, reports
+// FromBulkEntry as true, and is refused with ErrCannotCommitView by Commit and
+// CommitUsingSpecificKey. An entry ID therefore no longer identifies a single
+// reference update: several views can share one ID. Code that persists an
+// (entry ID, ref) pair must load it back with GetReferenceUpdaterEntryForRef.
 type ReferenceEntry struct {
 	// ID contains the Git hash for the commit corresponding to the entry.
 	ID githash.Hash
@@ -123,6 +179,17 @@ type ReferenceEntry struct {
 
 	// CustomFields contains application-defined metadata for the entry.
 	CustomFields CustomFields
+
+	// isView is true when this value is a per-ref projection of a
+	// BulkReferenceEntry. Views share the bulk entry's ID and Number and
+	// cannot be committed.
+	isView bool
+}
+
+// FromBulkEntry reports whether this entry is a per-ref view of a
+// BulkReferenceEntry. The ID of a view is the bulk entry's commit ID.
+func (e *ReferenceEntry) FromBulkEntry() bool {
+	return e.isView
 }
 
 // NewReferenceEntry returns a ReferenceEntry object for a normal RSL entry.
@@ -149,7 +216,12 @@ func (e *ReferenceEntry) GetTargetID() githash.Hash {
 // entry's number is 0 (unset), the current entry's number is set to 1. The
 // numbering starts from 1 as 0 is used to signal the lack of numbering.
 func (e *ReferenceEntry) Commit(storer gitstore.Storer, sign bool) error {
-	if err := e.setEntryNumber(storer); err != nil {
+	if e.isView {
+		return ErrCannotCommitView
+	}
+
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -158,7 +230,7 @@ func (e *ReferenceEntry) Commit(storer gitstore.Storer, sign bool) error {
 		return err
 	}
 
-	return commitEntry(storer, message, sign)
+	return commitEntry(storer, message, sign, expectedTip)
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
@@ -169,7 +241,12 @@ func (e *ReferenceEntry) Commit(storer gitstore.Storer, sign bool) error {
 // the parent entry's number is 0 (unset), the current entry's number is set to
 // 1. The numbering starts from 1 as 0 is used to signal the lack of numbering.
 func (e *ReferenceEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingKeyBytes []byte) error {
-	if err := e.setEntryNumber(storer); err != nil {
+	if e.isView {
+		return ErrCannotCommitView
+	}
+
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -178,7 +255,7 @@ func (e *ReferenceEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingK
 		return err
 	}
 
-	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes, expectedTip)
 }
 
 func (e *ReferenceEntry) GetNumber() uint64 {
@@ -194,7 +271,7 @@ func (e *ReferenceEntry) GetCustomField(key string) (string, bool) {
 // to-be-skipped.
 func (e *ReferenceEntry) SkippedBy(annotations []*AnnotationEntry) bool {
 	for _, annotation := range annotations {
-		if annotation.RefersTo(e.ID) && annotation.Skip {
+		if annotation.Skip && annotation.AppliesTo(e.ID, e.RefName) {
 			return true
 		}
 	}
@@ -202,20 +279,14 @@ func (e *ReferenceEntry) SkippedBy(annotations []*AnnotationEntry) bool {
 	return false
 }
 
-func (e *ReferenceEntry) setEntryNumber(storer gitstore.Storer) error {
-	latestEntry, err := GetLatestEntry(storer)
-	if err == nil {
-		e.Number = latestEntry.GetNumber() + 1
-	} else {
-		if errors.Is(err, ErrRSLEntryNotFound) {
-			// First entry
-			e.Number = 1
-		} else {
-			return err
-		}
+func (e *ReferenceEntry) setEntryNumber(storer gitstore.Storer) (githash.Hash, error) {
+	number, tip, err := nextEntryNumber(storer)
+	if err != nil {
+		return tip, err
 	}
 
-	return nil
+	e.Number = number
+	return tip, nil
 }
 
 func checkSingleLineField(value string) error {
@@ -249,12 +320,21 @@ func (e *ReferenceEntry) createCommitMessage(includeNumber bool) (string, error)
 // producing a legacy unnumbered entry. It exists to exercise the RSL's support
 // for repositories that transition from unnumbered to numbered entries.
 func (e *ReferenceEntry) CommitWithoutNumber(storer gitstore.Storer) error {
+	if e.isView {
+		return ErrCannotCommitView
+	}
+
+	expectedTip, err := currentTip(storer)
+	if err != nil {
+		return err
+	}
+
 	message, err := e.createCommitMessage(false)
 	if err != nil {
 		return err
 	}
 
-	return commitEntry(storer, message, false)
+	return commitEntry(storer, message, false, expectedTip)
 }
 
 // AnnotationEntry is a type of RSL record that references prior items in the
@@ -267,6 +347,16 @@ type AnnotationEntry struct {
 
 	// RSLEntryIDs contains one or more Git hashes for the RSL entries the annotation applies to.
 	RSLEntryIDs []githash.Hash
+
+	// Refs holds optional ref qualifiers keyed by the hex string of an entry
+	// in RSLEntryIDs. An entry ID with no key, or an empty list, is referred
+	// to as a whole. An entry ID with qualifiers is referred to only for the
+	// listed reference updates. Qualifiers are only valid against bulk
+	// reference entries. Nil when the annotation has no qualifiers.
+	// Qualifiers are not validated against the target entry at parse time.
+	// That happens in validateTargets at commit time, so a qualifier naming
+	// a ref the target does not update applies to nothing.
+	Refs map[string][]string
 
 	// Skip indicates if the RSLEntryIDs must be skipped during gittuf workflows.
 	Skip bool
@@ -288,6 +378,45 @@ func NewAnnotationEntry(rslEntryIDs []githash.Hash, skip bool, message string, o
 	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Skip: skip, Message: message, CustomFields: options.customFields}
 }
 
+// NewAnnotationEntryWithQualifiers returns an annotation that applies to the
+// listed entries, restricted for the keyed entries to the listed reference
+// updates. Keys are entry ID hex strings and must also appear in rslEntryIDs.
+func NewAnnotationEntryWithQualifiers(rslEntryIDs []githash.Hash, refs map[string][]string, skip bool, message string, opts ...EntryOption) *AnnotationEntry {
+	// The map is cloned so the annotation does not alias the caller's, and
+	// keys with no refs are dropped: they mean the whole entry, which is how
+	// an absent key already reads. A nil map keeps codec round trips equal.
+	var qualifiers map[string][]string
+	for id, refNames := range refs {
+		if len(refNames) == 0 {
+			continue
+		}
+		if qualifiers == nil {
+			qualifiers = make(map[string][]string, len(refs))
+		}
+		qualifiers[id] = slices.Clone(refNames)
+	}
+
+	options := applyEntryOptions(opts)
+	return &AnnotationEntry{RSLEntryIDs: rslEntryIDs, Refs: qualifiers, Skip: skip, Message: message, CustomFields: options.customFields}
+}
+
+// AppliesTo reports whether the annotation applies to the reference update
+// for refName in entryID. An unqualified mention applies to every update in
+// the entry. A qualified mention applies only to the listed refs.
+func (a *AnnotationEntry) AppliesTo(entryID githash.Hash, refName string) bool {
+	if !a.RefersTo(entryID) {
+		return false
+	}
+	if len(a.Refs) == 0 {
+		return true
+	}
+	refs, qualified := a.Refs[entryID.String()]
+	if !qualified || len(refs) == 0 {
+		return true
+	}
+	return slices.Contains(refs, refName)
+}
+
 func (a *AnnotationEntry) GetID() githash.Hash {
 	return a.ID
 }
@@ -298,14 +427,12 @@ func (a *AnnotationEntry) GetID() githash.Hash {
 // is 0 (unset), the current entry's number is set to 1. The numbering starts
 // from 1 as 0 is used to signal the lack of numbering.
 func (a *AnnotationEntry) Commit(storer gitstore.Storer, sign bool) error {
-	// Check if referred entries exist in the RSL namespace.
-	for _, id := range a.RSLEntryIDs {
-		if _, err := GetEntry(storer, id); err != nil {
-			return err
-		}
+	if err := a.validateTargets(storer); err != nil {
+		return err
 	}
 
-	if err := a.setEntryNumber(storer); err != nil {
+	expectedTip, err := a.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -314,8 +441,7 @@ func (a *AnnotationEntry) Commit(storer gitstore.Storer, sign bool) error {
 		return err
 	}
 
-	err = commitEntry(storer, message, sign)
-	return err
+	return commitEntry(storer, message, sign, expectedTip)
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
@@ -326,14 +452,12 @@ func (a *AnnotationEntry) Commit(storer gitstore.Storer, sign bool) error {
 // the parent entry's number is 0 (unset), the current entry's number is set to
 // 1. The numbering starts from 1 as 0 is used to signal the lack of numbering.
 func (a *AnnotationEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingKeyBytes []byte) error {
-	// Check if referred entries exist in the RSL namespace.
-	for _, id := range a.RSLEntryIDs {
-		if _, err := GetEntry(storer, id); err != nil {
-			return err
-		}
+	if err := a.validateTargets(storer); err != nil {
+		return err
 	}
 
-	if err := a.setEntryNumber(storer); err != nil {
+	expectedTip, err := a.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -342,8 +466,7 @@ func (a *AnnotationEntry) CommitUsingSpecificKey(storer gitstore.Storer, signing
 		return err
 	}
 
-	err = commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
-	return err
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes, expectedTip)
 }
 
 func (a *AnnotationEntry) GetNumber() uint64 {
@@ -353,6 +476,67 @@ func (a *AnnotationEntry) GetNumber() uint64 {
 func (a *AnnotationEntry) GetCustomField(key string) (string, bool) {
 	value, has := a.CustomFields[key]
 	return value, has
+}
+
+// validateTargets checks that every referenced entry exists and that every
+// ref qualifier names a reference update in a bulk reference entry.
+func (a *AnnotationEntry) validateTargets(storer gitstore.Storer) error {
+	knownIDs := make(map[string]struct{}, len(a.RSLEntryIDs))
+	for _, id := range a.RSLEntryIDs {
+		key := id.String()
+		// An entry ID listed twice without qualifiers has always been
+		// legal and means the same as listing it once. With qualifiers it
+		// cannot round trip: createCommitMessage emits the qualifiers once
+		// per occurrence and the parser attaches them to the most recent
+		// entry ID, so the list would grow on every read and write cycle.
+		if _, duplicate := knownIDs[key]; duplicate && len(a.Refs[key]) != 0 {
+			return fmt.Errorf("%w: entry %s is listed more than once with ref qualifiers", ErrInvalidAnnotationQualifier, key)
+		}
+		knownIDs[key] = struct{}{}
+	}
+
+	// Keys are sorted so the reported key does not depend on map order.
+	qualifiedIDs := make([]string, 0, len(a.Refs))
+	for id := range a.Refs {
+		qualifiedIDs = append(qualifiedIDs, id)
+	}
+	slices.Sort(qualifiedIDs)
+
+	for _, id := range qualifiedIDs {
+		if _, known := knownIDs[id]; !known {
+			return fmt.Errorf("%w: entry %s is not referred to by the annotation", ErrInvalidAnnotationQualifier, id)
+		}
+	}
+
+	for _, id := range a.RSLEntryIDs {
+		target, err := GetEntry(storer, id)
+		if err != nil {
+			return err
+		}
+
+		refs := a.Refs[id.String()]
+		if len(refs) == 0 {
+			continue
+		}
+
+		bulk, isBulk := target.(*BulkReferenceEntry)
+		if !isBulk {
+			return fmt.Errorf("%w: entry %s is not a bulk reference entry", ErrInvalidAnnotationQualifier, id.String())
+		}
+		for _, refName := range refs {
+			found := false
+			for _, update := range bulk.Updates {
+				if update.RefName == refName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("%w: entry %s does not update %s", ErrInvalidAnnotationQualifier, id.String(), refName)
+			}
+		}
+	}
+	return nil
 }
 
 // RefersTo returns true if the specified entryID is referred to by the
@@ -367,20 +551,17 @@ func (a *AnnotationEntry) RefersTo(entryID githash.Hash) bool {
 	return false
 }
 
-func (a *AnnotationEntry) setEntryNumber(storer gitstore.Storer) error {
-	latestEntry, err := GetLatestEntry(storer)
-	if err == nil {
-		a.Number = latestEntry.GetNumber() + 1
-	} else {
-		if errors.Is(err, ErrRSLEntryNotFound) {
-			// First entry -> can an annotation actually be first? TODO
-			a.Number = 1
-		} else {
-			return err
-		}
+// TODO: can an annotation actually be the first entry in the RSL? If it cannot,
+// the number 1 that nextEntryNumber assigns for an empty RSL is unreachable
+// here.
+func (a *AnnotationEntry) setEntryNumber(storer gitstore.Storer) (githash.Hash, error) {
+	number, tip, err := nextEntryNumber(storer)
+	if err != nil {
+		return tip, err
 	}
 
-	return nil
+	a.Number = number
+	return tip, nil
 }
 
 func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error) {
@@ -391,6 +572,12 @@ func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error
 
 	for _, entry := range a.RSLEntryIDs {
 		lines = append(lines, fmt.Sprintf("%s: %s", EntryIDKey, entry.String()))
+		for _, refName := range a.Refs[entry.String()] {
+			if err := validateBulkRefName(refName); err != nil {
+				return "", err
+			}
+			lines = append(lines, fmt.Sprintf("%s: %s", RefKey, refName))
+		}
 	}
 
 	if a.Skip {
@@ -427,11 +614,13 @@ func (a *AnnotationEntry) createCommitMessage(includeNumber bool) (string, error
 // producing a legacy unnumbered entry. It exists to exercise the RSL's support
 // for repositories that transition from unnumbered to numbered entries.
 func (a *AnnotationEntry) CommitWithoutNumber(storer gitstore.Storer) error {
-	// Check if referred entries exist in the RSL namespace.
-	for _, id := range a.RSLEntryIDs {
-		if _, err := GetEntry(storer, id); err != nil {
-			return err
-		}
+	if err := a.validateTargets(storer); err != nil {
+		return err
+	}
+
+	expectedTip, err := currentTip(storer)
+	if err != nil {
+		return err
 	}
 
 	message, err := a.createCommitMessage(false)
@@ -439,8 +628,7 @@ func (a *AnnotationEntry) CommitWithoutNumber(storer gitstore.Storer) error {
 		return err
 	}
 
-	err = commitEntry(storer, message, false)
-	return err
+	return commitEntry(storer, message, false, expectedTip)
 }
 
 // PropagationEntry represents a record of execution of gittuf's repository
@@ -462,7 +650,11 @@ type PropagationEntry struct {
 	UpstreamRepository string
 
 	// UpstreamEntryID records the upstream repository's RSL entry ID whose
-	// contents were propagated.
+	// contents were propagated. When the upstream repository uses bulk
+	// reference entries, the ID alone does not identify one reference
+	// update, because a bulk entry records several. Consumers must pair the
+	// ID with the upstream reference named by the propagation directive and
+	// resolve it with GetReferenceUpdaterEntryForRef.
 	UpstreamEntryID githash.Hash
 
 	// Number contains a strictly increasing number that hints at entry ordering.
@@ -501,7 +693,8 @@ func (e *PropagationEntry) GetTargetID() githash.Hash {
 // entry's number is 0 (unset), the current entry's number is set to 1. The
 // numbering starts from 1 as 0 is used to signal the lack of numbering.
 func (e *PropagationEntry) Commit(storer gitstore.Storer, sign bool) error {
-	if err := e.setEntryNumber(storer); err != nil {
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -510,7 +703,7 @@ func (e *PropagationEntry) Commit(storer gitstore.Storer, sign bool) error {
 		return err
 	}
 
-	return commitEntry(storer, message, sign)
+	return commitEntry(storer, message, sign, expectedTip)
 }
 
 // CommitUsingSpecificKey creates a commit object in the RSL for the
@@ -521,7 +714,8 @@ func (e *PropagationEntry) Commit(storer gitstore.Storer, sign bool) error {
 // the parent entry's number is 0 (unset), the current entry's number is set to
 // 1. The numbering starts from 1 as 0 is used to signal the lack of numbering.
 func (e *PropagationEntry) CommitUsingSpecificKey(storer gitstore.Storer, signingKeyBytes []byte) error {
-	if err := e.setEntryNumber(storer); err != nil {
+	expectedTip, err := e.setEntryNumber(storer)
+	if err != nil {
 		return err
 	}
 
@@ -530,7 +724,7 @@ func (e *PropagationEntry) CommitUsingSpecificKey(storer gitstore.Storer, signin
 		return err
 	}
 
-	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes)
+	return commitEntryUsingSpecificKey(storer, message, signingKeyBytes, expectedTip)
 }
 
 func (e PropagationEntry) GetNumber() uint64 {
@@ -542,20 +736,14 @@ func (e *PropagationEntry) GetCustomField(key string) (string, bool) {
 	return value, has
 }
 
-func (e *PropagationEntry) setEntryNumber(storer gitstore.Storer) error {
-	latestEntry, err := GetLatestEntry(storer)
-	if err == nil {
-		e.Number = latestEntry.GetNumber() + 1
-	} else {
-		if errors.Is(err, ErrRSLEntryNotFound) {
-			// First entry
-			e.Number = 1
-		} else {
-			return err
-		}
+func (e *PropagationEntry) setEntryNumber(storer gitstore.Storer) (githash.Hash, error) {
+	number, tip, err := nextEntryNumber(storer)
+	if err != nil {
+		return tip, err
 	}
 
-	return nil
+	e.Number = number
+	return tip, nil
 }
 
 func (e *PropagationEntry) createCommitMessage(includeNumber bool) (string, error) {
@@ -690,13 +878,19 @@ func GetNonGittufParentReferenceUpdaterEntryForEntry(storer gitstore.Storer, ent
 
 	var targetEntry ReferenceUpdaterEntry
 	for {
-		switch iterator := it.(type) {
-		case ReferenceUpdaterEntry:
-			if !strings.HasPrefix(iterator.GetRefName(), gittufNamespacePrefix) {
-				targetEntry = iterator
+		if annotation, isAnnotation := it.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+		} else {
+			updaters, err := referenceUpdatersNewestFirst(it)
+			if err != nil {
+				return nil, nil, err
 			}
-		case *AnnotationEntry:
-			allAnnotations = append(allAnnotations, iterator)
+			for _, iterator := range updaters {
+				if !strings.HasPrefix(iterator.GetRefName(), gittufNamespacePrefix) {
+					targetEntry = iterator
+					break
+				}
+			}
 		}
 
 		if targetEntry != nil {
@@ -810,48 +1004,54 @@ func GetLatestReferenceUpdaterEntry(storer gitstore.Storer, opts ...GetLatestRef
 
 	var targetEntry ReferenceUpdaterEntry
 	for {
-		switch iterator := iteratorT.(type) {
-		case ReferenceUpdaterEntry:
-			matchesConditions := true
-
-			if options.Reference != "" && iterator.GetRefName() != options.Reference {
-				matchesConditions = false
+		if annotation, isAnnotation := iteratorT.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+		} else {
+			updaters, err := referenceUpdatersNewestFirst(iteratorT)
+			if err != nil {
+				return nil, nil, err
 			}
 
-			if matchesConditions && options.IsReferenceEntry {
-				if _, isReferenceEntry := iterator.(*ReferenceEntry); !isReferenceEntry {
+			for _, iterator := range updaters {
+				matchesConditions := true
+
+				if options.Reference != "" && iterator.GetRefName() != options.Reference {
 					matchesConditions = false
 				}
-			}
 
-			// Only reference entry can be skipped
-			referenceEntry, isReferenceEntry := iterator.(*ReferenceEntry)
-			if isReferenceEntry {
-				if matchesConditions && options.Unskipped && referenceEntry.SkippedBy(allAnnotations) {
-					// SkippedBy ensures only the applicable
-					// annotations that refer to the entry
-					// are used
+				if matchesConditions && options.IsReferenceEntry {
+					if _, isReferenceEntry := iterator.(*ReferenceEntry); !isReferenceEntry {
+						matchesConditions = false
+					}
+				}
+
+				// Only reference entries can be skipped
+				referenceEntry, isReferenceEntry := iterator.(*ReferenceEntry)
+				if isReferenceEntry {
+					if matchesConditions && options.Unskipped && referenceEntry.SkippedBy(allAnnotations) {
+						// SkippedBy ensures only the applicable
+						// annotations that refer to the entry
+						// are used
+						matchesConditions = false
+					}
+				}
+
+				if matchesConditions && options.IsPropagationEntryForRepository != "" {
+					propagationEntry, isPropagationEntry := iterator.(*PropagationEntry)
+					if !isPropagationEntry || propagationEntry.UpstreamRepository != options.IsPropagationEntryForRepository {
+						matchesConditions = false
+					}
+				}
+
+				if matchesConditions && options.NonGittuf && strings.HasPrefix(iterator.GetRefName(), gittufNamespacePrefix) {
 					matchesConditions = false
 				}
-			}
 
-			if matchesConditions && options.IsPropagationEntryForRepository != "" {
-				propagationEntry, isPropagationEntry := iterator.(*PropagationEntry)
-				if !isPropagationEntry || propagationEntry.UpstreamRepository != options.IsPropagationEntryForRepository {
-					matchesConditions = false
+				if matchesConditions {
+					targetEntry = iterator
+					break
 				}
 			}
-
-			if matchesConditions && options.NonGittuf && strings.HasPrefix(iterator.GetRefName(), gittufNamespacePrefix) {
-				matchesConditions = false
-			}
-
-			if matchesConditions {
-				targetEntry = iterator
-			}
-
-		case *AnnotationEntry:
-			allAnnotations = append(allAnnotations, iterator)
 		}
 
 		if targetEntry != nil {
@@ -898,13 +1098,22 @@ func GetFirstReferenceUpdaterEntryForRef(storer gitstore.Storer, targetRef strin
 	var firstEntry ReferenceUpdaterEntry
 
 	for {
-		switch entry := iteratorT.(type) {
-		case ReferenceUpdaterEntry:
-			if targetRef == "" || entry.GetRefName() == targetRef {
-				firstEntry = entry
+		if annotation, isAnnotation := iteratorT.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+		} else {
+			// Listed order, so the first match in an entry is the oldest
+			// update in it. Each entry overwrites the previous candidate
+			// because the walk moves towards the start of the RSL.
+			updaters, err := referenceUpdaters(iteratorT)
+			if err != nil {
+				return nil, nil, err
 			}
-		case *AnnotationEntry:
-			allAnnotations = append(allAnnotations, entry)
+			for _, entry := range updaters {
+				if targetRef == "" || entry.GetRefName() == targetRef {
+					firstEntry = entry
+					break
+				}
+			}
 		}
 
 		parentT, err := GetParentForEntry(storer, iteratorT)
@@ -928,11 +1137,13 @@ func GetFirstReferenceUpdaterEntryForRef(storer gitstore.Storer, targetRef strin
 	return firstEntry, annotations, nil
 }
 
-// SkipAllInvalidReferenceEntriesForRef identifies invalid RSL reference entries.
-// Each invalid entry points to a target that is not reachable for the current
-// target of the same reference, indicating that history has been rewritten via a
-// rebase for the reference. After the invalid entries are identified, an annotation
-// entry is created that marks all of these entries as to be skipped.
+// SkipAllInvalidReferenceEntriesForRef identifies RSL reference entries for
+// targetRef whose targets are not reachable from the ref's latest recorded
+// target, which indicates the ref's history was rewritten. It records one
+// annotation skipping them. Only entries for targetRef are inspected. When an
+// invalid entry is a view of a bulk reference entry, the annotation is
+// qualified with targetRef so the other updates in that bulk entry are
+// unaffected.
 func SkipAllInvalidReferenceEntriesForRef(storer gitstore.Storer, targetRef string, signCommit bool) error {
 	slog.Debug("Checking if RSL entries point to commits not in the target ref...")
 
@@ -941,23 +1152,43 @@ func SkipAllInvalidReferenceEntriesForRef(storer gitstore.Storer, targetRef stri
 		return err
 	}
 
-	iteratorEntry, _, err := GetLatestReferenceUpdaterEntry(storer, ForReference(targetRef), BeforeEntryID(latestEntry.GetID()))
-	if err != nil {
-		if errors.Is(err, ErrRSLEntryNotFound) {
-			// We don't have a parent to check if invalid
-			// So we assume the current one is valid
-			// TODO: should we cross reference state of the branch?
-			return nil
+	entriesToSkip := []githash.Hash{}
+	qualifiers := map[string][]string{}
+	sawPriorEntry := false
+
+	// One backwards walk from the entry holding the ref's latest recorded
+	// target. GetParentForEntry resolves by commit ID, so it accepts a view
+	// of a bulk entry and returns that bulk entry's parent. At most one
+	// update in each parent can be for targetRef because refs are unique
+	// within an entry.
+	var iterator Entry = latestEntry
+	foundValidEntry := false
+	for !foundValidEntry {
+		iterator, err = GetParentForEntry(storer, iterator)
+		if err != nil {
+			if errors.Is(err, ErrRSLEntryNotFound) {
+				break
+			}
+			return err
 		}
 
-		return err
-	}
-	iterator := Entry(iteratorEntry)
+		updaters, err := referenceUpdaters(iterator)
+		if err != nil {
+			return err
+		}
 
-	entriesToSkip := []githash.Hash{}
+		for _, updater := range updaters {
+			if updater.GetRefName() != targetRef {
+				continue
+			}
 
-	for {
-		if entry, ok := iterator.(*ReferenceEntry); ok {
+			entry, isReferenceEntry := updater.(*ReferenceEntry)
+			if !isReferenceEntry {
+				// Only reference entries and their views can be skipped.
+				break
+			}
+			sawPriorEntry = true
+
 			isAncestor, err := storer.KnowsCommit(latestEntry.GetTargetID(), entry.TargetID)
 			if err != nil {
 				return err
@@ -966,40 +1197,42 @@ func SkipAllInvalidReferenceEntriesForRef(storer gitstore.Storer, targetRef stri
 			if !isAncestor {
 				slog.Debug(fmt.Sprintf("For target ref %s, found RSL entry '%s' pointing to a commit, '%s', that does not exist in the target ref.", targetRef, entry.ID, entry.TargetID))
 				entriesToSkip = append(entriesToSkip, entry.ID)
+				if entry.FromBulkEntry() {
+					qualifiers[entry.ID.String()] = []string{targetRef}
+				}
 			} else {
 				slog.Debug(fmt.Sprintf("For target ref %s, found RSL entry '%s' pointing to a commit, '%s', that exists in the target ref. No more commits to skip.", targetRef, entry.ID, entry.TargetID))
-				break
+				foundValidEntry = true
 			}
+
+			break
 		}
-		iterator, err = GetParentForEntry(storer, iterator)
-		if err != nil {
-			if errors.Is(err, ErrRSLEntryNotFound) {
-				break
-			}
-			return err
-		}
+	}
+
+	if !sawPriorEntry {
+		// We don't have a prior entry for the ref to check if invalid, so we
+		// assume the current one is valid.
+		// TODO: should we cross reference state of the branch?
+		return nil
 	}
 
 	if len(entriesToSkip) == 0 {
 		return nil
 	}
 
-	return NewAnnotationEntry(entriesToSkip, true, "Automated skip of reference entries pointing to non-existent entries").Commit(storer, signCommit)
+	return NewAnnotationEntryWithQualifiers(entriesToSkip, qualifiers, true, "Automated skip of reference entries pointing to non-existent entries").Commit(storer, signCommit)
 }
 
-// GetFirstReferenceUpdaterEntryForCommit returns the first reference entry in
-// the RSL that either records the commit itself or a descendent of the commit.
-// This establishes the first time a commit was seen in the repository,
-// irrespective of the ref it was associated with, and we can infer things like
-// the active developers who could have signed the commit.
+// GetFirstReferenceUpdaterEntryForCommit returns the first reference updater
+// that either records the commit itself or a descendant of the commit. It
+// walks the RSL from the tip and inspects every non-gittuf update in each
+// entry, so a commit reachable only through one update of a bulk entry is
+// found. Like the previous implementation it assumes that once a commit is
+// recorded, every later entry carrying non-gittuf updates still contains it,
+// and it reports ErrNoRecordOfCommit when the most recent non-gittuf updates
+// do not contain the commit.
 func GetFirstReferenceUpdaterEntryForCommit(storer gitstore.Storer, commitID githash.Hash) (ReferenceUpdaterEntry, []*AnnotationEntry, error) {
-	// We check entries in pairs. In the initial case, we have the latest entry
-	// and its parent. At all times, the parent in the pair is being tested.
-	// If the latest entry is a descendant of the target commit, we start
-	// checking the parent. The first pair where the parent entry is not
-	// descended from the target commit, we return the other entry in the pair.
-
-	firstEntry, firstAnnotations, err := GetLatestReferenceUpdaterEntry(storer, ForNonGittufReference())
+	iterator, err := GetLatestEntry(storer)
 	if err != nil {
 		if errors.Is(err, ErrRSLEntryNotFound) {
 			return nil, nil, ErrNoRecordOfCommit
@@ -1007,34 +1240,60 @@ func GetFirstReferenceUpdaterEntryForCommit(storer gitstore.Storer, commitID git
 		return nil, nil, err
 	}
 
-	knowsCommit, err := storer.KnowsCommit(firstEntry.GetTargetID(), commitID)
-	if err != nil {
-		return nil, nil, err
-	}
-	if !knowsCommit {
-		return nil, nil, ErrNoRecordOfCommit
-	}
+	allAnnotations := []*AnnotationEntry{}
+	var candidate ReferenceUpdaterEntry
 
 	for {
-		iteratorEntry, iteratorAnnotations, err := GetNonGittufParentReferenceUpdaterEntryForEntry(storer, firstEntry)
+		if annotation, isAnnotation := iterator.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+		} else {
+			updaters, err := referenceUpdatersNewestFirst(iterator)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			hasNonGittuf := false
+			knowsInThisEntry := false
+			for _, updater := range updaters {
+				if strings.HasPrefix(updater.GetRefName(), gittufNamespacePrefix) {
+					continue
+				}
+				hasNonGittuf = true
+
+				knows, err := storer.KnowsCommit(updater.GetTargetID(), commitID)
+				if err != nil {
+					return nil, nil, err
+				}
+				if knows {
+					knowsInThisEntry = true
+					// Newest first, so the final assignment is the first
+					// listed update in this entry.
+					candidate = updater
+				}
+			}
+
+			if hasNonGittuf && !knowsInThisEntry {
+				if candidate == nil {
+					return nil, nil, ErrNoRecordOfCommit
+				}
+				break
+			}
+		}
+
+		iterator, err = GetParentForEntry(storer, iterator)
 		if err != nil {
 			if errors.Is(err, ErrRSLEntryNotFound) {
-				return firstEntry, firstAnnotations, nil
+				break
 			}
 			return nil, nil, err
 		}
-
-		knowsCommit, err := storer.KnowsCommit(iteratorEntry.GetTargetID(), commitID)
-		if err != nil {
-			return nil, nil, err
-		}
-		if !knowsCommit {
-			return firstEntry, firstAnnotations, nil
-		}
-
-		firstEntry = iteratorEntry
-		firstAnnotations = iteratorAnnotations
 	}
+
+	if candidate == nil {
+		return nil, nil, ErrNoRecordOfCommit
+	}
+
+	return candidate, filterAnnotationsForRelevantAnnotations(allAnnotations, candidate.GetID()), nil
 }
 
 // GetReferenceUpdaterEntriesInRange returns a list of reference entries between
@@ -1042,6 +1301,12 @@ func GetFirstReferenceUpdaterEntryForCommit(storer gitstore.Storer, commitID git
 // entry in the range. The annotations map is keyed by the ID of the reference
 // entry, with the value being a list of annotations that apply to that
 // reference entry.
+//
+// The annotation lists are per entry, not per reference update. A bulk
+// reference entry contributes one view per ref and they all share an entry ID,
+// so a list may hold annotations qualified to a different ref in the same
+// entry. Consumers must narrow it with AnnotationEntry.AppliesTo or
+// ReferenceEntry.SkippedBy.
 func GetReferenceUpdaterEntriesInRange(storer gitstore.Storer, firstID, lastID githash.Hash) ([]ReferenceUpdaterEntry, map[string][]*AnnotationEntry, error) {
 	return GetReferenceUpdaterEntriesInRangeForRef(storer, firstID, lastID, "")
 }
@@ -1051,6 +1316,12 @@ func GetReferenceUpdaterEntriesInRange(storer gitstore.Storer, firstID, lastID g
 // to each reference entry in the range. The annotations map is keyed by the ID
 // of the reference entry, with the value being a list of annotations that apply
 // to that reference entry.
+//
+// Filtering by ref narrows the returned entries but not the annotation lists.
+// They stay keyed by entry ID and are therefore per entry, so an annotation
+// qualified to another ref in the same bulk reference entry is still present.
+// Consumers must narrow it with AnnotationEntry.AppliesTo or
+// ReferenceEntry.SkippedBy.
 func GetReferenceUpdaterEntriesInRangeForRef(storer gitstore.Storer, firstID, lastID githash.Hash, refName string) ([]ReferenceUpdaterEntry, map[string][]*AnnotationEntry, error) {
 	// We have to iterate from latest to get the annotations that refer to the
 	// last requested entry
@@ -1076,21 +1347,37 @@ func GetReferenceUpdaterEntriesInRangeForRef(storer gitstore.Storer, firstID, la
 
 	entryStack := []ReferenceUpdaterEntry{}
 	inRange := map[string]bool{}
+	isRelevant := func(entry ReferenceUpdaterEntry) bool {
+		// It's a relevant entry if:
+		// a) there's no refName set, or
+		// b) the entry's refName matches the set refName, or
+		// c) the entry is for a gittuf namespace
+		return len(refName) == 0 || entry.GetRefName() == refName || isRelevantGittufRef(entry.GetRefName())
+	}
+	pushRelevant := func(entry Entry) error {
+		if annotation, isAnnotation := entry.(*AnnotationEntry); isAnnotation {
+			allAnnotations = append(allAnnotations, annotation)
+			return nil
+		}
+		// Views are pushed newest first because entryStack is reversed
+		// below, which restores listed order.
+		updaters, err := referenceUpdatersNewestFirst(entry)
+		if err != nil {
+			return err
+		}
+		for _, updater := range updaters {
+			if isRelevant(updater) {
+				entryStack = append(entryStack, updater)
+				inRange[updater.GetID().String()] = true
+			}
+		}
+		return nil
+	}
 	for !iterator.GetID().Equal(firstID.Bytes()) {
 		// Here, all items are relevant until the one corresponding to first is
 		// found
-		switch it := iterator.(type) {
-		case ReferenceUpdaterEntry:
-			if len(refName) == 0 || it.GetRefName() == refName || isRelevantGittufRef(it.GetRefName()) {
-				// It's a relevant entry if:
-				// a) there's no refName set, or
-				// b) the entry's refName matches the set refName, or
-				// c) the entry is for a gittuf namespace
-				entryStack = append(entryStack, it)
-				inRange[it.GetID().String()] = true
-			}
-		case *AnnotationEntry:
-			allAnnotations = append(allAnnotations, it)
+		if err := pushRelevant(iterator); err != nil {
+			return nil, nil, err
 		}
 
 		parent, err := GetParentForEntry(storer, iterator)
@@ -1100,17 +1387,12 @@ func GetReferenceUpdaterEntriesInRangeForRef(storer gitstore.Storer, firstID, la
 		iterator = parent
 	}
 
-	// Handle the item corresponding to first explicitly
-	// If it's an annotation, ignore it as it refers to something before the
-	// range we care about
-	if entry, isEntry := iterator.(ReferenceUpdaterEntry); isEntry {
-		if len(refName) == 0 || entry.GetRefName() == refName || isRelevantGittufRef(entry.GetRefName()) {
-			// It's a relevant entry if:
-			// a) there's no refName set, or
-			// b) the entry's refName matches the set refName, or
-			// c) the entry is for a gittuf namespace
-			entryStack = append(entryStack, entry)
-			inRange[entry.GetID().String()] = true
+	// Handle the item corresponding to first explicitly. If it's an
+	// annotation, ignore it as it refers to something before the range we
+	// care about, so pushRelevant is only called for updater entries.
+	if _, isAnnotation := iterator.(*AnnotationEntry); !isAnnotation {
+		if err := pushRelevant(iterator); err != nil {
+			return nil, nil, err
 		}
 	}
 
@@ -1184,6 +1466,12 @@ func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
 		return entry, nil
 	case strings.HasPrefix(text, PropagationEntryHeader):
 		entry, err := parsePropagationEntryText(id, text)
+		if err != nil {
+			return nil, err
+		}
+		return entry, nil
+	case strings.HasPrefix(text, BulkReferenceEntryHeader):
+		entry, err := parseBulkReferenceEntryText(id, text)
 		if err != nil {
 			return nil, err
 		}
@@ -1321,6 +1609,25 @@ func parseAnnotationEntryText(id githash.Hash, text string) (*AnnotationEntry, e
 				return nil, err
 			}
 			annotation.RSLEntryIDs = append(annotation.RSLEntryIDs, hash)
+
+		case RefKey:
+			if state != expectEntryID || len(annotation.RSLEntryIDs) == 0 {
+				return nil, ErrInvalidRSLEntry
+			}
+			if err := validateBulkRefName(value); err != nil {
+				return nil, err
+			}
+			if annotation.Refs == nil {
+				annotation.Refs = map[string][]string{}
+			}
+			lastID := annotation.RSLEntryIDs[len(annotation.RSLEntryIDs)-1].String()
+			// The same ref for the same entry is recorded once. An entry ID
+			// may appear more than once in the message, and the writer
+			// re-emits its qualifiers each time, so appending blindly would
+			// double the list on every round trip.
+			if !slices.Contains(annotation.Refs[lastID], value) {
+				annotation.Refs[lastID] = append(annotation.Refs[lastID], value)
+			}
 
 		case SkipKey:
 			if state != expectEntryID || len(annotation.RSLEntryIDs) == 0 {
@@ -1482,6 +1789,11 @@ func setNumber(dst *uint64, value string) error {
 	return nil
 }
 
+// filterAnnotationsForRelevantAnnotations returns the annotations that refer
+// to entryID. The result is per entry, not per reference update: a qualified
+// annotation is kept for the whole entry, so every per-ref view of a bulk
+// reference entry receives it. Consumers must narrow the list themselves with
+// AnnotationEntry.AppliesTo or ReferenceEntry.SkippedBy.
 func filterAnnotationsForRelevantAnnotations(allAnnotations []*AnnotationEntry, entryID githash.Hash) []*AnnotationEntry {
 	annotations := []*AnnotationEntry{}
 	for _, annotation := range allAnnotations {

--- a/pkg/rsl/rsl.go
+++ b/pkg/rsl/rsl.go
@@ -55,6 +55,7 @@ var (
 	ErrInvalidGetLatestReferenceUpdaterEntryOptions = errors.New("invalid options presented for getting latest reference updater entry (are both before or until conditions set or is the before number less than the until number?)")
 	ErrCannotUseEntryNumberFilter                   = errors.New("current RSL entries are not numbered, cannot use number range options")
 	ErrInvalidUntilEntryNumberCondition             = errors.New("cannot meet until entry number condition")
+	ErrUnknownRSLEntryType                          = fmt.Errorf("%w: RSL entry is of an unknown type", ErrInvalidRSLEntry)
 )
 
 // commitEntry commits an RSL entry: an empty-tree commit on Ref carrying the
@@ -1152,6 +1153,18 @@ func ParseEntryText(id githash.Hash, text string) (Entry, error) {
 	return parseRSLEntryText(id, text)
 }
 
+const unknownEntryTypeGuidance = "This repository may use a gittuf feature newer than this client. Upgrade gittuf to the latest release and retry. If this client is already the latest release, the entry may be corrupt or malicious and should be reported to the repository owners."
+
+const maxHeaderInError = 80
+
+func newUnknownEntryTypeError(id githash.Hash, text string) error {
+	header, _, _ := strings.Cut(text, "\n")
+	if len(header) > maxHeaderInError {
+		header = header[:maxHeaderInError] + "..."
+	}
+	return fmt.Errorf("%w: entry %s has header %q. %s", ErrUnknownRSLEntryType, id.String(), header, unknownEntryTypeGuidance)
+}
+
 func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
 	// Each parser returns a concrete pointer type. Assign to a local and return
 	// an explicit nil interface on error: returning the typed nil pointer
@@ -1176,7 +1189,7 @@ func parseRSLEntryText(id githash.Hash, text string) (Entry, error) {
 		}
 		return entry, nil
 	default:
-		return nil, ErrInvalidRSLEntry
+		return nil, newUnknownEntryTypeError(id, text)
 	}
 }
 

--- a/pkg/rsl/rsl_test.go
+++ b/pkg/rsl/rsl_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/gittuf/gittuf/pkg/customfields"
@@ -697,4 +698,20 @@ func BenchmarkParseRSLEntryText(b *testing.B) {
 			b.Fatal(err)
 		}
 	}
+}
+
+func TestParseRSLEntryTextUnknownHeader(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseRSLEntryText(githash.ZeroHash, "RSL Future Entry\n\nsomething: else")
+	assert.ErrorIs(t, err, ErrUnknownRSLEntryType)
+	assert.ErrorIs(t, err, ErrInvalidRSLEntry)
+	assert.ErrorContains(t, err, `"RSL Future Entry"`)
+	assert.ErrorContains(t, err, "Upgrade gittuf to the latest release")
+
+	longHeader := "RSL " + strings.Repeat("x", 200) + " Entry"
+	_, err = parseRSLEntryText(githash.ZeroHash, longHeader+"\n\nsomething: else")
+	assert.ErrorIs(t, err, ErrUnknownRSLEntryType)
+	assert.ErrorContains(t, err, longHeader[:maxHeaderInError]+"...")
+	assert.NotContains(t, err.Error(), longHeader)
 }

--- a/pkg/rsl/rsl_test.go
+++ b/pkg/rsl/rsl_test.go
@@ -608,6 +608,7 @@ func FuzzParseRSLEntryText(f *testing.F) {
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", ReferenceEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash))
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s", AnnotationEntryHeader, EntryIDKey, fuzzZeroHash, SkipKey, "true"))
 	f.Add(fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s", PropagationEntryHeader, RefKey, "refs/heads/main", TargetIDKey, fuzzZeroHash, UpstreamRepositoryKey, "https://git.example.com:8443/repo", UpstreamEntryIDKey, fuzzNonZeroHash))
+	f.Add(fmt.Sprintf("%s\n\nrefs/heads/main: %s\nrefs/heads/feature: %s\n\n%s: %d", BulkReferenceEntryHeader, fuzzZeroHash, fuzzNonZeroHash, NumberKey, 3))
 
 	f.Fuzz(func(_ *testing.T, text string) {
 		_, _ = parseRSLEntryText(githash.ZeroHash, text)
@@ -714,4 +715,221 @@ func TestParseRSLEntryTextUnknownHeader(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnknownRSLEntryType)
 	assert.ErrorContains(t, err, longHeader[:maxHeaderInError]+"...")
 	assert.NotContains(t, err.Error(), longHeader)
+}
+
+func TestAnnotationEntryQualifiersCodec(t *testing.T) {
+	t.Parallel()
+
+	nonZeroHash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zero := githash.ZeroHash.String()
+
+	annotation := NewAnnotationEntryWithQualifiers(
+		[]githash.Hash{githash.ZeroHash, nonZeroHash},
+		map[string][]string{zero: {"refs/heads/feature", "refs/tags/v1"}},
+		true,
+		"",
+	)
+	annotation.Number = 40
+
+	expected := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: true\n%s: %d",
+		AnnotationEntryHeader,
+		EntryIDKey, zero,
+		RefKey, "refs/heads/feature",
+		RefKey, "refs/tags/v1",
+		EntryIDKey, nonZeroHash.String(),
+		SkipKey,
+		NumberKey, 40)
+
+	message, err := annotation.createCommitMessage(true)
+	require.NoError(t, err)
+	assert.Equal(t, expected, message)
+
+	parsed, err := parseRSLEntryText(githash.ZeroHash, message)
+	require.NoError(t, err)
+	annotation.ID = githash.ZeroHash
+	assert.Equal(t, annotation, parsed)
+}
+
+func TestAnnotationEntryQualifiersCodecDuplicateEntryID(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+
+	annotation := NewAnnotationEntryWithQualifiers(
+		[]githash.Hash{githash.ZeroHash, githash.ZeroHash},
+		map[string][]string{zero: {"refs/heads/feature"}},
+		true,
+		"",
+	)
+	annotation.Number = 41
+
+	expected := fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: %s\n%s: %s\n%s: true\n%s: %d",
+		AnnotationEntryHeader,
+		EntryIDKey, zero,
+		RefKey, "refs/heads/feature",
+		EntryIDKey, zero,
+		RefKey, "refs/heads/feature",
+		SkipKey,
+		NumberKey, 41)
+
+	message, err := annotation.createCommitMessage(true)
+	require.NoError(t, err)
+	assert.Equal(t, expected, message)
+
+	// The writer emits the qualifier once per occurrence of the entry ID, so
+	// the parser must not grow the list when the ID occurs again.
+	parsed, err := parseRSLEntryText(githash.ZeroHash, message)
+	require.NoError(t, err)
+	annotation.ID = githash.ZeroHash
+	assert.Equal(t, annotation, parsed)
+}
+
+func TestAnnotationEntryQualifiersCodecRejectsInvalidRefs(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+
+	tests := map[string]struct {
+		refName       string
+		expectedError error
+	}{
+		"not fully qualified": {
+			refName:       "main",
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"gittuf namespace": {
+			refName:       "refs/gittuf/policy",
+			expectedError: ErrGittufReferenceInBulkEntry,
+		},
+		"surrounding whitespace": {
+			refName:       " refs/heads/main ",
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"line break": {
+			refName:       "refs/heads/main\nref: refs/heads/other",
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"empty": {
+			refName:       "",
+			expectedError: ErrInvalidRSLEntry,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			annotation := &AnnotationEntry{
+				RSLEntryIDs: []githash.Hash{githash.ZeroHash},
+				Refs:        map[string][]string{zero: {test.refName}},
+				Skip:        true,
+				Number:      1,
+			}
+			_, err := annotation.createCommitMessage(true)
+			assert.ErrorIs(t, err, test.expectedError)
+		})
+	}
+}
+
+func TestParseAnnotationEntryTextQualifiers(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+
+	tests := map[string]struct {
+		message       string
+		expectedRefs  map[string][]string
+		expectedError error
+	}{
+		"no qualifiers leaves Refs nil": {
+			message:      fmt.Sprintf("%s\n\n%s: %s\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, SkipKey),
+			expectedRefs: nil,
+		},
+		"one qualifier": {
+			message:      fmt.Sprintf("%s\n\n%s: %s\n%s: refs/heads/a\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, RefKey, SkipKey),
+			expectedRefs: map[string][]string{zero: {"refs/heads/a"}},
+		},
+		"empty ref value": {
+			message:       fmt.Sprintf("%s\n\n%s: %s\n%s:\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, RefKey, SkipKey),
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"qualifier attaches to the preceding entryID": {
+			message:      fmt.Sprintf("%s\n\n%s: %s\n%s: %s\n%s: refs/heads/a\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, EntryIDKey, "abcdef12345678900987654321fedcbaabcdef12", RefKey, SkipKey),
+			expectedRefs: map[string][]string{"abcdef12345678900987654321fedcbaabcdef12": {"refs/heads/a"}},
+		},
+		"ref before any entryID": {
+			message:       fmt.Sprintf("%s\n\n%s: refs/heads/a\n%s: %s\n%s: true", AnnotationEntryHeader, RefKey, EntryIDKey, zero, SkipKey),
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"ref after skip": {
+			message:       fmt.Sprintf("%s\n\n%s: %s\n%s: true\n%s: refs/heads/a", AnnotationEntryHeader, EntryIDKey, zero, SkipKey, RefKey),
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"not fully qualified": {
+			message:       fmt.Sprintf("%s\n\n%s: %s\n%s: main\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, RefKey, SkipKey),
+			expectedError: ErrInvalidRSLEntry,
+		},
+		"gittuf namespace": {
+			message:       fmt.Sprintf("%s\n\n%s: %s\n%s: refs/gittuf/policy\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, RefKey, SkipKey),
+			expectedError: ErrGittufReferenceInBulkEntry,
+		},
+		"duplicate ref for the same entry is deduped": {
+			message:      fmt.Sprintf("%s\n\n%s: %s\n%s: refs/heads/a\n%s: refs/heads/a\n%s: refs/heads/b\n%s: true", AnnotationEntryHeader, EntryIDKey, zero, RefKey, RefKey, RefKey, SkipKey),
+			expectedRefs: map[string][]string{zero: {"refs/heads/a", "refs/heads/b"}},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			entry, err := parseRSLEntryText(githash.ZeroHash, test.message)
+			if test.expectedError != nil {
+				assert.ErrorIs(t, err, test.expectedError)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedRefs, entry.(*AnnotationEntry).Refs)
+		})
+	}
+}
+
+func TestAnnotationAppliesTo(t *testing.T) {
+	t.Parallel()
+
+	nonZeroHash, err := NewHash("abcdef12345678900987654321fedcbaabcdef12")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unqualified := NewAnnotationEntry([]githash.Hash{githash.ZeroHash}, true, "")
+	assert.True(t, unqualified.AppliesTo(githash.ZeroHash, "refs/heads/any"))
+	assert.False(t, unqualified.AppliesTo(nonZeroHash, "refs/heads/any"))
+
+	qualified := NewAnnotationEntryWithQualifiers([]githash.Hash{githash.ZeroHash}, map[string][]string{githash.ZeroHash.String(): {"refs/heads/a"}}, true, "")
+	assert.True(t, qualified.AppliesTo(githash.ZeroHash, "refs/heads/a"))
+	assert.False(t, qualified.AppliesTo(githash.ZeroHash, "refs/heads/b"))
+	assert.True(t, qualified.RefersTo(githash.ZeroHash))
+
+	view := &ReferenceEntry{ID: githash.ZeroHash, RefName: "refs/heads/b", isView: true}
+	assert.False(t, view.SkippedBy([]*AnnotationEntry{qualified}))
+	assert.True(t, view.SkippedBy([]*AnnotationEntry{unqualified}))
+}
+
+func TestNewAnnotationEntryWithQualifiers(t *testing.T) {
+	t.Parallel()
+
+	zero := githash.ZeroHash.String()
+	refs := map[string][]string{zero: {"refs/heads/a"}, "unqualified": {}}
+
+	annotation := NewAnnotationEntryWithQualifiers([]githash.Hash{githash.ZeroHash}, refs, true, "")
+	assert.Equal(t, map[string][]string{zero: {"refs/heads/a"}}, annotation.Refs)
+
+	refs[zero][0] = "refs/heads/mutated"
+	refs["added"] = []string{"refs/heads/b"}
+	assert.Equal(t, map[string][]string{zero: {"refs/heads/a"}}, annotation.Refs)
+
+	pruned := NewAnnotationEntryWithQualifiers([]githash.Hash{githash.ZeroHash}, map[string][]string{zero: {}}, true, "")
+	assert.Nil(t, pruned.Refs)
 }

--- a/scripts/test-compat.sh
+++ b/scripts/test-compat.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# Copyright The gittuf Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pins how previously released gittuf clients behave on repositories written
+# by the current tree. Scenario 1: a repository whose entries are all plain
+# reference entries is fully readable by every listed release. Scenario 2: a
+# repository containing one bulk reference entry makes every listed release
+# fail closed, and the oldest release must not silently read it as a single
+# update. Scenario 3: entries written by each release are readable by the
+# current tree. Scenario 4: the optional ref qualifier on an annotation is
+# ignored by every listed release rather than breaking them.
+set -euo pipefail
+
+# Run from the repository root so `go install .` builds the current tree
+# regardless of the caller's working directory.
+cd "$(dirname "$0")/.."
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+command -v ssh-keygen >/dev/null || fail "ssh-keygen is required"
+
+VERSIONS=${COMPAT_VERSIONS:-"v0.8.1 v0.14.1 v0.16.0"}
+GO=${GO:-go}
+WORK=$(mktemp -d)
+# Set KEEP_WORK=1 to inspect the scratch repositories after a failure.
+if [ "${KEEP_WORK:-}" = "1" ]; then
+  echo "keeping work directory $WORK"
+else
+  trap 'rm -rf "$WORK"' EXIT
+fi
+BIN="$WORK/bin"
+mkdir -p "$BIN"
+
+echo "building current tree"
+GOBIN="$BIN" $GO install . >/dev/null
+mv "$BIN/gittuf" "$BIN/gittuf-current"
+
+for v in $VERSIONS; do
+  echo "installing gittuf@$v"
+  GOBIN="$BIN" $GO install "github.com/gittuf/gittuf@$v" >/dev/null
+  mv "$BIN/gittuf" "$BIN/gittuf-$v"
+done
+
+ZERO=0000000000000000000000000000000000000000
+
+# Every listed release signs RSL entries and v0.8.1 has no unsigned mode, so
+# each scratch repository gets an SSH signing key.
+ssh-keygen -q -t ed25519 -N "" -f "$WORK/signing-key"
+
+new_repo() {
+  local dir="$1"
+  # The listed releases predate gittuf's SHA-256 support, so the scratch
+  # repositories are pinned to SHA-1.
+  git init -q -b main --object-format=sha1 "$dir"
+  git -C "$dir" config user.name compat
+  git -C "$dir" config user.email compat@example.com
+  git -C "$dir" config gpg.format ssh
+  git -C "$dir" config user.signingkey "$WORK/signing-key"
+  git -C "$dir" config commit.gpgsign false
+  git -C "$dir" commit -q --allow-empty -m init
+  git -C "$dir" branch feature
+}
+
+# record_with runs `rsl record` for a release. Releases before v0.9.0 have no
+# --local-only flag and never contact a remote, so the flag is dropped when
+# the release rejects it. On failure the second attempt's combined output is
+# printed so the caller can report why the release refused to record.
+record_with() {
+  local bin="$1" dir="$2" ref="$3"
+  if (cd "$dir" && "$bin" rsl record "$ref" --local-only >/dev/null 2>&1); then
+    return 0
+  fi
+  (cd "$dir" && "$bin" rsl record "$ref" 2>&1)
+}
+
+# write_rsl_entry appends a commit carrying the given message to the RSL and
+# echoes its ID. Entries that no gittuf command can produce are written this
+# way, in the exact wire format the current writer produces.
+write_rsl_entry() {
+  local dir="$1" msgfile="$2"
+  local tree parent id
+  tree=$(git -C "$dir" hash-object -t tree /dev/null)
+  parent=$(git -C "$dir" rev-parse refs/gittuf/reference-state-log)
+  id=$(git -C "$dir" commit-tree "$tree" -p "$parent" -F "$msgfile")
+  git -C "$dir" update-ref refs/gittuf/reference-state-log "$id"
+  echo "$id"
+}
+
+# pem_message renders an annotation message the way the writer's PEM encoder
+# does. Messages are kept short enough to fit the encoder's 64 column line.
+pem_message() {
+  printf -- '-----BEGIN MESSAGE-----\n%s\n-----END MESSAGE-----' "$(printf '%s' "$1" | base64 | tr -d '\n')"
+}
+
+echo "scenario 1: current tree writes reference entries, every release reads them"
+R1="$WORK/s1"; new_repo "$R1"
+(cd "$R1" && "$BIN/gittuf-current" rsl record refs/heads/main --local-only >/dev/null)
+(cd "$R1" && "$BIN/gittuf-current" rsl record refs/heads/feature --local-only >/dev/null)
+for v in $VERSIONS; do
+  out=$(cd "$R1" && "$BIN/gittuf-$v" rsl log 2>&1) || fail "$v cannot read per-ref entries: $out"
+  grep -q "refs/heads/main" <<<"$out" || fail "$v log missing main"
+  grep -q "refs/heads/feature" <<<"$out" || fail "$v log missing feature"
+done
+
+echo "scenario 2: a bulk entry makes every release fail closed"
+R2="$WORK/s2"; new_repo "$R2"
+(cd "$R2" && "$BIN/gittuf-current" rsl record refs/heads/main --local-only >/dev/null)
+# No gittuf command records two references in one call: `rsl record` takes a
+# single reference, and the only caller of the bulk writer is the
+# git-remote-gittuf transport during a push, which needs an SSH or HTTP
+# server. The entry is therefore written by hand, in the exact wire format
+# the current writer produces.
+MSG="$WORK/bulk.msg"
+printf 'RSL Bulk Reference Entry\n\nrefs/heads/aaa: %s\nrefs/heads/zzz: %s\n\nnumber: 2' "$ZERO" "$ZERO" > "$MSG"
+BULK=$(write_rsl_entry "$R2" "$MSG")
+for v in $VERSIONS; do
+  if out=$(cd "$R2" && "$BIN/gittuf-$v" rsl log 2>&1); then
+    fail "$v accepted a bulk entry: $out"
+  fi
+  grep -q "invalid format or is of unexpected type" <<<"$out" || fail "$v failed for an unexpected reason: $out"
+  if grep -q "refs/heads/zzz" <<<"$out"; then
+    fail "$v silently read the bulk entry as a single update"
+  fi
+done
+out=$(cd "$R2" && "$BIN/gittuf-current" rsl log 2>&1) || fail "current tree cannot read its own bulk entry: $out"
+grep -q "bulk entry $BULK" <<<"$out" || fail "current tree did not render the bulk entry"
+
+echo "scenario 3: each release writes, current tree reads"
+for v in $VERSIONS; do
+  R3="$WORK/s3-$v"; new_repo "$R3"
+  out=$(record_with "$BIN/gittuf-$v" "$R3" refs/heads/main) || fail "$v could not record an entry: $out"
+  out=$(cd "$R3" && "$BIN/gittuf-current" rsl log 2>&1) || fail "current tree cannot read entries from $v: $out"
+  grep -q "refs/heads/main" <<<"$out" || fail "current tree log missing main for $v"
+done
+
+echo "scenario 4: an annotation's ref qualifier does not break any release"
+# A qualifier is only legal on a bulk entry, so a release that meets one also
+# meets the bulk entry it qualifies and fails closed there: it can never act
+# on the annotation's narrowed skip. 4a pins that. 4b isolates the ref key
+# itself by putting it on an annotation for a plain reference entry, the shape
+# a future writer would produce if qualifiers were extended to those entries,
+# and pins that releases parse it and silently drop the qualifier, widening
+# the skip to the whole entry.
+R4A="$WORK/s4a"; new_repo "$R4A"
+(cd "$R4A" && "$BIN/gittuf-current" rsl record refs/heads/main --local-only >/dev/null)
+MSG="$WORK/bulk-4a.msg"
+printf 'RSL Bulk Reference Entry\n\nrefs/heads/aaa: %s\nrefs/heads/zzz: %s\n\nnumber: 2' "$ZERO" "$ZERO" > "$MSG"
+BULK4A=$(write_rsl_entry "$R4A" "$MSG")
+MSG="$WORK/annotation-4a.msg"
+printf 'RSL Annotation Entry\n\nentryID: %s\nref: refs/heads/aaa\nskip: true\nnumber: 3\n%s' \
+  "$BULK4A" "$(pem_message 'skip aaa only')" > "$MSG"
+ANN4A=$(write_rsl_entry "$R4A" "$MSG")
+for v in $VERSIONS; do
+  if out=$(cd "$R4A" && "$BIN/gittuf-$v" rsl log 2>&1); then
+    fail "$v accepted a qualified annotation's bulk entry: $out"
+  fi
+  grep -q "invalid format or is of unexpected type" <<<"$out" || fail "$v failed for an unexpected reason: $out"
+  if grep -q "refs/heads/aaa" <<<"$out"; then
+    fail "$v acted on a qualified annotation instead of failing closed"
+  fi
+done
+out=$(cd "$R4A" && "$BIN/gittuf-current" rsl log 2>&1) || fail "current tree cannot read its own qualified annotation: $out"
+grep -q "bulk entry $BULK4A" <<<"$out" || fail "current tree did not render the bulk entry"
+grep -q "Annotation ID: $ANN4A" <<<"$out" || fail "current tree did not render the annotation"
+grep -q "Refs:          refs/heads/aaa" <<<"$out" || fail "current tree did not render the annotation's qualifier"
+
+R4B="$WORK/s4b"; new_repo "$R4B"
+(cd "$R4B" && "$BIN/gittuf-current" rsl record refs/heads/main --local-only >/dev/null)
+ENTRY4B=$(git -C "$R4B" rev-parse refs/gittuf/reference-state-log)
+MSG="$WORK/annotation-4b.msg"
+printf 'RSL Annotation Entry\n\nentryID: %s\nref: refs/heads/main\nskip: true\nnumber: 2\n%s' \
+  "$ENTRY4B" "$(pem_message 'skip main')" > "$MSG"
+write_rsl_entry "$R4B" "$MSG" >/dev/null
+for v in $VERSIONS; do
+  out=$(cd "$R4B" && "$BIN/gittuf-$v" rsl log 2>&1) || fail "$v cannot read an annotation carrying a ref: $out"
+  grep -q "entry $ENTRY4B (skipped)" <<<"$out" || fail "$v did not apply the annotation's skip: $out"
+  grep -q "skip main" <<<"$out" || fail "$v did not decode the annotation message: $out"
+done
+out=$(cd "$R4B" && "$BIN/gittuf-current" rsl log 2>&1) || fail "current tree cannot read the annotation: $out"
+grep -q "entry $ENTRY4B (skipped)" <<<"$out" || fail "current tree did not render the entry as skipped: $out"
+
+echo "compat matrix passed for: $VERSIONS"


### PR DESCRIPTION
## Description

Record several reference updates under one signature, so a push that
updates multiple refs costs one RSL entry and one signing operation
instead of one per ref. Annotation entries gain optional `ref`
qualifiers, letting a skip target a single update inside a bulk entry.

Old clients fail closed on the new entry type: every release through
v0.16.0 rejects an RSL containing a bulk entry rather than misreading
it, so verifying a repository that has one requires upgrading to the
latest gittuf. `make test-compat` pins that behaviour against v0.8.1,
v0.14.1 and v0.16.0, along with the annotation `ref` qualifier, which
those releases parse and ignore.

Depends on #1581 to improve user experience for unknown types.

## AI Usage

<!-- Select which box below describes your use of generative AI for this PR. -->

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

Prototyping, wiring up and tests.

## Contributor Checklist

<!-- Please review the checklist below and attest by checking all boxes.-->

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
