### PR TITLE
test: add end-to-end integration tests for the gittuf transport

### DIFF
--- a/.github/workflows/transport-integration-tests.yml
+++ b/.github/workflows/transport-integration-tests.yml
@@ -1,0 +1,31 @@
+name: Transport integration tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'internal/git-remote-gittuf/**'
+      - 'test/integration/transport/**'
+permissions: read-all
+jobs:
+  transport-integration:
+    name: Transport integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
+        with:
+          go-version: '1.26'
+      - name: Install openssh-server
+        run: sudo apt-get update && sudo apt-get install -y openssh-server
+      - name: Build gittuf
+        run: make just-install
+      - name: Run transport integration tests
+        run: bash test/integration/transport/run.sh

--- a/test/integration/transport/httpbackend/main.go
+++ b/test/integration/transport/httpbackend/main.go
@@ -1,0 +1,42 @@
+// Command httpbackend serves one or more bare git repositories over HTTP
+// using git-http-backend, for use in transport integration tests.
+//
+// Usage: httpbackend <project-root> <listen-addr>
+package main
+
+import (
+	"log"
+	"net/http"
+	"net/http/cgi"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		log.Fatalf("usage: %s <project-root> <listen-addr>", os.Args[0])
+	}
+
+	root := os.Args[1]
+	addr := os.Args[2]
+
+	out, err := exec.Command("git", "--exec-path").Output()
+	if err != nil {
+		log.Fatalf("unable to resolve git exec-path: %v", err)
+	}
+	backend := strings.TrimSpace(string(out)) + "/git-http-backend"
+
+	handler := &cgi.Handler{
+		Path: backend,
+		Root: "/",
+		Dir:  root,
+		Env: []string{
+			"GIT_PROJECT_ROOT=" + root,
+			"GIT_HTTP_EXPORT_ALL=1",
+		},
+	}
+
+	log.Printf("serving %s on %s", root, addr)
+	log.Fatal(http.ListenAndServe(addr, handler))
+}

--- a/test/integration/transport/run.sh
+++ b/test/integration/transport/run.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# End-to-end integration tests for the gittuf transport (curl + SSH).
+set -uo pipefail
+
+REPO_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+WORKDIR="$(mktemp -d)"
+FAILURES=0
+
+# Isolate git config from the developer's environment so a global
+# user.signingkey / commit.gpgsign can't interfere with the test repos.
+export GIT_CONFIG_GLOBAL="$WORKDIR/gitconfig-empty"
+export GIT_CONFIG_SYSTEM=/dev/null
+touch "$GIT_CONFIG_GLOBAL"
+
+cleanup() {
+  [[ -n "${HTTP_PID:-}" ]] && kill "$HTTP_PID" 2>/dev/null
+  [[ -n "${SSHD_PID:-}" ]] && kill "$SSHD_PID" 2>/dev/null
+  rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; FAILURES=$((FAILURES+1)); }
+
+init_local_repo() {
+  local dir="$1"
+  git init --initial-branch=main "$dir" >/dev/null
+  pushd "$dir" >/dev/null
+  git config user.name "Integration Test"
+  git config user.email "test@example.com"
+  git config commit.gpgsign false
+  git config tag.gpgsign false
+  git config gpg.format ssh
+  git commit --allow-empty -m "initial commit" >/dev/null
+
+  git config user.signingkey "$WORKDIR/root"
+  gittuf trust init -k "$WORKDIR/root" --create-rsl-entry >/dev/null
+  gittuf trust add-policy-key -k "$WORKDIR/root" --policy-key "$WORKDIR/targets.pub" --create-rsl-entry >/dev/null
+
+  git config user.signingkey "$WORKDIR/targets"
+  gittuf policy init -k "$WORKDIR/targets" --create-rsl-entry >/dev/null
+  gittuf policy apply -k "$WORKDIR/targets" --local-only --create-rsl-entry >/dev/null
+  popd >/dev/null
+}
+
+ssh-keygen -t ed25519 -f "$WORKDIR/root" -N "" -q
+ssh-keygen -t ed25519 -f "$WORKDIR/targets" -N "" -q
+
+HTTPBACKEND_BIN="$WORKDIR/httpbackend"
+go build -o "$HTTPBACKEND_BIN" "$REPO_ROOT_DIR/test/integration/transport/httpbackend"
+
+# HTTP (curl handler) scenarios
+HTTP_REMOTE_ROOT="$WORKDIR/http-remote"
+mkdir -p "$HTTP_REMOTE_ROOT"
+git init --bare "$HTTP_REMOTE_ROOT/repo.git" >/dev/null
+git -C "$HTTP_REMOTE_ROOT/repo.git" config http.receivepack true
+
+"$HTTPBACKEND_BIN" "$HTTP_REMOTE_ROOT" "127.0.0.1:8090" &
+HTTP_PID=$!
+
+for i in $(seq 1 20); do
+  if curl -s -o /dev/null "http://127.0.0.1:8090/"; then
+    break
+  fi
+  sleep 0.5
+done
+
+HTTP_LOCAL="$WORKDIR/http-local"
+init_local_repo "$HTTP_LOCAL"
+
+pushd "$HTTP_LOCAL" >/dev/null
+git remote add origin "gittuf::http://127.0.0.1:8090/repo.git"
+
+if git push origin main "refs/gittuf/*:refs/gittuf/*" >/tmp/http-push.log 2>&1; then
+  pass "[http] push main + all gittuf refs together"
+else
+  fail "[http] push main + all gittuf refs together"; cat /tmp/http-push.log
+fi
+popd >/dev/null
+
+HTTP_CLONE="$WORKDIR/http-clone"
+if git clone "gittuf::http://127.0.0.1:8090/repo.git" "$HTTP_CLONE" >/tmp/http-clone.log 2>&1; then
+  if git -C "$HTTP_CLONE" show-ref | grep -q "refs/gittuf/policy"; then
+    pass "[http] clone syncs remote gittuf refs"
+  else
+    fail "[http] clone did not sync refs/gittuf/policy"
+  fi
+else
+  fail "[http] clone from remote failed"; cat /tmp/http-clone.log
+fi
+
+# Push the RSL ref standalone, before it exists on the remote.
+pushd "$HTTP_LOCAL" >/dev/null
+if git push origin refs/gittuf/reference-state-log:refs/gittuf/reference-state-log >/tmp/http-rsl.log 2>&1; then
+  pass "[http] standalone RSL ref push"
+else
+  fail "[http] standalone RSL ref push"; cat /tmp/http-rsl.log
+fi
+popd >/dev/null
+
+kill "$HTTP_PID" 2>/dev/null; wait "$HTTP_PID" 2>/dev/null; HTTP_PID=""
+
+# SSH scenarios
+SSHD_DIR="$WORKDIR/sshd"
+SSH_REMOTE_ROOT="$WORKDIR/ssh-remote"
+mkdir -p "$SSH_REMOTE_ROOT"
+git init --bare "$SSH_REMOTE_ROOT/repo.git" >/dev/null
+git -C "$SSH_REMOTE_ROOT/repo.git" config http.receivepack true
+
+SSH_PORT="$("$REPO_ROOT_DIR/test/integration/transport/setup-sshd.sh" "$SSHD_DIR" "$SSH_REMOTE_ROOT" | tail -1)"
+SSHD_PID="$(cat "$SSHD_DIR/sshd.pid")"
+
+export GIT_SSH_COMMAND="ssh -p ${SSH_PORT} -i ${SSHD_DIR}/client_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o SendEnv=GIT_PROTOCOL"
+
+SSH_LOCAL="$WORKDIR/ssh-local"
+init_local_repo "$SSH_LOCAL"
+
+pushd "$SSH_LOCAL" >/dev/null
+git remote add origin "gittuf::ssh://127.0.0.1:${SSH_REMOTE_ROOT}/repo.git"
+
+if timeout 30 git push origin main "refs/gittuf/*:refs/gittuf/*" >/tmp/ssh-push.log 2>&1; then
+  pass "[ssh] push main + all gittuf refs together"
+else
+  fail "[ssh] push main + all gittuf refs together"; cat /tmp/ssh-push.log
+fi
+popd >/dev/null
+
+SSH_CLONE="$WORKDIR/ssh-clone"
+if timeout 30 git clone "gittuf::ssh://127.0.0.1:${SSH_REMOTE_ROOT}/repo.git" "$SSH_CLONE" >/tmp/ssh-clone.log 2>&1; then
+  if git -C "$SSH_CLONE" show-ref | grep -q "refs/gittuf/policy"; then
+    pass "[ssh] clone syncs remote gittuf refs"
+  else
+    fail "[ssh] clone did not sync refs/gittuf/policy"
+  fi
+else
+  fail "[ssh] clone from remote failed"; cat /tmp/ssh-clone.log
+fi
+
+pushd "$SSH_LOCAL" >/dev/null
+if timeout 30 git push origin refs/gittuf/reference-state-log:refs/gittuf/reference-state-log >/tmp/ssh-rsl.log 2>&1; then
+  pass "[ssh] standalone RSL ref push"
+else
+  fail "[ssh] standalone RSL ref push"; cat /tmp/ssh-rsl.log
+fi
+popd >/dev/null
+
+kill "$SSHD_PID" 2>/dev/null; SSHD_PID=""
+
+if [[ "$FAILURES" -gt 0 ]]; then
+  echo "$FAILURES scenario(s) failed"
+  exit 1
+fi
+echo "all scenarios passed"

--- a/test/integration/transport/run.sh
+++ b/test/integration/transport/run.sh
@@ -21,6 +21,7 @@ trap cleanup EXIT
 
 pass() { echo "PASS: $1"; }
 fail() { echo "FAIL: $1"; FAILURES=$((FAILURES+1)); }
+known_issue() { echo "KNOWN ISSUE (see gittuf/gittuf#1231): $1"; }
 
 init_local_repo() {
   local dir="$1"
@@ -83,7 +84,7 @@ if git clone "gittuf::http://127.0.0.1:8090/repo.git" "$HTTP_CLONE" >/tmp/http-c
   if git -C "$HTTP_CLONE" show-ref | grep -q "refs/gittuf/policy"; then
     pass "[http] clone syncs remote gittuf refs"
   else
-    fail "[http] clone did not sync refs/gittuf/policy"
+    known_issue "[http] clone does not sync refs/gittuf/policy (suspected race in main.go packfile-wait loop)"
   fi
 else
   fail "[http] clone from remote failed"; cat /tmp/http-clone.log
@@ -130,17 +131,18 @@ if timeout 30 git clone "gittuf::ssh://127.0.0.1:${SSH_REMOTE_ROOT}/repo.git" "$
   if git -C "$SSH_CLONE" show-ref | grep -q "refs/gittuf/policy"; then
     pass "[ssh] clone syncs remote gittuf refs"
   else
-    fail "[ssh] clone did not sync refs/gittuf/policy"
+    known_issue "[ssh] clone did not sync refs/gittuf/policy"
   fi
 else
-  fail "[ssh] clone from remote failed"; cat /tmp/ssh-clone.log
+  known_issue "[ssh] clone from remote failed (suspected double-scanner issue in ssh.go stateless-connect)"
 fi
 
 pushd "$SSH_LOCAL" >/dev/null
 if timeout 30 git push origin refs/gittuf/reference-state-log:refs/gittuf/reference-state-log >/tmp/ssh-rsl.log 2>&1; then
-  pass "[ssh] standalone RSL ref push"
+  echo "NOTE [ssh]: standalone RSL push succeeded, known issue may be fixed, update this script"
+  fail "[ssh] standalone RSL ref push unexpectedly succeeded"
 else
-  fail "[ssh] standalone RSL ref push"; cat /tmp/ssh-rsl.log
+  known_issue "[ssh] standalone RSL ref push fails (ReconcileLocalRSLWithRemote)"
 fi
 popd >/dev/null
 

--- a/test/integration/transport/setup-sshd.sh
+++ b/test/integration/transport/setup-sshd.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Sets up a throwaway sshd instance for transport integration tests.
+# Prints the port it's listening on and the path to the client SSH key to use.
+set -euo pipefail
+
+SSHD_DIR="$1"   # working directory for keys/config/pidfile
+REPO_ROOT="$2"  # directory to expose as the git repo root over SSH
+
+mkdir -p "$SSHD_DIR"
+
+# host key
+ssh-keygen -t ed25519 -f "$SSHD_DIR/host_key" -N "" -q
+
+# client key + authorize it
+ssh-keygen -t ed25519 -f "$SSHD_DIR/client_key" -N "" -q
+cat "$SSHD_DIR/client_key.pub" > "$SSHD_DIR/authorized_keys"
+chmod 600 "$SSHD_DIR/authorized_keys"
+
+PORT=2222
+
+cat > "$SSHD_DIR/sshd_config" << CONF
+Port ${PORT}
+ListenAddress 127.0.0.1
+HostKey ${SSHD_DIR}/host_key
+AuthorizedKeysFile ${SSHD_DIR}/authorized_keys
+PubkeyAuthentication yes
+PasswordAuthentication no
+StrictModes no
+UsePAM no
+PidFile ${SSHD_DIR}/sshd.pid
+AcceptEnv GIT_PROTOCOL
+LogLevel VERBOSE
+Subsystem sftp internal-sftp
+CONF
+
+/usr/sbin/sshd -f "$SSHD_DIR/sshd_config" -D -e > "$SSHD_DIR/sshd.log" 2>&1 < /dev/null &
+SSHD_PID=$!
+disown
+echo "$SSHD_PID" > "$SSHD_DIR/sshd.pid"
+
+sleep 1
+
+echo "$PORT"


### PR DESCRIPTION
Closes #1231

This adds end to end integration tests for git-remote-gittuf, covering both the curl (HTTP) and SSH handlers. Tests use real git push and git clone against a real HTTP server (git-http-backend wrapped in a small Go binary) and a real local sshd, not calling transport internals directly, as discussed in the issue.

## What's tested

- HTTP: push (main + all gittuf refs together via the wildcard refspec), clone syncing gittuf refs, standalone RSL ref push after the wildcard push
- SSH: same three scenarios, using a real sshd with AcceptEnv GIT_PROTOCOL set (needed this, otherwise the client's GIT_PROTOCOL=version=2 never reaches the server and it silently falls back to v0/v1)

## Structure

Two commits on purpose, per @patzielinski's suggestion in the issue:
1. The tester itself, no special casing for anything
2. A second commit that marks the known issues below as non-fatal, so the rest of the suite can still pass in CI

Plus a third commit for the GitHub Actions workflow.

## Known issues found while building this (not fixed here)

- HTTP clone does not sync refs/gittuf/* locally. Confirmed the remote itself is fine via git fsck, so this looks like a race in main.go's loop that waits for the packfile write to finish before calling SetReference. Reproduced this consistently across 3/3 runs once I switched the test server from go run to a prebuilt binary, which removed some startup delay that was probably masking it before.
- SSH clone hangs and the remote hangs up unexpectedly. Traced this to ssh.go's stateless-connect handler. wroteWants never gets reset to false in a way that stops a second bufio.Scanner from being created over the same partially read helperStdOut, which looks like it duplicates bytes off the wire.
- Standalone RSL ref push fails the first time if the ref doesn't already exist on the remote. Already discussed in #1231, ReconcileLocalRSLWithRemote tries to fetch a remote ref that doesn't exist yet.

Happy to open separate issues for the first two if that's preferred, or keep tracking them here. Didn't try fixing any of these myself since I wanted a second opinion first, especially on the SSH one.