### PR TITLE
rsl: preserve annotation targets when reconciling diverged local RSL

### DIFF
--- a/experimental/gittuf/rsl.go
+++ b/experimental/gittuf/rsl.go
@@ -391,8 +391,18 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 
 	// Apply local only entries on top of the new local RSL
 	// localOnlyEntries is in reverse order
+	//
+	// Reapplying an entry changes its parent and/or its RSL number, so it is
+	// committed with a new ID. Annotation entries refer to the entries they
+	// annotate by ID, so as we replay entries here, we track how each
+	// original entry's ID maps to the new ID it is assigned, and rewrite an
+	// annotation's referenced IDs using that mapping. Otherwise, a skip
+	// annotation on a reapplied entry would silently stop applying to it, as
+	// it would still refer to the original entry's now unreachable ID.
+	oldToNewEntryID := map[string]githash.Hash{}
 	for i := len(localOnlyEntries) - 1; i >= 0; i-- {
-		slog.Debug(fmt.Sprintf("Reapplying entry '%s'...", localOnlyEntries[i].GetID().String()))
+		originalEntryID := localOnlyEntries[i].GetID()
+		slog.Debug(fmt.Sprintf("Reapplying entry '%s'...", originalEntryID.String()))
 
 		// We create a new object so as to apply anything the
 		// entry may contain that is inferred at commit time
@@ -403,20 +413,33 @@ func (r *Repository) ReconcileLocalRSLWithRemote(ctx context.Context, remoteName
 		switch entry := localOnlyEntries[i].(type) {
 		case *rsl.ReferenceEntry:
 			if err := rsl.NewReferenceEntry(entry.RefName, entry.TargetID, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
-				return fmt.Errorf("unable to reapply reference entry '%s': %w", entry.ID.String(), err)
+				return fmt.Errorf("unable to reapply reference entry '%s': %w", originalEntryID.String(), err)
 			}
 		case *rsl.AnnotationEntry:
-			if err := rsl.NewAnnotationEntry(entry.RSLEntryIDs, entry.Skip, entry.Message, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
-				return fmt.Errorf("unable to reapply annotation entry '%s': %w", entry.ID.String(), err)
+			rslEntryIDs := make([]githash.Hash, 0, len(entry.RSLEntryIDs))
+			for _, id := range entry.RSLEntryIDs {
+				if newID, ok := oldToNewEntryID[id.String()]; ok {
+					// The annotated entry was itself reapplied earlier in
+					// this loop and was assigned a new ID; the annotation
+					// must follow it rather than the stale ID.
+					id = newID
+				}
+				rslEntryIDs = append(rslEntryIDs, id)
+			}
+
+			if err := rsl.NewAnnotationEntry(rslEntryIDs, entry.Skip, entry.Message, rsl.WithCustomFields(entry.CustomFields)).Commit(r.r, sign); err != nil {
+				return fmt.Errorf("unable to reapply annotation entry '%s': %w", originalEntryID.String(), err)
 			}
 		}
 
+		currentTip, err := r.r.GetReference(rsl.Ref)
+		if err != nil {
+			return fmt.Errorf("unable to get current tip of the RSL: %w", err)
+		}
+		oldToNewEntryID[originalEntryID.String()] = currentTip
+
 		if slog.Default().Enabled(ctx, slog.LevelDebug) {
-			currentTip, err := r.r.GetReference(rsl.Ref)
-			if err != nil {
-				return fmt.Errorf("unable to get current tip of the RSL: %w", err)
-			}
-			slog.Debug("New entry ID for '%s' is '%s'", localOnlyEntries[i].GetID().String(), currentTip.String())
+			slog.Debug("New entry ID for '%s' is '%s'", originalEntryID.String(), currentTip.String())
 		}
 	}
 

--- a/experimental/gittuf/rsl_test.go
+++ b/experimental/gittuf/rsl_test.go
@@ -708,6 +708,180 @@ func TestReconcileLocalRSLWithRemote(t *testing.T) {
 		assert.Equal(t, originalEntry.(*rsl.ReferenceEntry).TargetID, currentEntry.(*rsl.ReferenceEntry).TargetID)
 	})
 
+	t.Run("remote and local have diverged, skip annotation on reapplied entry is preserved", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+		remoteRepo := &Repository{r: remoteR}
+
+		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate remote actions
+		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
+		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
+		localRepo := &Repository{r: localR}
+
+		// Simulate remote actions on refName, so local and remote diverge
+		// without touching the same ref
+		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate local actions: record an entry for a different ref, then
+		// immediately skip it via an annotation
+		if _, err := localRepo.r.Commit(emptyTreeHash, anotherRefName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := localRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		skippedEntryID, err := localRepo.r.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if err := localRepo.RecordRSLAnnotation(testCtx, []string{skippedEntryID.String()}, true, "skip bad entry", false, rslopts.WithAnnotateLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Sanity check: prior to reconciliation, the entry is skipped
+		latestBefore, annotationsBefore, err := rsl.GetLatestReferenceUpdaterEntry(localRepo.r, rsl.ForReference(anotherRefName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Equal(t, skippedEntryID, latestBefore.GetID())
+		require.True(t, latestBefore.(*rsl.ReferenceEntry).SkippedBy(annotationsBefore))
+
+		err = localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false)
+		assert.Nil(t, err)
+
+		// After reconciliation, the reapplied entry (which now has a
+		// different ID) must still be marked as skipped by the reapplied
+		// annotation
+		latestAfter, annotationsAfter, err := rsl.GetLatestReferenceUpdaterEntry(localRepo.r, rsl.ForReference(anotherRefName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assert.NotEqual(t, skippedEntryID, latestAfter.GetID(), "test is invalid if entry's ID didn't change on reapply")
+		assert.True(t, latestAfter.(*rsl.ReferenceEntry).SkippedBy(annotationsAfter), "skip annotation must still apply to the reapplied entry")
+	})
+
+	t.Run("remote and local have diverged, annotation separated from its target is preserved", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)
+		remoteRepo := &Repository{r: remoteR}
+
+		treeBuilder := gitinterface.NewTreeBuilder(remoteR)
+		emptyTreeHash, err := treeBuilder.WriteTreeFromEntries(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate remote actions
+		if _, err := remoteR.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Clone remote repository
+		localTmpDir := filepath.Join(os.TempDir(), fmt.Sprintf("local-%s", t.Name()))
+		defer os.RemoveAll(localTmpDir) //nolint:errcheck
+		localR, err := gitinterface.CloneAndFetchRepository(tmpDir, localTmpDir, refName, []string{rsl.Ref}, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Nil(t, localR.SetGitConfig("user.name", "Jane Doe"))
+		require.Nil(t, localR.SetGitConfig("user.email", "jane.doe@example.com"))
+		localRepo := &Repository{r: localR}
+
+		// Simulate remote actions on refName, so local and remote diverge
+		// without touching the same ref
+		if _, err := remoteRepo.r.Commit(emptyTreeHash, refName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := remoteRepo.RecordRSLEntryForReference(testCtx, refName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Simulate local actions: record an entry for a different ref...
+		if _, err := localRepo.r.Commit(emptyTreeHash, anotherRefName, "Test commit", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := localRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false, rslopts.WithRecordLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+		annotatedEntryID, err := localRepo.r.GetReference(rsl.Ref)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// ...then record one more, unrelated entry before annotating the
+		// first one, so the annotation is not immediately adjacent to its
+		// target in the RSL
+		if _, err := localRepo.r.Commit(emptyTreeHash, anotherRefName, "Test commit 2", false); err != nil {
+			t.Fatal(err)
+		}
+		if err := localRepo.RecordRSLEntryForReference(testCtx, anotherRefName, false, rslopts.WithRecordLocalOnly(), rslopts.WithSkipCheckForDuplicateEntry()); err != nil {
+			t.Fatal(err)
+		}
+
+		// Not a skip, just informational
+		if err := localRepo.RecordRSLAnnotation(testCtx, []string{annotatedEntryID.String()}, false, "informational note", false, rslopts.WithAnnotateLocalOnly()); err != nil {
+			t.Fatal(err)
+		}
+
+		err = localRepo.ReconcileLocalRSLWithRemote(testCtx, remoteName, false)
+		assert.Nil(t, err)
+
+		// Walk the reconciled RSL for anotherRefName and confirm the
+		// reapplied annotation refers to the reapplied entry it originally
+		// annotated, using the entry's new ID rather than the stale one
+		firstEntry, _, err := rsl.GetFirstReferenceUpdaterEntryForRef(localRepo.r, anotherRefName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		lastEntry, _, err := rsl.GetLatestReferenceUpdaterEntry(localRepo.r, rsl.ForReference(anotherRefName))
+		if err != nil {
+			t.Fatal(err)
+		}
+		entries, annotationMap, err := rsl.GetReferenceUpdaterEntriesInRangeForRef(localRepo.r, firstEntry.GetID(), lastEntry.GetID(), anotherRefName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		require.Len(t, entries, 2)
+
+		reapplyingEntryID := entries[0].GetID()
+		assert.NotEqual(t, annotatedEntryID, reapplyingEntryID, "test is invalid if entry's ID didn't change on reapply")
+
+		annotations, has := annotationMap[reapplyingEntryID.String()]
+		require.True(t, has, "reapplied annotation must still refer to the reapplied entry")
+		require.Len(t, annotations, 1)
+		assert.Equal(t, "informational note", annotations[0].Message)
+	})
+
 	t.Run("remote and local have diverged but modify same ref", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		remoteR := gitinterface.CreateTestGitRepository(t, tmpDir, false)


### PR DESCRIPTION
## Description

Fixes #1587.

### Problem

`ReconcileLocalRSLWithRemote` handles the case where a local RSL has diverged from its remote (both sides touched different, non-overlapping refs). It resets the local RSL to the remote's tip and then replays local-only entries on top of it. Replaying a `ReferenceEntry` naturally gives it a new commit ID (its parent and RSL number changed), and that's already covered by existing tests.

The bug is in how `AnnotationEntry` was replayed: it was recommitted with its original `RSLEntryIDs`, which still pointed at the *old* ID of whatever it annotated. That old ID no longer exists in the reconciled RSL, so the annotation silently stopped matching anything. Concretely, a skip annotation on a local-only entry stopped applying to it once the RSL was reconciled with a diverged remote, and the entry would come back as unskipped, with no error or warning.

### Root cause

In `experimental/gittuf/rsl.go`, the replay loop in `ReconcileLocalRSLWithRemote` recreated each local-only entry from scratch (so inferred fields like the RSL number are recomputed correctly), but for annotations it reused `entry.RSLEntryIDs` verbatim instead of pointing at whatever new ID the annotated entry received during replay.

### Fix

While replaying local-only entries, track a map from each entry's original ID to the new ID it's assigned once committed. When replaying an `AnnotationEntry`, rewrite its `RSLEntryIDs` through that map before recommitting, falling back to the original ID for anything that wasn't itself replayed (i.e. entries from before the common ancestor, which didn't move). This is a small, localized change to the replay loop; nothing about the reconciliation algorithm itself changes.

### Testing

Added two regression tests to `TestReconcileLocalRSLWithRemote` in `experimental/gittuf/rsl_test.go`:
- a skip annotation directly on a local-only entry that gets replayed, confirming `SkippedBy` still reports the reapplied entry as skipped afterwards
- a non-skip annotation separated from its target by another local-only entry, confirming the reapplied annotation still resolves to the reapplied entry via `GetReferenceUpdaterEntriesInRangeForRef`

I confirmed both new tests fail against the code before this fix (annotation ends up detached) and pass with it.

Ran `go build ./...`, `go vet ./experimental/...`, `golangci-lint run ./experimental/gittuf/...` (clean), the full `pkg/rsl` suite, and `experimental/gittuf`'s `TestReconcileLocalRSLWithRemote` suite, all passing. The rest of `internal/policy` has pre-existing `ssh-keygen -Y sign` failures in this environment unrelated to this change (reproducible on `main` without this patch too).

### Impact

This only affects the RSL-divergence-reconciliation path (`ReconcileLocalRSLWithRemote`, used from `Sync`/`RecordRSLEntryForReference` etc. when local and remote RSLs have diverged on different refs). No change to behavior when there's no divergence, and no change to how `ReferenceEntry` replay works.

## AI Usage

- [ ] I **did not** use generative AI at all in making the content of this pull
  request.
- [x] I **did** use generative AI in some form in making the content of this
  pull request. I have described my use of AI below.

I used AI to investigate the codebase. I manually reviewed and verified the change myself, including confirming the new tests fail before the fix and pass after it. The commit message and this description are my own summary of that work.

## Contributor Checklist

- [x] I **have manually reviewed all content** submitted to gittuf in this pull
  request.
- [x] I fully understand the content I am submitting.
- [x] The changes introduced are documented and have tests included if
  applicable.
- [x] My changes do not infringe on copyright/trademarks/etc.
- [x] All commits in this pull request include a [DCO
  Signoff](https://wiki.linuxfoundation.org/dco).
- [x] By submitting this pull request, I agree to follow the gittuf [Code of
  Conduct](https://github.com/gittuf/community/blob/main/CODE-OF-CONDUCT.md).
